### PR TITLE
Fix ESLint errors

### DIFF
--- a/components/lib/i18n-sanitize.js
+++ b/components/lib/i18n-sanitize.js
@@ -1,3 +1,4 @@
+/* global globalThis */
 const WHITELISTED_TAGS = ['STRONG', 'EM', 'CODE', 'A'];
 
 // Reuse one text node to escape HTML

--- a/components/translations/translations.fr.js
+++ b/components/translations/translations.fr.js
@@ -3,9 +3,10 @@ import {
   prepareFormatDateOnly,
   prepareFormatDistanceToNow,
   prepareFormatHours,
+  prepareFormatDatetime,
 } from '../lib/i18n-date.js';
 import { prepareNumberUnitFormatter } from '../lib/i18n-number.js';
-import { prepareFormatDatetime } from '../lib/i18n-date';
+
 import { sanitize } from '../lib/i18n-sanitize';
 
 export const lang = 'fr';


### PR DESCRIPTION
Hi!

The following command  reported errors:

```sh
$ npm run lint

> @clevercloud/components@1.3.0 lint /home/foo/bar/clever-components
> eslint components stories tasks


/home/foo/bar/clever-components/components/lib/i18n-sanitize.js
  7:7  error  'globalThis' is not defined  no-undef

/home/foo/bar/clever-components/components/translations/translations.fr.js
  6:8   error  '/home/foo/bar/clever-components/components/lib/i18n-date.js' imported multiple times  import/no-duplicates
  8:39  error  '/home/foo/bar/clever-components/components/lib/i18n-date.js' imported multiple times  import/no-duplicates

✖ 3 problems (3 errors, 0 warnings)
  1 error and 0 warnings potentially fixable with the `--fix` option.
```

Then I used `npm run lint:fix` to automatically fixed the `translations.fr.js` file.

I've also added a `global` comment to be able to use the global object `globalThis`.

Signed-off-by: Antoine Leblanc <ant.leblanc@gmail.com>