### PR TITLE
moved typedef imports to above class declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ title: Changelog
 * Improve type definitions documentation:
   * move types to a `types.d.ts` for each web components section
   * add a script to automate type definition generation
+  * moved typedef imports to above class declaration to avoid events not showing up on the docs 
 
 ## 7.6.0 (2021-10-28)
 

--- a/docs/cc-example-component.js
+++ b/docs/cc-example-component.js
@@ -19,6 +19,10 @@ const SKELETON_FOOBAR = [
 ];
 
 /**
+ * @typedef {import('./types.js').ExampleInterface} ExampleInterface
+ */
+
+/**
  * A component doing X and Y (one liner description of your component).
  *
  * ## Details
@@ -32,8 +36,6 @@ const SKELETON_FOOBAR = [
  * * Technical details about foo.
  * * Technical details about bar.
  * * Technical details about baz.
- *
- * @typedef {import('./types.js').ExampleInterface} ExampleInterface
  *
  * @cssdisplay block
  *

--- a/src/addon/cc-addon-admin.js
+++ b/src/addon/cc-addon-admin.js
@@ -8,14 +8,18 @@ import { dispatchCustomEvent } from '../lib/events.js';
 import { i18n } from '../lib/i18n.js';
 
 /**
+ * @typedef {import('./types.js').Addon} Addon
+ * @typedef {import('./types.js').ErrorType} ErrorType
+ */
+
+/**
  * A component displaying the admin interface of an add-on to edit its name or delete the add-on.
  *
  * ## Details
  *
  * * When addon is nullish, a skeleton screen UI pattern is displayed (loading hint).
  *
- * @typedef {import('./types.js').Addon} Addon
- * @typedef {import('./types.js').ErrorType} ErrorType
+
  *
  * @cssdisplay block
  *

--- a/src/addon/cc-addon-backups.js
+++ b/src/addon/cc-addon-backups.js
@@ -21,15 +21,17 @@ const SKELETON_BACKUPS = {
 };
 
 /**
+ * @typedef {import('./types.js').BackupDetails} BackupDetails
+ * @typedef {import('./types.js').Backup} Backup
+ * @typedef {import('./types.js').OverlayType} OverlayType
+ */
+
+/**
  * A components to display backups available for an add-on.
  *
  * ## Details
  *
  * * When `backups` is nullish, a skeleton screen UI pattern is displayed (loading hint).
- *
- * @typedef {import('./types.js').BackupDetails} BackupDetails
- * @typedef {import('./types.js').Backup} Backup
- * @typedef {import('./types.js').OverlayType} OverlayType
  *
  * @cssdisplay grid
  */

--- a/src/addon/cc-addon-credentials.js
+++ b/src/addon/cc-addon-credentials.js
@@ -8,15 +8,17 @@ import { i18n } from '../lib/i18n.js';
 import { skeletonStyles } from '../styles/skeleton.js';
 
 /**
+ * @typedef {import('./types.js').Credential} Credential
+ * @typedef {import('../types.js').ToggleStateType} ToggleStateType
+ * @typedef {import('./types.js').AddonType} AddonType
+ */
+
+/**
  * A component to display an add-on credentials.
  *
  * ## Details
  *
  * * When the `value` of a credential is nullish, a skeleton UI pattern is displayed (loading hint).
- *
- * @typedef {import('./types.js').Credential} Credential
- * @typedef {import('../types.js').ToggleStateType} ToggleStateType
- * @typedef {import('./types.js').AddonType} AddonType
  *
  * @cssdisplay block
  */

--- a/src/addon/cc-addon-elasticsearch-options.js
+++ b/src/addon/cc-addon-elasticsearch-options.js
@@ -9,10 +9,12 @@ const KIBANA_LOGO_URL = 'https://static-assets.cellar.services.clever-cloud.com/
 const APM_LOGO_URL = 'https://static-assets.cellar.services.clever-cloud.com/logos/elasticsearch-apm.svg';
 
 /**
- * A component that displays the available options of an elasticsearch add-on.
- *
  * @typedef {import('./types.js').Option} Option
  * @typedef {import('./types.js').ElasticOptions} ElasticOptions
+ */
+
+/**
+ * A component that displays the available options of an elasticsearch add-on.
  *
  * @cssdisplay block
  *

--- a/src/addon/cc-addon-features.js
+++ b/src/addon/cc-addon-features.js
@@ -29,6 +29,10 @@ const SKELETON_FEATURES = [
 ];
 
 /**
+ * @typedef {import('./types.js').Feature} Feature
+ */
+
+/**
  * A component to display an add-on set of features.
  *
  * ## Details
@@ -36,8 +40,6 @@ const SKELETON_FEATURES = [
  * * When `features` is nullish, a skeleton screen UI pattern is displayed (loading hint).
  * * We don't have a proper i18n and icon system for feature names. For the time being, the (lower cased) name is used as some kind of code to match an icon and maybe translate the name of the feature.
  * * We don't have a proper i18n system for feature values. For the time being, the (lower cased) value is used as some kind of code to maybe translate the value of the feature.
- *
- * @typedef {import('./types.js').Feature} Feature
  *
  * @cssdisplay block
  */

--- a/src/addon/cc-addon-jenkins-options.js
+++ b/src/addon/cc-addon-jenkins-options.js
@@ -6,10 +6,12 @@ import { i18n } from '../lib/i18n.js';
 import { ccAddonEncryptionAtRestOption } from '../templates/cc-addon-encryption-at-rest-option.js';
 
 /**
- * A component that displays the available options of a Jenkins add-on.
- *
  * @typedef {import('./types.js').Option} Option
  * @typedef {import('./types.js').GenericOptions} GenericOptions
+ */
+
+/**
+ * A component that displays the available options of a Jenkins add-on.
  *
  * @cssdisplay block
  *

--- a/src/addon/cc-addon-linked-apps.js
+++ b/src/addon/cc-addon-linked-apps.js
@@ -17,13 +17,15 @@ const SKELETON_APPLICATIONS = [
 ];
 
 /**
+ * @typedef {import('../types.js').Application} Application
+ */
+
+/**
  * A component to display applications linked to an add-on.
  *
  * ## Details
  *
  * * When applications is nullish, a skeleton screen UI pattern is displayed (loading hint).
- *
- * @typedef {import('../types.js').Application} Application
  *
  * @cssdisplay block
  */

--- a/src/addon/cc-addon-mongodb-options.js
+++ b/src/addon/cc-addon-mongodb-options.js
@@ -6,10 +6,11 @@ import { i18n } from '../lib/i18n.js';
 import { ccAddonEncryptionAtRestOption } from '../templates/cc-addon-encryption-at-rest-option.js';
 
 /**
- * A component that displays the available options of a MongoDB add-on.
- *
  * @typedef {import('./types.js').Option} Option
  * @typedef {import('./types.js').GenericOptions} GenericOptions
+ */
+/**
+ * A component that displays the available options of a MongoDB add-on.
  *
  * @cssdisplay block
  *

--- a/src/addon/cc-addon-mysql-options.js
+++ b/src/addon/cc-addon-mysql-options.js
@@ -6,10 +6,12 @@ import { i18n } from '../lib/i18n.js';
 import { ccAddonEncryptionAtRestOption } from '../templates/cc-addon-encryption-at-rest-option.js';
 
 /**
- * A component that displays the available options of a MySQL add-on.
- *
  * @typedef {import('./types.js').Option} Option
  * @typedef {import('./types.js').GenericOptions} GenericOptions
+ */
+
+/**
+ * A component that displays the available options of a MySQL add-on.
  *
  * @cssdisplay block
  *

--- a/src/addon/cc-addon-option-form.js
+++ b/src/addon/cc-addon-option-form.js
@@ -7,9 +7,11 @@ import { i18n } from '../lib/i18n.js';
 import { linkStyles } from '../templates/cc-link.js';
 
 /**
- * A component that displays a form of `<cc-addon-option>`.
- *
  * @typedef {import('./types.js').Option} Option
+ */
+
+/**
+ * A component that displays a form of `<cc-addon-option>`.
  *
  * @cssdisplay block
  *

--- a/src/addon/cc-addon-postgresql-options.js
+++ b/src/addon/cc-addon-postgresql-options.js
@@ -6,10 +6,12 @@ import { i18n } from '../lib/i18n.js';
 import { ccAddonEncryptionAtRestOption } from '../templates/cc-addon-encryption-at-rest-option.js';
 
 /**
- * A component that displays the available options of a PostgreSQL add-on.
- *
  * @typedef {import('./types.js').Option} Option
  * @typedef {import('./types.js').GenericOptions} GenericOptions
+ */
+
+/**
+ * A component that displays the available options of a PostgreSQL add-on.
  *
  * @cssdisplay block
  *

--- a/src/addon/cc-addon-redis-options.js
+++ b/src/addon/cc-addon-redis-options.js
@@ -6,10 +6,12 @@ import { i18n } from '../lib/i18n.js';
 import { ccAddonEncryptionAtRestOption } from '../templates/cc-addon-encryption-at-rest-option.js';
 
 /**
- * A component that displays the available options of a Redis add-on.
- *
  * @typedef {import('./types.js').Option} Option
  * @typedef {import('./types.js').GenericOptions} GenericOptions
+ */
+
+/**
+ * A component that displays the available options of a Redis add-on.
  *
  * @cssdisplay block
  *

--- a/src/addon/cc-elasticsearch-info.js
+++ b/src/addon/cc-elasticsearch-info.js
@@ -16,14 +16,16 @@ const APM_LOGO_URL = 'https://static-assets.cellar.services.clever-cloud.com/log
 const ELASTICSEARCH_DOCUMENTATION = 'https://www.clever-cloud.com/doc/addons/elastic/';
 
 /**
+ * @typedef {import('./types.js').Link} Link
+ */
+
+/**
  * A component to display various links (Documentation, kibana, APM) for an elasticsearch service.
  *
  * ## Details
  *
  * * You need to list the links you want to display in `links`.
  * * You can omit the `href` property while you wait for the real link, a skeleton UI (loading hint) will be displayed.
- *
- * @typedef {import('./types.js').Link} Link
  *
  * @cssdisplay block
  */

--- a/src/addon/cc-header-addon.js
+++ b/src/addon/cc-header-addon.js
@@ -21,13 +21,15 @@ const SKELETON_ADDON = {
 const SKELETON_VERSION = '????????';
 
 /**
+ * @typedef {import('./types.js').Addon} Addon
+ */
+
+/**
  * A component to display various info about an add-on (name, plan, version...).
  *
  * ## Details
  *
  * * When `addon` or `version` are null, a skeleton screen UI pattern is displayed (loading hint) on the corresponding zone.
- *
- * @typedef {import('./types.js').Addon} Addon
  *
  * @cssdisplay block
  */

--- a/src/addon/cc-jenkins-info.js
+++ b/src/addon/cc-jenkins-info.js
@@ -14,9 +14,11 @@ const JENKINS_LOGO_URL = 'https://static-assets.cellar.services.clever-cloud.com
 const JENKINS_DOCUMENTATION = 'https://www.clever-cloud.com/doc/deploy/addon/jenkins/';
 
 /**
- * A component to display various informations (Documentation, access, updates, ...) for a Jenkins service.
- *
  * @typedef {import('./types.js').Versions} Versions
+ */
+
+/**
+ * A component to display various informations (Documentation, access, updates, ...) for a Jenkins service.
  *
  * @cssdisplay block
  */

--- a/src/atoms/cc-beta.js
+++ b/src/atoms/cc-beta.js
@@ -2,9 +2,11 @@ import { css, html, LitElement } from 'lit-element';
 import { i18n } from '../lib/i18n.js';
 
 /**
- * A layout component to position a simple beta ribbon around any content.
- *
  * @typedef {import('./types.js').PositionType} PositionType
+ */
+
+/**
+ * A layout component to position a simple beta ribbon around any content.
  *
  * @cssdisplay grid
  *

--- a/src/atoms/cc-html-frame.js
+++ b/src/atoms/cc-html-frame.js
@@ -3,9 +3,11 @@ import { ifDefined } from 'lit-html/directives/if-defined.js';
 import './cc-loader.js';
 
 /**
- * A low level component that takes some HMTL and puts it in an iframe.
- *
  * @typedef {import('./types.js').IframeSandbox} IframeSandbox
+ */
+
+/**
+ * A low level component that takes some HMTL and puts it in an iframe.
  *
  * ## Details
  *

--- a/src/atoms/cc-toggle.js
+++ b/src/atoms/cc-toggle.js
@@ -5,6 +5,10 @@ import { repeat } from 'lit-html/directives/repeat.js';
 import { dispatchCustomEvent } from '../lib/events.js';
 
 /**
+ * @typedef {import('./types.js').Choice} Choice
+ */
+
+/**
  * A radio/checkbox input group component acting like a toggle between many options.
  *
  * ## When to use?
@@ -23,8 +27,6 @@ import { dispatchCustomEvent } from '../lib/events.js';
  * * Single mode (default) uses native `input[type=radio]` under the hood to keep native behaviour (a11y, keyboards...).
  * * Multiple mode uses native `input[type=checkbox]` under the hood to keep native behaviour (a11y, keyboards...).
  * * We decided to use a JavaScript array of objects for the choices because it's way simpler to implement and not that dirtier to use.
- *
- * @typedef {import('./types.js').Choice} Choice
  *
  * @cssdisplay flex
  *

--- a/src/env-var/cc-env-var-create.js
+++ b/src/env-var/cc-env-var-create.js
@@ -9,14 +9,16 @@ import { i18n } from '../lib/i18n.js';
 import { defaultThemeStyles } from '../styles/default-theme.js';
 
 /**
+ * @typedef {import('./types.js').Variable} Variable
+ */
+
+/**
  * A small form to create a new environment variable with validations on the name.
  *
  * ## Details
  *
  * * The validation of the variable name format is handled with [@clevercloud/client](https://github.com/CleverCloud/clever-client.js/blob/master/esm/utils/env-vars.js)
  * * The validation of existing names is handled with the `variablesNames` property which is a list of already existing names.
- *
- * @typedef {import('./types.js').Variable} Variable
  *
  * @cssdisplay block
  *

--- a/src/env-var/cc-env-var-editor-expert.js
+++ b/src/env-var/cc-env-var-editor-expert.js
@@ -14,10 +14,12 @@ const SKELETON_VARIABLES = [
 ];
 
 /**
- * A high level environment variable editor to create/edit/delete all variables at once as a big string (properly parsed with validation and error messages).
- *
  * @typedef {import('./types.js').ParseError} ParseError
  * @typedef {import('./types.js').Variable} Variable
+ */
+
+/**
+ * A high level environment variable editor to create/edit/delete all variables at once as a big string (properly parsed with validation and error messages).
  *
  * @cssdisplay block / none (with `[hidden]`)
  *

--- a/src/env-var/cc-env-var-editor-simple.js
+++ b/src/env-var/cc-env-var-editor-simple.js
@@ -12,9 +12,11 @@ const SKELETON_VARIABLES = [
 ];
 
 /**
- * A high level environment variable editor to create/edit/delete variables one at a time (with validation and error messages).
- *
  * @typedef {import('./types.js').Variable} Variable
+ */
+
+/**
+ * A high level environment variable editor to create/edit/delete variables one at a time (with validation and error messages).
  *
  * @cssdisplay grid / none (with `[hidden]`)
  *

--- a/src/env-var/cc-env-var-form.js
+++ b/src/env-var/cc-env-var-form.js
@@ -13,16 +13,18 @@ import { i18n } from '../lib/i18n.js';
 import { linkStyles } from '../templates/cc-link.js';
 
 /**
+ * @typedef {import('./types.js').ContextType} ContextType
+ * @typedef {import('./types.js').ErrorType} ErrorType
+ * @typedef {import('./types.js').Variable} Variable
+ */
+
+/**
  * A high level environment variable form (wrapping simple editor and expert editor into one interface).
  *
  * ## Details
  *
  * * You can set a custom `heading` and description with the default <slot>.
  * * You can also set a context to get the appropriate heading and description (with translations).
- *
- * @typedef {import('./types.js').ContextType} ContextType
- * @typedef {import('./types.js').ErrorType} ErrorType
- * @typedef {import('./types.js').Variable} Variable
  *
  * @cssdisplay block
  *

--- a/src/env-var/cc-env-var-input.js
+++ b/src/env-var/cc-env-var-input.js
@@ -9,10 +9,12 @@ import { defaultThemeStyles } from '../styles/default-theme.js';
 import { skeletonStyles } from '../styles/skeleton.js';
 
 /**
- * A small input to manipulate an environement variable.
- *
  * @typedef {import('./types.js').Variable} Variable
  * @typedef {import('./types.js').VariableName} VariableName
+ */
+
+/**
+ * A small input to manipulate an environement variable.
  *
  * @cssdisplay block
  *

--- a/src/env-var/cc-env-var-linked-services.js
+++ b/src/env-var/cc-env-var-linked-services.js
@@ -6,10 +6,12 @@ import { ifDefined } from 'lit-html/directives/if-defined.js';
 import { i18n } from '../lib/i18n.js';
 
 /**
- * A component to display groups of readonly `<cc-env-var-form>` for linked apps of add-ons.
- *
  * @typedef {import('./types.js').EnvType} EnvType
  * @typedef {import('./types.js').Service} Service
+ */
+
+/**
+ * A component to display groups of readonly `<cc-env-var-form>` for linked apps of add-ons.
  *
  * ## Details
  *

--- a/src/invoices/cc-invoice-list.js
+++ b/src/invoices/cc-invoice-list.js
@@ -21,9 +21,11 @@ function maxFromStrings (strings) {
 }
 
 /**
- * A component to display a list of invoices in paginated categories.
- *
  * @typedef {import('./types.js').Invoice} Invoice
+ */
+
+/**
+ * A component to display a list of invoices in paginated categories.
  *
  * @cssdisplay block
  */

--- a/src/invoices/cc-invoice-table.js
+++ b/src/invoices/cc-invoice-table.js
@@ -26,9 +26,11 @@ const SKELETON_INVOICES = [
 ];
 
 /**
- * A table component to display a list of invoices.
- *
  * @typedef {import('./types.js').Invoice} Invoice
+ */
+
+/**
+ * A table component to display a list of invoices.
  *
  * @cssdisplay block
  */

--- a/src/invoices/cc-invoice.js
+++ b/src/invoices/cc-invoice.js
@@ -20,10 +20,12 @@ const SKELETON_INVOICE = {
 };
 
 /**
- * A block component to display an HTML invoice.
- *
  * @typedef {import('./types.js').Amount} Amount
  * @typedef {import('./types.js').Invoice} Invoice
+ */
+
+/**
+ * A block component to display an HTML invoice.
  *
  * @cssdisplay block
  */

--- a/src/maps/cc-logsmap.js
+++ b/src/maps/cc-logsmap.js
@@ -6,6 +6,13 @@ import { dispatchCustomEvent } from '../lib/events.js';
 import { i18n } from '../lib/i18n.js';
 
 /**
+ * @typedef {import('./types.js').HeatmapPoint} HeatmapPoint
+ * @typedef {import('./types.js').MapModeType} MapModeType
+ * @typedef {import('./types.js').Point} Point
+ * @typedef {import('./types.js').PointsOptions} PointsOptions
+ */
+
+/**
  * World map of access logs with two modes: blinking dots or heatmap.
  *
  * ## Details
@@ -14,11 +21,6 @@ import { i18n } from '../lib/i18n.js';
  * * It has predefined i18n label for the toggle and the legend (to display logs).
  * * The legend is contextualized to an organization or an app so you MUST set either `orgaName` or `appName` but not both.
  * * The component has a default height of 15rem and a default width 20rem but this can be overridden with CSS.
- *
- * @typedef {import('./types.js').HeatmapPoint} HeatmapPoint
- * @typedef {import('./types.js').MapModeType} MapModeType
- * @typedef {import('./types.js').Point} Point
- * @typedef {import('./types.js').PointsOptions} PointsOptions
  *
  * @cssdisplay block
  *

--- a/src/maps/cc-map-marker-server.js
+++ b/src/maps/cc-map-marker-server.js
@@ -1,13 +1,15 @@
 import { css, LitElement, svg } from 'lit-element';
 
 /**
+ * @typedef {import('./types.js').MarkerStateType} MarkerStateType
+ */
+
+/**
  * A map marker displayed as a server inside a bubble with blinking dots for LEDs when state is "selected".
  *
  * ## Technical details
  *
  * * `size`, `anchor` and `tooltip` are readonly.
- *
- * @typedef {import('./types.js').MarkerStateType} MarkerStateType
  *
  * @cssdisplay inline-block
  */

--- a/src/maps/cc-map.js
+++ b/src/maps/cc-map.js
@@ -10,6 +10,12 @@ import { withResizeObserver } from '../mixins/with-resize-observer.js';
 import { leafletStyles } from '../styles/leaflet.js';
 
 /**
+ * @typedef {import('./types.js').HeatmapPoint} HeatmapPoint
+ * @typedef {import('./types.js').MapModeType} MapModeType
+ * @typedef {import('./types.js').Point} Point
+ */
+
+/**
  * World map with two modes: positioned markers or heatmap.
  *
  * ## Details
@@ -18,10 +24,6 @@ import { leafletStyles } from '../styles/leaflet.js';
  * * When using `points`, you need to specify which HTML tag should be used to create and display the marker.
  * * The marker DOM element should expose `size`, `anchor` and `tooltip` to help this component place the marker and tooltip correctly on the map.
  * * When using `points`, you can specify some text for the tooltip but you can also specify which HTML tag to use to create and display the tooltip.
- *
- * @typedef {import('./types.js').HeatmapPoint} HeatmapPoint
- * @typedef {import('./types.js').MapModeType} MapModeType
- * @typedef {import('./types.js').Point} Point
  *
  * @cssdisplay flex
  *

--- a/src/molecules/cc-block.js
+++ b/src/molecules/cc-block.js
@@ -9,13 +9,15 @@ const downSvg = new URL('../assets/down.svg', import.meta.url).href;
 const upSvg = new URL('../assets/up.svg', import.meta.url).href;
 
 /**
+ * @typedef {import('../types.js').ToggleStateType} ToggleStateType
+ */
+
+/**
  * A display component with mostly HTML+CSS and a open/close toggle feature.
  *
  * ## Details
  *
  * * The main section is wrapped in a `<cc-expand>` so variation of this section height will be animated.
- *
- * @typedef {import('../types.js').ToggleStateType} ToggleStateType
  *
  * @cssdisplay grid
  *

--- a/src/molecules/cc-error.js
+++ b/src/molecules/cc-error.js
@@ -7,6 +7,10 @@ import { i18n } from '../lib/i18n.js';
 const warningSvg = new URL('../assets/warning.svg', import.meta.url).href;
 
 /**
+ * @typedef {import('./types.js').ErrorModeType} ErrorModeType
+ */
+
+/**
  * A display component for error messages with 4 modes: inline (default), info, loading or confirm.
  *
  * ## Details
@@ -15,8 +19,6 @@ const warningSvg = new URL('../assets/warning.svg', import.meta.url).href;
  * * Use `"info"` when you want to display the message in a bordered "box".
  * * Use `"loading"` when you want to display the message in a bordered "box" with a loader.
  * * Use `"confirm"` when you want to display the message in a bordered "box" with a confirm "OK" button.
- *
- * @typedef {import('./types.js').ErrorModeType} ErrorModeType
  *
  * @cssdisplay block
  *

--- a/src/overview/cc-header-app.js
+++ b/src/overview/cc-header-app.js
@@ -45,16 +45,18 @@ const SKELETON_APP = {
 const SKELETON_STATUS = 'unknown';
 
 /**
+ * @typedef {import('../types.js').App} App
+ * @typedef {import('../types.js').AppStatus} AppStatus
+ * @typedef {import('../types.js').Zone} Zone
+ */
+
+/**
  * A component to display various info about an app (name, commits, status...).
  *
  * ## Details
  *
  * * When `app` and `status` are null, a skeleton screen UI pattern is displayed (loading hint).
  * * When only `status` is null, a skeleton screen UI pattern is displayed on the buttons and status message.
- *
- * @typedef {import('../types.js').App} App
- * @typedef {import('../types.js').AppStatus} AppStatus
- * @typedef {import('../types.js').Zone} Zone
  *
  * @cssdisplay block
  *

--- a/src/overview/cc-header-orga.js
+++ b/src/overview/cc-header-orga.js
@@ -15,13 +15,15 @@ const SKELETON_ORGA = {
 };
 
 /**
+ * @typedef {import('../types.js').Organisation} Organisation
+ */
+
+/**
  * A component to display various info about an orga (name and enterprise status).
  *
  * ## Details
  *
  * * When `orga` is nullish, a skeleton screen UI pattern is displayed (loading hint)
- *
- * @typedef {import('../types.js').Organisation} Organisation
  *
  * @cssdisplay block
  */

--- a/src/overview/cc-overview.js
+++ b/src/overview/cc-overview.js
@@ -2,6 +2,10 @@ import { css, html, LitElement } from 'lit-element';
 import { withResizeObserver } from '../mixins/with-resize-observer.js';
 
 /**
+ * @typedef {import('./types.js').ModeType} ModeType
+ */
+
+/**
  * A display only component (just HTML+CSS) to layout heads, a main and several tiles.
  *
  * ## Details
@@ -13,8 +17,6 @@ import { withResizeObserver } from '../mixins/with-resize-observer.js';
  * * The number of columns is variable and depends directly on the width of the component (with some help from `withResizeObserver`).
  * * `mode="app"` for 6 tiles
  * * `mode="orga"` for 2 tiles
- *
- * @typedef {import('./types.js').ModeType} ModeType
  *
  * @cssdisplay grid
  *

--- a/src/overview/cc-tile-consumption.js
+++ b/src/overview/cc-tile-consumption.js
@@ -12,13 +12,15 @@ const SKELETON_CONSUMPTION = {
 };
 
 /**
+ * @typedef {import('./types.js').Consumption} Consumption
+ */
+
+/**
  * A "tile" component to display consumption info (yesterday and over last 30 days).
  *
  * ## Details
  *
  * * When `consumption` is nullish, a skeleton screen UI pattern is displayed (loading hint).
- *
- * @typedef {import('./types.js').Consumption} Consumption
  *
  * @cssdisplay grid
  */

--- a/src/overview/cc-tile-deployments.js
+++ b/src/overview/cc-tile-deployments.js
@@ -13,13 +13,15 @@ const SKELETON_DEPLOYS = [
 ];
 
 /**
+ * @typedef {import('./types.js').Deployment} Deployment
+ */
+
+/**
  * A "tile" component to display a list of deployments (status, humanized time ago and logs link).
  *
  * ## Details
  *
  * * When `deployments` is nullish, a skeleton screen UI pattern is displayed (loading hint)
- *
- * @typedef {import('./types.js').Deployment} Deployment
  *
  * @cssdisplay grid
  */

--- a/src/overview/cc-tile-instances.js
+++ b/src/overview/cc-tile-instances.js
@@ -23,13 +23,15 @@ const SKELETON_INSTANCES = {
 };
 
 /**
+ * @typedef {import('./types.js').InstancesState} InstancesState
+ */
+
+/**
  * A "tile" component to display current status of running and deploying instances for a given app.
  *
  * ## Details
  *
  * * When `instances` is nullish, a loader is displayed.
- *
- * @typedef {import('./types.js').InstancesState} InstancesState
  *
  * @cssdisplay grid
  */

--- a/src/overview/cc-tile-requests.js
+++ b/src/overview/cc-tile-requests.js
@@ -20,6 +20,10 @@ const SKELETON_REQUESTS = Array
   .map(() => [0, 0, 1]);
 
 /**
+ * @typedef {import('./types.js').RequestsData} RequestsData
+ */
+
+/**
  * A "tile" component to display HTTP requests distribution over the last 24 hours in a bar chart.
  *
  * ## Details
@@ -30,8 +34,6 @@ const SKELETON_REQUESTS = Array
  *   * 6 bars of 4 hours
  *   * 8 bars of 3 hours
  *   * 12 bars of 2 hours
- *
- * @typedef {import('./types.js').RequestsData} RequestsData
  *
  * @cssdisplay grid
  */

--- a/src/overview/cc-tile-scalability.js
+++ b/src/overview/cc-tile-scalability.js
@@ -15,13 +15,15 @@ const SKELETON_SCALABILITY = {
 };
 
 /**
+ * @typedef {import('./types.js').Scalability} Scalability
+ */
+
+/**
  * A "tile" component to display the current config of scalability for a given app.
  *
  * ## Details
  *
  * * When `scalability` is nullish, a skeleton screen UI pattern is displayed (loading hint).
- *
- * @typedef {import('./types.js').Scalability} Scalability
  *
  * @cssdisplay grid
  */

--- a/src/overview/cc-tile-status-codes.js
+++ b/src/overview/cc-tile-status-codes.js
@@ -30,14 +30,16 @@ const COLORS = {
 const SKELETON_STATUS_CODES = { 200: 1 };
 
 /**
+ * @typedef {import('./types.js').StatusCodesData} StatusCodesData
+ */
+
+/**
  * A "tile" component to display HTTP response status codes in a pie chart (donut).
  *
  * ## Details
 
  * * When `data` is nullish, a skeleton screen UI pattern is displayed (loading hint).
  * * A short doc is available when the (i) button is clicked.
- *
- * @typedef {import('./types.js').StatusCodesData} StatusCodesData
  *
  * @cssdisplay grid
  */

--- a/src/pricing/cc-pricing-estimation.js
+++ b/src/pricing/cc-pricing-estimation.js
@@ -16,10 +16,12 @@ const CONTACT_URL = 'https://www.clever-cloud.com/en/contact-sales';
 const SIGN_UP_URL = 'https://api.clever-cloud.com/v2/sessions/signup';
 
 /**
- * A component to display a list of selected product plans with the ability to change their quantity or remove them from the list.
- *
  * @typedef {import('./types.js').Currency} Currency
  * @typedef {import('./types.js').Plan} Plan
+ */
+
+/**
+ * A component to display a list of selected product plans with the ability to change their quantity or remove them from the list.
  *
  * @cssdisplay block
  *

--- a/src/pricing/cc-pricing-header.js
+++ b/src/pricing/cc-pricing-header.js
@@ -20,11 +20,13 @@ const SKELETON_ZONES = [];
 const CURRENCY_EUR = { code: 'EUR', changeRate: 1 };
 
 /**
- * A component that displays a total price and allows the selection of a currency and a zone.
- *
  * @typedef {import('./types.js').Currency} Currency
  * @typedef {import('./types.js').Plan} Plan
  * @typedef {import('../types.js').Zone} Zone
+ */
+
+/**
+ * A component that displays a total price and allows the selection of a currency and a zone.
  *
  * @cssdisplay block
  *

--- a/src/pricing/cc-pricing-page.js
+++ b/src/pricing/cc-pricing-page.js
@@ -8,10 +8,12 @@ import { dispatchCustomEvent } from '../lib/events.js';
 const CURRENCY_EUR = { code: 'EUR', changeRate: 1 };
 
 /**
- * A component to display a pricing simulator with a list of `<cc-pricing-product>` in the default slot.
- *
  * @typedef {import('./types.js').Currency} Currency
  * @typedef {import('../types.js').Zone} Zone
+ */
+
+/**
+ * A component to display a pricing simulator with a list of `<cc-pricing-product>` in the default slot.
  *
  * @cssdisplay block
  *

--- a/src/pricing/cc-pricing-product-consumption.js
+++ b/src/pricing/cc-pricing-product-consumption.js
@@ -44,6 +44,14 @@ const SKELETON_INTERVALS = [
 ];
 
 /**
+ * @typedef {import('./types.js').ActionType} ActionType
+ * @typedef {import('./types.js').Interval} Interval
+ * @typedef {import('./types.js').Currency} Currency
+ * @typedef {import('./types.js').Plan} Plan
+ * @typedef {import('./types.js').Section} Section
+ */
+
+/**
  * A component to simulate pricing for products with consumption based pricings (Cellar, FS Buckets, Pulsar...).
  *
  * ## Details
@@ -52,12 +60,6 @@ const SKELETON_INTERVALS = [
  * * Interval ranges are defined in bytes.
  * * To comply with `<cc-pricing-product>`, the price in the event `cc-pricing-product:add-plan` is in "euros / 1 hour".
  * * When a section has a nullish `intervals`, a skeleton screen UI pattern is displayed for this section (loading hint).
- *
- * @typedef {import('./types.js').ActionType} ActionType
- * @typedef {import('./types.js').Interval} Interval
- * @typedef {import('./types.js').Currency} Currency
- * @typedef {import('./types.js').Plan} Plan
- * @typedef {import('./types.js').Section} Section
  *
  * @cssdisplay block
  *

--- a/src/pricing/cc-pricing-product.js
+++ b/src/pricing/cc-pricing-product.js
@@ -23,13 +23,15 @@ const DEFAULT_TEMPORALITY = [
 ];
 
 /**
- * A component to display product informations: icon, name, description with plans and their features.
- *
  * @typedef {import('./types.js').ActionType} ActionType
  * @typedef {import('./types.js').Currency} Currency
  * @typedef {import('./types.js').Feature} Feature
  * @typedef {import('./types.js').Plan} Plan
  * @typedef {import('./types.js').Temporality} Temporality
+ */
+
+/**
+ * A component to display product informations: icon, name, description with plans and their features.
  *
  * @cssdisplay block
  *

--- a/src/pricing/cc-pricing-table.js
+++ b/src/pricing/cc-pricing-table.js
@@ -34,6 +34,14 @@ const DEFAULT_TEMPORALITY = [
 ];
 
 /**
+ * @typedef {import('./types.js').ActionType} ActionType
+ * @typedef {import('./types.js').Currency} Currency
+ * @typedef {import('./types.js').Feature} Feature
+ * @typedef {import('./types.js').Plan} Plan
+ * @typedef {import('./types.js').Temporality} Temporality
+ */
+
+/**
  * A component to display product plans and their features.
  *
  * ## Details
@@ -41,12 +49,6 @@ const DEFAULT_TEMPORALITY = [
  * * The plans are sorted by price.
  * * If a plan has a feature that is not listed in `features`, it will be ignored.
  * * If a feature has a `code` that is not supported, it will be ignored.
- *
- * @typedef {import('./types.js').ActionType} ActionType
- * @typedef {import('./types.js').Currency} Currency
- * @typedef {import('./types.js').Feature} Feature
- * @typedef {import('./types.js').Plan} Plan
- * @typedef {import('./types.js').Temporality} Temporality
  *
  * @cssdisplay block
  *

--- a/src/saas/cc-grafana-info.js
+++ b/src/saas/cc-grafana-info.js
@@ -16,11 +16,13 @@ const GRAFANA_ADDON_SCREEN = 'https://static-assets.cellar.services.clever-cloud
 const GRAFANA_DOCUMENTATION = 'https://www.clever-cloud.com/doc/administrate/metrics/overview/';
 
 /**
- * A component to display information about grafana and allow some actions: enable, disable, reset.
- *
  * @typedef {import('./types.js').GrafanaErrorType} GrafanaErrorType
  * @typedef {import('./types.js').GrafanaStatusType} GrafanaStatusType
  * @typedef {import('./types.js').GrafanaWaitingType} GrafanaWaitingType
+ */
+
+/**
+ * A component to display information about grafana and allow some actions: enable, disable, reset.
  *
  * @cssdisplay block
  *

--- a/src/saas/cc-heptapod-info.js
+++ b/src/saas/cc-heptapod-info.js
@@ -18,13 +18,15 @@ const SKELETON_STATISTICS = {
 const HEPTAPOD_LOGO_URL = 'https://static-assets.cellar.services.clever-cloud.com/logos/heptapod.svg';
 
 /**
+ * @typedef {import('./types.js').Statistics} Statistics
+ */
+
+/**
  * A component that shows a summary of our Heptapod SaaS offer.
  *
  * ## Details
  *
  * * When `statistics` is nullish, a skeleton screen UI pattern is displayed (loading hint).
- *
- * @typedef {import('./types.js').Statistics} Statistics
  *
  * @cssdisplay block
  */

--- a/src/tcp-redirections/cc-tcp-redirection-form.js
+++ b/src/tcp-redirections/cc-tcp-redirection-form.js
@@ -11,11 +11,13 @@ const SKELETON_REDIRECTIONS = [
 ];
 
 /**
- * An interface to create / delete TCP redirections in the context of an application.
- *
  * @typedef {import('./types.js').ContextRedirectionType} ContextRedirectionType
  * @typedef {import('./types.js').Redirection} Redirection
  * @typedef {import('./types.js').RedirectionNamespace} RedirectionNamespace
+ */
+
+/**
+ * An interface to create / delete TCP redirections in the context of an application.
  *
  * @cssdisplay block
  *

--- a/src/tcp-redirections/cc-tcp-redirection.js
+++ b/src/tcp-redirections/cc-tcp-redirection.js
@@ -14,10 +14,12 @@ const noRedirectionSvg = new URL('../assets/redirection-off.svg', import.meta.ur
 const redirectionSvg = new URL('../assets/redirection-on.svg', import.meta.url).href;
 
 /**
- * A small form to create or delete a TCP redirection.
- *
  * @typedef {import('./types.js').RedirectionNamespace} RedirectionNamespace
  * @typedef {import('./types.js').Redirection} Redirection
+ */
+
+/**
+ * A small form to create or delete a TCP redirection.
  *
  * @cssdisplay block
  *

--- a/src/zones/cc-zone-input.js
+++ b/src/zones/cc-zone-input.js
@@ -13,15 +13,17 @@ import { withResizeObserver } from '../mixins/with-resize-observer.js';
 const SKELETON_ZONES = new Array(6).fill(null);
 
 /**
+ * @typedef {import('../maps/types.js').Point} Point
+ * @typedef {import('../types.js').Zone} Zone
+ */
+
+/**
  * A input component to select a zone with a map and a list.
  *
  * ## Details
  *
  * * When `zones` is nullish, a skeleton screen UI pattern is displayed (loading hint).
  * * Zones are sorted in the list using `tags`. Clever Cloud, then private, then regular alphanumeric sort on the city name.
- *
- * @typedef {import('../maps/types.js').Point} Point
- * @typedef {import('../types.js').Zone} Zone
  *
  * @cssdisplay grid
  *

--- a/src/zones/cc-zone.js
+++ b/src/zones/cc-zone.js
@@ -19,6 +19,11 @@ const SKELETON_ZONE = {
 const PRIVATE_ZONE = 'scope:private';
 
 /**
+ * @typedef {import('./types.js').ModeType} ModeType
+ * @typedef {import('../types.js').Zone} Zone
+ */
+
+/**
  * A display component to show information about a zone.
  *
  * ## Details
@@ -27,9 +32,6 @@ const PRIVATE_ZONE = 'scope:private';
  * * When a tag prefixed with `infra:` is used, the corresponding logo is displayed.
  * * When the `scope:private` tag is used, the optional `displayName` of the zone will be used instead of the City + Country.
  * * If the browser supports it, the `countryCode` will be used to display a translated version of the country's name.
- *
- * @typedef {import('./types.js').ModeType} ModeType
- * @typedef {import('../types.js').Zone} Zone
  *
  * @cssdisplay flex
  *


### PR DESCRIPTION
typedef imports have been moved to above class declaration to avoid events not showing up on the docs.

Plugin had not to be changed.  If you put another jsdoc comment above the class declaration and you check the AST with Typescript you will see that the js doc comment still appears on the class declaration.  
However, it is separated from the one just above the class declaration as you can see on the screenshots below which make the events on the doc working again. 
![Capture d’écran de 2021-12-16 14-32-22](https://user-images.githubusercontent.com/32012475/146382409-74179d9e-6bae-4666-80ce-3d0a989813bd.png)
![Capture d’écran de 2021-12-16 14-39-25](https://user-images.githubusercontent.com/32012475/146382412-3d04beeb-7682-444a-a165-9cbfd893cf32.png)

