### PR TITLE
refactor: use code folding regions in CSS (especially for responsive with COMMON/BIG/SMALL modes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ title: Changelog
 * refactor: try to use `?.` when it's a bit simpler
 * i18n: use Intl.PluralRules instead of custom code
 * refactor: move sub render methods `_renderFoo()` below the main `render()` method
+* refactor: use code folding regions in CSS (especially for responsive with COMMON/BIG/SMALL modes)
 
 ## 7.0.0 (2021-09-03)
 

--- a/docs/cc-example-component.js
+++ b/docs/cc-example-component.js
@@ -194,6 +194,29 @@ export class CcExampleComponent extends LitElement {
           /* You may use another display type but you need to define one. */
           display: block;
         }
+
+        /* You may use "regions" to help code editors fold main sections of your styles. It's often needed with responsive and COMMON/BIG/SMALL regions. */
+
+        /*region COMMON*/
+        .foobar {
+          color: red;
+        }
+
+        /*endregion*/
+
+        /*region BIG*/
+        .foobar.big {
+          color: blue;
+        }
+
+        /*endregion*/
+
+        /*region SMALL*/
+        .foobar.small {
+          color: green;
+        }
+
+        /*endregion*/
       `,
     ];
   }

--- a/src/invoices/cc-invoice-table.js
+++ b/src/invoices/cc-invoice-table.js
@@ -139,8 +139,10 @@ export class CcInvoiceTable extends withResizeObserver(LitElement) {
             <cc-img class="invoice-icon" src=${fileSvg}></cc-img>
             <div class="invoice-text ${classMap({ skeleton })}">
               ${i18n('cc-invoice-table.text', {
-      number: invoice.number, date: invoice.emissionDate, amount: invoice.total.amount,
-    })}
+                number: invoice.number,
+                date: invoice.emissionDate,
+                amount: invoice.total.amount,
+              })}
               <br>
               ${this._renderLinks(skeleton, invoice)}
             </div>
@@ -171,7 +173,8 @@ export class CcInvoiceTable extends withResizeObserver(LitElement) {
         :host {
           display: block;
         }
-        
+
+        /*region COMMON*/
         /* we should use a class (something like "number-value") but it's not possible right now in i18n */
         code {
           font-family: var(--cc-ff-monospace);
@@ -190,9 +193,10 @@ export class CcInvoiceTable extends withResizeObserver(LitElement) {
           --cc-gap: 1rem;
           --cc-align-items: center;
         }
-        
-        /* SMALL MODE */
 
+        /*endregion*/
+
+        /*region SMALL*/
         .invoice-list {
           display: grid;
           gap: 1.5rem;
@@ -231,14 +235,15 @@ export class CcInvoiceTable extends withResizeObserver(LitElement) {
           color: transparent;
         }
 
-        /* BIG MODE */
-        
+        /*endregion*/
+
+        /*region BIG*/
         table {
           border-collapse: collapse;
           border-radius: 5px;
           overflow: hidden;
         }
-        
+
         th,
         td {
           padding: 0.5rem 1rem;
@@ -256,7 +261,7 @@ export class CcInvoiceTable extends withResizeObserver(LitElement) {
         tr:not(:last-child) td {
           border-bottom: 1px solid #ddd;
         }
-        
+
         /* applied on th and td */
         .number {
           text-align: right;
@@ -266,7 +271,7 @@ export class CcInvoiceTable extends withResizeObserver(LitElement) {
           /* "-ø###,###.##" OR "-### ###,## ø" => 13ch */
           min-width: 13ch;
         }
-        
+
         tr:hover td {
           background-color: #f5f5f5;
         }
@@ -274,6 +279,8 @@ export class CcInvoiceTable extends withResizeObserver(LitElement) {
         table .skeleton {
           background-color: #bbb;
         }
+
+        /*endregion*/
       `,
     ];
   }

--- a/src/overview/cc-overview.js
+++ b/src/overview/cc-overview.js
@@ -56,7 +56,7 @@ export class CcOverview extends withResizeObserver(LitElement) {
         grid-gap: 1rem;
       }
 
-      /* GRID LAYOUT */
+      /*region GRID LAYOUT*/
       :host([w-lt-570]) {
         grid-template-columns: [main-start] 1fr [main-end];
       }
@@ -73,7 +73,9 @@ export class CcOverview extends withResizeObserver(LitElement) {
         grid-template-columns: [main-start] 1fr 1fr 1fr [main-end] 1fr;
       }
 
-      /* GRID LAYOUT (app) */
+      /*endregion*/
+
+      /*region GRID LAYOUT (app)*/
       :host([mode="app"][w-lt-570]) {
         grid-template-rows: repeat(calc(var(--cc-overview-head-count) + 6), min-content) [main-start] 1fr [main-end];
       }
@@ -90,7 +92,9 @@ export class CcOverview extends withResizeObserver(LitElement) {
         grid-template-rows: repeat(calc(var(--cc-overview-head-count) + 1), min-content) [main-start] 1fr 1fr [main-end];
       }
 
-      /* GRID LAYOUT (orga) */
+      /*endregion*/
+
+      /*region GRID LAYOUT (orga)*/
       :host([mode="orga"][w-lt-570]) {
         grid-template-rows: repeat(calc(var(--cc-overview-head-count) + 2), min-content) [main-start] 1fr [main-end];
       }
@@ -102,6 +106,8 @@ export class CcOverview extends withResizeObserver(LitElement) {
       :host([mode="orga"][w-gte-860]) {
         grid-template-rows: repeat(calc(var(--cc-overview-head-count) + 0), min-content) [main-start] 1fr 1fr [main-end];
       }
+
+      /*endregion*/
 
       /* .head TILE POSITION/SIZE */
       ::slotted(*.head) {

--- a/src/pricing/cc-pricing-estimation.js
+++ b/src/pricing/cc-pricing-estimation.js
@@ -271,12 +271,11 @@ export class CcPricingEstimation extends withResizeObserver(LitElement) {
     return [
       // language=CSS
       css`
-        /*#region COMMON*/
-
         :host {
           display: block;
         }
 
+        /*region COMMON*/
         .input-number {
           --cc-input-number-align: center;
           /* This is enough to display up to 999 */
@@ -354,10 +353,9 @@ export class CcPricingEstimation extends withResizeObserver(LitElement) {
           background-color: rgba(255, 255, 255, 0.1);
         }
 
-        /*#endregion*/
+        /*endregion*/
 
-        /*#region BIG*/
-
+        /*region BIG*/
         .number-align {
           text-align: right;
         }
@@ -411,10 +409,9 @@ export class CcPricingEstimation extends withResizeObserver(LitElement) {
           padding: 0.75em 1em;
         }
 
-        /*#endregion*/
+        /*endregion*/
 
-        /*#region SMALL*/
-
+        /*region SMALL*/
         .plan {
           align-items: center;
           border-top: 1px solid #e5e5e5;
@@ -485,7 +482,7 @@ export class CcPricingEstimation extends withResizeObserver(LitElement) {
           padding: 0.75em 1em;
         }
 
-        /*#endregion*/
+        /*endregion*/
       `,
     ];
   }

--- a/src/pricing/cc-pricing-product-consumption.js
+++ b/src/pricing/cc-pricing-product-consumption.js
@@ -438,8 +438,6 @@ export class CcPricingProductConsumption extends withResizeObserver(LitElement) 
       skeletonStyles,
       // language=CSS
       css`
-        /*#region COMMON*/
-
         :host {
           background-color: #fff;
           display: block;
@@ -449,6 +447,7 @@ export class CcPricingProductConsumption extends withResizeObserver(LitElement) 
           --cc-skeleton-state: paused;
         }
 
+        /*region COMMON*/
         .head {
           border-radius: 0.25em;
           display: grid;
@@ -647,10 +646,9 @@ export class CcPricingProductConsumption extends withResizeObserver(LitElement) 
           background-color: #bbb;
         }
 
-        /*#endregion COMMON*/
+        /*endregion*/
 
-        /*#region BIG*/
-
+        /*region BIG*/
         .body--big {
           grid-template-columns:
             1em
@@ -687,10 +685,9 @@ export class CcPricingProductConsumption extends withResizeObserver(LitElement) 
           margin-left: 2em;
         }
 
-        /*#endregion BIG*/
+        /*endregion*/
 
-        /*#region SMALL*/
-
+        /*region SMALL*/
         .body--small {
           grid-template-columns:
             1em
@@ -731,7 +728,7 @@ export class CcPricingProductConsumption extends withResizeObserver(LitElement) 
           display: none;
         }
 
-        /*#endregion SMALL*/
+        /*endregion*/
       `,
     ];
   }

--- a/src/pricing/cc-pricing-table.js
+++ b/src/pricing/cc-pricing-table.js
@@ -289,6 +289,7 @@ export class CcPricingTable extends withResizeObserver(LitElement) {
           display: block;
         }
 
+        /*region COMMON*/
         .number-align {
           text-align: right;
         }
@@ -305,8 +306,9 @@ export class CcPricingTable extends withResizeObserver(LitElement) {
           font-weight: bold;
         }
 
-        /* BIG SIZE */
+        /*endregion*/
 
+        /*region BIG*/
         table {
           border-collapse: collapse;
           border-spacing: 0;
@@ -347,8 +349,9 @@ export class CcPricingTable extends withResizeObserver(LitElement) {
           position: absolute;
         }
 
-        /* SMALL SIZE */
+        /*endregion*/
 
+        /*region SMALL*/
         .plan {
           align-items: center;
           border-top: 1px solid #e5e5e5;
@@ -420,6 +423,8 @@ export class CcPricingTable extends withResizeObserver(LitElement) {
         .plan[data-state="opened"] .feature-value {
           margin-right: 0.5em;
         }
+
+        /*endregion*/
       `,
     ];
   }


### PR DESCRIPTION
Fixes #282 (must merge #315 before)