### PR TITLE
Form controls: Help texts and error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@ title: Changelog
 
 ## Unreleased (????-??-??)
 
-* colors: use variables to specify colors and swap old colors for new contrasted ones.
+* colors: use variables to specify colors and swap old colors for new contrasted ones. Add ADR about colors and Design Tokens.
 * all-form-controls story: display disabled and readonly form controls next to each other to make sure they look the same.
 * New component:
   * `<cc-warning-payment>`
+* cc-input-text: add help text and error message support as well as their related stories. Remove label stories and add label inside all stories.
+* cc-input-number: add help text and error message support as well as their related stories. Remove label stories and add label inside all stories.
+* cc-select: add help text support as well as its related story.
 
 ...
 

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -351,8 +351,12 @@ export const translations = {
   'cc-heptapod-info.storage-bytes': ({ storage }) => formatBytes(storage, 1),
   'cc-heptapod-info.storage-description': `Storage size`,
   //#endregion
+  //#region cc-input-number
+  'cc-input-number.required': `required`,
+  //#endregion
   //#region cc-input-text
   'cc-input-text.clipboard': `Copy to clipboard`,
+  'cc-input-text.required': `required`,
   'cc-input-text.secret.hide': `Hide secret`,
   'cc-input-text.secret.show': `Show secret`,
   //#endregion

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -364,8 +364,12 @@ export const translations = {
   'cc-heptapod-info.storage-bytes': ({ storage }) => formatBytes(storage, 1),
   'cc-heptapod-info.storage-description': `Stockage utilisé`,
   //#endregion
+  //#region cc-input-number
+  'cc-input-number.required': `obligatoire`,
+  //#endregion
   //#region cc-input-text
   'cc-input-text.clipboard': `Copier dans le presse-papier`,
+  'cc-input-text.required': `obligatoire`,
   'cc-input-text.secret.hide': `Cacher le secret`,
   'cc-input-text.secret.show': `Afficher le secret`,
   //#endregion

--- a/stories/atoms/cc-input-number.stories.js
+++ b/stories/atoms/cc-input-number.stories.js
@@ -4,15 +4,15 @@ import { enhanceStoriesNames } from '../lib/story-names.js';
 import { allFormControlsStory } from './all-form-controls.js';
 
 const baseItems = [
-  {},
-  { value: 100 },
-  { value: 200, disabled: true },
-  { value: 300, readonly: true },
-  { value: 400, skeleton: true },
+  { label: 'The Label' },
+  { label: 'The Label', value: 100 },
+  { label: 'The Label', value: 200, disabled: true },
+  { label: 'The Label', value: 300, readonly: true },
+  { label: 'The Label', value: 400, skeleton: true },
 ];
 
 const minMaxItems = [
-  { label: '' },
+  { label: 'The Label' },
   { value: 5, min: 0, max: 10, label: 'Min: 0, Max: 10' },
   { value: 0, min: 0, max: 10, label: 'Min: 0, Max: 10' },
   { value: 10, min: 0, max: 10, label: 'Min: 0, Max: 10' },
@@ -41,8 +41,35 @@ export const defaultStory = makeStory(conf, {
   items: baseItems,
 });
 
-export const label = makeStory(conf, {
-  items: baseItems.map((p) => ({ ...p, label: 'The label' })),
+export const required = makeStory(conf, {
+  items: baseItems.map((p) => ({ ...p, required: true })),
+});
+
+export const helpMessage = makeStory(conf, {
+  items: baseItems.map((p) => ({
+    ...p,
+    required: true,
+    innerHTML: '<p slot="help">Must be an integer</p>',
+  })),
+});
+
+export const errorMessage = makeStory(conf, {
+  items: baseItems.map((p) => ({
+    ...p,
+    required: true,
+    innerHTML: '<p slot="error">You must enter a value</p>',
+  })),
+});
+
+export const errorMessageWithHelpMessage = makeStory(conf, {
+  items: baseItems.map((p) => ({
+    ...p,
+    required: true,
+    innerHTML: `
+      <p slot="help">Must be an integer</p>
+      <p slot="error">You must enter a value</p>
+    `,
+  })),
 });
 
 export const controls = makeStory(conf, {
@@ -126,7 +153,10 @@ export const allFormControls = allFormControlsStory;
 
 enhanceStoriesNames({
   defaultStory,
-  label,
+  required,
+  helpMessage,
+  errorMessage,
+  errorMessageWithHelpMessage,
   controls,
   minMax,
   minMaxWithControls,

--- a/stories/atoms/cc-input-text.stories.js
+++ b/stories/atoms/cc-input-text.stories.js
@@ -14,16 +14,16 @@ Etiam vestibulum placerat massa eget lacinia. Aenean bibendum, massa id mattis v
 Integer posuere tortor sit amet nisl sollicitudin, at tempus ipsum semper.`;
 
 const baseItems = [
-  { placeholder: 'No value yet...' },
-  { placeholder: 'No value yet...', value: 'Simple value' },
-  { placeholder: 'No value yet...', value: 'Disabled value', disabled: true },
-  { placeholder: 'No value yet...', value: 'Readonly value', readonly: true },
-  { placeholder: 'No value yet...', value: 'Skeleton', skeleton: true },
-  { placeholder: 'No value yet...', multi: true },
-  { placeholder: 'No value yet...', multi: true, value: 'Simple value\nOther lines...' },
-  { placeholder: 'No value yet...', multi: true, value: 'Disabled value\nOther lines...', disabled: true },
-  { placeholder: 'No value yet...', multi: true, value: 'Readonly value\nOther lines...', readonly: true },
-  { placeholder: 'No value yet...', multi: true, value: 'Skeleton\nOther lines...', skeleton: true },
+  { label: 'The label', placeholder: 'No value yet...' },
+  { label: 'The label', placeholder: 'No value yet...', value: 'Simple value' },
+  { label: 'The label', placeholder: 'No value yet...', value: 'Disabled value', disabled: true },
+  { label: 'The label', placeholder: 'No value yet...', value: 'Readonly value', readonly: true },
+  { label: 'The label', placeholder: 'No value yet...', value: 'Skeleton', skeleton: true },
+  { label: 'The label', placeholder: 'No value yet...', multi: true },
+  { label: 'The label', placeholder: 'No value yet...', multi: true, value: 'Simple value\nOther lines...' },
+  { label: 'The label', placeholder: 'No value yet...', multi: true, value: 'Disabled value\nOther lines...', disabled: true },
+  { label: 'The label', placeholder: 'No value yet...', multi: true, value: 'Readonly value\nOther lines...', readonly: true },
+  { label: 'The label', placeholder: 'No value yet...', multi: true, value: 'Skeleton\nOther lines...', skeleton: true },
 ];
 
 const tagsItems = [
@@ -68,21 +68,51 @@ const conf = {
 
 export const defaultStory = makeStory(conf, {
   items: [
-    { placeholder: 'No value yet...' },
-    { value: 'Some example text' },
-    { value: 'Disabled value', disabled: true },
-    { value: 'Readonly value', readonly: true },
-    { value: 'Copy to clipboard', clipboard: true },
-    { value: 'Hidden secret', secret: true },
-    { value: 'Skeleton', skeleton: true },
-    { value: 'Line one\nLine two\nLine three', multi: true },
-    { tags: ['tag1', 'tag2', 'tag-name:tag-value', 'very-very-very-very-long-tag'] },
+    { label: 'The Label', placeholder: 'No value yet...' },
+    { label: 'The Label', value: 'Some example text' },
+    { label: 'The Label', value: 'Disabled value', disabled: true },
+    { label: 'The Label', value: 'Readonly value', readonly: true },
+    { label: 'The Label', value: 'Copy to clipboard', clipboard: true },
+    { label: 'The Label', value: 'Hidden secret', secret: true },
+    { label: 'The Label', value: 'Skeleton', skeleton: true },
+    { label: 'The Label', value: 'Line one\nLine two\nLine three', multi: true },
+    { label: 'The Label', tags: ['tag1', 'tag2', 'tag-name:tag-value', 'very-very-very-very-long-tag'] },
   ],
 });
 
-export const label = makeStory(conf, {
+export const required = makeStory(conf, {
   css: `cc-input-text { margin: 1rem 0.5rem; }`,
-  items: baseItems.map((p) => ({ ...p, label: 'The label' })),
+  items: baseItems.map((p) => ({ ...p, required: true })),
+});
+
+export const helpMessage = makeStory(conf, {
+  css: `cc-input-text { margin: 1rem 0.5rem; }`,
+  items: baseItems.map((p) => ({
+    ...p,
+    required: true,
+    innerHTML: '<p slot="help">Must be at least 7 characters long</p>',
+  })),
+});
+
+export const errorMessage = makeStory(conf, {
+  css: `cc-input-text { margin: 1rem 0.5rem; }`,
+  items: baseItems.map((p) => ({
+    ...p,
+    required: true,
+    innerHTML: '<p slot="error">You must enter a value</p>',
+  })),
+});
+
+export const errorMessageWithHelpMessage = makeStory(conf, {
+  css: `cc-input-text { margin: 1rem 0.5rem; }`,
+  items: baseItems.map((p) => ({
+    ...p,
+    required: true,
+    innerHTML: `
+      <p slot="help">Must be at least 7 characters long</p>
+      <p slot="error">You must enter a value</p>
+    `,
+  })),
 });
 
 export const clipboard = makeStory(conf, {
@@ -154,7 +184,10 @@ export const allFormControls = allFormControlsStory;
 
 enhanceStoriesNames({
   defaultStory,
-  label,
+  required,
+  helpMessage,
+  errorMessage,
+  errorMessageWithHelpMessage,
   clipboard,
   clipboardWithAutoAdjust,
   clipboardWithAutoAdjustAndCssOverride,

--- a/stories/atoms/cc-select.stories.js
+++ b/stories/atoms/cc-select.stories.js
@@ -63,6 +63,45 @@ export const required = makeStory(conf, {
   ],
 });
 
+export const helpMessage = makeStory(conf, {
+  items: [
+    {
+      label: 'Favourite artist',
+      placeholder: '-- Select an artist --',
+      required: true,
+      options: baseOptions,
+      innerHTML: '<p slot="help">There can be only one.</p>',
+    },
+  ],
+});
+
+export const errorMessage = makeStory(conf, {
+  items: [
+    {
+      label: 'Favourite artist',
+      placeholder: '-- Select an artist --',
+      required: true,
+      options: baseOptions,
+      innerHTML: '<p slot="error">A value must be selected.</p>',
+    },
+  ],
+});
+
+export const errorMessageWithHelpMessage = makeStory(conf, {
+  items: [
+    {
+      label: 'Favourite artist',
+      placeholder: '-- Select an artist --',
+      required: true,
+      options: baseOptions,
+      innerHTML: `
+        <p slot="help">There can be only one.</p>
+        <p slot="error">A value must be selected.</p>
+      `,
+    },
+  ],
+});
+
 export const disabled = makeStory(conf, {
   items: [
     {
@@ -95,24 +134,14 @@ export const longContentWihFixedWidth = makeStory(
   },
 );
 
-export const errorMessage = makeStory(conf, {
-  items: [
-    {
-      label: 'Favourite artist',
-      placeholder: '-- Select an artist --',
-      required: true,
-      options: baseOptions,
-      innerHTML: `<p slot="error">A value must be selected.</p>`,
-    },
-  ],
-});
-
 export const allFormControls = allFormControlsStory;
 
 enhanceStoriesNames({
   defaultStory,
-  errorMessage,
-  longContentWihFixedWidth,
   required,
+  helpMessage,
+  errorMessage,
+  errorMessageWithHelpMessage,
+  longContentWihFixedWidth,
   allFormControls,
 });


### PR DESCRIPTION
# Changelog:
## cc-input-text & cc-input-number
* Add help text and error message support as well as their related stories.
* Remove label stories.
* Add label inside all stories.

## cc-select
* Add help text support as well as its related story.
* Tweaked label CSS to make it simpler.

# Sidenote:
- Code format: hope prettier and I did not mess things up @hsablonniere :angel: 
- [Preview](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-input/required-and-help-text/index.html)


TODO before merging:
- [x] Check preview on Safari :dizzy_face: 
- [x] Run lint fix
