### PR TITLE
Change .input display to flex

### DIFF
--- a/src/atoms/cc-input-text.js
+++ b/src/atoms/cc-input-text.js
@@ -329,7 +329,7 @@ export class CcInputText extends LitElement {
           background: #fff;
           border: 1px solid #000;
           box-sizing: border-box;
-          display: block;
+          display: flex;
           font-family: monospace;
           font-size: unset;
           margin: 0;


### PR DESCRIPTION
fix #321 

### flex and not inline-flex
`inline-flex` also works but as the wrapper is a grid with two elements with the same grid area, both rules will produce the same effect, so it is wise to use the shorter of the two

## Other possibility
It is also possible to change the `white-space` rule of .input-underlayer from `pre-wrap` to `normal`. 