### PR TITLE
Add <cc-jenkins-info> component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ title: Changelog
   * `<cc-pricing-header>`
   * `<cc-pricing-estimation>`
   * `<cc-pricing-page>` (with smart definition)
+  * `<cc-jenkins-info>` (with smart definition)
 
 ## 6.10.0 (2021-07-08)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "6.10.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@clevercloud/client": "^7.4.0",
+        "@clevercloud/client": "^7.6.0",
         "@shoelace-style/shoelace": "^2.0.0-beta.47",
         "chart.js": "^3.5.0",
         "chartjs-plugin-datalabels": "^2.0.0",
@@ -3551,12 +3551,18 @@
       "dev": true
     },
     "node_modules/@clevercloud/client": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@clevercloud/client/-/client-7.4.0.tgz",
-      "integrity": "sha512-5CkwwMZ/HJpaTfpVmqRkLm6/ISyZVnHyuhrD84XLD5gbpB/KOJg5lHAFbBvEMmszQm1sNyXeOAzSd/7fjSqbNg==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@clevercloud/client/-/client-7.6.0.tgz",
+      "integrity": "sha512-o1AkYm/6ho5QBmgFfDgPSvbjbOCm2p4C4RtC5UQVyTdtLpBErxIKuvbodTr9BF/PpzVUn94ZQE1lGXTDJO8x8A==",
       "dependencies": {
         "component-emitter": "^1.3.0",
         "oauth-1.0a": "^2.2.6"
+      },
+      "peerDependencies": {
+        "baconjs": "^0.7.83",
+        "eventsource": "^1.0.7",
+        "superagent": "^6.1.0",
+        "ws": "^7.4.3"
       }
     },
     "node_modules/@custom-elements-manifest/analyzer": {
@@ -6126,8 +6132,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "node_modules/atob": {
       "version": "2.1.2",
@@ -6620,6 +6625,12 @@
       "bin": {
         "babylon": "bin/babylon.js"
       }
+    },
+    "node_modules/baconjs": {
+      "version": "0.7.95",
+      "resolved": "https://registry.npmjs.org/baconjs/-/baconjs-0.7.95.tgz",
+      "integrity": "sha512-3qp0GuAfEUlJybSVPQ2oai8VYO0aSTJf4wP/jYZpgaffEXi31VBcqSlVmD8ahmXXGzgdO+yFk9onDnt2ZJJXxA==",
+      "peer": true
     },
     "node_modules/bail": {
       "version": "1.0.5",
@@ -7373,7 +7384,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -7509,8 +7519,7 @@
     "node_modules/cookiejar": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
-      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
-      "dev": true
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
     },
     "node_modules/cookies": {
       "version": "0.8.0",
@@ -7629,7 +7638,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -7758,7 +7766,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -8926,6 +8933,18 @@
         "node": ">=0.4.x"
       }
     },
+    "node_modules/eventsource": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.0.tgz",
+      "integrity": "sha512-VSJjT5oCNrFvCS6igjzPAt5hBzQ2qPBFIbJ03zLI9SE0mxwZpMw6BfJrbFHm1a141AavMEB8JHmBhWAd66PfCg==",
+      "peer": true,
+      "dependencies": {
+        "original": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/expand-brackets": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
@@ -9186,8 +9205,7 @@
     "node_modules/fast-safe-stringify": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
-      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
-      "dev": true
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
     },
     "node_modules/fastq": {
       "version": "1.6.0",
@@ -9415,7 +9433,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
       "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -9437,8 +9454,7 @@
     "node_modules/formidable": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
-      "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q==",
-      "dev": true
+      "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q=="
     },
     "node_modules/fragment-cache": {
       "version": "0.2.1",
@@ -10302,8 +10318,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/inline-style-parser": {
       "version": "0.1.1",
@@ -11739,7 +11754,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
       "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -11870,7 +11884,6 @@
       "version": "1.47.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
       "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -11879,7 +11892,6 @@
       "version": "2.1.30",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.30.tgz",
       "integrity": "sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.47.0"
       },
@@ -11987,8 +11999,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/nanoid": {
       "version": "3.1.22",
@@ -12355,6 +12366,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/original": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
+      "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
+      "peer": true,
+      "dependencies": {
+        "url-parse": "^1.4.3"
       }
     },
     "node_modules/p-limit": {
@@ -12852,6 +12872,12 @@
       "engines": {
         "node": ">=0.4.x"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "peer": true
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -14045,6 +14071,12 @@
         "node": ">=0.10.5"
       }
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+      "peer": true
+    },
     "node_modules/resize-observer-polyfill": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
@@ -14511,8 +14543,7 @@
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/safe-regex": {
       "version": "1.1.0",
@@ -15262,7 +15293,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -15572,7 +15602,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-6.1.0.tgz",
       "integrity": "sha512-OUDHEssirmplo3F+1HWKUrUjvnQuA+nZI6i/JJBdXb5eq9IyEQwPyPpqND+SSsxf6TygpBEkUjISVRN4/VOpeg==",
-      "dev": true,
       "dependencies": {
         "component-emitter": "^1.3.0",
         "cookiejar": "^2.1.2",
@@ -15594,7 +15623,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -15606,7 +15634,6 @@
       "version": "2.4.6",
       "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
       "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
-      "dev": true,
       "bin": {
         "mime": "cli.js"
       },
@@ -15618,7 +15645,6 @@
       "version": "6.9.4",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
       "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -15627,7 +15653,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dev": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -15641,7 +15666,6 @@
       "version": "7.3.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
       "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -15655,8 +15679,7 @@
     "node_modules/superagent/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/supports-color": {
       "version": "5.5.0",
@@ -16449,6 +16472,16 @@
         "querystring": "0.2.0"
       }
     },
+    "node_modules/url-parse": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.3.tgz",
+      "integrity": "sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==",
+      "peer": true,
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/url/node_modules/punycode": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
@@ -16467,8 +16500,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "node_modules/util.promisify": {
       "version": "1.0.0",
@@ -16798,7 +16830,6 @@
       "version": "7.4.5",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.5.tgz",
       "integrity": "sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==",
-      "dev": true,
       "engines": {
         "node": ">=8.3.0"
       }
@@ -20399,9 +20430,9 @@
       "dev": true
     },
     "@clevercloud/client": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/@clevercloud/client/-/client-7.4.0.tgz",
-      "integrity": "sha512-5CkwwMZ/HJpaTfpVmqRkLm6/ISyZVnHyuhrD84XLD5gbpB/KOJg5lHAFbBvEMmszQm1sNyXeOAzSd/7fjSqbNg==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/@clevercloud/client/-/client-7.6.0.tgz",
+      "integrity": "sha512-o1AkYm/6ho5QBmgFfDgPSvbjbOCm2p4C4RtC5UQVyTdtLpBErxIKuvbodTr9BF/PpzVUn94ZQE1lGXTDJO8x8A==",
       "requires": {
         "component-emitter": "^1.3.0",
         "oauth-1.0a": "^2.2.6"
@@ -22672,8 +22703,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "atob": {
       "version": "2.1.2",
@@ -23120,6 +23150,12 @@
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
       "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
       "dev": true
+    },
+    "baconjs": {
+      "version": "0.7.95",
+      "resolved": "https://registry.npmjs.org/baconjs/-/baconjs-0.7.95.tgz",
+      "integrity": "sha512-3qp0GuAfEUlJybSVPQ2oai8VYO0aSTJf4wP/jYZpgaffEXi31VBcqSlVmD8ahmXXGzgdO+yFk9onDnt2ZJJXxA==",
+      "peer": true
     },
     "bail": {
       "version": "1.0.5",
@@ -23760,7 +23796,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -23871,8 +23906,7 @@
     "cookiejar": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
-      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
-      "dev": true
+      "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA=="
     },
     "cookies": {
       "version": "0.8.0",
@@ -23974,7 +24008,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "dev": true,
       "requires": {
         "ms": "^2.1.1"
       }
@@ -24074,8 +24107,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "delegate": {
       "version": "3.2.0",
@@ -25049,6 +25081,15 @@
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
       "dev": true
     },
+    "eventsource": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.0.tgz",
+      "integrity": "sha512-VSJjT5oCNrFvCS6igjzPAt5hBzQ2qPBFIbJ03zLI9SE0mxwZpMw6BfJrbFHm1a141AavMEB8JHmBhWAd66PfCg==",
+      "peer": true,
+      "requires": {
+        "original": "^1.0.0"
+      }
+    },
     "expand-brackets": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
@@ -25264,8 +25305,7 @@
     "fast-safe-stringify": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
-      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==",
-      "dev": true
+      "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
     },
     "fastq": {
       "version": "1.6.0",
@@ -25451,7 +25491,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
       "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
-      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -25467,8 +25506,7 @@
     "formidable": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
-      "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q==",
-      "dev": true
+      "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q=="
     },
     "fragment-cache": {
       "version": "0.2.1",
@@ -26199,8 +26237,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "inline-style-parser": {
       "version": "0.1.1",
@@ -27447,8 +27484,7 @@
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
-      "dev": true
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "micromark": {
       "version": "2.11.4",
@@ -27571,14 +27607,12 @@
     "mime-db": {
       "version": "1.47.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.47.0.tgz",
-      "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw==",
-      "dev": true
+      "integrity": "sha512-QBmA/G2y+IfeS4oktet3qRZ+P5kPhCKRXxXnQEudYqUaEioAU1/Lq2us3D/t1Jfo4hE9REQPrbB7K5sOczJVIw=="
     },
     "mime-types": {
       "version": "2.1.30",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.30.tgz",
       "integrity": "sha512-crmjA4bLtR8m9qLpHvgxSChT+XoSlZi8J4n/aIdn3z92e/U47Z0V/yl+Wh9W046GgFVAmoNR/fmdbZYcSSIUeg==",
-      "dev": true,
       "requires": {
         "mime-db": "1.47.0"
       }
@@ -27666,8 +27700,7 @@
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "nanoid": {
       "version": "3.1.22",
@@ -27967,6 +28000,15 @@
         "prelude-ls": "^1.2.1",
         "type-check": "^0.4.0",
         "word-wrap": "^1.2.3"
+      }
+    },
+    "original": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
+      "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
+      "peer": true,
+      "requires": {
+        "url-parse": "^1.4.3"
       }
     },
     "p-limit": {
@@ -28377,6 +28419,12 @@
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
       "dev": true
+    },
+    "querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "peer": true
     },
     "randombytes": {
       "version": "2.1.0",
@@ -29504,6 +29552,12 @@
       "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
       "dev": true
     },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+      "peer": true
+    },
     "resize-observer-polyfill": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
@@ -29894,8 +29948,7 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -30576,7 +30629,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -30832,7 +30884,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-6.1.0.tgz",
       "integrity": "sha512-OUDHEssirmplo3F+1HWKUrUjvnQuA+nZI6i/JJBdXb5eq9IyEQwPyPpqND+SSsxf6TygpBEkUjISVRN4/VOpeg==",
-      "dev": true,
       "requires": {
         "component-emitter": "^1.3.0",
         "cookiejar": "^2.1.2",
@@ -30851,7 +30902,6 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
           "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
           "requires": {
             "yallist": "^4.0.0"
           }
@@ -30859,20 +30909,17 @@
         "mime": {
           "version": "2.4.6",
           "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
-          "dev": true
+          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
         },
         "qs": {
           "version": "6.9.4",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
-          "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ==",
-          "dev": true
+          "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
         },
         "readable-stream": {
           "version": "3.6.0",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
           "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -30883,7 +30930,6 @@
           "version": "7.3.4",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
           "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-          "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -30891,8 +30937,7 @@
         "yallist": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         }
       }
     },
@@ -31588,6 +31633,16 @@
         }
       }
     },
+    "url-parse": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.3.tgz",
+      "integrity": "sha512-IIORyIQD9rvj0A4CLWsHkBBJuNqWpFQe224b6j9t/ABmquIS0qDU2pY6kl6AuOrL5OkCXHMCFNe1jBcuAggjvQ==",
+      "peer": true,
+      "requires": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
@@ -31597,8 +31652,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "util.promisify": {
       "version": "1.0.0",
@@ -31878,8 +31932,7 @@
     "ws": {
       "version": "7.4.5",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.5.tgz",
-      "integrity": "sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==",
-      "dev": true
+      "integrity": "sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g=="
     },
     "xml2js": {
       "version": "0.4.19",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "storybook:dev": "wds"
   },
   "dependencies": {
-    "@clevercloud/client": "^7.4.0",
+    "@clevercloud/client": "^7.6.0",
     "@shoelace-style/shoelace": "^2.0.0-beta.47",
     "chart.js": "^3.5.0",
     "chartjs-plugin-datalabels": "^2.0.0",

--- a/src/addon/cc-jenkins-info.js
+++ b/src/addon/cc-jenkins-info.js
@@ -1,0 +1,140 @@
+import '../atoms/cc-img.js';
+import '../molecules/cc-block-section.js';
+import '../molecules/cc-block.js';
+import '../molecules/cc-error.js';
+import { css, html, LitElement } from 'lit-element';
+import { classMap } from 'lit-html/directives/class-map.js';
+import { i18n } from '../lib/i18n.js';
+import { skeletonStyles } from '../styles/skeleton.js';
+import { ccLink, linkStyles } from '../templates/cc-link.js';
+
+const infoSvg = new URL('../assets/info.svg', import.meta.url).href;
+
+const JENKINS_LOGO_URL = 'https://static-assets.cellar.services.clever-cloud.com/logos/jenkins.svg';
+const JENKINS_DOCUMENTATION = 'https://www.clever-cloud.com/doc/addons/jenkins/';
+
+/**
+ * A component to display various informations (Documentation, access, updates, ...) for a Jenkins service.
+ *
+ * ## Type definitions
+ *
+ * ```js
+ * interface Versions {
+ *   current: String,
+ *   available: String
+ * }
+ * ```
+ *
+ * @cssdisplay block
+ *
+ * @prop {Boolean} error - Display an error message.
+ * @prop {String} jenkinsLink - Provides the HTTP link of the Jenkins service.
+ * @prop {String} jenkinsManageLink - Provides the HTTP link of the Jenkins management interface.
+ * @prop {Versions} versions - Provides the current and available version of the Jenkins add-on.
+ */
+export class CcJenkinsInfo extends LitElement {
+
+  static get properties () {
+    return {
+      error: { type: Boolean },
+      jenkinsLink: { type: String, attribute: 'jenkins-link' },
+      jenkinsManageLink: { type: String, attribute: 'jenkins-manage-link' },
+      versions: { type: Object },
+    };
+  }
+
+  constructor () {
+    super();
+    this.error = false;
+  }
+
+  render () {
+    const versions = this.versions ?? {};
+    const hasNewVersion = versions.current !== versions.available;
+
+    return html`
+
+      <cc-block ribbon=${i18n('cc-jenkins-info.info')} no-head>
+        ${!this.error ? html`
+          <div class="info-text">${i18n('cc-jenkins-info.text')}</div>
+
+          <cc-block-section>
+            <div slot="title">${i18n('cc-jenkins-info.open-jenkins.title')}</div>
+            <div slot="info">${i18n('cc-jenkins-info.open-jenkins.text')}</div>
+            <div class="one-line-form">
+              ${ccLink(this.jenkinsLink, html`
+                <cc-img src="${JENKINS_LOGO_URL}"></cc-img><span class="${classMap({ skeleton: (this.jenkinsLink == null) })}">${i18n('cc-jenkins-info.open-jenkins.link')}</span>
+              `)}
+            </div>
+          </cc-block-section>
+
+          <cc-block-section>
+            <div slot="title">${i18n('cc-jenkins-info.documentation.title')}</div>
+            <div slot="info">${i18n('cc-jenkins-info.documentation.text')}</div>
+            <div class="one-line-form">
+              ${ccLink(JENKINS_DOCUMENTATION, html`
+                <cc-img src="${infoSvg}"></cc-img><span>${i18n('cc-jenkins-info.documentation.link')}</span>
+              `)}
+            </div>
+          </cc-block-section>
+
+          <cc-block-section>
+            <div slot="title">${i18n('cc-jenkins-info.update.title')}</div>
+            <div slot="info">${i18n('cc-jenkins-info.update.text')}</div>
+            <div class="one-line-form">
+              ${ccLink(this.jenkinsManageLink, html`
+                <cc-img src="${infoSvg}"></cc-img>
+                <span class="${classMap({ skeleton: (this.versions == null) })}">
+                  ${hasNewVersion ? i18n('cc-jenkins-info.update.new-version', { version: versions.available }) : i18n('cc-jenkins-info.update.up-to-date')}
+                </span>
+              `)}
+            </div>
+          </cc-block-section>
+        ` : ''}
+
+        ${this.error ? html`
+          <cc-error>${i18n('cc-jenkins-info.error')}</cc-error>
+        ` : ''}
+
+      </cc-block>
+    `;
+  }
+
+  static get styles () {
+    return [
+      skeletonStyles,
+      linkStyles,
+      // language=CSS
+      css`
+        :host {
+          --cc-gap: 1rem;
+          display: block;
+        }
+
+        .cc-link {
+          align-items: center;
+          display: flex;
+        }
+
+        cc-img {
+          border-radius: 0.25rem;
+          flex: 0 0 auto;
+          height: 1.5rem;
+          margin-right: 0.5rem;
+          width: 1.5rem;
+        }
+
+        /* SKELETON */
+        .skeleton {
+          background-color: #bbb;
+        }
+
+        cc-error {
+          text-align: center;
+        }
+      `,
+    ];
+  }
+}
+
+window.customElements.define('cc-jenkins-info', CcJenkinsInfo);

--- a/src/addon/cc-jenkins-info.smart.js
+++ b/src/addon/cc-jenkins-info.smart.js
@@ -1,0 +1,54 @@
+import './cc-jenkins-info.js';
+import '../smart/cc-smart-container.js';
+import { getAddon, getJenkinsUpdates } from '@clevercloud/client/esm/api/v4/addon-providers.js';
+import { combineLatest, LastPromise, merge, unsubscribeWithSignal } from '../lib/observables.js';
+import { sendToApi } from '../lib/send-to-api.js';
+import { defineComponent } from '../lib/smart-manager.js';
+
+defineComponent({
+  selector: 'cc-jenkins-info',
+  params: {
+    apiConfig: { type: Object },
+    addonId: { type: String },
+  },
+  onConnect (container, component, context$, disconnectSignal) {
+
+    const addon_lp = new LastPromise();
+    const jenkinsUpdates_lp = new LastPromise();
+    const addonUpdateCenter = combineLatest(addon_lp.value$, jenkinsUpdates_lp.value$);
+
+    const error$ = merge(addon_lp.error$, jenkinsUpdates_lp.error$);
+
+    unsubscribeWithSignal(disconnectSignal, [
+
+      error$.subscribe(console.error),
+      error$.subscribe(() => (component.error = true)),
+      addonUpdateCenter.subscribe(([addon, updateCenter]) => {
+        component.jenkinsLink = `https://${addon.host}`;
+        component.jenkinsManageLink = updateCenter.manageLink;
+        component.versions = updateCenter.versions;
+      }),
+
+      context$.subscribe(({ apiConfig, addonId }) => {
+
+        component.error = false;
+        component.jenkinsManageLink = null;
+        component.versions = null;
+
+        if (apiConfig != null && addonId != null) {
+          addon_lp.push((signal) => fetchAddon({ apiConfig, signal, addonId }));
+          jenkinsUpdates_lp.push((signal) => fetchUpdates({ apiConfig, signal, addonId }));
+        }
+      }),
+
+    ]);
+  },
+});
+
+function fetchUpdates ({ apiConfig, signal, addonId }) {
+  return getJenkinsUpdates({ addonId }).then(sendToApi({ apiConfig, signal }));
+}
+
+function fetchAddon ({ apiConfig, signal, addonId }) {
+  return getAddon({ providerId: 'jenkins', addonId }).then(sendToApi({ apiConfig, signal }));
+}

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -330,6 +330,21 @@ export const translations = {
   'cc-invoice-table.total.label': `Total`,
   'cc-invoice-table.total.value': ({ amount }) => `${formatCurrency(lang, amount)}`,
   //#endregion
+  //#region cc-jenkins-info
+  'cc-jenkins-info.documentation.link': `Read the documentation`,
+  'cc-jenkins-info.documentation.text': `Our documentation can help you start using Jenkins and create jobs that run on Clever Cloud docker applications.`,
+  'cc-jenkins-info.documentation.title': `Documentation`,
+  'cc-jenkins-info.error': `An error occured while fetching the information about this add-on.`,
+  'cc-jenkins-info.info': `Info`,
+  'cc-jenkins-info.open-jenkins.link': `Access Jenkins`,
+  'cc-jenkins-info.open-jenkins.text': `Access Jenkins using the Clever Cloud SSO (Single Sign-On). Organisation members can also access the Jenkins service.`,
+  'cc-jenkins-info.open-jenkins.title': `Access Jenkins`,
+  'cc-jenkins-info.text': `This add-on is part of the Jenkins offer. You can find the documentation and various information below.`,
+  'cc-jenkins-info.update.new-version': ({ version }) => `Jenkins version ${version} is available!`,
+  'cc-jenkins-info.update.text': `Jenkins and its plugins often get updates. You can automatically update Jenkins and its plugins using its dedicated WEB interface.`,
+  'cc-jenkins-info.update.title': `Updates`,
+  'cc-jenkins-info.update.up-to-date': `Your Jenkins version is up-to-date.`,
+  //#endregion
   //#region cc-logsmap
   'cc-logsmap.legend.heatmap': ({ orgaName }) => sanitize`Heatmap of HTTP requests received by all apps from <strong>${orgaName}</strong> during the last 24 hours.`,
   'cc-logsmap.legend.heatmap.app': ({ appName }) => sanitize`Heatmap of HTTP requests received by <strong>${appName}</strong> during the last 24 hours.`,

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -343,6 +343,21 @@ export const translations = {
   'cc-invoice-table.total.label': `Total`,
   'cc-invoice-table.total.value': ({ amount }) => `${formatCurrency(lang, amount)}`,
   //#endregion
+  //#region cc-jenkins-info
+  'cc-jenkins-info.documentation.link': `Consulter la documentation`,
+  'cc-jenkins-info.documentation.text': `Notre documentation peut vous accompagner pour commencer à utiliser Jenkins ainsi qu'à créer des jobs qui s'exécutent dans des runners Docker sur Clever Cloud.`,
+  'cc-jenkins-info.documentation.title': `Documentation`,
+  'cc-jenkins-info.error': `Une erreur est survenue pendant le chargement des informations liées à cet add-on.`,
+  'cc-jenkins-info.info': `Info`,
+  'cc-jenkins-info.open-jenkins.link': `Accéder à Jenkins`,
+  'cc-jenkins-info.open-jenkins.text': `Accédez à Jenkins de manière authentifiée via le SSO (Single Sign-On) Clever Cloud. Les différents membres de l'organisation peuvent accéder au service Jenkins.`,
+  'cc-jenkins-info.open-jenkins.title': `Accéder à Jenkins`,
+  'cc-jenkins-info.text': `Cet add-on fait partie de l'offre Jenkins. Vous pouvez retrouver la documentation ainsi que différentes informations ci-dessous.`,
+  'cc-jenkins-info.update.new-version': ({ version }) => `La version ${version} de Jenkins est disponible !`,
+  'cc-jenkins-info.update.text': `Jenkins et ses plugins reçoivent régulièrement des mises à jour. Vous pouvez mettre à jour automatiquement votre instance ainsi que ses plugins à travers l'interface Jenkins.`,
+  'cc-jenkins-info.update.title': `Mises à jour`,
+  'cc-jenkins-info.update.up-to-date': `Votre version de Jenkins est à jour.`,
+  //#endregion
   //#region cc-logsmap
   'cc-logsmap.legend.heatmap': ({ orgaName }) => sanitize`Carte de chaleur des requêtes HTTP reçues par les applications de <strong>${orgaName}</strong> durant les dernières 24 heures.`,
   'cc-logsmap.legend.heatmap.app': ({ appName }) => sanitize`Carte de chaleur des requêtes HTTP reçues par l'application <strong>${appName}</strong> durant les dernières 24 heures.`,

--- a/stories/addon/cc-jenkins-info.smart.md
+++ b/stories/addon/cc-jenkins-info.smart.md
@@ -1,0 +1,58 @@
+---
+kind: '🛠 Addon/<cc-jenkins-info>'
+title: '💡 Smart'
+---
+# 💡 Smart `<cc-jenkins-info>`
+
+## ℹ️ Details
+
+<table>
+  <tr><td><strong>Component    </strong> <td><a href="https://www.clever-cloud.com/doc/clever-components/?path=/docs/%F0%9F%9B%A0-addon-cc-jenkins-info--default-story"><code>&lt;cc-jenkins-info&gt;</code></a>
+  <tr><td><strong>Selector     </strong> <td><code>cc-jenkins-info</code>
+  <tr><td><strong>Requires auth</strong> <td>Yes
+</table>
+
+## ⚙️ Params
+
+<table>
+  <tr><th>Name                   <th>Type                   <th>Details                                                     <th>Default
+  <tr><td><code>apiConfig</code> <td><code>ApiConfig</code> <td>Object with API configuration (target host, tokens...)      <td>
+  <tr><td><code>addonId</code>   <td><code>String</code>    <td>UUID prefixed with <code>addon_</code>                      <td>
+</table>
+
+```js
+interface ApiConfig {
+  API_HOST: String,
+  API_OAUTH_TOKEN: String,
+  API_OAUTH_TOKEN_SECRET: String,
+  OAUTH_CONSUMER_KEY: String,
+  OAUTH_CONSUMER_SECRET: String,
+}
+```
+
+## 🌐 API endpoints
+
+<!-- List API endpoints used by the component here with the details. -->
+
+<table>
+  <tr><th>Method <th>URL                                                                    <th>Cache?
+  <tr><td>GET    <td><code>/v4/addon-providers/{providerId}/addons/{addonId}</code>         <td>Default
+  <tr><td>GET    <td><code>/v4/addon-providers/jenkins/addons/{addonId}/updates</code>      <td>Default
+</table>
+
+## ⬇️️ Examples
+
+```html
+<cc-smart-container context='{
+  "apiConfig": {
+    API_HOST: "",
+    API_OAUTH_TOKEN: "",
+    API_OAUTH_TOKEN_SECRET: "",
+    OAUTH_CONSUMER_KEY: "",
+    OAUTH_CONSUMER_SECRET: "",
+  },
+  "addonId": "",
+}'>
+  <cc-jenkins-info></cc-jenkins-info>
+</cc-smart-container>
+```

--- a/stories/addon/cc-jenkins-info.stories.js
+++ b/stories/addon/cc-jenkins-info.stories.js
@@ -1,0 +1,72 @@
+import '../../src/addon/cc-jenkins-info.js';
+import { makeStory, storyWait } from '../lib/make-story.js';
+import { enhanceStoriesNames } from '../lib/story-names.js';
+
+export default {
+  title: '🛠 Addon/<cc-jenkins-info>',
+  component: 'cc-jenkins-info',
+};
+
+const conf = {
+  component: 'cc-jenkins-info',
+  css: `
+    cc-jenkins-info {
+      margin-bottom: 1rem;
+    }
+  `,
+};
+
+const jenkinsLink = 'https://my-jenkins.example.com';
+const jenkinsManageLink = 'https://my-jenkins.example.com/manage';
+const differentVersions = { current: 'v2.1.3', available: 'v2.1.4' };
+const sameVersions = { current: 'v2.1.3', available: 'v2.1.3' };
+
+export const defaultStory = makeStory(conf, {
+  items: [{ jenkinsLink, jenkinsManageLink, versions: sameVersions }],
+});
+
+export const skeleton = makeStory(conf, {
+  items: [{}],
+});
+
+export const errorStory = makeStory(conf, {
+  items: [{ error: true }],
+});
+
+export const dataLoadedWithSameVersion = makeStory(conf, {
+  items: [{ jenkinsLink, jenkinsManageLink, versions: sameVersions }],
+});
+
+export const dataLoadedWithDifferentVersions = makeStory(conf, {
+  items: [{ jenkinsLink, jenkinsManageLink, versions: differentVersions }],
+});
+
+export const simulations = makeStory(conf, {
+  items: [
+    {},
+    {},
+    {},
+  ],
+  simulations: [
+    storyWait(2000, ([componentUpToDate, componentWithUpdate, componentError]) => {
+      componentUpToDate.jenkinsLink = jenkinsLink;
+      componentUpToDate.jenkinsManageLink = jenkinsManageLink;
+      componentUpToDate.versions = sameVersions;
+
+      componentWithUpdate.jenkinsLink = jenkinsLink;
+      componentWithUpdate.jenkinsManageLink = jenkinsManageLink;
+      componentWithUpdate.versions = differentVersions;
+
+      componentError.error = true;
+    }),
+  ],
+});
+
+enhanceStoriesNames({
+  defaultStory,
+  skeleton,
+  errorStory,
+  dataLoadedWithSameVersion,
+  dataLoadedWithDifferentVersions,
+  simulations,
+});


### PR DESCRIPTION
This PR adds a new component, named `<cc-jenkins-info>` with its smart definition.

This component will be used to display some information about a Jenkins add-on like the documentation link, the link to the Jenkins UI and some information about available updates.

This PR also bumps the `@clevercloud/client` dependency to `^7.6.0` as we need a new endpoint released in that version for the smart component.

Fix #272