### PR TITLE
task: improve i18n check display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ title: Changelog
 * `<cc-zone-input>`: make server markers not focusable.
 * `<cc-addon-admin>`: fix skeleton mode
 
+### For devs
+
+* Improve display of `components:check-i18n` task.
+
 ## 9.0.0 (2022-07-19)
 
 ### ⚠️ BREAKING CHANGES


### PR DESCRIPTION
Fixes #91.

- Remove log of each single file scanned.
- Display amount of file scanned, key missing and key unused.
- Display success message when no key are missing or being unused.
- Regroup languages for each key missing or unused.
- Add some colors and emojis.
- Display task execution duration.