### PR TITLE
cc-toggle: remove spacing when empty

### DIFF
--- a/src/atoms/cc-toggle.js
+++ b/src/atoms/cc-toggle.js
@@ -112,6 +112,7 @@ export class CcToggle extends LitElement {
   render () {
 
     const classes = {
+      'toggle-group': this.choices?.length > 0,
       disabled: this.disabled,
       enabled: !this.disabled,
       'display-normal': !this.subtle,
@@ -130,7 +131,7 @@ export class CcToggle extends LitElement {
     return html`
       <fieldset>
         <legend>${this.legend}</legend>
-        <div class="toggle-group ${classMap(classes)}">
+        <div class=${classMap(classes)}>
           ${repeat(this.choices, ({ value }) => value, ({ label, image, value }) => html`
             <input
               type=${type}


### PR DESCRIPTION
Fixes #156.

Although I'm not sure if I properly fixed what was expected (as there is legitimately no specific story for this use case).

To reproduce the use case I had in mind, in the `cc-toggle` default story, in the lower "Controls" tab, empty the `choices` property (to an empty array):
- currently: renders an empty component but with a vertical blank space;
- fixed: renders an empty component that takes no vertical space.