### PR TITLE
cc-toggle: remove padding when legend is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ title: Changelog
 ## Unreleased (????-??-??)
 
 * Add new custom ESLint rules to enforce conventions over translation files
+* cc-toggle: remove padding when legend is empty
 
 ## 6.5.1 (2021-05-07)
 

--- a/src/atoms/cc-toggle.js
+++ b/src/atoms/cc-toggle.js
@@ -173,7 +173,7 @@ export class CcToggle extends LitElement {
           width: 100%;
         }
 
-        legend {
+        legend:not(:empty) {
           padding-bottom: 0.35rem;
         }
 


### PR DESCRIPTION
Fixes #174 