### PR TITLE
cc-button: fix Safari element.animate()

### DIFF
--- a/components/atoms/cc-button.js
+++ b/components/atoms/cc-button.js
@@ -127,14 +127,6 @@ export class CcButton extends LitElement {
     // outlined is not default except in simple mode
     modes.outlined = this.outlined || modes.simple;
 
-    // When delay mechanism is set, we need a cancel label
-    // We don't want the button width to change when the user clicks and toggles between normal and cancel mode
-    // That's why (see CSS) we put both labels on 2 lines and only reduce the height of the one we want to hide
-    // This way, when delay is set, the button has a min width of the largest label (normal or cancel)
-    const $cancelLabel = (this.delay != null)
-      ? html`<div class=${classMap({ hidden: !this._cancelMode })}>${i18n('cc-button.cancel')}</div>`
-      : '';
-
     return html`<button
       type="button"
       class=${classMap(modes)}
@@ -142,7 +134,15 @@ export class CcButton extends LitElement {
       @click=${this._onClick}
     >
       <div class=${classMap({ hidden: this._cancelMode })}><slot></slot></div>
-      ${$cancelLabel}
+      <!--
+        When delay mechanism is set, we need a cancel label
+        We don't want the button width to change when the user clicks and toggles between normal and cancel mode
+        That's why (see CSS) we put both labels on 2 lines and only reduce the height of the one we want to hide
+        This way, when delay is set, the button has a min width of the largest label (normal or cancel)
+      -->
+      ${this.delay != null ? html`
+        <div class=${classMap({ hidden: !this._cancelMode })}>${i18n('cc-button.cancel')}</div>
+      ` : ''}
     </button>`;
   }
 

--- a/components/atoms/cc-button.js
+++ b/components/atoms/cc-button.js
@@ -92,16 +92,6 @@ export class CcButton extends LitElement {
     }
     else {
       this._cancelMode = true;
-      this._animation = this.shadowRoot.querySelector('button').animate(
-        [
-          { backgroundSize: '0 10%' },
-          { backgroundSize: '100% 10%' },
-        ],
-        {
-          duration: this.delay * 1000,
-          easing: 'linear',
-        },
-      );
       this._timeoutId = setTimeout(() => {
         dispatchCustomEvent(this, 'click');
         this._cancelMode = false;
@@ -142,6 +132,7 @@ export class CcButton extends LitElement {
       -->
       ${this.delay != null ? html`
         <div class=${classMap({ hidden: !this._cancelMode })}>${i18n('cc-button.cancel')}</div>
+        <progress class=${classMap({ active: this._cancelMode })} style="--delay: ${this.delay}s"></progress>
       ` : ''}
     </button>`;
   }
@@ -175,7 +166,10 @@ export class CcButton extends LitElement {
           cursor: pointer;
           font-weight: bold;
           min-height: 2rem;
+          overflow: hidden;
           padding: 0 0.5rem;
+          /* used to absolutely position the <progress> */
+          position: relative;
           text-transform: uppercase;
           -moz-user-select: none;
           -webkit-user-select: none;
@@ -212,16 +206,7 @@ export class CcButton extends LitElement {
           color: #fff;
         }
 
-        button {
-          /* used for delay animation, same color as text */
-          background-image: linear-gradient(#fff, #fff);
-          background-position: left bottom;
-          background-repeat: no-repeat;
-          background-size: 0;
-        }
-
         .outlined {
-          background-image: linear-gradient(var(--btn-color), var(--btn-color));
           background-color: #fff;
           color: var(--btn-color);
         }
@@ -268,6 +253,39 @@ export class CcButton extends LitElement {
           color: transparent;
           height: 0;
           overflow: hidden;
+        }
+
+        /* progress bar for delay, see https://css-tricks.com/html5-progress-element */
+        progress {
+          -webkit-appearance: none;
+          -moz-appearance: none;
+          appearance: none;
+          border: none;
+          bottom: 0;
+          height: 0.2rem;
+          left: 0;
+          position: absolute;
+          width: 0;
+        }
+        
+        progress.active {
+          transition: width var(--delay) linear;
+          width: 100%;
+        }
+
+        progress,
+        progress::-webkit-progress-bar {
+          background-color: #fff;
+        }
+
+        .outlined progress,
+        .outlined progress::-webkit-progress-bar {
+          background-color: var(--btn-color);
+        }
+
+        progress::-webkit-progress-value,
+        progress::-moz-progress-bar {
+          background-color: transparent;
         }
 
         /* We can do this because we set a visible focus state */

--- a/components/atoms/cc-button.js
+++ b/components/atoms/cc-button.js
@@ -260,7 +260,7 @@ export class CcButton extends LitElement {
         /* TRANSITIONS */
         button {
           box-shadow: 0 0 0 0 rgba(255, 255, 255, 0);
-          transition: all 75ms ease-in-out;
+          transition: box-shadow 75ms ease-in-out;
         }
 
         /* special hide, see template comments about it */

--- a/components/atoms/cc-expand.js
+++ b/components/atoms/cc-expand.js
@@ -37,6 +37,7 @@ export class CcExpand extends HTMLElement {
         return;
       }
       if (this._oldHeight != null) {
+        // This is not supported in Safari yet but it's purely decorative so let's keep it like that
         this.animate(
           [
             { height: this._oldHeight },

--- a/components/atoms/cc-input-text.js
+++ b/components/atoms/cc-input-text.js
@@ -174,7 +174,7 @@ export class CcInputText extends LitElement {
           box-shadow: 0 0 0 0 rgba(255, 255, 255, 0);
           overflow: hidden;
           padding: 0.15rem 0.5rem;
-          transition: all 75ms ease-in-out, height 0ms;
+          transition: box-shadow 75ms ease-in-out, height 0ms;
         }
 
         .wrapper:focus-within {

--- a/components/info-tiles/cc-info-instances.js
+++ b/components/info-tiles/cc-info-instances.js
@@ -100,6 +100,7 @@ export class CcInfoInstances extends LitElement {
     // NOTE: This does not handle the case where someone has different flavors running or deploying
     if (this._lastRunningCount !== runningInstancesCount) {
       this.updateComplete.then(() => {
+        // This is not supported in Safari yet but it's purely decorative so let's keep it like that
         animate(this.shadowRoot, '.instances[data-type=running] .count-bubble', ...QUICK_SHRINK);
         this._lastRunningCount = runningInstancesCount;
       });
@@ -107,6 +108,7 @@ export class CcInfoInstances extends LitElement {
 
     if (this._lastDeployingCount !== deployingInstancesCount) {
       this.updateComplete.then(() => {
+        // This is not supported in Safari yet but it's purely decorative so let's keep it like that
         animate(this.shadowRoot, '.instances[data-type=deploying] .count-bubble', ...QUICK_SHRINK);
         this._lastDeployingCount = deployingInstancesCount;
       });


### PR DESCRIPTION
This is sad, but Safari does not support `element.animate()`.
In most cases this is ok not to have the animation (cc-expand, cc-info-instances).

In the case of the delay animation of a `<cc-button>`, we really need it.
We went for a `<progress>` element in the DOM and we animated its background.