### PR TITLE
Some breaking changes

### DIFF
--- a/src/addon/cc-addon-admin.js
+++ b/src/addon/cc-addon-admin.js
@@ -174,11 +174,6 @@ export class CcAddonAdmin extends LitElement {
           flex: 1 1 10rem;
           margin-right: 0.5rem;
         }
-
-        cc-input-text,
-        cc-button {
-          margin: 0;
-        }
       `,
     ];
   }

--- a/src/addon/cc-addon-backups.js
+++ b/src/addon/cc-addon-backups.js
@@ -334,10 +334,6 @@ export class CcAddonBackups extends LitElement {
           cursor: help;
         }
 
-        cc-input-text {
-          margin: 0;
-        }
-
         /* SKELETON */
         .skeleton {
           background-color: #bbb;
@@ -352,6 +348,7 @@ export class CcAddonBackups extends LitElement {
         .cc-link,
         cc-button[link] {
           margin-right: 0.5rem;
+          vertical-align: baseline;
         }
       `,
     ];

--- a/src/addon/cc-addon-credentials.js
+++ b/src/addon/cc-addon-credentials.js
@@ -1,4 +1,5 @@
 import '../atoms/cc-input-text.js';
+import '../atoms/cc-flex-gap.js';
 import '../molecules/cc-block.js';
 import '../molecules/cc-error.js';
 import { css, html, LitElement } from 'lit-element';
@@ -87,7 +88,7 @@ export class CcAddonCredentials extends LitElement {
           <div>${this._getDescription(this.type)}</div>
           
           ${this.credentials != null ? html`
-            <div class="credential-list">
+            <cc-flex-gap class="credential-list">
               ${this.credentials.map(({ type, secret, value }) => html`
                 <cc-input-text readonly clipboard
                   ?secret=${secret}
@@ -96,7 +97,7 @@ export class CcAddonCredentials extends LitElement {
                   label=${this._getFieldName(type)}
                 ></cc-input-text>
               `)}
-            </div>
+            </cc-flex-gap>
           ` : ''}
         ` : ''}
         
@@ -117,15 +118,11 @@ export class CcAddonCredentials extends LitElement {
         }
 
         .credential-list {
-          display: flex;
-          flex-wrap: wrap;
-          margin: -1rem;
-          padding: 0.5rem;
+          --cc-gap: 1rem;
         }
 
         cc-input-text {
           flex: 1 0 18rem;
-          margin: 0.5rem;
         }
 
         /* SKELETON */

--- a/src/addon/cc-addon-features.js
+++ b/src/addon/cc-addon-features.js
@@ -1,3 +1,4 @@
+import '../atoms/cc-flex-gap.js';
 import '../molecules/cc-block.js';
 import '../molecules/cc-error.js';
 import { css, html, LitElement } from 'lit-element';
@@ -125,7 +126,7 @@ export class CcAddonFeatures extends LitElement {
         
         ${!this.error ? html`
           <div>${i18n('cc-addon-features.details')}</div>
-          <div class="feature-list">
+          <cc-flex-gap class="feature-list">
             ${features.map((feature) => html`
               <div class="feature ${classMap({ skeleton })}">
                 ${feature.icon != null ? html`
@@ -137,7 +138,7 @@ export class CcAddonFeatures extends LitElement {
                 <div class="feature-value">${feature.value}</div>
               </div>
             `)}
-          </div>
+          </cc-flex-gap>
         ` : ''}
   
         ${this.error ? html`
@@ -157,13 +158,10 @@ export class CcAddonFeatures extends LitElement {
         }
 
         .feature-list {
-          --color: #496D93;
-          --gap: 1rem;
           --bdw: 2px;
+          --cc-gap: 1rem;
+          --color: #496D93;
           --padding: 0.6rem;
-          display: flex;
-          flex-wrap: wrap;
-          margin: calc(var(--gap) / -2);
         }
 
         .feature {
@@ -172,7 +170,6 @@ export class CcAddonFeatures extends LitElement {
           border: var(--bdw) solid var(--color);
           display: flex;
           flex-wrap: wrap;
-          margin: calc(var(--gap) / 2);
         }
 
         .feature-icon {

--- a/src/addon/cc-elasticsearch-info.js
+++ b/src/addon/cc-elasticsearch-info.js
@@ -1,4 +1,5 @@
 import '../atoms/cc-img.js';
+import '../atoms/cc-flex-gap.js';
 import '../molecules/cc-error.js';
 import { css, html, LitElement } from 'lit-element';
 import { classMap } from 'lit-html/directives/class-map.js';
@@ -62,7 +63,7 @@ export class CcElasticsearchInfo extends LitElement {
       ${!this.error ? html`
         <div class="info-text">${i18n('cc-elasticsearch-info.text')}</div>
         
-        <div class="link-list">
+        <cc-flex-gap class="link-list">
           ${ccLink(ELASTICSEARCH_DOCUMENTATION, html`
             <cc-img src="${infoSvg}"></cc-img><span>${i18n('cc-elasticsearch-info.link.doc')}</span>
           `)}
@@ -81,7 +82,7 @@ export class CcElasticsearchInfo extends LitElement {
               <cc-img src="${APM_LOGO_URL}"></cc-img><span class="${classMap({ skeleton: (apmLink.href == null) })}">${i18n('cc-elasticsearch-info.link.apm')}</span>
             `)}
           ` : ''}
-        </div>
+        </cc-flex-gap>
       ` : ''}
 
       ${this.error ? html`
@@ -97,26 +98,21 @@ export class CcElasticsearchInfo extends LitElement {
       // language=CSS
       css`
         :host {
+          --cc-gap: 1rem;
           background-color: #fff;
           border-radius: 0.25rem;
           border: 1px solid #bcc2d1;
           display: grid;
-          grid-gap: 1rem;
+          grid-gap: var(--cc-gap);
           overflow: hidden;
-          padding: 1rem 1rem 1rem 4rem;
+          padding: var(--cc-gap);
+          padding-left: 4rem;
           position: relative;
-        }
-
-        .link-list {
-          display: flex;
-          flex-wrap: wrap;
-          margin: -0.5rem -0.75rem;
         }
 
         .cc-link {
           align-items: center;
           display: flex;
-          margin: 0.5rem 0.75rem;
         }
 
         cc-img {

--- a/src/addon/cc-elasticsearch-options.js
+++ b/src/addon/cc-elasticsearch-options.js
@@ -176,7 +176,7 @@ export class CcElasticsearchOptions extends LitElement {
 
         cc-toggle {
           justify-self: end;
-          margin: 0.5rem 0 0;
+          margin-top: 0.5rem;
         }
 
         .option--enabled cc-toggle {
@@ -186,10 +186,6 @@ export class CcElasticsearchOptions extends LitElement {
         .button-bar {
           display: grid;
           justify-content: flex-end;
-        }
-
-        cc-button {
-          margin: 0;
         }
 
         [title] {

--- a/src/addon/cc-header-addon.js
+++ b/src/addon/cc-header-addon.js
@@ -1,5 +1,6 @@
 import '../atoms/cc-img.js';
 import '../atoms/cc-input-text.js';
+import '../atoms/cc-flex-gap.js';
 import '../molecules/cc-error.js';
 import { css, html, LitElement } from 'lit-element';
 import { classMap } from 'lit-html/directives/class-map.js';
@@ -87,17 +88,17 @@ export class CcHeaderAddon extends LitElement {
 
     return html`
       ${!this.error ? html`
-        <div class="main">
+        <cc-flex-gap class="main">
         
           <cc-img class="logo" src="${ifDefined(addon.provider.logoUrl)}"
             ?skeleton=${skeleton} text="${addon.provider.name}" title="${ifDefined(addon.provider.name)}"></cc-img>
         
           <div class="details">
             <div class="name"><span class="${classMap({ skeleton })}">${addon.name}</span></div>
-            <cc-input-text class="id" readonly clipboard value="${ifDefined(addon.id)}" ?skeleton=${skeleton}></cc-input-text>
+            <cc-input-text readonly clipboard value="${ifDefined(addon.id)}" ?skeleton=${skeleton}></cc-input-text>
           </div>
 
-          <div class="description">
+          <cc-flex-gap class="description">
             <div class="description-item">
               <div class="description-label">${i18n('cc-header-addon.plan')}</div>
               <div class="${classMap({ skeleton })}">${addon.plan.name}</div>
@@ -110,8 +111,8 @@ export class CcHeaderAddon extends LitElement {
               <div class="description-label">${i18n('cc-header-addon.creation-date')}</div>
               <div class="${classMap({ skeleton })}" title="${ifDefined(creationDateFull)}">${creationDateShort}</div>
             </div>
-          </div>
-        </div>
+          </cc-flex-gap>
+        </cc-flex-gap>
       ` : ''}
 
       ${this.error ? html`
@@ -126,6 +127,7 @@ export class CcHeaderAddon extends LitElement {
       // language=CSS
       css`
         :host {
+          --cc-gap: 1rem;
           background-color: #fff;
           border-radius: 0.25rem;
           border: 1px solid #bcc2d1;
@@ -133,23 +135,17 @@ export class CcHeaderAddon extends LitElement {
         }
 
         .main {
-          align-items: center;
-          display: flex;
-          flex-wrap: wrap;
-          justify-content: flex-start;
+          padding: var(--cc-gap);
         }
 
         .logo {
-          align-self: flex-start;
           border-radius: 0.25rem;
           height: 3.25rem;
-          margin: 1rem;
           width: 3.25rem;
         }
 
         .details {
           flex: 1 1 0;
-          margin: 1rem 1rem 1rem 0;
         }
 
         .name,
@@ -163,18 +159,12 @@ export class CcHeaderAddon extends LitElement {
           min-width: 12rem;
         }
 
-        .id {
-          margin: 0;
-        }
-
         .description {
-          display: flex;
-          padding: 0.5rem 1rem 0.5rem 0;
+          align-self: center;
         }
 
         .description-item {
           flex: 1 1 auto;
-          margin: 0.5rem 0 0.5rem 1rem;
         }
 
         .description-label {
@@ -182,7 +172,7 @@ export class CcHeaderAddon extends LitElement {
         }
 
         cc-error {
-          padding: 1rem;
+          padding: var(--cc-gap);
           text-align: center;
         }
 

--- a/src/atoms/cc-button.js
+++ b/src/atoms/cc-button.js
@@ -157,20 +157,22 @@ export class CcButton extends LitElement {
       .disabled=${this.disabled || this.skeleton || this.waiting}
       @click=${this._onClick}
     >
-      <div class=${classMap({ hidden: this._cancelMode })}>
+      <!--
+        When delay mechanism is set, we need a cancel label.
+        We don't want the button width to change when the user clicks and toggles between normal and cancel mode.
+        That's why (see CSS) we put both labels in a grid, in the same cell and hide (visibility:hidden) the one we don't want.
+        This way, when delay is set, the button has a min width of the largest label (normal or cancel).
+      -->
+      <div class="text-wrapper ${classMap({ 'cancel-mode': this._cancelMode })}">
         ${this.image != null ? html`
           <img src=${this.image} alt="">
         ` : ''}
-        <slot></slot>
+        <div class="text-normal"><slot></slot></div>
+        ${delay != null ? html`
+          <div class="text-cancel">${i18n('cc-button.cancel')}</div>
+        ` : ''}
       </div>
-      <!--
-        When delay mechanism is set, we need a cancel label
-        We don't want the button width to change when the user clicks and toggles between normal and cancel mode
-        That's why (see CSS) we put both labels on 2 lines and only reduce the height of the one we want to hide
-        This way, when delay is set, the button has a min width of the largest label (normal or cancel)
-      -->
       ${delay != null ? html`
-        <div class=${classMap({ hidden: !this._cancelMode })}>${i18n('cc-button.cancel')}</div>
         <progress class="delay ${classMap({ active: this._cancelMode })}" style="--delay: ${delay}s"></progress>
       ` : ''}
       ${waiting ? html`
@@ -188,13 +190,7 @@ export class CcButton extends LitElement {
         :host {
           box-sizing: border-box;
           display: inline-block;
-          margin: 0.2rem;
-          vertical-align: top;
-        }
-
-        :host([link]) {
-          margin: 0;
-          vertical-align: initial;
+          vertical-align: middle;
         }
 
         /* RESET */
@@ -298,11 +294,19 @@ export class CcButton extends LitElement {
           transition: box-shadow 75ms ease-in-out;
         }
 
-        /* special hide, see template comments about it */
-        .hidden {
-          color: transparent;
-          height: 0;
-          overflow: hidden;
+        /* DELAY CANCEL MODE SUPERPOSITION WITH GRID */
+        .text-wrapper {
+          display: grid;
+        }
+
+        .text-normal,
+        .text-cancel {
+          grid-area: 1 / 1 / 2 / 2;
+        }
+
+        .text-wrapper.cancel-mode .text-normal,
+        .text-wrapper:not(.cancel-mode) .text-cancel {
+          visibility: hidden;
         }
 
         /* progress bar for delay, see https://css-tricks.com/html5-progress-element */
@@ -339,8 +343,12 @@ export class CcButton extends LitElement {
         }
 
         @keyframes waiting {
-          from { left: -52%; }
-          to   { left: 52%;  }
+          from {
+            left: -52%;
+          }
+          to {
+            left: 52%;
+          }
         }
 
         progress.waiting {

--- a/src/atoms/cc-flex-gap.js
+++ b/src/atoms/cc-flex-gap.js
@@ -1,0 +1,46 @@
+const createElement = (tagName) => document.createElement(tagName);
+const appendChild = (parent, child) => parent.appendChild(child);
+
+/**
+ * A pure layout component used to overcome the lack of `gap` in CSS flex containers.
+ *
+ * ## Technical details
+ *
+ * * This component does not use lit* deps on purpose (keep small and not useful).
+ * * The source code is written in a way so it can be the smallest possible, while keeping a reasonable readability level.
+ * * This feature exist in Firefox: https://developer.mozilla.org/en-US/docs/Web/CSS/gap.
+ *
+ * Here is the technique:
+ *
+ * * Use `display: flex` on a container.
+ * * Use a negative margin of half the gap on this container.
+ * * Use a positive margin of half the gap on its children.
+ * * Sadly, due to margin collapsing behaviour between the container with negative margins and its parent,
+ * * the negative margin of the container will be displayed as white space in its parent.
+ * * There are a few techniques to prevent this.
+ * * We chose to use a `display: grid` on the parent to disable the margin collapsing while preserving potential overflow like focus rings etc...
+ *
+ * @cssprop {Number} --cc-gap - The gap between children.
+ */
+export class CcFlexGap extends HTMLElement {
+
+  constructor () {
+    super();
+
+    const shadow = this.attachShadow({ mode: 'open' });
+
+    const style = createElement('style');
+    style.textContent = `:host{display:grid}::slotted(*){margin:calc(var(--cc-gap)/2)}`;
+
+    const flexContainer = createElement('div');
+    flexContainer.style = `display:flex;flex-wrap:wrap;margin:calc(var(--cc-gap)/-2);`;
+
+    const slot = createElement('slot');
+
+    appendChild(shadow, style);
+    appendChild(shadow, flexContainer);
+    appendChild(flexContainer, slot);
+  }
+}
+
+window.customElements.define('cc-flex-gap', CcFlexGap);

--- a/src/atoms/cc-input-text.js
+++ b/src/atoms/cc-input-text.js
@@ -281,7 +281,6 @@ export class CcInputText extends LitElement {
       css`
         :host {
           display: inline-block;
-          margin: 0.2rem;
         }
 
         :host([multi]) {

--- a/src/atoms/cc-toggle.js
+++ b/src/atoms/cc-toggle.js
@@ -77,7 +77,6 @@ export class CcToggle extends LitElement {
         :host {
           --cc-toggle-color: #334252;
           display: flex;
-          margin: 0.2rem;
         }
 
         .toggle-group {

--- a/src/env-var/cc-env-var-create.js
+++ b/src/env-var/cc-env-var-create.js
@@ -26,9 +26,9 @@ import { i18n } from '../lib/i18n.js';
  * @prop {Boolean} disabled - Sets `disabled` attribute on inputs and button.
  * @prop {String[]} variablesNames - Sets list of existing variables names (so we can display an error if it already exists).
  *
- * @event {CustomEvent<Variable>} env-var-create:create - Fires the variable whenever the add button is clicked.
+ * @event {CustomEvent<Variable>} cc-env-var-create:create - Fires the variable whenever the add button is clicked.
  */
-export class EnvVarCreate extends LitElement {
+export class CcEnvVarCreate extends LitElement {
 
   static get properties () {
     return {
@@ -172,4 +172,4 @@ export class EnvVarCreate extends LitElement {
   }
 }
 
-window.customElements.define('env-var-create', EnvVarCreate);
+window.customElements.define('cc-env-var-create', CcEnvVarCreate);

--- a/src/env-var/cc-env-var-create.js
+++ b/src/env-var/cc-env-var-create.js
@@ -1,4 +1,5 @@
 import '../atoms/cc-button.js';
+import '../atoms/cc-flex-gap.js';
 import '../atoms/cc-input-text.js';
 import '../molecules/cc-error.js';
 import { validateName } from '@clevercloud/client/esm/utils/env-vars.js';
@@ -84,7 +85,8 @@ export class CcEnvVarCreate extends LitElement {
     const hasErrors = isNameInvalid || isNameAlreadyDefined;
 
     return html`
-      <div class="wrapper">
+      <cc-flex-gap>
+        
         <cc-input-text
           class="name"
           name="name"
@@ -94,7 +96,9 @@ export class CcEnvVarCreate extends LitElement {
           @cc-input-text:input=${this._onNameInput}
           @cc-input-text:requestimplicitsubmit=${(e) => this._onRequestSubmit(e, hasErrors)}
         ></cc-input-text>
-        <span class="input-btn">
+        
+        <cc-flex-gap class="input-btn">
+          
           <cc-input-text
             class="value"
             name="value"
@@ -105,13 +109,16 @@ export class CcEnvVarCreate extends LitElement {
             @cc-input-text:input=${this._onValueInput}
             @cc-input-text:requestimplicitsubmit=${(e) => this._onRequestSubmit(e, hasErrors)}
           ></cc-input-text>
+          
           <cc-button
             primary
             ?disabled=${hasErrors || this.disabled}
             @cc-button:click=${this._onSubmit}
           >${i18n(`env-var-create.create-button`)}</cc-button>
-        </span>
-      </div>
+          
+        </cc-flex-gap>
+      </cc-flex-gap>
+      
       ${(isNameInvalid && this._variableName !== '') ? html`
         <cc-error>${i18n(`env-var-create.errors.invalid-name`, { name: this._variableName })}</cc-error>
       ` : ''}
@@ -126,12 +133,8 @@ export class CcEnvVarCreate extends LitElement {
       // language=CSS
       css`
         :host {
+          --cc-gap: 0.5rem;
           display: block;
-        }
-
-        .wrapper {
-          display: flex;
-          flex-wrap: wrap;
         }
 
         .name {
@@ -139,9 +142,7 @@ export class CcEnvVarCreate extends LitElement {
         }
 
         .input-btn {
-          display: flex;
           flex: 2 1 27rem;
-          flex-wrap: wrap;
         }
 
         .value {
@@ -157,7 +158,7 @@ export class CcEnvVarCreate extends LitElement {
         }
 
         cc-error {
-          margin: 0.5rem 0.2rem 0.2rem;
+          margin: 0.5rem 0;
         }
 
         /* i18n error message may contain <code> tags */

--- a/src/env-var/cc-env-var-editor-expert.js
+++ b/src/env-var/cc-env-var-editor-expert.js
@@ -22,9 +22,9 @@ import { i18n } from '../lib/i18n.js';
  * @prop {Boolean} disabled - Sets `disabled` attribute on inputs and buttons.
  * @prop {Variable[]} variables - Sets the list of variables.
  *
- * @event {CustomEvent<Variable[]>} env-var-editor-expert:change - Fires the new list of variables whenever something changes in the list.
+ * @event {CustomEvent<Variable[]>} cc-env-var-editor-expert:change - Fires the new list of variables whenever something changes in the list.
  */
-export class EnvVarEditorExpert extends LitElement {
+export class CcEnvVarEditorExpert extends LitElement {
 
   static get properties () {
     return {
@@ -58,7 +58,7 @@ export class EnvVarEditorExpert extends LitElement {
   set variables (variables) {
 
     this._skeleton = (variables == null);
-    const vars = this._skeleton ? EnvVarEditorExpert.skeletonVariables : variables;
+    const vars = this._skeleton ? CcEnvVarEditorExpert.skeletonVariables : variables;
 
     const filteredVariables = vars
       .filter(({ isDeleted }) => !isDeleted);
@@ -165,4 +165,4 @@ export class EnvVarEditorExpert extends LitElement {
   }
 }
 
-window.customElements.define('env-var-editor-expert', EnvVarEditorExpert);
+window.customElements.define('cc-env-var-editor-expert', CcEnvVarEditorExpert);

--- a/src/env-var/cc-env-var-editor-expert.js
+++ b/src/env-var/cc-env-var-editor-expert.js
@@ -145,12 +145,9 @@ export class CcEnvVarEditorExpert extends LitElement {
         }
 
         .error-list {
-          margin: 0.5rem 0.2rem 0.2rem;
-        }
-
-        cc-error {
-          line-height: 1.75;
-          padding: 0.25rem 0;
+          display: grid;
+          grid-gap: 0.75rem;
+          margin-top: 1rem;
         }
 
         /* i18n error message may contain <code> tags */

--- a/src/env-var/cc-env-var-editor-simple.js
+++ b/src/env-var/cc-env-var-editor-simple.js
@@ -129,14 +129,15 @@ export class CcEnvVarEditorSimple extends LitElement {
     // language=CSS
     return css`
       :host {
-        display: block;
+        display: grid;
+        grid-gap: 0.5rem;
       }
 
       :host([hidden]) {
         display: none;
       }
 
-      env-var-create {
+      cc-env-var-create {
         margin-bottom: 1rem;
       }
 
@@ -144,10 +145,6 @@ export class CcEnvVarEditorSimple extends LitElement {
         color: #555;
         margin: 0.2rem;
         font-style: italic;
-      }
-
-      env-var-input {
-        margin-bottom: 0.25rem;
       }
     `;
   }

--- a/src/env-var/cc-env-var-editor-simple.js
+++ b/src/env-var/cc-env-var-editor-simple.js
@@ -1,5 +1,5 @@
-import './env-var-create.js';
-import './env-var-input.js';
+import './cc-env-var-create.js';
+import './cc-env-var-input.js';
 import { css, html, LitElement } from 'lit-element';
 import { repeat } from 'lit-html/directives/repeat.js';
 import { dispatchCustomEvent } from '../lib/events.js';
@@ -22,9 +22,9 @@ import { i18n } from '../lib/i18n.js';
  * @prop {Boolean} disabled - Sets `disabled` attribute on inputs and buttons.
  * @prop {Variable[]} variables - Sets the list of variables.
  *
- * @event {CustomEvent<Variable[]>} env-var-editor-simple:change - Fires the new list of variables whenever something changes in the list.
+ * @event {CustomEvent<Variable[]>} cc-env-var-editor-simple:change - Fires the new list of variables whenever something changes in the list.
  */
-export class EnvVarEditorSimple extends LitElement {
+export class CcEnvVarEditorSimple extends LitElement {
 
   static get properties () {
     return {
@@ -90,17 +90,17 @@ export class EnvVarEditorSimple extends LitElement {
   render () {
 
     const skeleton = (this.variables == null);
-    const variables = skeleton ? EnvVarEditorSimple.skeletonVariables : this.variables;
+    const variables = skeleton ? CcEnvVarEditorSimple.skeletonVariables : this.variables;
     const variablesNames = variables.map(({ name }) => name);
 
     return html`
       
       ${!this.readonly ? html`
-        <env-var-create
+        <cc-env-var-create
           ?disabled=${skeleton || this.disabled}
           .variablesNames=${variablesNames}
-          @env-var-create:create=${this._onCreate}
-        ></env-var-create>
+          @cc-env-var-create:create=${this._onCreate}
+        ></cc-env-var-create>
       ` : ''}
       
       <div class="message" ?hidden=${variables != null && variables.length !== 0}>
@@ -108,7 +108,7 @@ export class EnvVarEditorSimple extends LitElement {
       </div>
       
       ${repeat(variables, ({ name }) => name, ({ name, value, isNew, isEdited, isDeleted }) => html`
-        <env-var-input
+        <cc-env-var-input
           name=${name}
           value=${value}
           ?new=${isNew}
@@ -117,10 +117,10 @@ export class EnvVarEditorSimple extends LitElement {
           ?skeleton=${skeleton}
           ?disabled=${this.disabled}
           ?readonly=${this.readonly}
-          @env-var-input:input=${this._onInput}
-          @env-var-input:delete=${this._onDelete}
-          @env-var-input:keep=${this._onKeep}
-        ></env-var-input>
+          @cc-env-var-input:input=${this._onInput}
+          @cc-env-var-input:delete=${this._onDelete}
+          @cc-env-var-input:keep=${this._onKeep}
+        ></cc-env-var-input>
       `)}
     `;
   }
@@ -153,4 +153,4 @@ export class EnvVarEditorSimple extends LitElement {
   }
 }
 
-window.customElements.define('env-var-editor-simple', EnvVarEditorSimple);
+window.customElements.define('cc-env-var-editor-simple', CcEnvVarEditorSimple);

--- a/src/env-var/cc-env-var-form.js
+++ b/src/env-var/cc-env-var-form.js
@@ -287,7 +287,6 @@ export class CcEnvVarForm extends LitElement {
           flex: 1 1 0;
           font-size: 1.2rem;
           font-weight: bold;
-          margin: 0.2rem;
         }
 
         .description {
@@ -295,7 +294,7 @@ export class CcEnvVarForm extends LitElement {
           color: #555;
           font-style: italic;
           line-height: 1.5;
-          margin: 0.2rem 0.2rem 1rem;
+          margin-bottom: 1rem;
         }
 
         .hasOverlay {
@@ -330,7 +329,7 @@ export class CcEnvVarForm extends LitElement {
         .button-bar {
           display: flex;
           flex-wrap: wrap;
-          margin-top: 1rem;
+          margin-top: 1.5rem;
         }
 
         .spacer {

--- a/src/env-var/cc-env-var-form.js
+++ b/src/env-var/cc-env-var-form.js
@@ -3,8 +3,8 @@ import '../atoms/cc-expand.js';
 import '../atoms/cc-loader.js';
 import '../atoms/cc-toggle.js';
 import '../molecules/cc-error.js';
-import './env-var-editor-expert.js';
-import './env-var-editor-simple.js';
+import './cc-env-var-editor-expert.js';
+import './cc-env-var-editor-simple.js';
 import { css, html, LitElement } from 'lit-element';
 import { classMap } from 'lit-html/directives/class-map.js';
 import { dispatchCustomEvent } from '../lib/events.js';
@@ -38,13 +38,13 @@ import { linkStyles } from '../templates/cc-link.js';
  * @prop {Boolean} saving - Enables saving sate (form is disabled and loader is displayed).
  * @prop {Variable[]} variables - Sets the list of variables.
  *
- * @event {CustomEvent} env-var-form:dismissed-error - Fires the type of error that was dismissed when the error button of an error message is clicked.
- * @event {CustomEvent} env-var-form:restart-app - Fires whenever the restart app button is clicked.
- * @event {CustomEvent<Variable[]>} env-var-form:submit - Fires the new list of variables whenever the submit button is clicked.
+ * @event {CustomEvent} cc-env-var-form:dismissed-error - Fires the type of error that was dismissed when the error button of an error message is clicked.
+ * @event {CustomEvent} cc-env-var-form:restart-app - Fires whenever the restart app button is clicked.
+ * @event {CustomEvent<Variable[]>} cc-env-var-form:submit - Fires the new list of variables whenever the submit button is clicked.
  *
  * @slot - Sets custom HTML description.
  */
-export class EnvVarForm extends LitElement {
+export class CcEnvVarForm extends LitElement {
 
   static get properties () {
     return {
@@ -199,7 +199,7 @@ export class EnvVarForm extends LitElement {
         <cc-toggle
           class="mode-switcher ${classMap({ hasOverlay })}"
           value=${this._mode}
-          .choices=${EnvVarForm.modes}
+          .choices=${CcEnvVarForm.modes}
           ?disabled=${isEditorDisabled}
           @cc-toggle:input=${this._onToggleMode}
         ></cc-toggle>
@@ -209,23 +209,23 @@ export class EnvVarForm extends LitElement {
       
       <div class="overlay-container">
         <cc-expand class=${classMap({ hasOverlay })}>
-          <env-var-editor-simple
+          <cc-env-var-editor-simple
             ?hidden=${this._mode !== 'SIMPLE'}
             .variables=${this._currentVariables}
             ?disabled=${isEditorDisabled}
             ?readonly=${this.readonly}
-            @env-var-editor-simple:change=${this._onChange}
+            @cc-env-var-editor-simple:change=${this._onChange}
             @cc-input-text:requestimplicitsubmit=${(e) => this._onRequestSubmit(e, isFormDisabled)}
-          ></env-var-editor-simple>
+          ></cc-env-var-editor-simple>
           
-          <env-var-editor-expert
+          <cc-env-var-editor-expert
             ?hidden=${this._mode !== 'EXPERT'}
             .variables=${this._expertVariables}
             ?disabled=${isEditorDisabled}
             ?readonly=${this.readonly}
-            @env-var-editor-expert:change=${this._onChange}
+            @cc-env-var-editor-expert:change=${this._onChange}
             @cc-input-text:requestimplicitsubmit=${(e) => this._onRequestSubmit(e, isFormDisabled)}
-          ></env-var-editor-expert>
+          ></cc-env-var-editor-expert>
         </cc-expand>
         
         ${this.error === 'loading' ? html`
@@ -341,4 +341,4 @@ export class EnvVarForm extends LitElement {
   }
 }
 
-window.customElements.define('env-var-form', EnvVarForm);
+window.customElements.define('cc-env-var-form', CcEnvVarForm);

--- a/src/env-var/cc-env-var-input.js
+++ b/src/env-var/cc-env-var-input.js
@@ -1,4 +1,5 @@
 import '../atoms/cc-button.js';
+import '../atoms/cc-flex-gap.js';
 import '../atoms/cc-input-text.js';
 import { css, html, LitElement } from 'lit-element';
 import { classMap } from 'lit-html/directives/class-map.js';
@@ -82,37 +83,41 @@ export class CcEnvVarInput extends LitElement {
   render () {
     // the no-whitespace comment trick helps users who triple click on the text to be sure to copy the text without any whitespaces
     return html`
-      <span class="name ${classMap({ deleted: this.deleted })}"><!-- no-whitespace
-        --><span class=${classMap({ skeleton: this.skeleton })}>${this.name}</span><!-- no-whitespace
-      --></span>
-      
-      <span class="input-btn">
-        <cc-input-text
-          class="value"
-          name=${this.name}
-          value=${this.value}
-          multi
-          clipboard
-          ?disabled=${this.deleted || this.disabled}
-          ?skeleton=${this.skeleton}
-          ?readonly=${this.readonly}
-          placeholder=${i18n('env-var-input.value-placeholder')}
-          @cc-input-text:input=${this._onInput}
-        ></cc-input-text>
+      <cc-flex-gap>
         
-        ${!this.readonly ? html`
-          <cc-button
+        <span class="name ${classMap({ deleted: this.deleted })}"><!-- no-whitespace
+          --><span class=${classMap({ skeleton: this.skeleton })}>${this.name}</span><!-- no-whitespace
+        --></span>
+        
+        <cc-flex-gap class="input-btn">
+          
+          <cc-input-text
+            class="value"
+            name=${this.name}
+            value=${this.value}
+            multi
+            clipboard
+            ?disabled=${this.deleted || this.disabled}
             ?skeleton=${this.skeleton}
-            ?disabled=${this.disabled}
-            ?danger=${!this.deleted}
-            ?outlined=${!this.deleted}
-            @cc-button:click=${this.deleted ? this._onKeep : this._onDelete}
-          >
-            ${this.deleted ? i18n('env-var-input.keep-button') : i18n('env-var-input.delete-button')}
-          </cc-button>
-        ` : ''}
-        
-      </span>
+            ?readonly=${this.readonly}
+            placeholder=${i18n('env-var-input.value-placeholder')}
+            @cc-input-text:input=${this._onInput}
+          ></cc-input-text>
+          
+          ${!this.readonly ? html`
+            <cc-button
+              ?skeleton=${this.skeleton}
+              ?disabled=${this.disabled}
+              ?danger=${!this.deleted}
+              ?outlined=${!this.deleted}
+              @cc-button:click=${this.deleted ? this._onKeep : this._onDelete}
+            >
+              ${this.deleted ? i18n('env-var-input.keep-button') : i18n('env-var-input.delete-button')}
+            </cc-button>
+          ` : ''}
+          
+        </cc-flex-gap>
+      </cc-flex-gap>
     `;
   }
 
@@ -122,12 +127,8 @@ export class CcEnvVarInput extends LitElement {
       // language=CSS
       css`
         :host {
-          display: flex;
-          flex-wrap: wrap;
-        }
-
-        :host([hidden]) {
-          display: none;
+          --cc-gap: 0.5rem;
+          display: block;
         }
 
         .name {
@@ -140,7 +141,6 @@ export class CcEnvVarInput extends LitElement {
           font-size: 14px;
           line-height: 1.4rem;
           padding-top: 0.3rem;
-          margin: 0.2rem;
           word-break: break-all;
         }
 
@@ -153,9 +153,7 @@ export class CcEnvVarInput extends LitElement {
         }
 
         .input-btn {
-          display: flex;
           flex: 2 1 27rem;
-          flex-wrap: wrap;
         }
 
         .value {

--- a/src/env-var/cc-env-var-input.js
+++ b/src/env-var/cc-env-var-input.js
@@ -33,11 +33,11 @@ import { skeleton } from '../styles/skeleton.js';
  * @prop {Boolean} skeleton - Enables skeleton screen UI pattern (loading hint).
  * @prop {String} value - Sets the value of the environment variable (can be empty).
  *
- * @event {CustomEvent<VariableName>} env-var-input:delete - Fires a variable name whenever the delete button is clicked.
- * @event {CustomEvent<Variable>} env-var-input:input - Fires a variable whenever its value changes.
- * @event {CustomEvent<VariableName>} env-var-input:keep - Fires a variable name whenever the keep button is clicked.
+ * @event {CustomEvent<VariableName>} cc-env-var-input:delete - Fires a variable name whenever the delete button is clicked.
+ * @event {CustomEvent<Variable>} cc-env-var-input:input - Fires a variable whenever its value changes.
+ * @event {CustomEvent<VariableName>} cc-env-var-input:keep - Fires a variable name whenever the keep button is clicked.
  */
-export class EnvVarInput extends LitElement {
+export class CcEnvVarInput extends LitElement {
 
   static get properties () {
     return {
@@ -175,4 +175,4 @@ export class EnvVarInput extends LitElement {
   }
 }
 
-window.customElements.define('env-var-input', EnvVarInput);
+window.customElements.define('cc-env-var-input', CcEnvVarInput);

--- a/src/env-var/cc-env-var-linked-services.js
+++ b/src/env-var/cc-env-var-linked-services.js
@@ -1,17 +1,17 @@
 import '../atoms/cc-loader.js';
 import '../molecules/cc-error.js';
-import './env-var-form.js';
+import './cc-env-var-form.js';
 import { css, html, LitElement } from 'lit-element';
 import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { i18n } from '../lib/i18n.js';
 
 /**
- * A component to display groups of readonly `<env-var-form>` for linked apps of add-ons.
+ * A component to display groups of readonly `<cc-env-var-form>` for linked apps of add-ons.
  *
  * ## Details
  *
  * * When `services` is nullish, a loading indicator is displayed with a message (corresponding to `type`).
- * * If `variables` on a service is nullish, the `<env-var-form>` will be in skeleton mode.
+ * * If `variables` on a service is nullish, the `<cc-env-var-form>` will be in skeleton mode.
  *
  * ## Type definitions
  *
@@ -35,7 +35,7 @@ import { i18n } from '../lib/i18n.js';
  * @prop {Service[]} services - List of add-ons or apps with their name and variables.
  * @prop {"addon"|"app"} type - Type of env vars to display linked add-ons or linked apps.
  */
-export class EnvVarLinkedServices extends LitElement {
+export class CcEnvVarLinkedServices extends LitElement {
 
   static get properties () {
     return {
@@ -123,9 +123,9 @@ export class EnvVarLinkedServices extends LitElement {
       ${this.services != null && !this.error && this.services.length > 0 ? html`
         <div class="service-list">
           ${this.services.map((s) => html`
-            <env-var-form readonly .variables=${s.variables} heading=${this._getServiceHeading(s.name)} error="${ifDefined(s.error)}">
+            <cc-env-var-form readonly .variables=${s.variables} heading=${this._getServiceHeading(s.name)} error="${ifDefined(s.error)}">
               ${this._getServiceDescription(s.name)}
-            </env-var-form>
+            </cc-env-var-form>
           `)}
         </div>
       ` : ''}
@@ -184,4 +184,4 @@ export class EnvVarLinkedServices extends LitElement {
   }
 }
 
-window.customElements.define('env-var-linked-services', EnvVarLinkedServices);
+window.customElements.define('cc-env-var-linked-services', CcEnvVarLinkedServices);

--- a/src/molecules/cc-block-section.js
+++ b/src/molecules/cc-block-section.js
@@ -55,6 +55,7 @@ export class CcBlockSection extends LitElement {
           color: hsl(351, 70%, 47%);
         }
 
+        /* TODO: We may want to adapt cc-flex-gap for this case one day */
         .section {
           display: flex;
           flex-wrap: wrap;

--- a/src/molecules/cc-error.js
+++ b/src/molecules/cc-error.js
@@ -93,7 +93,6 @@ export class CcError extends LitElement {
 
         cc-button {
           display: block;
-          margin: 0;
         }
       `,
     ];

--- a/src/overview/cc-header-app.js
+++ b/src/overview/cc-header-app.js
@@ -1,4 +1,5 @@
 import '../atoms/cc-button.js';
+import '../atoms/cc-flex-gap.js';
 import '../molecules/cc-error.js';
 import { css, html, LitElement } from 'lit-element';
 import { classMap } from 'lit-html/directives/class-map.js';
@@ -198,7 +199,7 @@ export class CcHeaderApp extends LitElement {
     }
     return html`
       <span
-        class="commit-item ${classMap({ 'cc-waiting': (type === 'starting') })}"
+        class="commit ${classMap({ 'cc-waiting': (type === 'starting') })}"
         title=${ifDefined(skeleton ? undefined : this._getCommitTitle(type, commit))}
         data-type=${type}
       >
@@ -238,7 +239,7 @@ export class CcHeaderApp extends LitElement {
     const disableButtonsTitle = this.disableButtons ? i18n('cc-header-app.disable-buttons') : undefined;
 
     return html`
-      <div class="main">
+      <cc-flex-gap class="main">
         <div class="flavor-logo ${classMap({ skeleton })}" title=${ifDefined(variantName)}>
           <!-- image has a presentation role => alt="" -->
           <img class="flavor-logo_img" src=${ifDefined(variantLogo)} alt="">
@@ -246,14 +247,14 @@ export class CcHeaderApp extends LitElement {
         
         <div class="details">
           <div class="name"><span class=${classMap({ skeleton })}>${name}</span></div>
-          <div class="commits">
+          <cc-flex-gap class="commits">
             ${this._renderCommit(commit, 'git', skeleton)}
             ${isRunning ? this._renderCommit(this.runningCommit, 'running', skeleton) : ''}
             ${isDeploying ? this._renderCommit(this.startingCommit, 'starting', skeleton) : ''}
-          </div>
+          </cc-flex-gap>
         </div>
         
-        <div class="buttons">
+        <cc-flex-gap class="buttons">
         
           ${canStart ? html`
             <cc-button title=${ifDefined(disableButtonsTitle)} ?disabled=${shouldDisableAllButtons} @cc-button:click=${() => this._onStart('normal')}>
@@ -292,8 +293,8 @@ export class CcHeaderApp extends LitElement {
             @cc-button:click=${this._onStop}
           >${i18n('cc-header-app.action.stop')}</cc-button>
           
-        </div>
-      </div>
+        </cc-flex-gap>
+      </cc-flex-gap>
       
       <div class="messages ${classMap({ 'cc-waiting': isDeploying })}">
         ${(shouldDisplayStatusMessage) ? html`
@@ -319,32 +320,26 @@ export class CcHeaderApp extends LitElement {
       // language=CSS
       css`
         :host {
+          --cc-gap: 1rem;
           background-color: #fff;
           border-radius: 0.25rem;
           border: 1px solid #bcc2d1;
-          display: flex;
-          flex-direction: column;
-          flex-wrap: wrap;
+          display: block;
         }
 
         cc-error {
-          padding: 1rem;
+          padding: var(--cc-gap);
           text-align: center;
         }
 
         .main {
-          align-items: center;
-          box-sizing: border-box;
-          display: flex;
-          flex-wrap: wrap;
-          justify-content: flex-end;
+          padding: var(--cc-gap);
         }
 
         .flavor-logo {
           border-radius: 0.25rem;
           align-self: flex-start;
           height: 3.25rem;
-          margin: 1rem;
           overflow: hidden;
           width: 3.25rem;
         }
@@ -363,8 +358,6 @@ export class CcHeaderApp extends LitElement {
           display: flex;
           flex-direction: column;
           flex: 1 1 0;
-          min-height: 3rem;
-          margin: 1rem 1rem 1rem 0;
           justify-content: space-between;
         }
 
@@ -374,27 +367,20 @@ export class CcHeaderApp extends LitElement {
           min-width: 12rem;
         }
 
-        .commits {
-          display: flex;
-          flex-wrap: wrap;
-        }
-
-        .commit-item {
+        .commit {
           align-items: flex-start;
           display: flex;
-          margin-right: 0.75rem;
-          margin-top: 0.5rem;
         }
 
-        .commit-item[data-type="git"] {
+        .commit[data-type="git"] {
           color: #5D5D5D;
         }
 
-        .commit-item[data-type="running"] {
+        .commit[data-type="running"] {
           color: #2faa60;
         }
 
-        .commit-item[data-type="starting"] {
+        .commit[data-type="starting"] {
           color: #2b96fd;
         }
 
@@ -411,14 +397,11 @@ export class CcHeaderApp extends LitElement {
         }
 
         .buttons {
-          display: flex;
-          flex-wrap: wrap;
-          padding: 0.5rem 1rem 0.5rem 0;
+          align-self: center;
         }
 
         cc-button {
           flex: 1 1 auto;
-          margin: 0.5rem 0 0.5rem 1rem;
           min-width: 0;
         }
 
@@ -433,7 +416,7 @@ export class CcHeaderApp extends LitElement {
           color: #2e2e2e;
           font-size: 0.9rem;
           font-style: italic;
-          padding: 0.4rem 1rem;
+          padding: 0.4rem var(--cc-gap);
         }
 
         .status-icon {

--- a/src/overview/cc-header-orga.js
+++ b/src/overview/cc-header-orga.js
@@ -1,4 +1,5 @@
 import '../atoms/cc-img.js';
+import '../atoms/cc-flex-gap.js';
 import '../molecules/cc-error.js';
 import { css, html, LitElement } from 'lit-element';
 import { classMap } from 'lit-html/directives/class-map.js';
@@ -62,7 +63,7 @@ export class CcHeaderOrga extends LitElement {
       .join('');
 
     return html`
-      <div class="wrapper ${classMap({ enterprise: orga.cleverEnterprise })}">
+      <cc-flex-gap class="wrapper ${classMap({ enterprise: orga.cleverEnterprise })}">
       
         ${this.error ? html`
           <cc-error>${i18n('cc-header-orga.error')}</cc-error>
@@ -89,7 +90,7 @@ export class CcHeaderOrga extends LitElement {
             </div>
           ` : ''}
         ` : ''}
-      </div>
+      </cc-flex-gap>
     `;
   }
 
@@ -99,17 +100,16 @@ export class CcHeaderOrga extends LitElement {
       // language=CSS
       css`
         :host {
+          --cc-gap: 1rem;
           display: block;
         }
 
         .wrapper {
-          align-items: stretch;
           background-color: #fff;
           border-radius: 0.25rem;
           border: 1px solid #bcc2d1;
-          display: flex;
-          flex-wrap: wrap;
-          padding: 0 1rem 1rem 1rem;
+          display: block;
+          padding: var(--cc-gap);
           overflow: hidden;
         }
 
@@ -118,15 +118,9 @@ export class CcHeaderOrga extends LitElement {
           border-width: 2px;
         }
 
-        cc-error {
-          margin-top: 1rem;
-        }
-
         .logo {
           border-radius: 0.25rem;
           height: 3.25rem;
-          margin-right: 1rem;
-          margin-top: 1rem;
           width: 3.25rem;
         }
 
@@ -134,16 +128,7 @@ export class CcHeaderOrga extends LitElement {
         .hotline {
           align-items: flex-start;
           display: flex;
-          margin-top: 1rem;
           flex-direction: column;
-        }
-
-        .details {
-          justify-content: center;
-          margin-right: 1rem;
-        }
-
-        .hotline {
           justify-content: space-between;
         }
 

--- a/src/tcp-redirections/cc-tcp-redirection.js
+++ b/src/tcp-redirections/cc-tcp-redirection.js
@@ -1,4 +1,5 @@
 import '../atoms/cc-button.js';
+import '../atoms/cc-flex-gap.js';
 import { css, html, LitElement } from 'lit-element';
 import { classMap } from 'lit-html/directives/class-map.js';
 import { assetUrl } from '../lib/asset-url.js';
@@ -123,34 +124,35 @@ export class CcTcpRedirection extends LitElement {
 
   render () {
     return html`
-      <span class="icon ${classMap({ skeleton: this.skeleton })}">
-        ${!this.waiting && !this.skeleton ? html`
-          <img src=${this._getIconUrl()} alt="">
-        ` : ''}
-        ${this.waiting ? html`
-      <cc-loader></cc-loader>
-    ` : ''}
-      </span>
-      <div class="text-button ${classMap({ 'cc-waiting': this.waiting })}">
-        <div class="text-wrapper">
-          <span class="text ${classMap({ skeleton: this.skeleton })}">${this._getHelpText()}</span>
-          ${this._getHelpTextAddendum() != null ? html`
-            <br>
-            <span class="text-addendum ${classMap({ skeleton: this.skeleton })}">${this._getHelpTextAddendum()}</span>
+      <cc-flex-gap class="wrapper">
+        <div class="icon ${classMap({ skeleton: this.skeleton })}">
+          ${!this.waiting && !this.skeleton ? html`
+            <img src=${this._getIconUrl()} alt="">
+          ` : ''}
+          ${this.waiting ? html`
+            <cc-loader></cc-loader>
           ` : ''}
         </div>
-        <cc-button
-          outlined
-          ?skeleton=${this.skeleton}
-          ?waiting=${this.waiting}
-          ?danger=${this._isRedirectionDefined()}
-          delay=${this._isRedirectionDefined() ? 3 : 0}
-          ?primary=${!this._isRedirectionDefined()}
-          @cc-button:click=${this._isRedirectionDefined() ? this._onDelete : this._onCreate}
-        >
-          ${this._getButtonText()}
-        </cc-button>
-      </div>
+        <cc-flex-gap class="text-button ${classMap({ 'cc-waiting': this.waiting })}">
+          <div class="text-wrapper">
+            <div class="text ${classMap({ skeleton: this.skeleton })}">${this._getHelpText()}</div>
+            ${this._getHelpTextAddendum() != null ? html`
+              <div class="text-addendum ${classMap({ skeleton: this.skeleton })}">${this._getHelpTextAddendum()}</div>
+            ` : ''}
+          </div>
+          <cc-button
+            outlined
+            ?skeleton=${this.skeleton}
+            ?waiting=${this.waiting}
+            ?danger=${this._isRedirectionDefined()}
+            delay=${this._isRedirectionDefined() ? 3 : 0}
+            ?primary=${!this._isRedirectionDefined()}
+            @cc-button:click=${this._isRedirectionDefined() ? this._onDelete : this._onCreate}
+          >
+            ${this._getButtonText()}
+          </cc-button>
+        </cc-flex-gap>
+      </cc-flex-gap>
     `;
   }
 
@@ -161,14 +163,16 @@ export class CcTcpRedirection extends LitElement {
       // language=CSS
       css`
         :host {
-          align-items: flex-start;
-          display: flex;
+          display: block;
+        }
+        
+        .wrapper {
+          --cc-gap: 0.8rem;
         }
 
         .icon {
           flex: 0 0 auto;
           height: 1.5rem;
-          margin-right: 0.8rem;
           width: 1.5rem;
         }
 
@@ -183,16 +187,7 @@ export class CcTcpRedirection extends LitElement {
         }
 
         .text-button {
-          align-items: flex-start;
-          display: flex;
           flex: 1 1 0;
-          flex-wrap: wrap;
-          margin: -0.25rem;
-        }
-
-        .text-wrapper,
-        cc-button {
-          margin: 0.25rem;
         }
 
         .text-wrapper {

--- a/stories/atoms/cc-button.stories.js
+++ b/stories/atoms/cc-button.stories.js
@@ -23,6 +23,11 @@ export default {
 const conf = {
   component: 'cc-button',
   events: ['cc-button:click'],
+  css: `
+    cc-button {
+      margin: 0.5rem;
+    }
+  `,
 };
 
 export const modes = makeStory(conf, {

--- a/stories/atoms/cc-flex-gap.stories.js
+++ b/stories/atoms/cc-flex-gap.stories.js
@@ -1,0 +1,53 @@
+import '../../src/atoms/cc-flex-gap.js';
+import notes from '../../.components-docs/cc-flex-gap.md';
+import { makeStory } from '../lib/make-story.js';
+import { enhanceStoriesNames } from '../lib/story-names.js';
+
+export default {
+  title: '🧬 Atoms|<cc-flex-gap>',
+  component: 'cc-flex-gap',
+  parameters: { notes },
+};
+
+const conf = {
+  component: 'cc-flex-gap',
+  css: `
+    cc-flex-gap {
+      background-color: #eee;
+    }
+    
+    cc-flex-gap > * {
+      border-radius: 0.25rem;
+      border:1px solid #000;
+      flex: 1 1 0;
+      padding: 0.5rem 1rem;
+    }
+  `,
+};
+
+const flexItemsHtml = Array.from(new Array(15))
+  .map((a, i) => `<div>item${'_'.repeat(i + 1)}${i + 1}</div>`)
+  .join('');
+
+export const defaultStory = makeStory(conf, {
+  items: [{ innerHTML: flexItemsHtml, style: '--cc-gap: 1rem' }],
+});
+
+export const noGap = makeStory(conf, {
+  items: [{ innerHTML: flexItemsHtml, style: '' }],
+});
+
+export const smallGap = makeStory(conf, {
+  items: [{ innerHTML: flexItemsHtml, style: '--cc-gap: 0.5rem' }],
+});
+
+export const bigGap = makeStory(conf, {
+  items: [{ innerHTML: flexItemsHtml, style: '--cc-gap: 2rem' }],
+});
+
+enhanceStoriesNames({
+  defaultStory,
+  noGap,
+  smallGap,
+  bigGap,
+});

--- a/stories/atoms/cc-input-text.stories.js
+++ b/stories/atoms/cc-input-text.stories.js
@@ -65,6 +65,11 @@ const conf = {
     'cc-input-text:tags',
     'cc-input-text:requestimplicitsubmit',
   ],
+  css: `
+    cc-input-text {
+      margin: 0.5rem;
+    }
+  `,
 };
 
 export const defaultStory = makeStory(conf, {
@@ -137,12 +142,12 @@ export const tags = makeStory(conf, {
 * Space separated values are highlighted with a colored background.
 * A \`cc-input-text:tags\` event is fired with the array of tags when the value changes (empty values are filtered out).
 * The \`tags\` feature does not work with \`multi\` or \`secret\`.`,
-  css: `cc-input-text { width: 300px; }`,
+  css: `cc-input-text { margin: 0.5rem; width: 300px; }`,
   items: tagsItems,
 });
 
 export const tagsWithClipboard = makeStory(conf, {
-  css: `cc-input-text { width: 300px; }`,
+  css: `cc-input-text { margin: 0.5rem; width: 300px; }`,
   items: tagsItems.map((p) => ({ ...p, clipboard: true })),
 });
 

--- a/stories/atoms/cc-toggle.stories.js
+++ b/stories/atoms/cc-toggle.stories.js
@@ -12,6 +12,11 @@ export default {
 const conf = {
   component: 'cc-toggle',
   events: ['cc-toggle:input'],
+  css: `
+    cc-toggle {
+      margin: 0.5rem;
+    }
+  `,
 };
 
 export const defaultStory = makeStory(conf, {

--- a/stories/env-var/cc-env-var-create.stories.js
+++ b/stories/env-var/cc-env-var-create.stories.js
@@ -1,17 +1,17 @@
-import '../../src/env-var/env-var-create.js';
-import notes from '../../.components-docs/env-var-create.md';
+import '../../src/env-var/cc-env-var-create.js';
+import notes from '../../.components-docs/cc-env-var-create.md';
 import { makeStory } from '../lib/make-story.js';
 import { enhanceStoriesNames } from '../lib/story-names.js';
 
 export default {
-  title: '🛠 Environment variables|<env-var-create>',
-  component: 'env-var-create',
+  title: '🛠 Environment variables|<cc-env-var-create>',
+  component: 'cc-env-var-create',
   parameters: { notes },
 };
 
 const conf = {
-  component: 'env-var-create',
-  events: ['env-var-create:create'],
+  component: 'cc-env-var-create',
+  events: ['cc-env-var-create:create'],
 };
 
 export const defaultStory = makeStory(conf, {

--- a/stories/env-var/cc-env-var-editor-expert.stories.js
+++ b/stories/env-var/cc-env-var-editor-expert.stories.js
@@ -1,5 +1,5 @@
-import '../../src/env-var/env-var-editor-simple.js';
-import notes from '../../.components-docs/env-var-editor-simple.md';
+import '../../src/env-var/cc-env-var-editor-expert.js';
+import notes from '../../.components-docs/cc-env-var-editor-expert.md';
 import { makeStory } from '../lib/make-story.js';
 import { enhanceStoriesNames } from '../lib/story-names.js';
 
@@ -19,14 +19,14 @@ const VARIABLES_SIMPLE = [
 ];
 
 export default {
-  title: '🛠 Environment variables|<env-var-editor-simple>',
-  component: 'env-var-editor-simple',
+  title: '🛠 Environment variables|<cc-env-var-editor-expert>',
+  component: 'cc-env-var-editor-expert',
   parameters: { notes },
 };
 
 const conf = {
-  component: 'env-var-editor-simple',
-  events: ['env-var-editor-simple:change'],
+  component: 'cc-env-var-editor-expert',
+  events: ['cc-env-var-editor-expert:change'],
 };
 
 export const defaultStory = makeStory(conf, {

--- a/stories/env-var/cc-env-var-editor-simple.stories.js
+++ b/stories/env-var/cc-env-var-editor-simple.stories.js
@@ -1,5 +1,5 @@
-import '../../src/env-var/env-var-editor-expert.js';
-import notes from '../../.components-docs/env-var-editor-expert.md';
+import '../../src/env-var/cc-env-var-editor-simple.js';
+import notes from '../../.components-docs/cc-env-var-editor-simple.md';
 import { makeStory } from '../lib/make-story.js';
 import { enhanceStoriesNames } from '../lib/story-names.js';
 
@@ -19,14 +19,14 @@ const VARIABLES_SIMPLE = [
 ];
 
 export default {
-  title: '🛠 Environment variables|<env-var-editor-expert>',
-  component: 'env-var-editor-expert',
+  title: '🛠 Environment variables|<cc-env-var-editor-simple>',
+  component: 'cc-env-var-editor-simple',
   parameters: { notes },
 };
 
 const conf = {
-  component: 'env-var-editor-expert',
-  events: ['env-var-editor-expert:change'],
+  component: 'cc-env-var-editor-simple',
+  events: ['cc-env-var-editor-simple:change'],
 };
 
 export const defaultStory = makeStory(conf, {

--- a/stories/env-var/cc-env-var-form.stories.js
+++ b/stories/env-var/cc-env-var-form.stories.js
@@ -1,5 +1,5 @@
-import '../../src/env-var/env-var-form.js';
-import notes from '../../.components-docs/env-var-form.md';
+import '../../src/env-var/cc-env-var-form.js';
+import notes from '../../.components-docs/cc-env-var-form.md';
 import { makeStory } from '../lib/make-story.js';
 import { enhanceStoriesNames } from '../lib/story-names.js';
 
@@ -11,14 +11,14 @@ const VARIABLES_FULL = [
 ];
 
 export default {
-  title: '🛠 Environment variables|<env-var-form>',
-  component: 'env-var-form',
+  title: '🛠 Environment variables|<cc-env-var-form>',
+  component: 'cc-env-var-form',
   parameters: { notes },
 };
 
 const conf = {
-  component: 'env-var-form',
-  events: ['env-var-form:submit', 'env-var-form:dismissed-error', 'env-var-form:restart-app'],
+  component: 'cc-env-var-form',
+  events: ['cc-env-var-form:submit', 'cc-env-var-form:dismissed-error', 'cc-env-var-form:restart-app'],
 };
 
 export const defaultStory = makeStory(conf, {

--- a/stories/env-var/cc-env-var-input.stories.js
+++ b/stories/env-var/cc-env-var-input.stories.js
@@ -1,17 +1,17 @@
-import '../../src/env-var/env-var-input.js';
-import notes from '../../.components-docs/env-var-input.md';
+import '../../src/env-var/cc-env-var-input.js';
+import notes from '../../.components-docs/cc-env-var-input.md';
 import { makeStory } from '../lib/make-story.js';
 import { enhanceStoriesNames } from '../lib/story-names.js';
 
 export default {
-  title: '🛠 Environment variables|<env-var-input>',
-  component: 'env-var-input',
+  title: '🛠 Environment variables|<cc-env-var-input>',
+  component: 'cc-env-var-input',
   parameters: { notes },
 };
 
 const conf = {
-  component: 'env-var-input',
-  events: ['env-var-input:input', 'env-var-input:delete', 'env-var-input:keep'],
+  component: 'cc-env-var-input',
+  events: ['cc-env-var-input:input', 'cc-env-var-input:delete', 'cc-env-var-input:keep'],
 };
 
 export const defaultStory = makeStory(conf, {

--- a/stories/env-var/cc-env-var-input.stories.js
+++ b/stories/env-var/cc-env-var-input.stories.js
@@ -31,23 +31,23 @@ export const multiline = makeStory(conf, {
 });
 
 export const newValue = makeStory(conf, {
-  items: [{ name: 'NEW', value: 'new value' }],
+  items: [{ name: 'NEW', value: 'new value', new: true }],
 });
 
 export const newAndEdited = makeStory(conf, {
-  items: [{ name: 'NEW_EDITED', value: 'new value edited' }],
+  items: [{ name: 'NEW_EDITED', value: 'new value edited', new: true, edited: true }],
 });
 
 export const edited = makeStory(conf, {
-  items: [{ name: 'EDITED', value: 'edited value' }],
+  items: [{ name: 'EDITED', value: 'edited value', edited: true }],
 });
 
 export const deleted = makeStory(conf, {
-  items: [{ name: 'DELETED', value: 'deleted value' }],
+  items: [{ name: 'DELETED', value: 'deleted value', deleted: true }],
 });
 
 export const editedAndDeleted = makeStory(conf, {
-  items: [{ name: 'EDITED_DELETED', value: 'edited deleted value' }],
+  items: [{ name: 'EDITED_DELETED', value: 'edited deleted value', edited: true, deleted: true }],
 });
 
 export const longName = makeStory(conf, {
@@ -66,11 +66,11 @@ export const skeleton = makeStory(conf, {
 });
 
 export const disabled = makeStory(conf, {
-  items: [{ name: 'DISABLED', value: 'disabled value' }],
+  items: [{ name: 'DISABLED', value: 'disabled value', disabled: true }],
 });
 
 export const readonly = makeStory(conf, {
-  items: [{ name: 'READONLY', value: 'readonly value' }],
+  items: [{ name: 'READONLY', value: 'readonly value', readonly: true }],
 });
 
 enhanceStoriesNames({

--- a/stories/env-var/cc-env-var-linked-services.stories.js
+++ b/stories/env-var/cc-env-var-linked-services.stories.js
@@ -1,5 +1,5 @@
-import '../../src/env-var/env-var-linked-services.js';
-import notes from '../../.components-docs/env-var-linked-services.md';
+import '../../src/env-var/cc-env-var-linked-services.js';
+import notes from '../../.components-docs/cc-env-var-linked-services.md';
 import { makeStory, storyWait } from '../lib/make-story.js';
 import { enhanceStoriesNames } from '../lib/story-names.js';
 
@@ -11,15 +11,15 @@ const VARIABLES_FULL = [
 ];
 
 export default {
-  title: '🛠 Environment variables|<env-var-linked-services>',
-  component: 'env-var-linked-services',
+  title: '🛠 Environment variables|<cc-env-var-linked-services>',
+  component: 'cc-env-var-linked-services',
   parameters: { notes },
 };
 
 const conf = {
-  component: 'env-var-linked-services',
+  component: 'cc-env-var-linked-services',
   css: `
-    env-var-linked-services {
+    cc-env-var-linked-services {
       margin-bottom: 1rem;
     }
   `,


### PR DESCRIPTION
The recent build change was a good opportunity to address a few breaking changes we wanted to do:

* rename env var components https://github.com/CleverCloud/clever-components/issues/95
* remove outter margins from some atom components https://github.com/CleverCloud/clever-components/issues/93

This margin business introduced a few problems when wrapping etc... Instead of copy/pasting the "flex gap with negative margin" pattern we used a few times in other components, we made a low level layout component to handle this case.

We took some time to apply this `<cc-flex-gap>` wherever possible, even if there was no impact from the margin update.