### PR TITLE
cc-badge: init component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ title: Changelog
 * `<cc-tcp-redirection-form>`: Use `<cc-badge>` to display redirection count.
 * `<cc-header-app>`: Change footer background to neutral.
 * `<cc-header-addon>`: Change footer background to neutral.
+* `<cc-header-orga>`: Use `<cc-badge>` to display org status and hotline number. 
 ...
 
 ## 7.12.0 (2022-05-20)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ title: Changelog
 * Color design tokens: add darker shades for light colors.
 * New component:
   * `<cc-badge>`
+* `<cc-tcp-redirection-form>`: Use `<cc-badge>` to display redirection count.
 ...
 
 ## 7.12.0 (2022-05-20)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ title: Changelog
 * New component:
   * `<cc-badge>`
 * `<cc-tcp-redirection-form>`: Use `<cc-badge>` to display redirection count.
+* `<cc-header-app>`: Change footer background to neutral.
 ...
 
 ## 7.12.0 (2022-05-20)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ title: Changelog
   * `<cc-badge>`
 * `<cc-tcp-redirection-form>`: Use `<cc-badge>` to display redirection count.
 * `<cc-header-app>`: Change footer background to neutral.
+* `<cc-header-addon>`: Change footer background to neutral.
 ...
 
 ## 7.12.0 (2022-05-20)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ title: Changelog
 * `<cc-article-list>`: fix error mode not triggering on XML parsing failure (smart). 
 * `parseRssFeed()`: trim XML string before parse to avoid whitespaces error.
 * `<cc-button>`: update waiting loader animation in circle state.
+* Color design tokens: add darker shades for light colors.
+...
 
 ## 7.12.0 (2022-05-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ title: Changelog
 * `parseRssFeed()`: trim XML string before parse to avoid whitespaces error.
 * `<cc-button>`: update waiting loader animation in circle state.
 * Color design tokens: add darker shades for light colors.
+* New component:
+  * `<cc-badge>`
 ...
 
 ## 7.12.0 (2022-05-20)

--- a/src/addon/cc-header-addon.js
+++ b/src/addon/cc-header-addon.js
@@ -133,6 +133,7 @@ export class CcHeaderAddon extends LitElement {
           border: 1px solid #bcc2d1;
           border-radius: 0.25rem;
           display: block;
+          overflow: hidden;
         }
 
         .main {
@@ -181,7 +182,7 @@ export class CcHeaderAddon extends LitElement {
           --cc-gap: 0.5rem;
           --cc-align-items: center;
           align-items: center;
-          background-color: var(--color-bg-primary-light);
+          background-color: var(--color-bg-neutral);
           box-shadow: inset 0 6px 6px -6px #a4b1c9;
           box-sizing: border-box;
           color: #2e2e2e;

--- a/src/assets/error.svg
+++ b/src/assets/error.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24">
+  <path fill="none" d="M0 0h24v24H0z"/>
+  <path d="M12 22C6.477 22 2 17.523 2 12S6.477 2 12 2s10 4.477 10 10-4.477 10-10 10zm-1-7v2h2v-2h-2zm0-8v6h2V7h-2z" fill="#be242d"/>
+</svg>

--- a/src/atoms/cc-badge.js
+++ b/src/atoms/cc-badge.js
@@ -1,0 +1,145 @@
+import { css, html, LitElement } from 'lit-element';
+import { defaultThemeStyles } from '../styles/default-theme.js';
+
+/**
+ * @typedef {import('./types.js').BadgeIntent} BadgeIntent
+ * @typedef {import('./types.js').BadgeWeight} BadgeWeight
+ */
+
+/**
+ * A component to highlight a small chunk of text.
+ *
+ * @cssdisplay inline-flex
+ */
+export class CcBadge extends LitElement {
+  static get properties () {
+    return {
+      circle: { type: Boolean, reflect: true },
+      iconAlt: { type: String, attribute: 'icon-alt' },
+      iconSrc: { type: String, attribute: 'icon-src' },
+      intent: { type: String, reflect: true },
+      weight: { type: String, reflect: true },
+    };
+  }
+
+  constructor () {
+    super();
+
+    /** @type {Boolean} Sets the badge to a bubble style. Should only be used to display 1 or 2 digits figures. */
+    this.circle = false;
+
+    /** @type {String|null} Sets the `alt` attribute value on the `<img>` tag. Only use if the image conveys additional info compared to surrounding text. */
+    this.iconAlt = null;
+
+    /** @type {String|null} Sets the icon displayed on the left of the text inside the badge. */
+    this.iconSrc = null;
+
+    /** @type {BadgeIntent} Sets the accent color used for the badge. */
+    this.intent = 'neutral';
+
+    /** @type {BadgeWeight} Sets the style of the badge depending on how much one wants it to stand out. */
+    this.weight = 'dimmed';
+  }
+
+  render () {
+    return html`
+      ${this.iconSrc != null ? html`
+        <img src=${this.iconSrc} alt=${this.iconAlt ?? ''}>
+      ` : ''}
+      <span>
+        <slot></slot>
+      </span>
+    `;
+  }
+
+  static get styles () {
+    return [
+      defaultThemeStyles,
+      // language=CSS
+      css`
+        :host {
+          align-items: center;
+          border-radius: 1em;
+          display: inline-flex;
+          font-size: 0.8em;
+          gap: 0.3em;
+          padding: 0.2em 0.8em;
+        }
+
+        :host([circle]) {
+          border-radius: 50%;
+          font-size: 1em;
+          height: 1.5em;
+          justify-content: center;
+          min-height: unset;
+          padding: 0;
+          width: 1.5em;
+        }
+
+        :host([weight="dimmed"]) {
+          background-color: var(--accent-color, #ccc);
+          color: var(--color-text-default);
+        }
+
+        :host([weight="strong"]) {
+          background-color: var(--accent-color, #777);
+          color: var(--color-text-inverted, #fff);
+        }
+
+        :host([weight="outlined"]) {
+          background-color: var(--color-bg-default, #fff);
+          /* roughly 1px. We want the border to scale with the font size so that outlined
+          badges still stand out as they should when font-size is increased. */
+          box-shadow: inset 0 0 0 0.06em var(--accent-color, #777);
+          color: var(--accent-color, #777);
+        }
+
+        :host([intent="info"]) {
+          --accent-color: var(--color-bg-primary);
+        }
+
+        :host([intent="info"][weight="dimmed"]) {
+          --accent-color: var(--color-bg-primary-light);
+        }
+
+        :host([intent="success"]) {
+          --accent-color: var(--color-bg-success);
+        }
+
+        :host([intent="success"][weight="dimmed"]) {
+          --accent-color: var(--color-bg-success-light);
+        }
+
+        :host([intent="danger"]) {
+          --accent-color: var(--color-bg-danger);
+        }
+
+        :host([intent="danger"][weight="dimmed"]) {
+          --accent-color: var(--color-bg-danger-light);
+        }
+
+        :host([intent="warning"]) {
+          --accent-color: var(--color-bg-warning);
+        }
+
+        :host([intent="warning"][weight="dimmed"]) {
+          --accent-color: var(--color-bg-warning-light);
+        }
+
+        :host([intent="neutral"]) {
+          --accent-color: var(--color-bg-strong);
+        }
+
+        :host([intent="neutral"][weight="dimmed"]) {
+          --accent-color: var(--color-bg-neutral-alt);
+        }
+
+        img {
+          height: 1em;
+        }
+      `,
+    ];
+  }
+}
+
+window.customElements.define('cc-badge', CcBadge);

--- a/src/atoms/types.d.ts
+++ b/src/atoms/types.d.ts
@@ -12,3 +12,7 @@ export interface Option {
 export type PositionType = "top-left" | "bottom-left" | "top-right" | "bottom-right";
 
 export type IframeSandbox = "allow-forms" | "allow-modals" | "allow-pointer-lock" | "allow-popups" | "allow-popups-to-escape-sandbox" | "allow-same-origin" | "allow-scripts" | "allow-top-navigation";
+
+export type BadgeIntent = 'neutral' | 'info' | 'success' | 'warning' | 'danger';
+
+export type BadgeWeight = 'strong' | 'dimmed' | 'outlined';

--- a/src/notices/cc-warning-payment.js
+++ b/src/notices/cc-warning-payment.js
@@ -100,7 +100,7 @@ export class CcWarningPayment extends LitElement {
       linkStyles,
       css`
         :host {
-          background-color: var(--color-bg-warning-light);
+          background-color: var(--color-bg-warning-lighter);
           border: var(--border-warning);
           border-radius: 0.25em;
           color: var(--color-text-default);

--- a/src/overview/cc-header-app.js
+++ b/src/overview/cc-header-app.js
@@ -330,6 +330,7 @@ export class CcHeaderApp extends LitElement {
           border: 1px solid #bcc2d1;
           border-radius: 0.25rem;
           display: block;
+          overflow: hidden;
         }
 
         cc-error {
@@ -407,7 +408,7 @@ export class CcHeaderApp extends LitElement {
           --cc-gap: 0.5rem;
           --cc-align-items: center;
           align-items: center;
-          background-color: var(--color-bg-primary-light);
+          background-color: var(--color-bg-neutral);
           box-shadow: inset 0 6px 6px -6px #a4b1c9;
           box-sizing: border-box;
           color: #2e2e2e;

--- a/src/overview/cc-header-orga.js
+++ b/src/overview/cc-header-orga.js
@@ -1,3 +1,4 @@
+import '../atoms/cc-badge.js';
 import '../atoms/cc-img.js';
 import '../atoms/cc-flex-gap.js';
 import '../molecules/cc-error.js';
@@ -70,9 +71,7 @@ export class CcHeaderOrga extends LitElement {
             <div class="name ${classMap({ skeleton })}">${orga.name}</div>
             ${orga.cleverEnterprise ? html`
               <div class="spacer"></div>
-              <div class="badge">
-                <img class="badge_img" src=${badgeSvg} alt=""> Clever Cloud Enterprise
-              </div>
+              <cc-badge weight="strong" intent="info" icon-src=${badgeSvg}>Clever Cloud Enterprise</cc-badge>
             ` : ''}
           </div>
           <div class="spacer"></div>
@@ -80,7 +79,7 @@ export class CcHeaderOrga extends LitElement {
             <div class="hotline">
               <div class="hotline_label">${i18n('cc-header-orga.hotline')}</div>
               <a class="hotline_number" href="tel:${orga.emergencyNumber}">
-                <img class="hotline_number_img" src=${phoneSvg} alt=""> ${orga.emergencyNumber}
+                <cc-badge weight="outlined" intent="info" icon-src=${phoneSvg}>${orga.emergencyNumber}</cc-badge>
               </a>
             </div>
           ` : ''}
@@ -141,46 +140,12 @@ export class CcHeaderOrga extends LitElement {
           min-width: 12rem;
         }
 
-        .badge,
-        .hotline_number {
-          align-items: center;
-          border-radius: 0.15rem;
-          display: flex;
-          font-size: 0.8rem;
-          font-weight: bold;
-          padding: 0.2rem 0.4rem;
+        .hotline_number cc-badge {
+          text-decoration: underline;
         }
 
-        .badge {
-          background: var(--color-bg-primary);
-          color: #fff;
-        }
-
-        .hotline_number {
-          border: 1px solid var(--color-bg-primary);
-          color: var(--color-text-primary);
-          cursor: pointer;
-        }
-
-        .badge_img,
-        .hotline_number_img {
-          height: 0.9rem;
-          margin-right: 0.4rem;
-          overflow: hidden;
-          width: 0.9rem;
-        }
-
-        .hotline_number:focus {
-          box-shadow: 0 0 0 .2em rgba(50, 115, 220, .25);
-          outline: 0;
-        }
-
-        .hotline_number:hover {
-          box-shadow: 0 1px 3px #888;
-        }
-
+        .hotline_number:focus,
         .hotline_number:active {
-          box-shadow: none;
           outline: 0;
         }
 
@@ -189,6 +154,17 @@ export class CcHeaderOrga extends LitElement {
           border: 0;
         }
 
+        .hotline_number:focus cc-badge {
+          box-shadow: 0 0 0 .2em rgba(50, 115, 220, .25);
+        }
+
+        .hotline_number:hover cc-badge {
+          box-shadow: 0 1px 3px #888;
+        }
+
+        .hotline_number:active cc-badge {
+          box-shadow: none;
+        }
         .spacer {
           flex: 1 1 0;
         }

--- a/src/styles/default-theme.js
+++ b/src/styles/default-theme.js
@@ -16,9 +16,11 @@ export const defaultThemeStyles = css`
     --color-blue: #3569aa;
     --color-blue-dark: #012a51;
     --color-blue-highlight: #0061bd;
-    --color-blue-light: #f1f5ff;
+    --color-blue-light: #cedcff;
+    --color-blue-lighter: #f1f5ff;
     --color-green: #098846;
-    --color-green-light: #e3ffd6;
+    --color-green-light: #baf0be;
+    --color-green-lighter: #e3ffd6;
     --color-grey-100: #0d0d0d;
     --color-grey-90: #262626;
     --color-grey-80: #404040;
@@ -36,11 +38,13 @@ export const defaultThemeStyles = css`
     --color-legacy-green: #2faa60;
     /* do not use except inside cc-tile-instances*/
     --color-legacy-red: #ff0032;
-    --color-orange-light: #fff9cb;
+    --color-orange-light: #fcf3b5;
+    --color-orange-lighter: #fff9cb;
     --color-orange: #c15807;
     --color-purple-light: #e0e0ff;
     --color-red: #be242d;
-    --color-red-light: #ffe4e1;
+    --color-red-light: #fbc8c2;
+    --color-red-lighter: #ffe4e1;
     --color-white: #ffffff;
     --color-yellow: #e9e138;
     /*endregion*/
@@ -93,6 +97,11 @@ export const defaultThemeStyles = css`
     For instance: delete / remove buttons. */
     --color-bg-danger: var(--color-red);
 
+    /* Usage: minimal way to make content stand out.
+    Weakest of all color options for danger content.
+    For instance: notice, badge. */
+    --color-bg-danger-light: var(--color-red-light);
+
     /* Usage: default background color
     -- Not used at the moment - will be when we allow theme override. -- */
     --color-bg-default: var(--color-white);
@@ -102,7 +111,7 @@ export const defaultThemeStyles = css`
     --color-bg-neutral: var(--color-grey-10);
 
     /* Usage: another shade neutral background that stands out a little bit from the default background and neutral one.
-    For instance: blocks, cards, table rows. */
+    For instance: blocks, cards, table rows, badge. */
     --color-bg-neutral-alt: var(--color-grey-15);
     
     /* Usage: element with a neutral background with active status.
@@ -126,7 +135,9 @@ export const defaultThemeStyles = css`
     For instance: Modal opening button, add an element without refreshing the page. */
     --color-bg-primary: var(--color-blue);
 
-    /* Usage: notice ? */
+    /* Usage: minimal way to make content stand out.
+    * Weakest of all color options for information content.
+    For instance: notice, badge. */
     --color-bg-primary-light: var(--color-blue-light);
 
     /* Usage: content that needs to stand out a little more than primary content.
@@ -146,13 +157,25 @@ export const defaultThemeStyles = css`
     -- Use this with --color-text-inverted --
     For instance: submit buttons */
     --color-bg-success: var(--color-green);
+
+    /* Usage: minimal way to make content stand out.
+    * Weakest of all color options for success content.
+    For instance: notice, badge. */
+    --color-bg-success-light: var(--color-green-light);
     
     /* Usage: elements containing short texts with a "caution" / "warning" meaning and usually interactive.
     For instance: ? */
     --color-bg-warning: var(--color-orange);
 
-    /* Usage: elements containing texts with a "caution" / "warning" meaning with text in --color-text-default */
+    /* Usage: elements containing a small chunk of text with a "caution" / "warning" meaning with text in --color-text-default.
+    * Weak of all color options for warning content
+    For instance: badge */
     --color-bg-warning-light: var(--color-orange-light);
+
+    /* Usage: elements containing sentences with a "caution" / "warning" meaning with text in --color-text-default.
+    * Weakest of all color options for warning content
+    For instance: warning when no payment method is set */
+    --color-bg-warning-lighter: var(--color-orange-lighter);
     /*endregion*/
 
     /*region Color Decisions(border)*/

--- a/src/tcp-redirections/cc-tcp-redirection-form.js
+++ b/src/tcp-redirections/cc-tcp-redirection-form.js
@@ -1,3 +1,4 @@
+import '../atoms/cc-badge.js';
 import '../molecules/cc-block.js';
 import '../molecules/cc-error.js';
 import './cc-tcp-redirection.js';
@@ -52,7 +53,7 @@ export class CcTcpRedirectionForm extends LitElement {
     if (this.context === 'admin' && this.redirections != null) {
       const howManyRedirections = this.redirections.filter(({ sourcePort }) => sourcePort != null).length;
       if (howManyRedirections >= 1) {
-        return html`<span class="count">${howManyRedirections}</span>`;
+        return html`<cc-badge circle weight="strong">${howManyRedirections}</cc-badge>`;
       }
     }
     return '';
@@ -101,13 +102,10 @@ export class CcTcpRedirectionForm extends LitElement {
           display: block;
         }
 
-        .count {
-          background-color: #3a3871;
-          border-radius: 10rem;
-          color: #fff;
-          font-size: 0.8rem;
+        cc-badge {
+          /* cc-block title changes the font-size to 1.2em, which makes our badge way too big */
+          font-size: 0.8em;
           margin-left: 0.5rem;
-          padding: 0.1rem 0.5rem;
           vertical-align: middle;
         }
 

--- a/stories/atoms/cc-badge.stories.js
+++ b/stories/atoms/cc-badge.stories.js
@@ -1,0 +1,145 @@
+import '../../src/atoms/cc-badge.js';
+import { makeStory } from '../lib/make-story.js';
+import { enhanceStoriesNames } from '../lib/story-names.js';
+
+const infoSvg = new URL('../../src/assets/info.svg', import.meta.url);
+const warningSvg = new URL('../../src/assets/warning.svg', import.meta.url);
+const errorSvg = new URL('../../src/assets/error.svg', import.meta.url);
+const tickSvg = new URL('../../src/assets/tick.svg', import.meta.url);
+const badgeSvg = new URL('../../src/assets/badge-white.svg', import.meta.url);
+
+const baseItems = [
+  {
+    intent: 'info',
+    weight: 'dimmed',
+    innerHTML: 'this is info',
+  },
+  {
+    intent: 'success',
+    weight: 'dimmed',
+    innerHTML: 'this is success',
+  },
+  {
+    intent: 'danger',
+    weight: 'dimmed',
+    innerHTML: 'this is danger',
+  },
+  {
+    intent: 'warning',
+    weight: 'dimmed',
+    innerHTML: 'this is warning',
+  },
+  {
+    intent: 'neutral',
+    weight: 'dimmed',
+    innerHTML: 'this is neutral',
+  },
+];
+
+export default {
+  title: '🧬 Atoms/<cc-badge>',
+  component: 'cc-badge',
+};
+
+const conf = {
+  component: 'cc-badge',
+  // language=CSS
+  css: `cc-badge {
+    margin-right: 1em;
+    margin-bottom: 1em;
+  }`,
+};
+
+export const dimmed = makeStory(conf, {
+  items: baseItems,
+});
+
+export const outlined = makeStory(conf, {
+  items: baseItems.map((badge) => ({ ...badge, weight: 'outlined' })),
+});
+
+export const strong = makeStory(conf, {
+  items: baseItems.map((badge) => ({ ...badge, weight: 'strong' })),
+});
+
+export const icons = makeStory(conf, {
+  items: [
+    {
+      intent: 'info',
+      weight: 'dimmed',
+      innerHTML: 'this is info',
+      iconSrc: infoSvg,
+      iconAlt: 'Info',
+    },
+    {
+      intent: 'success',
+      weight: 'outlined',
+      innerHTML: 'this is success',
+      iconSrc: tickSvg,
+      iconAlt: 'Success',
+    },
+    {
+      intent: 'danger',
+      weight: 'outlined',
+      innerHTML: 'this is danger',
+      iconSrc: errorSvg,
+      iconAlt: 'Error',
+    },
+    {
+      intent: 'warning',
+      weight: 'strong',
+      innerHTML: 'this is warning',
+      iconSrc: warningSvg,
+      iconAlt: 'Warning',
+    },
+    {
+      intent: 'neutral',
+      weight: 'strong',
+      innerHTML: 'this is neutral',
+      iconSrc: badgeSvg,
+    },
+  ],
+});
+
+export const circleWithNumber = makeStory(conf, {
+  items: [
+    {
+      intent: 'info',
+      weight: 'dimmed',
+      innerHTML: '1',
+      circle: true,
+    },
+    {
+      intent: 'success',
+      weight: 'outlined',
+      innerHTML: '2',
+      circle: true,
+    },
+    {
+      intent: 'danger',
+      weight: 'outlined',
+      innerHTML: '10',
+      circle: true,
+    },
+    {
+      intent: 'warning',
+      weight: 'strong',
+      innerHTML: '5',
+      circle: true,
+    },
+    {
+      intent: 'neutral',
+      weight: 'strong',
+      innerHTML: '1',
+      circle: true,
+    },
+  ],
+});
+
+enhanceStoriesNames({
+  dimmed,
+  outlined,
+  strong,
+  icons,
+  circleWithNumber,
+});


### PR DESCRIPTION
:wave: Hey there ! 

Fixes #462 

The [preview](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-badge/index.html?path=/story/%F0%9F%A7%AC-atoms-cc-badge--dimmed) has been updated following your feedback (thanks again :heart:)

Padding and font-size have been reduced just a little bit. The size is very close to what what we use in `<cc-orga-member-card>` and `<cc-email-list>` and it matches what was already used in `<cc-header-orga>`.

# To review:

## UI

* [`<cc-badge>` stories](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-badge/index.html?path=/story/%F0%9F%A7%AC-atoms-cc-badge--dimmed),
* [`<cc-header-orga>` stories](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-badge/index.html?path=/story/%F0%9F%9B%A0-overview-cc-header-orga--default-story) (org status and hotline use `<cc-badge>`),
* [`<cc-tile-instances>` stories](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-badge/index.html?path=/story/🛠-overview-cc-tile-instances--default-story)  (bubble uses `<cc-badge>`),
* [`<cc-tcp-redirection-form>` "context admin" story](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-badge/index.html?path=/story/%F0%9F%9B%A0-tcp-redirections-cc-tcp-redirection-form--data-loaded-with-context-admin) (notif bubble uses `<cc-badge>`),
* [`<cc-header-app>` stories](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-badge/index.html?path=/story/%F0%9F%9B%A0-overview-cc-header-app--default-story) (footer bg is neutral now),
* [`<cc-header-addon>` stories](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-badge/index.html?path=/story/%F0%9F%9B%A0-addon-cc-header-addon--default-story) (footer bg is neutral now),

## Code

Every commit :sweat_smile: 

# TODO

- [x] Lint fix
- [x] Rebase