### PR TITLE
cc-input-text: fix tags underline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ title: Changelog
   * add `temporality` feature
   * add plans and features for Jenkins runner (hard coded in the smart definition)
 * `<cc-pricing-product-consumption>`: fix plan name for non bytes with cc-pricing-product:add-plan event
+* `<cc-input-text>`: fix tags underline
 
 ### For devs
 

--- a/src/atoms/cc-input-text.js
+++ b/src/atoms/cc-input-text.js
@@ -218,9 +218,9 @@ export class CcInputText extends LitElement {
                 We use this to display colored background rectangles behind space separated values. 
                 This needs to be on the same line and the 2 level parent is important to keep scroll behaviour.
               -->
-              <div class="input input-underlayer" style="--rows: ${rows}">
-                <div class="all-tags">${tags}</div>
-              </div>
+              <div class="input input-underlayer" style="--rows: ${rows}"><!--
+                --><div class="all-tags">${tags}</div><!--
+              --></div>
             ` : ''}
             <textarea
               id=${this._uniqueName}


### PR DESCRIPTION
Thanks to @antoinemialot PR #322 I finally took time to fix #321.
It was a regression in c5e51e8557b01a87f143904669439f355fd95e46.
This solution is fragile. We'll have to address it someday.