### PR TITLE
cc-input-number: fix controls mode not working properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ title: Changelog
 
 ## Unreleased (????-??-??)
 
-...
+* `<cc-input-number>`: fix controls mode not working properly from types introduction
 
 ## 7.9.1 (2022-03-15)
 

--- a/src/atoms/cc-input-number.js
+++ b/src/atoms/cc-input-number.js
@@ -145,8 +145,8 @@ export class CcInputNumber extends LitElement {
 
     const value = (this.value != null) ? this.value : 0;
     const controls = (this.controls && !this.skeleton);
-    const minDisabled = (this.value <= this.min);
-    const maxDisabled = (this.value >= this.max);
+    const minDisabled = (this.value <= this.min) && (this.min != null);
+    const maxDisabled = (this.value >= this.max) && (this.max != null);
 
     return html`
 


### PR DESCRIPTION
Probably due to the types introduction min and max were set to null by default in the constructor which caused the condition to check if the controls should be disabled when checking min and max broke because it wasn't checking if they were null (which means we don't have a min or max)