### PR TITLE
Encryption at rest: update documentation link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ title: Changelog
 
 ## Unreleased (????-??-??)
 
+* `cc-addon-encryption-at-rest-option` template
+  * Drop documentation URL parameter
+
 ...
 
 ## 5.4.0 (2020-12-08)

--- a/src/addon/cc-addon-mongodb-options.js
+++ b/src/addon/cc-addon-mongodb-options.js
@@ -5,8 +5,6 @@ import { dispatchCustomEvent } from '../lib/events.js';
 import { i18n } from '../lib/i18n.js';
 import { ccAddonEncryptionAtRestOption } from '../templates/cc-addon-encryption-at-rest-option.js';
 
-const ENCRYPTION_DOCUMENTATION_URL = 'https://www.clever-cloud.com/doc/addons/mongodb/#encryption-at-rest';
-
 /**
  * A component that displays the available options of a MongoDB add-on.
  *
@@ -57,7 +55,7 @@ export class CcAddonMongodbOptions extends LitElement {
       .map((option) => {
         switch (option.name) {
           case 'encryption':
-            return ccAddonEncryptionAtRestOption(ENCRYPTION_DOCUMENTATION_URL, option);
+            return ccAddonEncryptionAtRestOption(option);
           default:
             return null;
         };

--- a/src/addon/cc-addon-mysql-options.js
+++ b/src/addon/cc-addon-mysql-options.js
@@ -5,8 +5,6 @@ import { dispatchCustomEvent } from '../lib/events.js';
 import { i18n } from '../lib/i18n.js';
 import { ccAddonEncryptionAtRestOption } from '../templates/cc-addon-encryption-at-rest-option.js';
 
-const ENCRYPTION_DOCUMENTATION_URL = 'https://www.clever-cloud.com/doc/addons/mysql/#encryption-at-rest';
-
 /**
  * A component that displays the available options of a MySQL add-on.
  *
@@ -57,7 +55,7 @@ export class CcAddonMysqlOptions extends LitElement {
       .map((option) => {
         switch (option.name) {
           case 'encryption':
-            return ccAddonEncryptionAtRestOption(ENCRYPTION_DOCUMENTATION_URL, option);
+            return ccAddonEncryptionAtRestOption(option);
           default:
             return null;
         };

--- a/src/addon/cc-addon-postgresql-options.js
+++ b/src/addon/cc-addon-postgresql-options.js
@@ -5,8 +5,6 @@ import { dispatchCustomEvent } from '../lib/events.js';
 import { i18n } from '../lib/i18n.js';
 import { ccAddonEncryptionAtRestOption } from '../templates/cc-addon-encryption-at-rest-option.js';
 
-const ENCRYPTION_DOCUMENTATION_URL = 'https://www.clever-cloud.com/doc/addons/postgresql/#encryption-at-rest';
-
 /**
  * A component that displays the available options of a PostgreSQL add-on.
  *
@@ -57,7 +55,7 @@ export class CcAddonPostgresqlOptions extends LitElement {
       .map((option) => {
         switch (option.name) {
           case 'encryption':
-            return ccAddonEncryptionAtRestOption(ENCRYPTION_DOCUMENTATION_URL, option);
+            return ccAddonEncryptionAtRestOption(option);
           default:
             return null;
         };

--- a/src/templates/cc-addon-encryption-at-rest-option.js
+++ b/src/templates/cc-addon-encryption-at-rest-option.js
@@ -6,9 +6,9 @@ const encryptionAtRestSvg = new URL('../assets/encryption-at-rest.svg', import.m
 
 const PRICE_PERCENT = 0.10;
 
-export const ccAddonEncryptionAtRestOption = (documentationLink, { enabled, price }) => {
+export const ccAddonEncryptionAtRestOption = ({ enabled, price }) => {
   const description = html`
-    <div class="option-details">${i18n('cc-addon-encryption-at-rest-option.description', { documentationLink })}</div>
+    <div class="option-details">${i18n('cc-addon-encryption-at-rest-option.description')}</div>
     <cc-error class="option-warning">
       ${i18n('cc-addon-encryption-at-rest-option.warning', { percent: PRICE_PERCENT, price })}
     </cc-error>

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -97,7 +97,7 @@ export const translations = {
   'cc-addon-elasticsearch-options.warning.apm': `If you enable this option, we'll deploy and manage an Elastic APM server application for you, this will lead to additional costs.`,
   'cc-addon-elasticsearch-options.warning.apm.details': (flavor) => sanitize`By default, the app will start on a <strong title="${formatFlavor(flavor)}">${flavor.name} instance</strong> which costs around <strong>${currencyFormatter.format(flavor.monthlyCost)} per month</strong>.`,
   // cc-addon-encryption-at-rest-option
-  'cc-addon-encryption-at-rest-option.description': ({ documentationLink }) => sanitize`Encryption at rest encrypts the entire data disk of your add-on. It prevents reading the stored data in case of a physical access to the hard drive. More information in our <a href="${documentationLink}">documentation</a>.`,
+  'cc-addon-encryption-at-rest-option.description': () => sanitize`Encryption at rest encrypts the entire data disk of your add-on. It prevents reading the stored data in case of a physical access to the hard drive. More information in our <a href="https://www.clever-cloud.com/doc/administrate/encryption-at-rest/">documentation</a>.`,
   'cc-addon-encryption-at-rest-option.title': `Encryption at rest`,
   'cc-addon-encryption-at-rest-option.warning': ({ percent, price }) => sanitize`This option is currently free. In the future, it will be billed ${percentFormatter.format(percent)} of the plan price, which amounts to <strong>${currencyFormatter.format(price)} per month</strong> here.`,
   // cc-addon-features

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -110,7 +110,7 @@ export const translations = {
   'cc-addon-elasticsearch-options.warning.apm': `Si vous activez cette option, nous allons déployer et gérer pour vous un APM server, ce qui entraînera des coûts supplémentaires.`,
   'cc-addon-elasticsearch-options.warning.apm.details': (flavor) => sanitize`Par défaut, l'app sera démarrée sur une <strong title="${formatFlavor(flavor)}">instance ${flavor.name}</strong> qui coûte environ <strong>${currencyFormatter.format(flavor.monthlyCost)} par mois</strong>. `,
   // cc-addon-encryption-at-rest-option
-  'cc-addon-encryption-at-rest-option.description': ({ documentationLink }) => sanitize`Le chiffrement au repos chiffre l'intégralité du disque de données afin de ne pas y stocker d'informations en clair. Grâce à cette sécurité, l'accès physique au disque empêchera toute lecture des données stockées. Plus d'information dans notre <a href="${documentationLink}">documentation</a>.`,
+  'cc-addon-encryption-at-rest-option.description': () => sanitize`Le chiffrement au repos chiffre l'intégralité du disque de données afin de ne pas y stocker d'informations en clair. Grâce à cette sécurité, l'accès physique au disque empêchera toute lecture des données stockées. Plus d'information dans notre <a href="https://www.clever-cloud.com/doc/administrate/encryption-at-rest/">documentation</a>.`,
   'cc-addon-encryption-at-rest-option.title': `Chiffrement au repos`,
   'cc-addon-encryption-at-rest-option.warning': ({ percent, price }) => sanitize`Cette option est actuellement gratuite. Dans le futur, elle sera facturée ${percentFormatter.format(percent)} du prix du plan, ce qui dans ce cas fait <strong>${currencyFormatter.format(price)} par mois.</strong>`,
   // cc-addon-features


### PR DESCRIPTION
There is now a dedicated documentation for this feature instead of
having it in each of the add-ons.

I guess this is a breaking change.