### PR TITLE
cc-select: use value property instead of selected attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ title: Changelog
 * `<cc-input-text>`: set default font back to `--cc-ff-monospace` when the input contains tags (BREAKING CHANGE).
 * Introduce a new project file structure (BREAKING CHANGE).
 * all components: change `rem` units to `em` (BREAKING CHANGE).
+* `<cc-select>`: use the `value` property of the select element instead of the `selected` attribute. The `value` prop should always be set when using the `<cc-select>` component. It may be set to an empty string if a `placeholder` is provided (BREAKING CHANGE).
 
 ### Components
 

--- a/src/components/cc-select/cc-select.stories.js
+++ b/src/components/cc-select/cc-select.stories.js
@@ -39,6 +39,7 @@ export const defaultStory = makeStory(conf, {
     {
       label: 'Favourite artist',
       placeholder: '-- Select an artist --',
+      value: '',
       options: baseOptions,
     },
     {
@@ -55,6 +56,7 @@ export const required = makeStory(conf, {
       label: 'Favourite artist',
       placeholder: '-- Select an artist --',
       required: true,
+      value: '',
       options: baseOptions,
     },
   ],
@@ -66,6 +68,7 @@ export const helpMessage = makeStory(conf, {
       label: 'Favourite artist',
       placeholder: '-- Select an artist --',
       required: true,
+      value: '',
       options: baseOptions,
       innerHTML: '<p slot="help">There can be only one.</p>',
     },
@@ -78,6 +81,7 @@ export const errorMessage = makeStory(conf, {
       label: 'Favourite artist',
       placeholder: '-- Select an artist --',
       required: true,
+      value: '',
       options: baseOptions,
       innerHTML: '<p slot="error">A value must be selected.</p>',
     },
@@ -90,6 +94,7 @@ export const errorMessageWithHelpMessage = makeStory(conf, {
       label: 'Favourite artist',
       placeholder: '-- Select an artist --',
       required: true,
+      value: '',
       options: baseOptions,
       innerHTML: `
         <p slot="help">There can be only one.</p>
@@ -104,12 +109,14 @@ export const inline = makeStory(conf, {
     {
       label: 'The label',
       inline: true,
+      value: 'LENNON',
       options: baseOptions,
     },
     {
       label: 'Favourite artist',
       placeholder: '-- Select an artist --',
       inline: true,
+      value: '',
       options: baseOptions,
     },
   ],
@@ -121,6 +128,7 @@ export const inlineWithRequired = makeStory(conf, {
       label: 'The label',
       inline: true,
       required: true,
+      value: 'LENNON',
       options: baseOptions,
     },
     {
@@ -128,6 +136,7 @@ export const inlineWithRequired = makeStory(conf, {
       placeholder: '-- Select an artist --',
       inline: true,
       required: true,
+      value: '',
       options: baseOptions,
     },
   ],
@@ -140,6 +149,7 @@ export const inlineWithErrorAndHelpMessages = makeStory(conf, {
       inline: true,
       required: true,
       options: baseOptions,
+      value: 'LENNON',
       innerHTML: `
         <p slot="help">There can be only one.</p>
         <p slot="error">A value must be selected.</p>
@@ -150,6 +160,7 @@ export const inlineWithErrorAndHelpMessages = makeStory(conf, {
       placeholder: '-- Select an artist --',
       inline: true,
       required: true,
+      value: '',
       options: baseOptions,
       innerHTML: `
         <p slot="help">There can be only one.</p>
@@ -163,7 +174,7 @@ export const disabled = makeStory(conf, {
   items: [
     {
       label: 'Favourite artist',
-      placeholder: '-- Select an artist --',
+      value: 'LENNON',
       disabled: true,
       options: baseOptions,
     },
@@ -185,6 +196,7 @@ export const longContentWihFixedWidth = makeStory(
         label: longContent,
         placeholder: '-- Select an artist --',
         required: true,
+        value: '',
         options: [...baseOptions.map(() => ({ label: longContent }))],
       },
     ],


### PR DESCRIPTION
Fixes #514 

# Issues:

## The selected attribute issue

The `cc-select` component was relying on the `selected` attribute instead of the value property.

```js
<option
  value=${option.value}
  ?selected=${option.value === this.value}
>
  ${option.label}
</option>
```

This led to inconsistent renders. 
The `value` of the component and the visually selected option could end up completely disconnected when trying to set the `value` of the component from outside (changing the value programmatically with no user action).

Also, the `selected` attribute is supposed to only be used to set the initial / default value of the `<select>` element.
It is not supposed to reflect the `<select>` value as explained in the [MDN Docs about the select element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/option#attr-selected).
It behaves just like the `checked` attribute, which I've always found confusing.

## The value property issue

Using the `value` property is not as simple as it looks with the `<select>` element.

The issue happens during the first render, if you want to set a default value.
The `value` property must match the `value` of one of the `<option>` elements inside the `<select>` element.
These `<option>` elements are generated from the `options` prop.
What seems to happen (thanks @Galimede for finding this out) is visible in the screenshot below:
![image](https://user-images.githubusercontent.com/100240294/181570331-0ce55cdb-4adc-40b1-83e1-3ee279f636ff.png)

1. update - Properties have been set with new values, it triggers a render.
2. rendering start - The component properties are set as they should, render updates the DOM based on these values.
3. during the rendering - It first tries to set the value of the `<select>` element, but no `<option>` has been added yet. The `<select>` value does not match any `<option>` value.
4. during the rendering - It then generates the `<option>` elements.
5. updated - render is over. The native `<select>` value does not match the component `value`. It seems it falls back to the first item from the list (which is the default behavior when no `value` is specified). 

If you want to check the debug yourself, you can use the [cc-select/debug-value-issue branch](https://github.com/CleverCloud/clever-components/tree/cc-select/debug-value-issue).
Use the "Required" story of the `cc-select` component.

# Solutions

We decided to add an internal `_value` property.
This property is updated **after any render** that was triggered by an update to the `options` or the `value` (`firstUpdated` lifecycle hook).
This property is synced with the native `<select>` value.

This way, we make sure that <option> elements have been rendered before updating the `<select>` value.

# Questions:

- do we rely on lit and an internal property like "_value" or on an imperative update of the `<select>` value ?
- when no value is provided to the `<cc-select>`, should we fallback to the first option (lit behavior ?) or display an empty `<select>` (native behavior) ? 
- when the value provided is inconsistent (does not match any option), what should we do ? Empty `<select>` vs first option select