### PR TITLE
cc-input-, cc-select, cc-toggle: support inline layout (label next to form field)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ title: Changelog
 * `<cc-header-orga>`: Use `<cc-badge>` to display org status and hotline number. 
 * `<cc-input-text>`: add `inline` prop to place the label on the left of the `<input>` element. Add new `inline` story to show this behavior.
 * `<cc-input-number>`: add `inline` prop to place the label on the left of the `<input>` element. Add new `inline` story to show this behavior.
+* `<cc-select>`: add `inline` prop to place the label on the left of the `<select>` element. Add new `inline` story to show this behavior.
 ...
 
 ## 7.12.0 (2022-05-20)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ title: Changelog
 * `<cc-input-number>`: add `inline` prop to place the label on the left of the `<input>` element. Add new `inline` story to show this behavior.
 * `<cc-select>`: add `inline` prop to place the label on the left of the `<select>` element. Add new `inline` story to show this behavior.
 * `<cc-toggle>`: add `inline` prop to place the label on the left of the group of radio input elements. Add new `inline` story to show this behavior.
+* `<cc-invoice-list>`: inline year filters (`<cc-toggle>` for desktop and `<cc-select>` for mobile).
 ...
 
 ## 7.12.0 (2022-05-20)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ title: Changelog
 * `<cc-input-text>`: add `inline` prop to place the label on the left of the `<input>` element. Add new `inline` story to show this behavior.
 * `<cc-input-number>`: add `inline` prop to place the label on the left of the `<input>` element. Add new `inline` story to show this behavior.
 * `<cc-select>`: add `inline` prop to place the label on the left of the `<select>` element. Add new `inline` story to show this behavior.
+* `<cc-toggle>`: add `inline` prop to place the label on the left of the group of radio input elements. Add new `inline` story to show this behavior.
 ...
 
 ## 7.12.0 (2022-05-20)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ title: Changelog
 * `<cc-header-addon>`: Change footer background to neutral.
 * `<cc-header-orga>`: Use `<cc-badge>` to display org status and hotline number. 
 * `<cc-input-text>`: add `inline` prop to place the label on the left of the `<input>` element. Add new `inline` story to show this behavior.
+* `<cc-input-number>`: add `inline` prop to place the label on the left of the `<input>` element. Add new `inline` story to show this behavior.
 ...
 
 ## 7.12.0 (2022-05-20)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ title: Changelog
 * `<cc-header-app>`: Change footer background to neutral.
 * `<cc-header-addon>`: Change footer background to neutral.
 * `<cc-header-orga>`: Use `<cc-badge>` to display org status and hotline number. 
+* `<cc-input-text>`: add `inline` prop to place the label on the left of the `<input>` element. Add new `inline` story to show this behavior.
 ...
 
 ## 7.12.0 (2022-05-20)

--- a/src/atoms/cc-input-number.js
+++ b/src/atoms/cc-input-number.js
@@ -32,6 +32,7 @@ export class CcInputNumber extends LitElement {
     return {
       controls: { type: Boolean },
       disabled: { type: Boolean, reflect: true },
+      inline: { type: Boolean, reflect: true },
       label: { type: String },
       max: { type: Number },
       min: { type: Number },
@@ -56,6 +57,11 @@ export class CcInputNumber extends LitElement {
 
     /** @type {boolean} Sets `disabled` attribute on inner native `<input>` element. */
     this.disabled = false;
+
+    /** @type {boolean} Sets the `<label>` on the left of the `<input>` element.
+     * Only use this if your form contains 1 or 2 fields and your labels are short.
+     */
+    this.inline = false;
 
     /** @type {string|null} Sets label for the input. */
     this.label = null;
@@ -213,11 +219,11 @@ export class CcInputNumber extends LitElement {
         ` : ''}
       </div>
 
-      <div id=${this._uniqueHelpId}>
+      <div class="help-container" id=${this._uniqueHelpId}>
         <slot name="help"></slot>
       </div>
 
-      <div id=${this._uniqueErrorId}>
+      <div class="error-container" id=${this._uniqueErrorId}>
         <slot name="error"></slot>
       </div>
     `;
@@ -234,6 +240,22 @@ export class CcInputNumber extends LitElement {
         }
 
         /*region Common to cc-input-* & cc-select*/
+        :host([inline]) {
+          display: inline-grid;
+          gap: 0 1em;
+          grid-template-areas: "label input"
+                              ". help"
+                              ". error";
+          grid-template-columns: auto 1fr;
+        }
+
+        .help-container {
+          grid-area: help;
+        }
+
+        .error-container {
+          grid-area: error;
+        }
         label {
           align-items: flex-end;
           cursor: pointer;
@@ -244,10 +266,23 @@ export class CcInputNumber extends LitElement {
           padding-bottom: 0.35em;
         }
 
+        :host([inline]) label {
+          flex-direction: column;
+          gap: 0;
+          grid-area: label;
+          justify-content: center;
+          line-height: normal;
+          padding: 0;
+        }
+
         .required {
           color: var(--color-text-light);
           font-size: 0.9em;
           font-variant: small-caps;
+        }
+
+        :host([inline]) .required {
+          font-size: 0.8em;
         }
 
         slot[name='help']::slotted(*) {
@@ -265,6 +300,8 @@ export class CcInputNumber extends LitElement {
         .meta-input {
           box-sizing: border-box;
           display: inline-flex;
+          grid-area: input;
+          height: max-content;
           overflow: visible;
           /* link to position:absolute of .ring */
           position: relative;

--- a/src/atoms/cc-input-text.js
+++ b/src/atoms/cc-input-text.js
@@ -61,6 +61,7 @@ export class CcInputText extends LitElement {
       clipboard: { type: Boolean, reflect: true },
       disabled: { type: Boolean, reflect: true },
       label: { type: String },
+      inline: { type: Boolean, reflect: true },
       multi: { type: Boolean, reflect: true },
       name: { type: String, reflect: true },
       placeholder: { type: String },
@@ -87,6 +88,11 @@ export class CcInputText extends LitElement {
 
     /** @type {boolean} Sets `disabled` attribute on inner native `<input>/<textarea>` element. */
     this.disabled = false;
+
+    /** @type {boolean} Sets the `<label>` on the left of the `<input>` element.
+     * Only use this if your form contains 1 or 2 fields and your labels are short.
+     */
+    this.inline = false;
 
     /** @type {string|null} Sets label for the input. */
     this.label = null;
@@ -324,11 +330,11 @@ export class CcInputText extends LitElement {
       </div>
 
       
-      <div id=${this._uniqueHelpId}>
+      <div class="help-container" id=${this._uniqueHelpId}>
         <slot name="help"></slot>
       </div>
 
-      <div id=${this._uniqueErrorId}>
+      <div class="error-container" id=${this._uniqueErrorId}>
         <slot name="error"></slot>
       </div>
     `;
@@ -348,7 +354,28 @@ export class CcInputText extends LitElement {
           display: block;
         }
 
-        /*region Common to cc-input-* & cc-select*/
+        /*region Common to cc-input-* & cc-select (apart from multi) */
+        :host([inline]) {
+          display: inline-grid;
+          gap: 0 1em;
+          grid-template-areas: "label input"
+                              ". help"
+                              ". error";
+          grid-template-columns: auto 1fr;
+        }
+
+        :host([inline][multi]) {
+          display: grid;
+        }
+
+        .help-container {
+          grid-area: help;
+        }
+
+        .error-container {
+          grid-area: error;
+        }
+
         label {
           align-items: flex-end;
           cursor: pointer;
@@ -359,10 +386,28 @@ export class CcInputText extends LitElement {
           padding-bottom: 0.35em;
         }
 
+        :host([inline]) label {
+          flex-direction: column;
+          gap: 0;
+          grid-area: label;
+          justify-content: center;
+          line-height: normal;
+          padding: 0;
+        }
+        
+        :host([inline][multi]) label {
+          /* Allows the label text to be aligned with the first line of the input. */
+          height: 2em;
+        }
+
         .required {
           color: var(--color-text-light);
           font-size: 0.9em;
           font-variant: small-caps;
+        }
+
+        :host([inline]) .required {
+          font-size: 0.8em;
         }
 
         slot[name='help']::slotted(*) {
@@ -380,6 +425,8 @@ export class CcInputText extends LitElement {
         .meta-input {
           box-sizing: border-box;
           display: inline-flex;
+          grid-area: input;
+          height: max-content;
           /* link to position:absolute of .ring */
           position: relative;
           vertical-align: top;

--- a/src/atoms/cc-select.js
+++ b/src/atoms/cc-select.js
@@ -22,6 +22,7 @@ export class CcSelect extends LitElement {
   static get properties () {
     return {
       disabled: { type: Boolean, reflect: true },
+      inline: { type: Boolean, reflect: true },
       /** @required */
       label: { type: String },
       name: { type: String, reflect: true },
@@ -40,6 +41,11 @@ export class CcSelect extends LitElement {
 
     /** @type {boolean} Sets `disabled` attribute on inner native `<select>` element. */
     this.disabled = false;
+
+    /** @type {boolean} Sets the `<label>` on the left of the `<select>` element.
+     * Only use this if your form contains 1 or 2 fields and your labels are short.
+     */
+    this.inline = false;
 
     /** @type {string|null} Sets `name` attribute on inner native `<select>` element. */
     this.name = null;
@@ -113,11 +119,11 @@ export class CcSelect extends LitElement {
         </select>
       </div>
 
-      <div id=${this._uniqueHelpId}>
+      <div class="help-container" id=${this._uniqueHelpId}>
         <slot name="help"></slot>
       </div>
 
-      <div id=${this._uniqueErrorId}>
+      <div class="error-container" id=${this._uniqueErrorId}>
         <slot name="error"></slot>
       </div>
     `;
@@ -133,6 +139,23 @@ export class CcSelect extends LitElement {
         }
 
         /*region Common to cc-input-* & cc-select*/
+        :host([inline]) {
+          display: inline-grid;
+          gap: 0 1em;
+          grid-template-areas: "label input"
+                              ". help"
+                              ". error";
+          grid-template-columns: auto 1fr;
+        }
+
+        .help-container {
+          grid-area: help;
+        }
+
+        .error-container {
+          grid-area: error;
+        }
+
         label {
           align-items: flex-end;
           cursor: pointer;
@@ -143,10 +166,23 @@ export class CcSelect extends LitElement {
           padding-bottom: 0.35em;
         }
 
+        :host([inline]) label {
+          flex-direction: column;
+          gap: 0;
+          grid-area: label;
+          justify-content: center;
+          line-height: normal;
+          padding: 0;
+        }
+
         .required {
           color: var(--color-text-light);
           font-size: 0.9em;
           font-variant: small-caps;
+        }
+
+        :host([inline]) .required {
+          font-size: 0.8em;
         }
 
         slot[name='help']::slotted(*) {
@@ -183,6 +219,7 @@ export class CcSelect extends LitElement {
           border: 1px solid #aaa;
           border-radius: 0.25em;
           box-sizing: border-box;
+          grid-area: input;
           height: 2em;
           padding: 0 3em 0 0.5em;
         }

--- a/src/atoms/cc-toggle.js
+++ b/src/atoms/cc-toggle.js
@@ -47,6 +47,7 @@ export class CcToggle extends LitElement {
       choices: { type: Array },
       disabled: { type: Boolean },
       hideText: { type: Boolean, attribute: 'hide-text' },
+      inline: { type: Boolean, reflect: true },
       legend: { type: String },
       multipleValues: { type: Array, attribute: 'multiple-values', reflect: true },
       subtle: { type: Boolean },
@@ -65,6 +66,11 @@ export class CcToggle extends LitElement {
 
     /** @type {boolean} Hides the text and only displays the image specified with `choices[i].image`. The text will be added as `title` on the inner `<label>` and an `aria-label` on the inner `<input>`. */
     this.hideText = false;
+
+    /** @type {boolean} Sets the `<label>` on the left of the `<select>` element.
+     * Only use this if your form contains 1 or 2 fields and your labels are short.
+     */
+    this.inline = false;
 
     /** @type {string|null} Sets a legend to describe the whole component (input group). */
     this.legend = null;
@@ -157,6 +163,7 @@ export class CcToggle extends LitElement {
           --cc-toggle-color: var(--color-bg-primary);
           --cc-toggle-img-filter: none;
           --cc-toggle-img-filter-selected: none;
+          --height: 2em;
           display: flex;
           flex-direction: column;
         }
@@ -185,12 +192,22 @@ export class CcToggle extends LitElement {
           padding-bottom: 0.35em;
         }
 
+        :host([inline]) legend {
+          /* cannot use flex to change legend position. Only solution is float. */
+          float: left;
+          /* used to vertically center the floated element. */
+          line-height: var(--height);
+          margin-right: 1em;
+          padding: 0;
+          width: max-content;
+        }
+
         .toggle-group {
           background-color: #fff;
           border-radius: 0.15em;
           box-sizing: border-box;
           display: flex;
-          height: 2em;
+          height: var(--height);
           line-height: 1.25;
           overflow: visible;
         }

--- a/src/invoices/cc-invoice-list.js
+++ b/src/invoices/cc-invoice-list.js
@@ -119,12 +119,14 @@ export class CcInvoiceList extends withResizeObserver(LitElement) {
                   legend=${i18n('cc-invoice-list.year')}
                   .choices=${yearChoices}
                   value=${yearFilter}
+                  inline
                   @cc-toggle:input=${this._onYearFilterValue}
                 ></cc-toggle>
                 <cc-select
                   label=${i18n('cc-invoice-list.year')}
                   .options=${yearChoices}
                   value=${yearFilter}
+                  inline
                   @cc-select:input=${this._onYearFilterValue}
                 ></cc-select>
               ` : ''}

--- a/stories/atoms/cc-input-number.stories.js
+++ b/stories/atoms/cc-input-number.stories.js
@@ -72,6 +72,36 @@ export const errorMessageWithHelpMessage = makeStory(conf, {
   })),
 });
 
+export const inline = makeStory(conf, {
+  css: `cc-input-number { margin: 1rem 0.5rem; }`,
+  items: baseItems.map((p) => ({
+    ...p,
+    inline: true,
+  })),
+});
+
+export const inlineWithRequired = makeStory(conf, {
+  css: `cc-input-number { margin: 1rem 0.5rem; }`,
+  items: baseItems.map((p) => ({
+    ...p,
+    inline: true,
+    required: true,
+  })),
+});
+
+export const inlineWithErrorAndHelpMessages = makeStory(conf, {
+  css: `cc-input-number { margin: 1rem 0.5rem; }`,
+  items: baseItems.map((p) => ({
+    ...p,
+    inline: true,
+    required: true,
+    innerHTML: `
+      <p slot="help">Must be an integer</p>
+      <p slot="error">You must enter a value</p>
+    `,
+  })),
+});
+
 export const controls = makeStory(conf, {
   items: baseItems.map((p) => ({ ...p, controls: true })),
 });
@@ -157,6 +187,9 @@ enhanceStoriesNames({
   helpMessage,
   errorMessage,
   errorMessageWithHelpMessage,
+  inline,
+  inlineWithRequired,
+  inlineWithErrorAndHelpMessages,
   controls,
   minMax,
   minMaxWithControls,

--- a/stories/atoms/cc-input-text.stories.js
+++ b/stories/atoms/cc-input-text.stories.js
@@ -115,6 +115,36 @@ export const errorMessageWithHelpMessage = makeStory(conf, {
   })),
 });
 
+export const inline = makeStory(conf, {
+  css: `cc-input-text { margin: 1rem 0.5rem; }`,
+  items: baseItems.map((p) => ({
+    ...p,
+    inline: true,
+  })),
+});
+
+export const inlineWithRequired = makeStory(conf, {
+  css: `cc-input-text { margin: 1rem 0.5rem; }`,
+  items: baseItems.map((p) => ({
+    ...p,
+    inline: true,
+    required: true,
+  })),
+});
+
+export const inlineWithErrorAndHelpMessages = makeStory(conf, {
+  css: `cc-input-text { margin: 1rem 0.5rem; }`,
+  items: baseItems.map((p) => ({
+    ...p,
+    inline: true,
+    required: true,
+    innerHTML: `
+      <p slot="help">Must be at least 7 characters long</p>
+      <p slot="error">You must enter a value</p>
+    `,
+  })),
+});
+
 export const clipboard = makeStory(conf, {
   items: baseItems.map((p) => ({ ...p, clipboard: true })),
 });
@@ -188,6 +218,9 @@ enhanceStoriesNames({
   helpMessage,
   errorMessage,
   errorMessageWithHelpMessage,
+  inline,
+  inlineWithRequired,
+  inlineWithErrorAndHelpMessages,
   clipboard,
   clipboardWithAutoAdjust,
   clipboardWithAutoAdjustAndCssOverride,

--- a/stories/atoms/cc-select.stories.js
+++ b/stories/atoms/cc-select.stories.js
@@ -102,6 +102,69 @@ export const errorMessageWithHelpMessage = makeStory(conf, {
   ],
 });
 
+export const inline = makeStory(conf, {
+  css: `cc-select { margin: 1rem 0.5rem; }`,
+  items: [
+    {
+      label: 'The label',
+      inline: true,
+      options: baseOptions,
+    },
+    {
+      label: 'Favourite artist',
+      placeholder: '-- Select an artist --',
+      inline: true,
+      options: baseOptions,
+    },
+  ],
+});
+
+export const inlineWithRequired = makeStory(conf, {
+  css: `cc-select { margin: 1rem 0.5rem; }`,
+  items: [
+    {
+      label: 'The label',
+      inline: true,
+      required: true,
+      options: baseOptions,
+    },
+    {
+      label: 'Favourite artist',
+      placeholder: '-- Select an artist --',
+      inline: true,
+      required: true,
+      options: baseOptions,
+    },
+  ],
+});
+
+export const inlineWithErrorAndHelpMessages = makeStory(conf, {
+  css: `cc-select { margin: 1rem 0.5rem; }`,
+  items: [
+    {
+      label: 'The label',
+      inline: true,
+      required: true,
+      options: baseOptions,
+      innerHTML: `
+        <p slot="help">There can be only one.</p>
+        <p slot="error">A value must be selected.</p>
+      `,
+    },
+    {
+      label: 'Favourite artist',
+      placeholder: '-- Select an artist --',
+      inline: true,
+      required: true,
+      options: baseOptions,
+      innerHTML: `
+        <p slot="help">There can be only one.</p>
+        <p slot="error">A value must be selected.</p>
+      `,
+    },
+  ],
+});
+
 export const disabled = makeStory(conf, {
   items: [
     {
@@ -142,6 +205,9 @@ enhanceStoriesNames({
   helpMessage,
   errorMessage,
   errorMessageWithHelpMessage,
+  inline,
+  inlineWithRequired,
+  inlineWithErrorAndHelpMessages,
   longContentWihFixedWidth,
   allFormControls,
 });

--- a/stories/atoms/cc-toggle.stories.js
+++ b/stories/atoms/cc-toggle.stories.js
@@ -120,6 +120,19 @@ export const legend = makeStory(conf, {
   items: normalAndSubtleItems.map((p) => ({ ...p, legend: 'The legend' })),
 });
 
+export const legendWithInline = makeStory({
+  ...conf,
+  css: `
+    :host {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem 0.5rem;
+    }
+  `,
+}, {
+  items: normalAndSubtleItems.map((p) => ({ ...p, legend: 'The legend', inline: true })),
+});
+
 export const multiple = makeStory(conf, {
   css: conf.css + `
     :host {
@@ -236,6 +249,7 @@ enhanceStoriesNames({
   defaultStory,
   disabled,
   legend,
+  legendWithInline,
   multiple,
   color,
   textTransform,


### PR DESCRIPTION
Fixes #451.

:wave: Hey there !

I updated the [Preview](https://clever-components-preview.cellar-c2.services.clever-cloud.com/form-fields/inline-label/index.html).

Most of the changes are related to `<cc-toggle>` and `<cc-invoice-list>` :+1: 

# Things to review:

## UI 

- "inline" stories (+ inline required and inline with error / help messages) for these components:
	- `<cc-input-number>`,
	- `<cc-input-text>`,
	- `<cc-select>`,
	- `<cc-toggle>` (only one inline story since `cc-toggle` does not support required and help messages (and I'm not sure it should but it's another subject).
- `<cc-invoice-list>` stories (both desktop and mobile), the "year" filter is now "inlined".

## Code

Every commit.

# TODO:

- [x] Lint fix
- [x] Rebase after #462 merge
