### PR TITLE
atoms: replace rem with em

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ title: Changelog
 
 ## Unreleased (????-??-??)
 
-...
+* `<cc-beta>`: replace rem with em
 
 ## 6.10.0 (2021-07-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ title: Changelog
 * `<cc-button>`: replace rem with em
 * `<cc-img>`: replace rem with em
 * `<cc-input-number>`: replace rem with em
+* `<cc-input-text>`: replace rem with em
 
 ## 6.10.0 (2021-07-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ title: Changelog
 * `<cc-input-number>`: replace rem with em
 * `<cc-input-text>`: replace rem with em
 * `<cc-loader>`: replace rem with em
+* `<cc-toggle>`: replace rem with em
 
 ## 6.10.0 (2021-07-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ title: Changelog
 ## Unreleased (????-??-??)
 
 * `<cc-beta>`: replace rem with em
+* `<cc-button>`: replace rem with em
 
 ## 6.10.0 (2021-07-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ title: Changelog
 * `<cc-beta>`: replace rem with em
 * `<cc-button>`: replace rem with em
 * `<cc-img>`: replace rem with em
+* `<cc-input-number>`: replace rem with em
 
 ## 6.10.0 (2021-07-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ title: Changelog
 * `<cc-img>`: replace rem with em
 * `<cc-input-number>`: replace rem with em
 * `<cc-input-text>`: replace rem with em
+* `<cc-loader>`: replace rem with em
 
 ## 6.10.0 (2021-07-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ title: Changelog
 
 * `<cc-beta>`: replace rem with em
 * `<cc-button>`: replace rem with em
+* `<cc-img>`: replace rem with em
 
 ## 6.10.0 (2021-07-08)
 

--- a/src/atoms/cc-beta.js
+++ b/src/atoms/cc-beta.js
@@ -50,11 +50,11 @@ export class CcBeta extends LitElement {
         }
 
         .beta {
-          --height: 1.5rem;
-          --width: 8rem;
+          --height: 1.75em;
+          --width: 8em;
           background: #3A3871;
           color: white;
-          font-size: 0.9rem;
+          font-size: 0.85em;
           font-weight: bold;
           height: var(--height);
           line-height: var(--height);
@@ -66,12 +66,12 @@ export class CcBeta extends LitElement {
         }
 
         :host([position^="top-"]) .beta {
-          --translate: 1.6rem;
+          --translate: 1.85em;
           top: calc(var(--height) / -2);
         }
 
         :host([position^="bottom-"]) .beta {
-          --translate: -1.6rem;
+          --translate: -1.85em;
           bottom: calc(var(--height) / -2);
         }
 

--- a/src/atoms/cc-button.js
+++ b/src/atoms/cc-button.js
@@ -164,36 +164,40 @@ export class CcButton extends LitElement {
       ? (this.textContent || '')
       : undefined;
 
-    return html`<button
-      type="button"
-      class=${classMap(modes)}
-      .disabled=${this.disabled || this.skeleton || this.waiting}
-      @click=${this._onClick}
-      title="${ifDefined(imageOnlyText)}"
-      aria-label="${ifDefined(imageOnlyText)}"
-    >
-      <!--
-        When delay mechanism is set, we need a cancel label.
-        We don't want the button width to change when the user clicks and toggles between normal and cancel mode.
-        That's why (see CSS) we put both labels in a grid, in the same cell and hide (visibility:hidden) the one we don't want.
-        This way, when delay is set, the button has a min width of the largest label (normal or cancel).
-      -->
-      <div class="text-wrapper ${classMap({ 'cancel-mode': this._cancelMode })}">
-        ${this.image != null ? html`
-          <img src=${this.image} alt="">
-        ` : ''}
-        <div class="text-normal"><slot></slot></div>
+    return html`
+      <button
+        type="button"
+        class=${classMap(modes)}
+        .disabled=${this.disabled || this.skeleton || this.waiting}
+        @click=${this._onClick}
+        title="${ifDefined(imageOnlyText)}"
+        aria-label="${ifDefined(imageOnlyText)}"
+      >
+        <!--
+          When delay mechanism is set, we need a cancel label.
+          We don't want the button width to change when the user clicks and toggles between normal and cancel mode.
+          That's why (see CSS) we put both labels in a grid, in the same cell and hide (visibility:hidden) the one we don't want.
+          This way, when delay is set, the button has a min width of the largest label (normal or cancel).
+        -->
+        <div class="text-wrapper ${classMap({ 'cancel-mode': this._cancelMode })}">
+          ${this.image != null ? html`
+            <img src=${this.image} alt="">
+          ` : ''}
+          <div class="text-normal">
+            <slot></slot>
+          </div>
+          ${delay != null ? html`
+            <div class="text-cancel">${i18n('cc-button.cancel')}</div>
+          ` : ''}
+        </div>
         ${delay != null ? html`
-          <div class="text-cancel">${i18n('cc-button.cancel')}</div>
+          <progress class="delay ${classMap({ active: this._cancelMode })}" style="--delay: ${delay}s"></progress>
         ` : ''}
-      </div>
-      ${delay != null ? html`
-        <progress class="delay ${classMap({ active: this._cancelMode })}" style="--delay: ${delay}s"></progress>
-      ` : ''}
-      ${waiting ? html`
-      <progress class="waiting"></progress>
-    ` : ''}
-    </button>`;
+        ${waiting ? html`
+          <progress class="waiting"></progress>
+        ` : ''}
+      </button>
+    `;
   }
 
   static get styles () {
@@ -222,13 +226,12 @@ export class CcButton extends LitElement {
         /* BASE */
         .btn {
           border: 1px solid #000;
-          border-radius: 0.15rem;
+          border-radius: 0.15em;
           cursor: pointer;
-          font-size: 14px;
           font-weight: bold;
-          min-height: 2rem;
+          min-height: 2em;
           overflow: hidden;
-          padding: 0 0.5rem;
+          padding: 0 0.5em;
           /* used to absolutely position the <progress> */
           position: relative;
           text-transform: uppercase;
@@ -271,7 +274,7 @@ export class CcButton extends LitElement {
           background-color: #fff;
           color: var(--btn-color);
         }
-        
+
         .circle {
           border-radius: 50%;
         }
@@ -282,10 +285,10 @@ export class CcButton extends LitElement {
         }
 
         .img-only {
-          height: 1.75rem;
+          height: 1.75em;
           min-height: 0;
           padding: 0;
-          width: 1.75rem;
+          width: 1.75em;
         }
 
         /* STATES */
@@ -328,7 +331,7 @@ export class CcButton extends LitElement {
         .text-wrapper {
           align-items: center;
           display: grid;
-          grid-gap: 0.5rem;
+          gap: 0.5em;
           grid-template-columns: min-content 1fr;
           height: 100%;
           justify-content: center;
@@ -336,19 +339,19 @@ export class CcButton extends LitElement {
         }
 
         .txt-only .text-wrapper {
-          grid-gap: 0;
+          gap: 0;
           grid-template-columns: 1fr;
         }
 
         .img-only .text-wrapper {
-          grid-gap: 0;
+          gap: 0;
           grid-template-columns: min-content;
         }
 
         img {
           display: block;
-          height: 1.25rem;
-          width: 1.25rem;
+          height: 1.25em;
+          width: 1.25em;
         }
 
         .img-only .text-normal {
@@ -359,6 +362,12 @@ export class CcButton extends LitElement {
         .text-normal,
         .text-cancel {
           grid-row: 1 / 2;
+        }
+
+        .text-normal,
+        .text-cancel {
+          /* Setting font-size here is easier than on .btn because of how "em" works */
+          font-size: 0.85em;
         }
 
         img {
@@ -401,7 +410,7 @@ export class CcButton extends LitElement {
           appearance: none;
           border: none;
           bottom: 0;
-          height: 0.2rem;
+          height: 0.2em;
           left: 0;
           position: absolute;
           width: 0;
@@ -429,7 +438,7 @@ export class CcButton extends LitElement {
           appearance: none;
           border: none;
           bottom: 0;
-          height: 0.2rem;
+          height: 0.2em;
           margin-left: calc(50% - calc(var(--width) / 2));
           position: absolute;
           width: var(--width);
@@ -444,6 +453,10 @@ export class CcButton extends LitElement {
         .cc-link {
           cursor: pointer;
           text-decoration: underline;
+        }
+
+        .cc-link .text-normal {
+          font-size: 1em;
         }
       `,
     ];

--- a/src/atoms/cc-img.js
+++ b/src/atoms/cc-img.js
@@ -118,9 +118,9 @@ export class CcImg extends LitElement {
         }
 
         .error-msg {
-          font-size: 0.9rem;
+          font-size: 0.85em;
           overflow: hidden;
-          padding: 0.25rem;
+          padding: 0.3em;
           text-align: center;
           text-overflow: ellipsis;
           white-space: nowrap;

--- a/src/atoms/cc-input-number.js
+++ b/src/atoms/cc-input-number.js
@@ -184,7 +184,7 @@ export class CcInputNumber extends LitElement {
         label {
           cursor: pointer;
           display: block;
-          padding-bottom: 0.35rem;
+          padding-bottom: 0.35em;
         }
 
         .meta-input {
@@ -200,7 +200,8 @@ export class CcInputNumber extends LitElement {
         .wrapper {
           display: grid;
           flex: 1 1 0;
-          margin: 0.15rem 0.5rem;
+          /* see input to know why 0.15em */
+          margin: 0.15em 0.5em;
           min-width: 0;
           overflow: hidden;
         }
@@ -213,8 +214,8 @@ export class CcInputNumber extends LitElement {
           border: 1px solid #000;
           box-sizing: border-box;
           display: block;
-          font-family: var(--cc-ff-monospace);
-          font-size: 14px;
+          font-family: monospace;
+          font-size: unset;
           margin: 0;
           padding: 0;
           resize: none;
@@ -237,9 +238,13 @@ export class CcInputNumber extends LitElement {
         input {
           background: none;
           border: none;
-          grid-area: 1 / 1 / 1 / 1;
-          height: 1.7rem;
-          line-height: 1.7rem;
+          font-family: var(--cc-ff-monospace);
+          font-size: 0.85em;
+          grid-area: 1 / 1 / 2 / 2;
+          /* 2em with a 0.85em font-size ~ 1.7em */
+          /* (2em - 1.7em) / 2 ~ 0.15em of padding (top and bottom) on the wrapper */
+          height: 2em;
+          line-height: 2em;
           overflow: hidden;
           text-align: var(--cc-input-number-align, left);
           z-index: 2;
@@ -265,7 +270,7 @@ export class CcInputNumber extends LitElement {
         .ring {
           background: #fff;
           border: 1px solid #aaa;
-          border-radius: 0.25rem;
+          border-radius: 0.25em;
           bottom: 0;
           box-shadow: 0 0 0 0 rgba(255, 255, 255, 0);
           left: 0;
@@ -322,22 +327,23 @@ export class CcInputNumber extends LitElement {
           border: none;
           display: block;
           font-family: inherit;
+          font-size: unset;
           margin: 0;
           padding: 0;
         }
 
         .btn {
-          border-radius: 0.15rem;
+          border-radius: 0.15em;
           cursor: pointer;
-          flex-shrink: 1;
-          height: 1.6rem;
-          margin: 0.2rem 0.2rem 0.2rem 0.2rem;
-          width: 1.6rem;
+          flex-shrink: 0;
+          height: 1.6em;
+          margin: 0.2em;
+          width: 1.6em;
           z-index: 2;
         }
 
         .btn:focus {
-          box-shadow: 0 0 0 .2rem rgba(50, 115, 220, .25);
+          box-shadow: 0 0 0 .2em rgba(50, 115, 220, .25);
           outline: 0;
         }
 

--- a/src/atoms/cc-input-text.js
+++ b/src/atoms/cc-input-text.js
@@ -296,7 +296,7 @@ export class CcInputText extends LitElement {
         label {
           cursor: pointer;
           display: block;
-          padding-bottom: 0.35rem;
+          padding-bottom: 0.35em;
         }
 
         .meta-input {
@@ -315,7 +315,8 @@ export class CcInputText extends LitElement {
         .wrapper {
           display: grid;
           flex: 1 1 0;
-          margin: 0.15rem 0.5rem;
+          /* see input to know why 0.15em */
+          margin: 0.15em 0.5em;
           min-width: 0;
           overflow: hidden;
         }
@@ -328,8 +329,8 @@ export class CcInputText extends LitElement {
           border: 1px solid #000;
           box-sizing: border-box;
           display: block;
-          font-family: var(--cc-ff-monospace);
-          font-size: 14px;
+          font-family: monospace;
+          font-size: unset;
           margin: 0;
           padding: 0;
           resize: none;
@@ -340,10 +341,14 @@ export class CcInputText extends LitElement {
         .input {
           background: none;
           border: none;
-          grid-area: 1 / 1 / 1 / 1;
+          font-family: var(--cc-ff-monospace);
+          font-size: 0.85em;
+          grid-area: 1 / 1 / 2 / 2;
           /* multiline behaviour */
-          height: calc(var(--rows, 1) * 1.7rem);
-          line-height: 1.7rem;
+          height: calc(var(--rows, 1) * 2em);
+          /* 2em with a 0.85em font-size ~ 1.7em */
+          /* (2em - 1.7em) / 2 ~ 0.15em of padding (top and bottom) on the wrapper */
+          line-height: 2em;
           overflow: hidden;
           z-index: 2;
         }
@@ -402,7 +407,7 @@ export class CcInputText extends LitElement {
         .ring {
           background: #fff;
           border: 1px solid #aaa;
-          border-radius: 0.25rem;
+          border-radius: 0.25em;
           bottom: 0;
           box-shadow: 0 0 0 0 rgba(255, 255, 255, 0);
           left: 0;
@@ -451,22 +456,23 @@ export class CcInputText extends LitElement {
           border: none;
           display: block;
           font-family: inherit;
+          font-size: unset;
           margin: 0;
           padding: 0;
         }
 
         .btn {
-          border-radius: 0.15rem;
+          border-radius: 0.15em;
           cursor: pointer;
           flex-shrink: 0;
-          height: 1.6rem;
-          margin: 0.2rem 0.2rem 0.2rem 0;
-          width: 1.6rem;
+          height: 1.6em;
+          margin: 0.2em 0.2em 0.2em 0;
+          width: 1.6em;
           z-index: 2;
         }
 
         .btn:focus {
-          box-shadow: 0 0 0 .2rem rgba(50, 115, 220, .25);
+          box-shadow: 0 0 0 .2em rgba(50, 115, 220, .25);
           outline: 0;
         }
 

--- a/src/atoms/cc-loader.js
+++ b/src/atoms/cc-loader.js
@@ -34,8 +34,8 @@ export class CcLoader extends LitElement {
           animation: progress-circular-rotate 1.75s linear infinite;
           height: 100%;
           margin: auto;
-          max-height: 2.5rem;
-          max-width: 2.5rem;
+          max-height: 2.5em;
+          max-width: 2.5em;
           width: 100%;
         }
 

--- a/src/atoms/cc-toggle.js
+++ b/src/atoms/cc-toggle.js
@@ -173,15 +173,15 @@ export class CcToggle extends LitElement {
         }
 
         legend:not(:empty) {
-          padding-bottom: 0.35rem;
+          padding-bottom: 0.35em;
         }
 
         .toggle-group {
           background-color: #fff;
-          border-radius: 0.15rem;
+          border-radius: 0.15em;
           box-sizing: border-box;
           display: flex;
-          height: 2rem;
+          height: 2em;
           line-height: 1.25;
           overflow: visible;
         }
@@ -208,11 +208,11 @@ export class CcToggle extends LitElement {
           color: var(--color-txt);
           cursor: pointer;
           display: grid;
-          font-size: 14px;
+          font-size: 0.85em;
           font-weight: bold;
           grid-auto-flow: column;
-          grid-gap: 0.5rem;
-          padding: 0 0.5rem;
+          gap: 0.6em;
+          padding: 0 0.6em;
           position: relative;
           text-transform: var(--cc-text-transform, uppercase);
           -moz-user-select: none;
@@ -227,11 +227,11 @@ export class CcToggle extends LitElement {
 
         label:first-of-type {
           border-left-width: 1px;
-          border-radius: 0.15rem 0 0 0.15rem;
+          border-radius: 0.15em 0 0 0.15em;
         }
 
         label:last-of-type {
-          border-radius: 0 0.15rem 0.15rem 0;
+          border-radius: 0 0.15em 0.15em 0;
           border-right-width: 1px;
         }
 
@@ -242,7 +242,7 @@ export class CcToggle extends LitElement {
         /* Used to display a background behind the text */
         label::before {
           background-color: var(--color-bg);
-          border-radius: .15rem;
+          border-radius: .15em;
           bottom: var(--space);
           content: '';
           display: block;
@@ -260,9 +260,9 @@ export class CcToggle extends LitElement {
           content: '';
           display: block;
           height: var(--space);
-          left: 0.25rem;
+          left: 0.25em;
           position: absolute;
-          right: 0.25rem;
+          right: 0.25em;
           z-index: 0;
         }
 
@@ -273,8 +273,8 @@ export class CcToggle extends LitElement {
 
         img {
           display: block;
-          height: 1.25rem;
-          width: 1.25rem;
+          height: 1.45em;
+          width: 1.45em;
         }
 
         /* NOT SELECTED */

--- a/src/overview/cc-tile-requests.js
+++ b/src/overview/cc-tile-requests.js
@@ -283,6 +283,7 @@ export class CcTileRequests extends withResizeObserver(LitElement) {
         }
 
         .docs-toggle {
+          font-size: 1rem;
           margin: 0 0 0 1rem;
         }
 

--- a/src/overview/cc-tile-status-codes.js
+++ b/src/overview/cc-tile-status-codes.js
@@ -251,6 +251,7 @@ export class CcTileStatusCodes extends LitElement {
         }
 
         .docs-toggle {
+          font-size: 1rem;
           margin: 0 0 0 1rem;
         }
 


### PR DESCRIPTION
* This patch replaces all `rem` with `em` in all atoms components
  * This also includes a modification on some tile components
* See https://github.com/CleverCloud/clever-components/issues/126#issuecomment-797600763 for context

NOTE: Some dimensions are a bit different