### PR TITLE
all-form-controls: add support and story for horizontal form layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ title: Changelog
 
 ## Unreleased (????-??-??)
 
+* `<cc-input-text>`: set line-height to 1.25em for the `<label>` element.
+* `<cc-input-number>`: set line-height to 1.25em for the `<label>` element.
+* `<cc-select>`: set line-height to 1.25em for the `<label>` element.
+* `<cc-toggle>`: set line-height to 1.25em for the `<legend>` element.
+* `defaultThemeStyles`: add variable to be used as `margin-top` value on a `<cc-button>` when one wants to align all form elements horizontally.
+* `all-form-controls` story: add new story with help message and add a note about how to handle horizontal layout inside forms.
 * New components:
   * `<cc-article-card>`
   * `<cc-article-list>` (with smart definition)

--- a/src/atoms/cc-input-number.js
+++ b/src/atoms/cc-input-number.js
@@ -240,6 +240,7 @@ export class CcInputNumber extends LitElement {
           display: flex;
           gap: 2em;
           justify-content: space-between;
+          line-height: 1.25em;
           padding-bottom: 0.35em;
         }
 

--- a/src/atoms/cc-input-text.js
+++ b/src/atoms/cc-input-text.js
@@ -355,6 +355,7 @@ export class CcInputText extends LitElement {
           display: flex;
           gap: 2em;
           justify-content: space-between;
+          line-height: 1.25em;
           padding-bottom: 0.35em;
         }
 

--- a/src/atoms/cc-select.js
+++ b/src/atoms/cc-select.js
@@ -139,6 +139,7 @@ export class CcSelect extends LitElement {
           display: flex;
           gap: 2em;
           justify-content: space-between;
+          line-height: 1.25em;
           padding-bottom: 0.35em;
         }
 

--- a/src/atoms/cc-toggle.js
+++ b/src/atoms/cc-toggle.js
@@ -181,6 +181,7 @@ export class CcToggle extends LitElement {
         }
 
         legend:not(:empty) {
+          line-height: 1.25em;
           padding-bottom: 0.35em;
         }
 

--- a/src/styles/default-theme.js
+++ b/src/styles/default-theme.js
@@ -159,5 +159,18 @@ export const defaultThemeStyles = css`
     /* Usage: with default background for an "outlined" style or warning background for "plain" style" ? */
     --border-warning: 1px solid var(--color-yellow);
     /*endregion*/
+      
+    /*region Margin Decisions*/
+    /* Usage: 
+    *   - in an horizontal form
+    *   - use flex and align-items: start; on the form
+    *   - use margin-top: var(--margin-top-btn-horizontal-form); on the <cc-button> element so that it aligns 
+    *   horizontally even when error / help messages are displayed. 
+    *  See the All Controls Story - Horizontal form section
+    *  
+    *  The 1.6em value comes from the label line-height (1.25em) and bottom padding (0.35em)
+    */
+    --margin-top-btn-horizontal-form: 1.6em;
+    /*endregion*/
   }
 `;

--- a/stories/atoms/all-form-controls.js
+++ b/stories/atoms/all-form-controls.js
@@ -3,52 +3,84 @@ import '../../src/atoms/cc-input-number.js';
 import '../../src/atoms/cc-input-text.js';
 import '../../src/atoms/cc-select.js';
 import '../../src/atoms/cc-toggle.js';
+import { defaultThemeStyles } from '../../src/styles/default-theme.js';
 import { makeStory } from '../lib/make-story.js';
 
 const conf = {
-  css: `
-    h1 {
-      font-size: 1.2em;
-      margin-bottom: 1em;
-    }
-
-    h1+div {
-      align-items: flex-end;
-      border-bottom: solid 1px gray;
-      display: flex;
-      gap: 1em;
-      margin-bottom: 2em;
-      padding-bottom: 2em;
-    }
-  `,
+  css: [
+    defaultThemeStyles.toString(),
+    // language=CSS
+    `
+      h1 {
+        font-size: 1.2em;
+        margin-bottom: 1em;
+      }
+  
+      form {
+        align-items: start;
+        border-bottom: solid 1px gray;
+        display: flex;
+        gap: 1em;
+        margin-bottom: 2em;
+        padding-bottom: 2em;
+      }
+      
+      code {
+        background-color: var(--color-bg-neutral);
+        padding: 0.3em;
+      }
+      
+      cc-button {
+        margin-top: var(--margin-top-btn-horizontal-form);
+      }
+    `].join('/n'),
 };
 
 export const allFormControlsStory = makeStory(conf,
   {
     dom: (container) => {
       container.innerHTML = `
-      <h1>All form controls - basic</h1>
-      <div>
-        <cc-button>The button</cc-button>
-        <cc-input-number label="The label" value="42"></cc-input-number>
-        <cc-input-text label="The label" value="The value"></cc-input-text>
-        <cc-select label="The label" options='[{ "label": "one", "value": "one" }, { "label": "two", "value": "two" }]' value="one"></cc-select>
-        <cc-toggle legend="The label" choices='[{ "label": "one", "value": "one" }, { "label": "two", "value": "two" }]' value="one"></cc-toggle>
-      </div>
-      <h1>All form controls - disabled</h1>
-      <div>
-        <cc-button disabled>The button</cc-button>
-        <cc-input-number label="The label" value="42" disabled></cc-input-number>
-        <cc-input-text label="The label" value="The value" disabled></cc-input-text>
-        <cc-select label="The label" options='[{ "label": "one", "value": "one" }, { "label": "two", "value": "two" }]' value="one" disabled></cc-select>
-        <cc-toggle legend="The label" choices='[{ "label": "one", "value": "one" }, { "label": "two", "value": "two" }]' value="one" disabled></cc-toggle>
-      </div>
-      <h1>Form controls with readonly mode</h1>
-      <div>
-        <cc-input-number label="The label" value="42" readonly></cc-input-number>
-        <cc-input-text label="The label" value="The value" readonly></cc-input-text>
-      </div>
-    `;
+        <h1>Horizontal layout for form elements</h1>
+        <p>To make sure the <code>cc-button</code> element aligns with other form elements even when an error / help message is displayed, do as follows:</p>
+        <ul>
+          <li>Use <code>display: flex;</code> on the container of the form elements (typically the <code>form</code> element).</li>
+          <li>Use <code>align-items: start;</code>.</li>
+          <li>Import <code>defaultThemeStyles</code> and use <code>margin-top: var(--margin-top-btn-horizontal-form);</code> on the <code>cc-button</code> element.</li>
+        </ul>
+        <h1>All form controls - basic</h1>
+        <form>
+          <cc-button>The button</cc-button>
+          <cc-input-number label="The label" value="42"></cc-input-number>
+          <cc-input-text label="The label" value="The value"></cc-input-text>
+          <cc-select label="The label" options='[{ "label": "one", "value": "one" }, { "label": "two", "value": "two" }]' value="one"></cc-select>
+          <cc-toggle legend="The label" choices='[{ "label": "one", "value": "one" }, { "label": "two", "value": "two" }]' value="one"></cc-toggle>
+        </form>
+        <h1>All form controls - disabled</h1>
+        <form>
+          <cc-button disabled>The button</cc-button>
+          <cc-input-number label="The label" value="42" disabled></cc-input-number>
+          <cc-input-text label="The label" value="The value" disabled></cc-input-text>
+          <cc-select label="The label" options='[{ "label": "one", "value": "one" }, { "label": "two", "value": "two" }]' value="one" disabled></cc-select>
+          <cc-toggle legend="The label" choices='[{ "label": "one", "value": "one" }, { "label": "two", "value": "two" }]' value="one" disabled></cc-toggle>
+        </form>
+        <h1>Form controls with readonly mode</h1>
+        <form>
+          <cc-input-number label="The label" value="42" readonly></cc-input-number>
+          <cc-input-text label="The label" value="The value" readonly></cc-input-text>
+        </form>
+        <h1>All form controls with help messages</h1>
+        <form>
+          <cc-button>The button</cc-button>
+          <cc-input-number label="The label" value="42"><p slot="help">Small help message</p></cc-input-number>
+          <cc-input-text label="The label" value="The value"><p slot="help">Small help message</p></cc-input-text>
+          <cc-select label="The label" options='[{ "label": "one", "value": "one" }, { "label": "two", "value": "two" }]' value="one">
+            <p slot="help">Small help message</p>
+          </cc-select>
+          <cc-toggle legend="The label" choices='[{ "label": "one", "value": "one" }, { "label": "two", "value": "two" }]' value="one">
+            <p slot="help">Small help message</p>
+          </cc-toggle>
+        </form>
+      `;
     },
   },
 );


### PR DESCRIPTION
Fixes #446 

- Added a new section in the `all-form-controls` story to showcase all form controls horizontally aligned with help messages below each form control.
- Specified line-height on the `<label>` (`cc-input-*` + `cc-select`)/ `<legend>` (`cc-toggle`) element of all the form controls.
- Aligned all the form controls from top (`align-items: start`).
- Added a margin variable in `defaultThemeStyles` to be used as `margin-top` value on a `cc-button` so that it is aligned with the rest of form controls (specifies an offset equal to `label` height (line-height + padding = `1.6em` )
- Added small paragraph to try and explain all of this :sweat_smile:.