### PR TITLE
Documentation about common accessibility rules

### DIFF
--- a/docs/guides/accessibility-reminders.md
+++ b/docs/guides/accessibility-reminders.md
@@ -1,0 +1,24 @@
+---
+kind: '📌 Docs'
+---
+# Quick accessibility reminders
+
+NOTE: This doc is a work in progress...
+
+## Explicit accessible names for links
+
+When UI contains several links with the same text, like "Read more" links for instance, we need to make sure each link is as explicit as possible for people using assistive technologies.
+
+To do so, we rely on the `aria-label` attribute.
+Its value **must begin with the visible text** and the **additional information must be placed after**:
+
+`aria-label="visible text - additional info"` (you can skip the "-" if you want, only the order is important here)
+
+
+### Example:
+A "Read the documentation" link leading to the "JavaScript application" documentation page should be as follows:
+```html
+  <a href="..." aria-label="Read the documentation - JavaScript application">Read the documentation</a>
+```
+
+To learn more about this subject, see the [G208 Technique of WCAG 2.2 - "Including the text of the visible label as part of the accessible name"](https://www.w3.org/WAI/WCAG22/Techniques/general/G208).


### PR DESCRIPTION
This documentation provides reminders for accessibility rules we should enforce through all the components.
These rules are solutions for common issues that we face.

At the moment, there is only one rule about providing accessible explicit names for links.
The documentation will be updated every time we face a new issue that is not specific to only one component.