### PR TITLE
cc-header-orga: fix vertical alignment

### DIFF
--- a/src/overview/cc-header-orga.js
+++ b/src/overview/cc-header-orga.js
@@ -129,6 +129,13 @@ export class CcHeaderOrga extends LitElement {
           align-items: flex-start;
           display: flex;
           flex-direction: column;
+        }
+
+        .details {
+          justify-content: center;
+        }
+
+        .hotline {
           justify-content: space-between;
         }
 


### PR DESCRIPTION
I missed this when doing the `<cc-flex-gap>` refactor.