### PR TITLE
make-story: fix lint error preventing prepack to work

### DIFF
--- a/stories/lib/make-story.js
+++ b/stories/lib/make-story.js
@@ -74,7 +74,7 @@ export function makeStory (...configs) {
       const allPropertiesAndAttributes = Object.entries(props)
         .map(([name, value]) => {
           // We should rely on the official attribute name but for now it's good enough
-          const attrName = name.replace(/[A-Z]/g, ((a) => '-' + a.toLowerCase()));
+          const attrName = name.replace(/[A-Z]/g, (a) => '-' + a.toLowerCase());
           if (value === true) {
             return `${attrName}`;
           }


### PR DESCRIPTION
Error:
```
/home/arnaud/Dev/clevercloud/clever-components/stories/lib/make-story.js
  77:51  error  Unnecessary parentheses around expression
  no-extra-parens

  ✖ 1 problem (1 error, 0 warnings)
    1 error and 0 warnings potentially fixable with the `--fix` option.
```