### PR TITLE
cc-button: update waiting loader animation in circle state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,10 @@ title: Changelog
 * `<cc-doc-card>`: rename title property to heading to fix a conflict.
 * `<cc-doc-list>`: use heading when initializing the cards instead of title.
 
-### Fixes 
+### Components 
 * `<cc-article-list>`: fix error mode not triggering on XML parsing failure (smart). 
 * `parseRssFeed()`: trim XML string before parse to avoid whitespaces error.
+* `<cc-button>`: update waiting loader animation in circle state.
 
 ## 7.12.0 (2022-05-20)
 

--- a/src/atoms/cc-button.js
+++ b/src/atoms/cc-button.js
@@ -52,7 +52,7 @@ export class CcButton extends LitElement {
       primary: { type: Boolean },
       skeleton: { type: Boolean },
       success: { type: Boolean },
-      waiting: { type: Boolean },
+      waiting: { type: Boolean, reflect: true },
       warning: { type: Boolean },
       _cancelMode: { type: Boolean, attribute: false },
     };
@@ -210,8 +210,13 @@ export class CcButton extends LitElement {
         ${delay != null ? html`
           <progress class="delay ${classMap({ active: this._cancelMode })}" style="--delay: ${delay}s"></progress>
         ` : ''}
-        ${waiting ? html`
+        ${waiting && !modes.circle ? html`
           <progress class="waiting"></progress>
+        ` : ''}
+        ${waiting && modes.circle ? html`
+          <svg class="circle-loader" viewBox="25 25 50 50" stroke-width="4" aria-hidden="true">
+            <circle fill="none" cx="50" cy="50" r="15" />
+          </svg>
         ` : ''}
       </button>
     `;
@@ -460,6 +465,54 @@ export class CcButton extends LitElement {
           margin-left: calc(50% - calc(var(--width) / 2));
           position: absolute;
           width: var(--width);
+        }
+
+        /* circle waiting mode - keyframes */
+        @keyframes rotate {
+          100% {
+            transform: rotate(360deg);
+          }
+        }
+
+        @keyframes stretch {
+          0% {
+            stroke-dasharray: 1, 200;
+            stroke-dashoffset: 0;
+          }
+          50% {
+            stroke-dasharray: 90, 200;
+            stroke-dashoffset: -35px;
+          }
+          100% {
+            stroke-dashoffset: -124px;
+          }
+        }
+
+        /* circle waiting mode - partial opacity */
+        :host([waiting]) button.circle {
+          opacity: 1;
+        }
+
+        :host([waiting]) button.circle .text-wrapper img {
+          opacity: 0.25;
+        }
+
+        /* circle waiting mode - core animation */
+        .circle-loader {
+          --bcw-speed: 2s;
+          animation: rotate var(--bcw-speed) linear infinite;
+          inset: 0;
+          position: absolute;
+          transform-origin: center;
+          vertical-align: middle;
+        }
+
+        .circle-loader circle {
+          animation: stretch calc(var(--bcw-speed) * 0.75) ease-in-out infinite;
+          stroke: currentColor;
+          stroke-dasharray: 1, 200;
+          stroke-dashoffset: 0;
+          stroke-linecap: round;
         }
 
         /* We can do this because we set a visible focus state */

--- a/stories/atoms/cc-button.stories.js
+++ b/stories/atoms/cc-button.stories.js
@@ -158,6 +158,13 @@ As you can see here, \`circle\` can only be used if there is an \`image\` and in
   ],
 });
 
+export const waitingAndCircle = makeStory(conf, {
+  items: [
+    { image: closeSvg, innerHTML: 'Close foo', hideText: true, circle: true, waiting: true },
+    { image: infoSvg, innerHTML: 'Info bar', hideText: true, circle: true, waiting: true },
+  ],
+});
+
 export const allFormControls = allFormControlsStory;
 
 enhanceStoriesNames({
@@ -175,5 +182,6 @@ enhanceStoriesNames({
   hideText,
   skeleton,
   circle,
+  waitingAndCircle,
   allFormControls,
 });


### PR DESCRIPTION
Here are some design proposal for the `cc-button` waiting mode in circle state :
- [preview](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-button-circle-loader/index.html?path=/story/%F0%9F%A7%AC-atoms-cc-button--circle-waiting)
- fixes #449 

I tried to present multiple combinations in the story, varying on:
- mode (simple, primary, success, etc.)
- icon size
- ring radius
- opacity (global, icon only, none)
- icon transparent or not

Note: feel free to zoom with the related action on the top toolbar.

Just vote for your overall favorite option! (and do not look at the code yet :smile:)