### PR TITLE
cc-header-orga: fix cc-badge usage with focus style

### DIFF
--- a/src/overview/cc-header-orga.js
+++ b/src/overview/cc-header-orga.js
@@ -140,8 +140,8 @@ export class CcHeaderOrga extends LitElement {
           min-width: 12rem;
         }
 
-        .hotline_number cc-badge {
-          text-decoration: underline;
+        .hotline_number {
+          border-radius: 1em;
         }
 
         .hotline_number:focus,
@@ -154,17 +154,24 @@ export class CcHeaderOrga extends LitElement {
           border: 0;
         }
 
-        .hotline_number:focus cc-badge {
+        .hotline_number:focus {
           box-shadow: 0 0 0 .2em rgba(50, 115, 220, .25);
         }
 
-        .hotline_number:hover cc-badge {
+        .hotline_number:hover {
           box-shadow: 0 1px 3px #888;
         }
 
-        .hotline_number:active cc-badge {
+        .hotline_number:active {
           box-shadow: none;
         }
+
+        .hotline_number cc-badge {
+          /* Prevent space below badge because of text lines */
+          display: flex;
+          text-decoration: underline;
+        }
+
         .spacer {
           flex: 1 1 0;
         }


### PR DESCRIPTION
Because the cc-badge uses a box-shadow as a "border", when overriding the box-shadow to create a focus ring in the `<cc-header-orga>`, the "border" disappeared like this:

![Capture d’écran du 2022-07-01 17-04-17](https://user-images.githubusercontent.com/236342/176920681-e9e9a12e-152f-428b-82bd-a8f8187ee061.png)

With this fix, we have the focus ring AND the "border":

![Capture d’écran du 2022-07-01 17-04-23](https://user-images.githubusercontent.com/236342/176920760-d79bcb23-b547-45f9-9366-6d052f7e80ea.png)