### PR TITLE
cc-action-dispatcher, ping all VMs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ title: Changelog
 * `<cc-zone-input>`: make server markers not focusable.
 * `<cc-addon-admin>`: fix skeleton mode
 * `<cc-env-var-form>`: fix toggling to JSON mode while in skeleton state.
+* New component:
+  * `<cc-action-dispatcher>`
 
 ### For devs
 

--- a/src/components/cc-action-dispatcher/cc-action-dispatcher.js
+++ b/src/components/cc-action-dispatcher/cc-action-dispatcher.js
@@ -1,0 +1,160 @@
+import '../cc-block/cc-block.js';
+import '../cc-error/cc-error.js';
+import '../cc-block-section/cc-block-section.js';
+import { css, html, LitElement } from 'lit';
+import { dispatchCustomEvent } from '../../lib/events.js';
+import { i18n } from '../../lib/i18n.js';
+
+/**
+ * @typedef {import('./cc-action-dispatcher.types.js').Response} Response
+ */
+
+/**
+ * A component to ping VMs and display their pong status.
+ *
+ * Action Dispatcher is an executable running on each Virtual Machine (VM) on Clever Cloud.
+ * The Action Dispatcher instance talks with the world through Pulsar, to fullfil a number of purposes (broadcasting wireguard configuration, receiving SSH keys...).
+ * The simplest action of Action Dispatcher is to respond to a Ping with a Pong.
+ *
+ * This clever component's ping button sends a request to the CC Admin API that itself pings all instances of Action Dispatcher.
+ *
+ * The CC Admin waits a bit and responds with:
+ *
+ * * how many VMs were pinged (numberOfPings)
+ * * how many Action Dispatcher responded with "pong" (numberOfPongs)
+ * * the ids of the silent instances (an array of strings)
+ *
+ * @event {CustomEvent} cc-action-dispatcher:send-ping - Ask the CCAdmin to ping all VMs
+ */
+export class CcActionDispatcher extends LitElement {
+
+  static get properties () {
+    return {
+      error: { type: Boolean },
+      response: { type: Object },
+      waiting: { type: Boolean },
+    };
+  }
+
+  constructor () {
+    super();
+
+    /** @type {boolean} Wether the API responded with an error. */
+    this.error = false;
+
+    /** @type {Response | null} The response we receive from the CC Admin. */
+    this.response = null;
+
+    /** @type {boolean} Wether the component is waiting for an API response. */
+    this.waiting = false;
+  }
+
+  _onClickSendPings () {
+    dispatchCustomEvent(this, 'send-ping');
+  }
+
+  render () {
+    return html`
+      <cc-block>
+
+        <div slot="title">Action Dispatcher</div>
+
+        <div class="text">
+          <p>${i18n('cc-action-dispatcher.context')}</p>
+          <cc-button
+            primary
+            ?waiting=${this.waiting}
+            @cc-button:click=${this._onClickSendPings}
+          >
+            ${i18n('cc-action-dispatcher.ping-button-content')}
+          </cc-button>
+        </div>
+
+        ${this.response != null ? html`
+          <div class="number-block-list">
+            <div class="number-block">
+              <div class="number-block-title">${i18n('cc-action-dispatcher.number-of-pings')}</div>
+              <div class="number-block-number">${this.response.numberOfPings}</div>
+            </div>
+            <div class="number-block">
+              <div class="number-block-title">${i18n('cc-action-dispatcher.number-of-pongs')}</div>
+              <div class="number-block-number">${this.response.numberOfPongs}</div>
+            </div>
+          </div>
+          <div>
+            <div class="instance-list-label">${i18n('cc-action-dispatcher.unresponsive-instances')}</div>
+            <div class="instance-list">
+              ${this.response.unresponsiveInstances.map((vm) => html`
+                <div>${vm}</div>
+              `)}
+            </div>
+          </div>
+        ` : ''}
+
+        ${this.error ? html`
+          <cc-error>
+            ${i18n('cc-action-dispatcher.error-message')}
+          </cc-error>
+        ` : ''}
+
+      </cc-block>
+    `;
+  }
+
+  static get styles () {
+    return [
+      // language=CSS
+      css`
+        :host {
+          display: block;
+        }
+
+        p {
+          margin: 0;
+        }
+
+        .text {
+          align-items: center;
+          display: flex;
+          flex-wrap: wrap;
+          gap: 1em;
+        }
+
+        .number-block-list {
+          display: flex;
+          gap: 1em;
+        }
+
+        .number-block {
+          background-color: var(--cc-color-bg-neutral);
+          border-radius: 0.25em;
+          padding: 1em;
+          text-align: center;
+        }
+
+        .number-block-title {
+          font-weight: bold;
+        }
+
+        .number-block-number {
+          color: var(--cc-color-text-primary-highlight);
+          font-size: 1.5em;
+          font-weight: bold;
+          margin-top: 0.5em;
+        }
+
+        .instance-list-label {
+          font-weight: bold;
+        }
+
+        .instance-list {
+          font-family: var(--cc-ff-monospace, monospace);
+          line-height: 1.6;
+          margin-top: 0.5em;
+        }
+      `,
+    ];
+  }
+}
+
+window.customElements.define('cc-action-dispatcher', CcActionDispatcher);

--- a/src/components/cc-action-dispatcher/cc-action-dispatcher.stories.js
+++ b/src/components/cc-action-dispatcher/cc-action-dispatcher.stories.js
@@ -1,0 +1,64 @@
+import './cc-action-dispatcher.js';
+import { makeStory, storyWait } from '../../stories/lib/make-story.js';
+import { enhanceStoriesNames } from '../../stories/lib/story-names.js';
+
+export default {
+  title: '🛠 Action Dispatcher/<cc-action-dispatcher>',
+  component: 'cc-action-dispatcher',
+};
+
+const conf = {
+  component: 'cc-action-dispatcher',
+};
+
+const exampleResponse = {
+  numberOfPings: 20,
+  numberOfPongs: 17,
+  unresponsiveInstances: [
+    '4cf96434-4692-4e09-86d2-5d1777e200c2',
+    '40bc890c-8785-4a69-8586-06d7d25f0c8b',
+    '2cddf144-01ba-4462-8325-14914507a973',
+  ],
+};
+
+export const defaultStory = makeStory(conf, {
+  items: [{}],
+});
+
+export const waiting = makeStory(conf, {
+  items: [{ waiting: true }],
+});
+
+export const error = makeStory(conf, {
+  items: [{ error: true }],
+});
+
+export const dataLoaded = makeStory(conf, {
+  items: [{
+    response: exampleResponse,
+  }],
+});
+
+export const simulations = makeStory(conf, {
+  items: [{}, {}],
+  simulations: [
+    storyWait(2000, ([component, componentError]) => {
+      component.waiting = true;
+      componentError.waiting = true;
+    }),
+    storyWait(2000, ([component, componentError]) => {
+      component.response = exampleResponse;
+      componentError.error = true;
+      component.waiting = false;
+      componentError.waiting = false;
+    }),
+  ],
+});
+
+enhanceStoriesNames({
+  defaultStory,
+  waiting,
+  error,
+  dataLoaded,
+  simulations,
+});

--- a/src/components/cc-action-dispatcher/cc-action-dispatcher.types.d.ts
+++ b/src/components/cc-action-dispatcher/cc-action-dispatcher.types.d.ts
@@ -1,0 +1,5 @@
+interface Response {
+    numberOfPings: number;
+    numberOfPongs: number;
+    unresponsiveInstances: string[];
+}

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -45,6 +45,14 @@ function formatFlavor (f) {
 
 export const translations = {
   LANGUAGE: 'English',
+  //#region cc-action-dispatcher
+  'cc-action-dispatcher.context': `This button allows you to send a ping to all Clever Cloud VMs.`,
+  'cc-action-dispatcher.error-message': `Something went wrong while sending actions to the VMs.`,
+  'cc-action-dispatcher.number-of-pings': `Number of VMs`,
+  'cc-action-dispatcher.number-of-pongs': `Number of responsive VMs`,
+  'cc-action-dispatcher.ping-button-content': ` Ping all VMs`,
+  'cc-action-dispatcher.unresponsive-instances': `Unresponsive VMs`,
+  //#endregion
   //#region cc-addon-admin
   'cc-addon-admin.addon-name': `Add-on name`,
   'cc-addon-admin.admin': `Administration`,

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -58,6 +58,14 @@ function formatFlavor (f) {
 
 export const translations = {
   LANGUAGE: 'Français',
+  //#region cc-action-dispatcher
+  'cc-action-dispatcher.context': `Ce bouton permet d'envoyer un ping à toutes les VMs sur Clever Cloud.`,
+  'cc-action-dispatcher.error-message': `Une erreur est survenue pendant l'envoi d'actions aux VMs.`,
+  'cc-action-dispatcher.number-of-pings': `Nombre de VMs`,
+  'cc-action-dispatcher.number-of-pongs': `Nombre de VMs répondantes`,
+  'cc-action-dispatcher.ping-button-content': `Envoyer le ping`,
+  'cc-action-dispatcher.unresponsive-instances': `VMs muettes`,
+  //#endregion
   //#region cc-addon-admin
   'cc-addon-admin.addon-name': `Nom de l'add-on`,
   'cc-addon-admin.admin': `Administration`,


### PR DESCRIPTION
Fixes #353 

We want to create a web component that sends a "ping all VMs" message to the CC Admin (in fact, ping the action dispatcher instances, there is one per VM). And display the results: how many VMs were pinged, how many answered with "pong", and the ids of the unresponsive action dispatcher instances.
