### PR TITLE
css: change rem units to em

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ title: Changelog
 * `<cc-toggle>`: update component host default `display` CSS property (BREAKING CHANGE).
 * `<cc-input-text>`: set default font back to `--cc-ff-monospace` when the input contains tags (BREAKING CHANGE).
 * Introduce a new project file structure (BREAKING CHANGE).
+* all components: change `rem` units to `em` (BREAKING CHANGE).
 
 ### Components
 
@@ -25,6 +26,7 @@ title: Changelog
 ### For devs
 
 * Improve display of `components:check-i18n` task.
+...
 
 ## 9.0.0 (2022-07-19)
 

--- a/src/components/cc-addon-admin/cc-addon-admin.js
+++ b/src/components/cc-addon-admin/cc-addon-admin.js
@@ -179,8 +179,8 @@ export class CcAddonAdmin extends LitElement {
         }
 
         .one-line-form cc-input-text {
-          flex: 1 1 10rem;
-          margin-right: 0.5rem;
+          flex: 1 1 10em;
+          margin-right: 0.5em;
         }
       `,
     ];

--- a/src/components/cc-addon-backups/cc-addon-backups.js
+++ b/src/components/cc-addon-backups/cc-addon-backups.js
@@ -338,29 +338,29 @@ export class CcAddonBackups extends LitElement {
       css`
         :host {
           display: grid;
-          grid-gap: 1rem;
+          grid-gap: 1em;
           line-height: 1.5;
         }
 
         .backup-list {
           display: grid;
-          grid-gap: 1.5rem;
+          grid-gap: 1.5em;
         }
 
         .backup {
           display: flex;
-          line-height: 1.5rem;
+          line-height: 1.5em;
         }
 
         .backup-icon,
         .backup-text {
-          margin-right: 0.5rem;
+          margin-right: 0.5em;
         }
 
         .backup-icon {
           flex: 0 0 auto;
-          height: 1.5rem;
-          width: 1.5rem;
+          height: 1.5em;
+          width: 1.5em;
         }
 
         .backup-icon img {
@@ -387,14 +387,14 @@ export class CcAddonBackups extends LitElement {
         }
 
         .overlay {
-          box-shadow: 0 0 1rem rgba(0, 0, 0, 0.4);
-          margin: 2rem;
+          box-shadow: 0 0 1em rgba(0, 0, 0, 0.4);
+          margin: 2em;
           max-width: 80%;
         }
 
         .cc-link,
         cc-button[link] {
-          margin-right: 0.5rem;
+          margin-right: 0.5em;
           vertical-align: baseline;
         }
 

--- a/src/components/cc-addon-credentials/cc-addon-credentials.js
+++ b/src/components/cc-addon-credentials/cc-addon-credentials.js
@@ -128,12 +128,12 @@ export class CcAddonCredentials extends LitElement {
         }
 
         .credential-list {
-          --cc-gap: 1rem;
+          --cc-gap: 1em;
         }
 
         cc-input-text {
           --cc-input-font-family: var(--cc-ff-monospace, monospace);
-          flex: 1 0 18rem;
+          flex: 1 0 18em;
         }
 
         /* SKELETON */

--- a/src/components/cc-addon-features/cc-addon-features.js
+++ b/src/components/cc-addon-features/cc-addon-features.js
@@ -154,9 +154,9 @@ export class CcAddonFeatures extends LitElement {
 
         .feature-list {
           --bdw: 2px;
-          --cc-gap: 1rem;
+          --cc-gap: 1em;
           --color: var(--cc-color-bg-primary);
-          --padding: 0.6rem;
+          --padding: 0.6em;
         }
 
         .feature {
@@ -170,7 +170,7 @@ export class CcAddonFeatures extends LitElement {
         .feature-icon {
           margin: calc(var(--padding) / 2) 0 calc(var(--padding) / 2) var(--padding);
           position: relative;
-          width: 1.3rem;
+          width: 1.3em;
         }
 
         .feature-icon_img {

--- a/src/components/cc-addon-linked-apps/cc-addon-linked-apps.js
+++ b/src/components/cc-addon-linked-apps/cc-addon-linked-apps.js
@@ -101,20 +101,20 @@ export class CcAddonLinkedApps extends LitElement {
         .application {
           align-items: flex-start;
           display: flex;
-          line-height: 1.6rem;
+          line-height: 1.6em;
         }
 
         .logo {
-          border-radius: 0.25rem;
+          border-radius: 0.25em;
           flex: 0 0 auto;
-          height: 1.6rem;
-          width: 1.6rem;
+          height: 1.6em;
+          width: 1.6em;
         }
 
         .details {
           --cc-align-items: center;
-          --cc-gap: 0.5rem;
-          margin-left: 0.5rem;
+          --cc-gap: 0.5em;
+          margin-left: 0.5em;
         }
 
         /* SKELETON */

--- a/src/components/cc-addon-option/cc-addon-option.js
+++ b/src/components/cc-addon-option/cc-addon-option.js
@@ -68,11 +68,11 @@ export class CcAddonOption extends LitElement {
       css`
         :host {
           background-color: var(--cc-color-bg-default, #fff);
-          border-radius: 0.25rem;
+          border-radius: 0.25em;
           display: grid;
-          grid-gap: 1rem;
+          grid-gap: 1em;
           grid-template-columns: min-content 1fr;
-          padding: 1rem;
+          padding: 1em;
         }
 
         ::slotted(.option-warning) {
@@ -82,13 +82,13 @@ export class CcAddonOption extends LitElement {
 
         .option-main {
           display: grid;
-          grid-gap: 0.5rem;
+          grid-gap: 0.5em;
         }
 
         .option-name {
           font-weight: bold;
           line-height: 1.6;
-          min-height: 1.6rem;
+          min-height: 1.6em;
         }
 
         :host(:not([enabled])) {
@@ -101,14 +101,14 @@ export class CcAddonOption extends LitElement {
         }
 
         .logo {
-          border-radius: 0.25rem;
-          height: 1.6rem;
-          width: 1.6rem;
+          border-radius: 0.25em;
+          height: 1.6em;
+          width: 1.6em;
         }
 
         cc-toggle {
           justify-self: end;
-          margin-top: 0.5rem;
+          margin-top: 0.5em;
         }
 
         :host([enabled]) cc-toggle {

--- a/src/components/cc-block-section/cc-block-section.js
+++ b/src/components/cc-block-section/cc-block-section.js
@@ -32,7 +32,7 @@ export class CcBlockSection extends LitElement {
         :host {
           background-color: var(--cc-color-bg-default, #fff);
           display: grid;
-          grid-gap: 1rem;
+          grid-gap: 1em;
         }
 
         /*
@@ -46,8 +46,8 @@ export class CcBlockSection extends LitElement {
          */
         :host(:not(:first-of-type)) {
           border-top: 1px solid #bcc2d1;
-          margin-top: 1rem;
-          padding-top: 2rem;
+          margin-top: 1em;
+          padding-top: 2em;
         }
 
         ::slotted([slot="title"]) {
@@ -62,23 +62,23 @@ export class CcBlockSection extends LitElement {
         .section {
           display: flex;
           flex-wrap: wrap;
-          margin: -0.5rem -1.5rem;
+          margin: -0.5em -1.5em;
         }
 
         ::slotted([slot="info"]),
         .main {
-          margin: 0.5rem 1.5rem;
+          margin: 0.5em 1.5em;
         }
 
         ::slotted([slot="info"]) {
-          flex: 1 1 15rem;
+          flex: 1 1 15em;
           line-height: 1.5;
         }
 
         .main {
           display: grid;
-          flex: 2 2 30rem;
-          grid-gap: 1rem;
+          flex: 2 2 30em;
+          grid-gap: 1em;
         }
       `,
     ];

--- a/src/components/cc-block/cc-block.js
+++ b/src/components/cc-block/cc-block.js
@@ -125,7 +125,7 @@ export class CcBlock extends LitElement {
         :host {
           background-color: var(--cc-color-bg-default, #fff);
           border: 1px solid #bcc2d1;
-          border-radius: 0.25rem;
+          border-radius: 0.25em;
           box-sizing: border-box;
           display: grid;
           overflow: hidden;
@@ -135,11 +135,11 @@ export class CcBlock extends LitElement {
         .head {
           align-items: center;
           display: flex;
-          padding: 1rem;
+          padding: 1em;
         }
 
         :host([ribbon]) .head {
-          padding-left: 3.5rem;
+          padding-left: 3.5em;
         }
 
         :host([state="open"]) .head:hover,
@@ -150,27 +150,27 @@ export class CcBlock extends LitElement {
 
         cc-img {
           align-self: flex-start;
-          border-radius: 0.25rem;
-          height: 1.5rem;
-          margin-right: 1rem;
-          width: 1.5rem;
+          border-radius: 0.25em;
+          height: 1.5em;
+          margin-right: 1em;
+          width: 1.5em;
         }
 
         ::slotted([slot="title"]) {
           color: var(--cc-color-text-strong);
           flex: 1 1 0;
-          font-size: 1.2rem;
+          font-size: 1.2em;
           font-weight: bold;
         }
 
         .info-ribbon {
-          --height: 1.5rem;
-          --width: 8rem;
+          --height: 1.5em;
+          --width: 8em;
           --r: -45deg;
-          --translate: 1.6rem;
+          --translate: 1.6em;
           background: var(--cc-color-bg-strong);
           color: white;
-          font-size: 0.9rem;
+          font-size: 0.9em;
           font-weight: bold;
           height: var(--height);
           left: calc(var(--width) / -2);
@@ -185,16 +185,16 @@ export class CcBlock extends LitElement {
 
         .main {
           display: grid;
-          grid-gap: 1rem;
-          padding: 0.5rem 1rem 1rem;
+          grid-gap: 1em;
+          padding: 0.5em 1em 1em;
         }
 
         :host([no-head]) .main {
-          padding: 1rem;
+          padding: 1em;
         }
 
         .main-wrapper--overlay {
-          filter: blur(0.3rem);
+          filter: blur(0.3em);
           opacity: 0.35;
         }
 
@@ -205,7 +205,7 @@ export class CcBlock extends LitElement {
         }
 
         :host([ribbon]) .main-wrapper {
-          padding-left: 2.5rem;
+          padding-left: 2.5em;
         }
 
         ::slotted([slot="overlay"]) {

--- a/src/components/cc-doc-card/cc-doc-card.js
+++ b/src/components/cc-doc-card/cc-doc-card.js
@@ -93,7 +93,7 @@ export class CcDocCard extends LitElement {
                   "link link";
           grid-template-columns: min-content 1fr;
           grid-template-rows: min-content 1fr min-content;
-          padding: 1rem;
+          padding: 1em;
         }
         
         .images {

--- a/src/components/cc-elasticsearch-info/cc-elasticsearch-info.js
+++ b/src/components/cc-elasticsearch-info/cc-elasticsearch-info.js
@@ -102,7 +102,7 @@ export class CcElasticsearchInfo extends LitElement {
       // language=CSS
       css`
         :host {
-          --cc-gap: 1rem;
+          --cc-gap: 1em;
           display: block;
         }
 
@@ -112,11 +112,11 @@ export class CcElasticsearchInfo extends LitElement {
         }
 
         cc-img {
-          border-radius: 0.25rem;
+          border-radius: 0.25em;
           flex: 0 0 auto;
-          height: 1.5rem;
-          margin-right: 0.5rem;
-          width: 1.5rem;
+          height: 1.5em;
+          margin-right: 0.5em;
+          width: 1.5em;
         }
 
         /* SKELETON */

--- a/src/components/cc-env-var-create/cc-env-var-create.js
+++ b/src/components/cc-env-var-create/cc-env-var-create.js
@@ -153,22 +153,22 @@ export class CcEnvVarCreate extends LitElement {
       // language=CSS
       css`
         :host {
-          --cc-gap: 0.5rem;
+          --cc-gap: 0.5em;
           display: block;
         }
 
         .name {
-          flex: 1 1 15rem;
+          flex: 1 1 15em;
         }
 
         .input-btn {
-          flex: 2 1 27rem;
+          flex: 2 1 27em;
         }
 
         .value {
           /* 100 seems weird but it is necessary */
           /* it helps to have a button that almost does not grow except when it wraps on its own line */
-          flex: 100 1 20rem;
+          flex: 100 1 20em;
         }
 
         cc-input-text {
@@ -177,20 +177,20 @@ export class CcEnvVarCreate extends LitElement {
 
         cc-button {
           align-self: flex-start;
-          flex: 1 1 6rem;
+          flex: 1 1 6em;
           white-space: nowrap;
         }
 
         cc-error {
-          margin: 0.5rem 0;
+          margin: 0.5em 0;
         }
 
         /* i18n error message may contain <code> tags */
         cc-error code {
           background-color: var(--cc-color-bg-neutral, #eeeeee);
-          border-radius: 0.25rem;
+          border-radius: 0.25em;
           font-family: var(--cc-ff-monospace, monospace);
-          padding: 0.15rem 0.3rem;
+          padding: 0.15em 0.3em;
         }
       `,
     ];

--- a/src/components/cc-env-var-editor-expert/cc-env-var-editor-expert.js
+++ b/src/components/cc-env-var-editor-expert/cc-env-var-editor-expert.js
@@ -183,8 +183,8 @@ export class CcEnvVarEditorExpert extends LitElement {
 
         .error-list {
           display: grid;
-          grid-gap: 0.75rem;
-          margin-top: 1rem;
+          grid-gap: 0.75em;
+          margin-top: 1em;
         }
 
         .example {
@@ -197,9 +197,9 @@ export class CcEnvVarEditorExpert extends LitElement {
         cc-error code,
         .example code {
           background-color: var(--cc-color-bg-neutral, #eeeeee);
-          border-radius: 0.25rem;
+          border-radius: 0.25em;
           font-family: var(--cc-ff-monospace, monospace);
-          padding: 0.15rem 0.3rem;
+          padding: 0.15em 0.3em;
         }
 
         cc-input-text {

--- a/src/components/cc-env-var-editor-json/cc-env-var-editor-json.js
+++ b/src/components/cc-env-var-editor-json/cc-env-var-editor-json.js
@@ -183,8 +183,8 @@ export class CcEnvVarEditorJson extends LitElement {
 
         .error-list {
           display: grid;
-          grid-gap: 0.75rem;
-          margin-top: 1rem;
+          grid-gap: 0.75em;
+          margin-top: 1em;
         }
 
         .example {
@@ -196,9 +196,9 @@ export class CcEnvVarEditorJson extends LitElement {
         cc-error code,
         .example code {
           background-color: var(--cc-color-bg-neutral, #eeeeee);
-          border-radius: 0.25rem;
+          border-radius: 0.25em;
           font-family: var(--cc-ff-monospace, monospace);
-          padding: 0.15rem 0.3rem;
+          padding: 0.15em 0.3em;
         }
 
         cc-input-text {

--- a/src/components/cc-env-var-editor-simple/cc-env-var-editor-simple.js
+++ b/src/components/cc-env-var-editor-simple/cc-env-var-editor-simple.js
@@ -132,7 +132,7 @@ export class CcEnvVarEditorSimple extends LitElement {
     return css`
       :host {
         display: grid;
-        grid-gap: 0.5rem;
+        grid-gap: 0.5em;
       }
 
       :host([hidden]) {
@@ -140,13 +140,13 @@ export class CcEnvVarEditorSimple extends LitElement {
       }
 
       cc-env-var-create {
-        margin-bottom: 1rem;
+        margin-bottom: 1em;
       }
 
       .message {
         color: var(--cc-color-text-weak);
         font-style: italic;
-        margin: 0.2rem;
+        margin: 0.2em;
       }
     `;
   }

--- a/src/components/cc-env-var-form/cc-env-var-form.js
+++ b/src/components/cc-env-var-form/cc-env-var-form.js
@@ -315,22 +315,22 @@ export class CcEnvVarForm extends LitElement {
         :host {
           background-color: var(--cc-color-bg-default, #fff);
           border: 1px solid #bcc2d1;
-          border-radius: 0.25rem;
+          border-radius: 0.25em;
           display: block;
-          padding: 1rem;
+          padding: 1em;
         }
 
         .header {
           align-items: flex-start;
           display: flex;
           justify-content: center;
-          margin-bottom: 0.5rem;
+          margin-bottom: 0.5em;
         }
 
         .heading {
           color: var(--cc-color-text-strong);
           flex: 1 1 0;
-          font-size: 1.2rem;
+          font-size: 1.2em;
           font-weight: bold;
         }
 
@@ -339,12 +339,12 @@ export class CcEnvVarForm extends LitElement {
           display: block;
           font-style: italic;
           line-height: 1.5;
-          margin-bottom: 1rem;
+          margin-bottom: 1em;
         }
 
         .hasOverlay {
           --cc-skeleton-state: paused;
-          filter: blur(0.3rem);
+          filter: blur(0.3em);
         }
 
         .overlay-container {
@@ -353,8 +353,8 @@ export class CcEnvVarForm extends LitElement {
 
         cc-expand {
           /* We need to spread so the focus rings can be visible even with cc-expand default overflow:hidden */
-          margin: -0.25rem;
-          padding: 0.25rem;
+          margin: -0.25em;
+          padding: 0.25em;
         }
 
         .error-container {
@@ -378,8 +378,8 @@ export class CcEnvVarForm extends LitElement {
         }
 
         .button-bar {
-          --cc-gap: 1rem;
-          margin-top: 1.5rem;
+          --cc-gap: 1em;
+          margin-top: 1.5em;
         }
 
         .spacer {

--- a/src/components/cc-env-var-input/cc-env-var-input.js
+++ b/src/components/cc-env-var-input/cc-env-var-input.js
@@ -127,19 +127,18 @@ export class CcEnvVarInput extends LitElement {
       // language=CSS
       css`
         :host {
-          --cc-gap: 0.5rem;
+          --cc-gap: 0.5em;
           display: block;
         }
 
         .name {
           box-sizing: border-box;
           display: inline-block;
-          flex: 1 1 15rem;
+          flex: 1 1 17em;
           font-family: var(--cc-ff-monospace, monospace);
-          /* I have a bug on Linux between Chrome and FF with rem on inputs */
-          font-size: 14px;
-          line-height: 1.4rem;
-          padding-top: 0.3rem;
+          font-size: 0.875em;
+          line-height: 1.6em;
+          padding-top: 0.35em;
           word-break: break-all;
         }
 
@@ -152,19 +151,19 @@ export class CcEnvVarInput extends LitElement {
         }
 
         .input-btn {
-          flex: 2 1 27rem;
+          flex: 2 1 27em;
         }
 
         .value {
           align-self: self-start;
           /* 100 seems weird but it is necessary */
           /* it helps to have a button that almost does not grow except when it wraps on its own line */
-          flex: 100 1 20rem;
+          flex: 100 1 20em;
         }
 
         cc-button {
           align-self: flex-start;
-          flex: 1 1 6rem;
+          flex: 1 1 6em;
           white-space: nowrap;
         }
 

--- a/src/components/cc-env-var-linked-services/cc-env-var-linked-services.js
+++ b/src/components/cc-env-var-linked-services/cc-env-var-linked-services.js
@@ -153,9 +153,9 @@ export class CcEnvVarLinkedServices extends LitElement {
         .error {
           background-color: var(--cc-color-bg-default, #fff);
           border: 1px solid #bcc2d1;
-          border-radius: 0.25rem;
+          border-radius: 0.25em;
           box-sizing: border-box;
-          padding: 1rem;
+          padding: 1em;
         }
 
         .loading {
@@ -163,14 +163,14 @@ export class CcEnvVarLinkedServices extends LitElement {
         }
 
         cc-loader {
-          height: 1.5rem;
-          margin-right: 1rem;
-          width: 1.5rem;
+          height: 1.5em;
+          margin-right: 1em;
+          width: 1.5em;
         }
 
         .service-list {
           display: grid;
-          grid-gap: 1rem;
+          grid-gap: 1em;
         }
 
         .empty-msg {

--- a/src/components/cc-error/cc-error.js
+++ b/src/components/cc-error/cc-error.js
@@ -76,13 +76,13 @@ export class CcError extends LitElement {
               align-items: center;
               background-color: var(--cc-color-bg-default, #fff);
               border: 1px solid #bcc2d1;
-              border-radius: 0.25rem;
-              box-shadow: 0 0 1rem rgba(0, 0, 0, 0.4);
+              border-radius: 0.25em;
+              box-shadow: 0 0 1em rgba(0, 0, 0, 0.4);
               display: grid;
-              grid-gap: 1rem;
+              grid-gap: 1em;
               justify-content: center;
               justify-items: center;
-              padding: 1rem;
+              padding: 1em;
           }
 
           :host([mode="loading"]) {
@@ -90,17 +90,17 @@ export class CcError extends LitElement {
           }
 
           cc-loader {
-              height: 1.5rem;
-              width: 1.5rem;
+              height: 1.5em;
+              width: 1.5em;
           }
 
           img {
               display: inline-block;
-              height: 1rem;
-              margin-right: 0.4rem;
-              margin-top: 0.1rem;
+              height: 1em;
+              margin-right: 0.4em;
+              margin-top: 0.1em;
               vertical-align: text-top;
-              width: 1rem;
+              width: 1em;
           }
 
           cc-button {

--- a/src/components/cc-expand/cc-expand.stories.js
+++ b/src/components/cc-expand/cc-expand.stories.js
@@ -21,7 +21,7 @@ export const defaultStory = makeStory(conf, {
   // language=CSS
   css: `
     .knob {
-      margin-bottom: 1rem;
+      margin-bottom: 1em;
     }
     cc-toggle {
       margin: 0;
@@ -29,7 +29,7 @@ export const defaultStory = makeStory(conf, {
     cc-expand {
       border: 3px solid blue;
     }
-    .box { background-color: tomato; margin: 1rem; }
+    .box { background-color: tomato; margin: 1em; }
     .box[data-size="small"] { height: 60px }
     .box[data-size="medium"] { height: 120px }
     .box[data-size="big"] { height: 180px }

--- a/src/components/cc-flex-gap/cc-flex-gap.stories.js
+++ b/src/components/cc-flex-gap/cc-flex-gap.stories.js
@@ -16,10 +16,10 @@ const conf = {
     }
     
     cc-flex-gap > * {
-      border-radius: 0.25rem;
-      border:1px solid #000;
+      border-radius: 0.25em;
+      border: 1px solid #000;
       flex: 1 1 0;
-      padding: 0.5rem 1rem;
+      padding: 0.5em 1em;
     }
   `,
 };
@@ -29,7 +29,7 @@ const flexItemsHtml = Array.from(new Array(15))
   .join('');
 
 export const defaultStory = makeStory(conf, {
-  items: [{ innerHTML: flexItemsHtml, style: '--cc-gap: 1rem' }],
+  items: [{ innerHTML: flexItemsHtml, style: '--cc-gap: 1em' }],
 });
 
 export const noGap = makeStory(conf, {
@@ -37,22 +37,22 @@ export const noGap = makeStory(conf, {
 });
 
 export const smallGap = makeStory(conf, {
-  items: [{ innerHTML: flexItemsHtml, style: '--cc-gap: 0.5rem' }],
+  items: [{ innerHTML: flexItemsHtml, style: '--cc-gap: 0.5em' }],
 });
 
 export const bigGap = makeStory(conf, {
-  items: [{ innerHTML: flexItemsHtml, style: '--cc-gap: 2rem' }],
+  items: [{ innerHTML: flexItemsHtml, style: '--cc-gap: 2em' }],
 });
 
 export const alignItems = makeStory(conf, {
   items: [
     {
       innerHTML: `
-        <div style="height: 1rem">One</div>
-        <div style="height: 3rem">Two</div>
-        <div style="height: 9rem">Three</div>
+        <div style="height: 1em">One</div>
+        <div style="height: 3em">Two</div>
+        <div style="height: 9em">Three</div>
       `,
-      style: '--cc-gap: 1rem; --cc-align-items: center',
+      style: '--cc-gap: 1em; --cc-align-items: center',
     },
   ],
 });

--- a/src/components/cc-header-addon/cc-header-addon.js
+++ b/src/components/cc-header-addon/cc-header-addon.js
@@ -126,10 +126,10 @@ export class CcHeaderAddon extends LitElement {
       // language=CSS
       css`
         :host {
-          --cc-gap: 1rem;
+          --cc-gap: 1em;
           background-color: var(--cc-color-bg-default, #fff);
           border: 1px solid #bcc2d1;
-          border-radius: 0.25rem;
+          border-radius: 0.25em;
           display: block;
           overflow: hidden;
         }
@@ -139,9 +139,9 @@ export class CcHeaderAddon extends LitElement {
         }
 
         .logo {
-          border-radius: 0.25rem;
-          height: 3.25rem;
-          width: 3.25rem;
+          border-radius: 0.25em;
+          height: 3.25em;
+          width: 3.25em;
         }
 
         .details {
@@ -150,13 +150,13 @@ export class CcHeaderAddon extends LitElement {
 
         .name,
         .description-label {
-          margin-bottom: 0.35rem;
+          margin-bottom: 0.35em;
         }
 
         .name {
-          font-size: 1.1rem;
+          font-size: 1.1em;
           font-weight: bold;
-          min-width: 12rem;
+          min-width: 11em;
         }
 
         .description {
@@ -177,15 +177,15 @@ export class CcHeaderAddon extends LitElement {
         }
 
         .messages {
-          --cc-gap: 0.5rem;
+          --cc-gap: 0.57em;
           --cc-align-items: center;
           align-items: center;
           background-color: var(--cc-color-bg-neutral);
           box-shadow: inset 0 6px 6px -6px rgba(0, 0, 0, 0.4);
           box-sizing: border-box;
-          font-size: 0.9rem;
+          font-size: 0.9em;
           justify-content: end;
-          padding: 0.6rem 1rem;
+          padding: 0.7em 1.1em;
         }
 
         cc-zone {

--- a/src/components/cc-header-app/cc-header-app.js
+++ b/src/components/cc-header-app/cc-header-app.js
@@ -323,10 +323,10 @@ export class CcHeaderApp extends LitElement {
       // language=CSS
       css`
         :host {
-          --cc-gap: 1rem;
+          --cc-gap: 1em;
           background-color: var(--cc-color-bg-default, #fff);
           border: 1px solid #bcc2d1;
-          border-radius: 0.25rem;
+          border-radius: 0.25em;
           display: block;
           overflow: hidden;
         }
@@ -342,10 +342,10 @@ export class CcHeaderApp extends LitElement {
 
         .flavor-logo {
           align-self: flex-start;
-          border-radius: 0.25rem;
-          height: 3.25rem;
+          border-radius: 0.25em;
+          height: 3.25em;
           overflow: hidden;
-          width: 3.25rem;
+          width: 3.25em;
         }
 
         .flavor-logo_img {
@@ -366,9 +366,9 @@ export class CcHeaderApp extends LitElement {
         }
 
         .name {
-          font-size: 1.1rem;
+          font-size: 1.1em;
           font-weight: bold;
-          min-width: 12rem;
+          min-width: 11em;
         }
 
         .commit {
@@ -377,10 +377,10 @@ export class CcHeaderApp extends LitElement {
         }
 
         .commit_img {
-          height: 1.1rem;
-          margin-right: 0.2rem;
+          height: 1.1em;
+          margin-right: 0.2em;
           overflow: hidden;
-          width: 1.1rem;
+          width: 1.1em;
         }
 
         /* We hide the right part of the commit this way so this can be part of a copy/paste */
@@ -402,20 +402,20 @@ export class CcHeaderApp extends LitElement {
         }
 
         .messages {
-          --cc-gap: 0.5rem;
+          --cc-gap: 0.57em;
           --cc-align-items: center;
           align-items: center;
           background-color: var(--cc-color-bg-neutral);
           box-shadow: inset 0 6px 6px -6px rgba(0, 0, 0, 0.4);
           box-sizing: border-box;
-          font-size: 0.9rem;
+          font-size: 0.9em;
           font-style: italic;
-          padding: 0.4rem 1rem;
+          padding: 0.45em 1.1em;
         }
 
         .status-icon {
-          height: 1.25rem;
-          min-width: 1.25rem;
+          height: 1.25em;
+          min-width: 1.25em;
         }
 
         .spacer {

--- a/src/components/cc-header-orga/cc-header-orga.js
+++ b/src/components/cc-header-orga/cc-header-orga.js
@@ -93,14 +93,14 @@ export class CcHeaderOrga extends LitElement {
       // language=CSS
       css`
         :host {
-          --cc-gap: 1rem;
+          --cc-gap: 1em;
           display: block;
         }
 
         .wrapper {
           background-color: var(--cc-color-bg-default, #fff);
           border: 1px solid #bcc2d1;
-          border-radius: 0.25rem;
+          border-radius: 0.25em;
           display: block;
           overflow: hidden;
           padding: var(--cc-gap);
@@ -112,9 +112,9 @@ export class CcHeaderOrga extends LitElement {
         }
 
         .logo {
-          border-radius: 0.25rem;
-          height: 3.25rem;
-          width: 3.25rem;
+          border-radius: 0.25em;
+          height: 3.25em;
+          width: 3.25em;
         }
 
         .details,
@@ -133,9 +133,9 @@ export class CcHeaderOrga extends LitElement {
         }
 
         .name {
-          font-size: 1.1rem;
+          font-size: 1.1em;
           font-weight: bold;
-          min-width: 12rem;
+          min-width: 11em;
         }
 
         .hotline_number {

--- a/src/components/cc-heptapod-info/cc-heptapod-info.js
+++ b/src/components/cc-heptapod-info/cc-heptapod-info.js
@@ -122,19 +122,19 @@ export class CcHeptapodInfo extends LitElement {
         }
 
         .header-logo {
-          height: 3.25rem;
-          width: 3.25rem;
+          height: 3.25em;
+          width: 3.25em;
         }
 
         .header-content {
           display: flex;
           flex-direction: column;
           justify-content: center;
-          margin-left: 1rem;
+          margin-left: 1em;
         }
 
         .pricing {
-          --cc-gap: 1rem;
+          --cc-gap: 1em;
         }
 
         .pricing-item {
@@ -152,7 +152,7 @@ export class CcHeptapodInfo extends LitElement {
         .no-statistics {
           color: var(--cc-color-text-weak);
           font-style: italic;
-          margin: 0.2rem;
+          margin: 0.2em;
         }
 
         /* SKELETON */

--- a/src/components/cc-heptapod-info/cc-heptapod-info.stories.js
+++ b/src/components/cc-heptapod-info/cc-heptapod-info.stories.js
@@ -12,7 +12,7 @@ const conf = {
   // language=CSS
   css: `
     cc-heptapod-info {
-      max-width: 40rem;
+      max-width: 40em;
     }
   `,
 };

--- a/src/components/cc-img/cc-img.stories.js
+++ b/src/components/cc-img/cc-img.stories.js
@@ -30,10 +30,10 @@ export const defaultStory = makeStory(conf, {
 
 export const imageFitContain = makeStory(conf, {
   items: [
-    { text: 'CC', src: 'https://assets.clever-cloud.com/infra/clever-cloud.svg', style: 'border: 1px solid #000; height: 7rem; width: 2rem;' },
-    { text: 'CC', src: 'https://assets.clever-cloud.com/infra/clever-cloud.svg', style: 'border: 1px solid #000; height: 2rem; width: 7rem;' },
-    { text: 'CC', src: 'https://assets.clever-cloud.com/infra/clever-cloud.svg', style: 'border: 1px solid #000; height: 7rem; width: 2rem; --cc-img-fit: contain;' },
-    { text: 'CC', src: 'https://assets.clever-cloud.com/infra/clever-cloud.svg', style: 'border: 1px solid #000; height: 2rem; width: 7rem; --cc-img-fit: contain;' },
+    { text: 'CC', src: 'https://assets.clever-cloud.com/infra/clever-cloud.svg', style: 'border: 1px solid #000; height: 7em; width: 2em;' },
+    { text: 'CC', src: 'https://assets.clever-cloud.com/infra/clever-cloud.svg', style: 'border: 1px solid #000; height: 2em; width: 7em;' },
+    { text: 'CC', src: 'https://assets.clever-cloud.com/infra/clever-cloud.svg', style: 'border: 1px solid #000; height: 7em; width: 2em; --cc-img-fit: contain;' },
+    { text: 'CC', src: 'https://assets.clever-cloud.com/infra/clever-cloud.svg', style: 'border: 1px solid #000; height: 2em; width: 7em; --cc-img-fit: contain;' },
   ],
 });
 

--- a/src/components/cc-input-number/cc-input-number.stories.js
+++ b/src/components/cc-input-number/cc-input-number.stories.js
@@ -156,7 +156,7 @@ export const customWidth = makeStory(conf, {
   css: `
     cc-input-number {
       display: block;
-      margin: 0.5rem;
+      margin: 0.5em;
     }
   `,
   items: Array

--- a/src/components/cc-invoice-table/cc-invoice-table.js
+++ b/src/components/cc-invoice-table/cc-invoice-table.js
@@ -160,7 +160,6 @@ export class CcInvoiceTable extends withResizeObserver(LitElement) {
         /* we should use a class (something like "number-value") but it's not possible right now in i18n */
         code {
           font-family: var(--cc-ff-monospace, monospace);
-          font-size: 1rem;
         }
 
         .credit-note {
@@ -172,7 +171,7 @@ export class CcInvoiceTable extends withResizeObserver(LitElement) {
         }
 
         .links {
-          --cc-gap: 1rem;
+          --cc-gap: 1em;
           --cc-align-items: center;
         }
 
@@ -181,23 +180,23 @@ export class CcInvoiceTable extends withResizeObserver(LitElement) {
         /*region SMALL*/
         .invoice-list {
           display: grid;
-          gap: 1.5rem;
+          gap: 1.5em;
         }
 
         .invoice {
           display: flex;
-          line-height: 1.5rem;
+          line-height: 1.5em;
         }
 
         .invoice-icon,
         .invoice-text {
-          margin-right: 0.5rem;
+          margin-right: 0.5em;
         }
 
         .invoice-icon {
           flex: 0 0 auto;
-          height: 1.5rem;
-          width: 1.5rem;
+          height: 1.5em;
+          width: 1.5em;
         }
 
         .invoice-text {
@@ -227,7 +226,7 @@ export class CcInvoiceTable extends withResizeObserver(LitElement) {
 
         th,
         td {
-          padding: 0.5rem 1rem;
+          padding: 0.5em 1em;
           text-align: left;
         }
 

--- a/src/components/cc-invoice/cc-invoice.js
+++ b/src/components/cc-invoice/cc-invoice.js
@@ -92,7 +92,7 @@ export class CcInvoice extends LitElement {
 
         [slot="button"] {
           align-self: start;
-          margin-left: 1rem;
+          margin-left: 1em;
         }
 
         .has-errors {
@@ -110,7 +110,7 @@ export class CcInvoice extends LitElement {
 
         .frame {
           /* height and max-width are roughly set to have a standard letter / A4 paper ratio */
-          box-shadow: 0 0 0.5rem rgba(0, 0, 0, 0.4);
+          box-shadow: 0 0 0.5em rgba(0, 0, 0, 0.4);
           height: 31cm;
           max-width: 22cm;
           width: 100%;

--- a/src/components/cc-jenkins-info/cc-jenkins-info.js
+++ b/src/components/cc-jenkins-info/cc-jenkins-info.js
@@ -108,7 +108,7 @@ export class CcJenkinsInfo extends LitElement {
       // language=CSS
       css`
         :host {
-          --cc-gap: 1rem;
+          --cc-gap: 1em;
           display: block;
         }
 
@@ -118,11 +118,11 @@ export class CcJenkinsInfo extends LitElement {
         }
 
         cc-img {
-          border-radius: 0.25rem;
+          border-radius: 0.25em;
           flex: 0 0 auto;
-          height: 1.5rem;
-          margin-right: 0.5rem;
-          width: 1.5rem;
+          height: 1.5em;
+          margin-right: 0.5em;
+          width: 1.5em;
         }
 
         /* SKELETON */

--- a/src/components/cc-loader/cc-loader.stories.js
+++ b/src/components/cc-loader/cc-loader.stories.js
@@ -20,29 +20,29 @@ const conf = {
 
 export const defaultStory = makeStory(conf, {
   items: [
-    { style: 'width: 5rem; height: 5rem' },
-    { style: 'width: 5rem; height: 5rem; --cc-loader-color: red' },
-    { style: 'width: 5rem; height: 5rem; --cc-loader-color: green' },
+    { style: 'width: 5em; height: 5em' },
+    { style: 'width: 5em; height: 5em; --cc-loader-color: red' },
+    { style: 'width: 5em; height: 5em; --cc-loader-color: green' },
   ],
 });
 
 export const smallContainer = makeStory(conf, {
-  items: [{ style: 'width: 1rem; height: 1rem' }],
+  items: [{ style: 'width: 1em; height: 1em' }],
 });
 
 export const bigContainerWithHorizontallyCentered = makeStory(conf, {
-  items: [{ style: 'width: 12rem; height: 6rem' }],
+  items: [{ style: 'width: 12em; height: 6em' }],
 });
 
 export const bigContainerWithVerticallyCentered = makeStory(conf, {
-  items: [{ style: 'width: 6rem; height: 10rem;' }],
+  items: [{ style: 'width: 6em; height: 10em;' }],
 });
 
 export const customColor = makeStory(conf, {
   items: [
-    { style: 'width: 12rem; height: 6rem; --cc-loader-color: red' },
-    { style: 'width: 12rem; height: 6rem; --cc-loader-color: green' },
-    { style: 'width: 12rem; height: 6rem; --cc-loader-color: orange' },
+    { style: 'width: 12em; height: 6em; --cc-loader-color: red' },
+    { style: 'width: 12em; height: 6em; --cc-loader-color: green' },
+    { style: 'width: 12em; height: 6em; --cc-loader-color: orange' },
   ],
 });
 

--- a/src/components/cc-logsmap/cc-logsmap.js
+++ b/src/components/cc-logsmap/cc-logsmap.js
@@ -20,7 +20,7 @@ import { i18n } from '../../lib/i18n.js';
  * * This component wraps `<cc-map>` with a clickable toggle for the mode.
  * * It has predefined i18n label for the toggle and the legend (to display logs).
  * * The legend is contextualized to an organization or an app so you MUST set either `orgaName` or `appName` but not both.
- * * The component has a default height of 15rem and a default width 20rem but this can be overridden with CSS.
+ * * The component has a default height of 15em and a default width 20em but this can be overridden with CSS.
  *
  * @cssdisplay block
  *
@@ -206,18 +206,18 @@ export class CcLogsMap extends LitElement {
       :host {
         background-color: var(--cc-color-bg-default, #fff);
         border: 1px solid #ccc;
-        border-radius: 0.25rem;
+        border-radius: 0.25em;
         display: block;
-        height: 15rem;
+        height: 15em;
         overflow: hidden;
         position: relative;
-        width: 20rem;
+        width: 20em;
       }
 
       cc-toggle {
-        left: 0.5rem;
+        left: 0.5em;
         position: absolute;
-        top: 0.5rem;
+        top: 0.5em;
         z-index: 2;
       }
 

--- a/src/components/cc-map/cc-map.js
+++ b/src/components/cc-map/cc-map.js
@@ -20,7 +20,7 @@ import { leafletStyles } from '../../styles/leaflet.js';
  *
  * ## Details
  *
- * * The component has a default height of 15rem and a default width 20rem but this can be overridden with CSS.
+ * * The component has a default height of 15em and a default width 20em but this can be overridden with CSS.
  * * When using `points`, you need to specify which HTML tag should be used to create and display the marker.
  * * The marker DOM element should expose `size`, `anchor` and `tooltip` to help this component place the marker and tooltip correctly on the map.
  * * When using `points`, you can specify some text for the tooltip but you can also specify which HTML tag to use to create and display the tooltip.
@@ -342,9 +342,9 @@ export class CcMap extends withResizeObserver(LitElement) {
           background-color: var(--cc-color-bg-default, #fff);
           display: flex;
           flex-direction: column;
-          height: 15rem;
+          height: 15em;
           position: relative;
-          width: 20rem;
+          width: 20em;
         }
 
         #cc-map-container {
@@ -363,7 +363,7 @@ export class CcMap extends withResizeObserver(LitElement) {
         :host([loading]) .legend,
         :host([error]) .legend,
         .legend.no-data {
-          filter: blur(.1rem);
+          filter: blur(.1em);
         }
 
         .leaflet-container {
@@ -382,9 +382,9 @@ export class CcMap extends withResizeObserver(LitElement) {
           background-color: var(--cc-color-bg-neutral);
           box-shadow: inset 0 6px 6px -6px rgba(0, 0, 0, 0.4);
           box-sizing: border-box;
-          font-size: 0.9rem;
+          font-size: 0.9em;
           font-style: italic;
-          padding: 0.4rem 1rem;
+          padding: 0.45em 1.1em;
         }
 
         .loader {
@@ -419,11 +419,11 @@ export class CcMap extends withResizeObserver(LitElement) {
           align-items: center;
           background-color: var(--cc-color-bg-default, #fff);
           border: 1px solid #bcc2d1;
-          border-radius: 0.25rem;
-          box-shadow: 0 0 1rem rgba(0, 0, 0, 0.4);
+          border-radius: 0.25em;
+          box-shadow: 0 0 1em rgba(0, 0, 0, 0.4);
           display: flex;
           justify-content: center;
-          padding: 1rem;
+          padding: 1em;
         }
 
         .cc-map-marker {

--- a/src/components/cc-map/cc-map.stories.js
+++ b/src/components/cc-map/cc-map.stories.js
@@ -57,8 +57,8 @@ export const emptyWithLegendInSlot = makeStory(conf, {
 
 export const emptyWithDifferentSizes = makeStory(conf, {
   items: [
-    { style: 'height:10rem; width:30rem' },
-    { style: 'height:20rem; width:15rem' },
+    { style: 'height:10em; width:30em' },
+    { style: 'height:20em; width:15em' },
   ],
 });
 

--- a/src/components/cc-matomo-info/cc-matomo-info.js
+++ b/src/components/cc-matomo-info/cc-matomo-info.js
@@ -109,7 +109,7 @@ export class CcMatomoInfo extends LitElement {
       // language=CSS
       css`
         :host {
-          --cc-gap: 1rem;
+          --cc-gap: 1em;
           display: block;
         }
 
@@ -127,11 +127,11 @@ export class CcMatomoInfo extends LitElement {
         }
 
         cc-img {
-          border-radius: 0.25rem;
+          border-radius: 0.25em;
           flex: 0 0 auto;
-          height: 1.5rem;
-          margin-right: 0.5rem;
-          width: 1.5rem;
+          height: 1.5em;
+          margin-right: 0.5em;
+          width: 1.5em;
         }
 
         .application-list > * {

--- a/src/components/cc-overview/cc-overview.js
+++ b/src/components/cc-overview/cc-overview.js
@@ -41,7 +41,7 @@ export class CcOverview extends withResizeObserver(LitElement) {
 
     /** @protected */
     this.breakpoints = {
-      // ceiled width with 275px tiles and 1rem (16px) gap
+      // ceiled width with 275px tiles and 1em (16px) gap
       width: [570, 860, 1150],
     };
   }
@@ -59,7 +59,7 @@ export class CcOverview extends withResizeObserver(LitElement) {
         /* We ask the user to specify this number (if > 1) because the information is known and detecting it automatically and properly requires a MutationObserver to count them in the \`<slot>\` and it seems overkill. */
         --cc-overview-head-count: 1;
         display: grid;
-        grid-gap: 1rem;
+        grid-gap: 1em;
       }
 
       /*region GRID LAYOUT*/
@@ -125,7 +125,7 @@ export class CcOverview extends withResizeObserver(LitElement) {
         grid-column: main-start / main-end;
         grid-row: main-start / main-end;
         height: auto;
-        min-height: 25rem;
+        min-height: 25em;
         width: auto;
       }
     `;

--- a/src/components/cc-overview/cc-overview.stories.js
+++ b/src/components/cc-overview/cc-overview.stories.js
@@ -38,7 +38,7 @@ const placeholderCss = `
   }
   cc-overview * {
     background-color: #eee;
-    padding: 1rem;
+    padding: 1em;
   }
   cc-overview .main {
     min-height: 200px;

--- a/src/components/cc-pricing-header/cc-pricing-header.stories.js
+++ b/src/components/cc-pricing-header/cc-pricing-header.stories.js
@@ -36,7 +36,7 @@ export const dataLoadedWithCustomStyles = makeStory(conf, {
   css: `
     cc-pricing-header {
       border-radius: 5px;
-      box-shadow: 0 0 0.5rem #aaa;
+      box-shadow: 0 0 0.5em #aaa;
       padding: 1em;
     }
   `,

--- a/src/components/cc-pricing-product-consumption/cc-pricing-product-consumption.stories.js
+++ b/src/components/cc-pricing-product-consumption/cc-pricing-product-consumption.stories.js
@@ -293,7 +293,7 @@ export const dataLoadedWithHeptapod = makeStory(conf, {
 export const dataLoadedWithCustomHead = makeStory(conf, {
   items: [{
     ...baseCellar,
-    innerHTML: `<div slot="head" style="padding: 1rem; background-color: lime;">The whole head section can be overriden with the head slot...</div>`,
+    innerHTML: `<div slot="head" style="padding: 1em; background-color: lime;">The whole head section can be overriden with the head slot...</div>`,
   }],
 });
 

--- a/src/components/cc-pricing-product/cc-pricing-product.stories.js
+++ b/src/components/cc-pricing-product/cc-pricing-product.stories.js
@@ -66,7 +66,7 @@ export const dataLoadedWithAddonRedis = makeStory(conf, {
 export const dataLoadedWithCustomHead = makeStory(conf, {
   items: [{
     ...getFullProductRuntime('node'),
-    innerHTML: `<div slot="head" style="padding: 1rem; background-color: lime;">The whole head section can be overriden with the head slot...</div>`,
+    innerHTML: `<div slot="head" style="padding: 1em; background-color: lime;">The whole head section can be overriden with the head slot...</div>`,
   }],
 });
 

--- a/src/components/cc-select/cc-select.js
+++ b/src/components/cc-select/cc-select.js
@@ -233,10 +233,6 @@ export class CcSelect extends LitElement {
           outline: 0;
         }
 
-        option {
-          padding: 1rem 0;
-        }
-
         .selectWrapper {
           display: inline-flex;
           position: relative;

--- a/src/components/cc-tcp-redirection-form/cc-tcp-redirection-form.js
+++ b/src/components/cc-tcp-redirection-form/cc-tcp-redirection-form.js
@@ -102,7 +102,7 @@ export class CcTcpRedirectionForm extends LitElement {
         cc-badge {
           /* cc-block title changes the font-size to 1.2em, which makes our badge way too big */
           font-size: 0.8em;
-          margin-left: 0.5rem;
+          margin-left: 0.5em;
           vertical-align: middle;
         }
 
@@ -112,14 +112,14 @@ export class CcTcpRedirectionForm extends LitElement {
 
         .description p {
           margin: 0;
-          margin-bottom: 1rem;
+          margin-bottom: 1em;
         }
 
         .description code {
           background-color: var(--cc-color-bg-neutral);
-          border-radius: 0.25rem;
+          border-radius: 0.25em;
           font-family: var(--cc-ff-monospace);
-          padding: 0.15rem 0.3rem;
+          padding: 0.15em 0.3em;
         }
       `,
     ];

--- a/src/components/cc-tcp-redirection/cc-tcp-redirection.js
+++ b/src/components/cc-tcp-redirection/cc-tcp-redirection.js
@@ -147,13 +147,13 @@ export class CcTcpRedirection extends LitElement {
         }
 
         .wrapper {
-          --cc-gap: 0.8rem;
+          --cc-gap: 0.8em;
         }
 
         .icon {
           flex: 0 0 auto;
-          height: 1.5rem;
-          width: 1.5rem;
+          height: 1.5em;
+          width: 1.5em;
         }
 
         .icon img {
@@ -171,8 +171,8 @@ export class CcTcpRedirection extends LitElement {
         }
 
         .text-wrapper {
-          flex: 1 1 30rem;
-          line-height: 1.6rem;
+          flex: 1 1 30em;
+          line-height: 1.6em;
         }
 
         .text strong {
@@ -181,9 +181,9 @@ export class CcTcpRedirection extends LitElement {
 
         .text:not(.skeleton) code {
           background-color: var(--cc-color-bg-neutral);
-          border-radius: 0.25rem;
+          border-radius: 0.25em;
           font-family: var(--cc-ff-monospace);
-          padding: 0.15rem 0.3rem;
+          padding: 0.15em 0.3em;
         }
 
         .text-addendum:not(.skeleton) {

--- a/src/components/cc-tile-consumption/cc-tile-consumption.js
+++ b/src/components/cc-tile-consumption/cc-tile-consumption.js
@@ -81,7 +81,7 @@ export class CcTileConsumption extends LitElement {
         .line {
           align-items: center;
           display: flex;
-          padding: 0.5rem 0;
+          padding: 0.5em 0;
           width: 100%;
         }
 

--- a/src/components/cc-tile-deployments/cc-tile-deployments.js
+++ b/src/components/cc-tile-deployments/cc-tile-deployments.js
@@ -110,7 +110,7 @@ export class CcTileDeployments extends LitElement {
       css`
         .tile_body {
           align-items: start;
-          grid-gap: 1rem;
+          grid-gap: 1em;
           grid-template-columns: auto auto auto;
           justify-content: space-between;
         }

--- a/src/components/cc-tile-instances/cc-tile-instances.js
+++ b/src/components/cc-tile-instances/cc-tile-instances.js
@@ -156,15 +156,15 @@ export class CcTileInstances extends LitElement {
         }
 
         .instances_status-img {
-          height: 1.75rem;
-          width: 1.75rem;
+          height: 1.75em;
+          width: 1.75em;
         }
 
         .instances_status {
           color: var(--status-color, #000000);
           flex: 1 1 0;
-          font-size: 1.2rem;
-          margin-left: 0.25rem;
+          font-size: 1.2em;
+          margin-left: 0.25em;
         }
 
         .size-label {

--- a/src/components/cc-tile-requests/cc-tile-requests.js
+++ b/src/components/cc-tile-requests/cc-tile-requests.js
@@ -290,8 +290,8 @@ export class CcTileRequests extends withResizeObserver(LitElement) {
         }
 
         .docs-toggle {
-          font-size: 1rem;
-          margin: 0 0 0 1rem;
+          font-size: 0.8em;
+          margin: 0 0 0 1em;
         }
 
         .chart-container {
@@ -325,7 +325,7 @@ export class CcTileRequests extends withResizeObserver(LitElement) {
 
         .tile_docs {
           align-self: center;
-          font-size: 0.9rem;
+          font-size: 0.9em;
           font-style: italic;
         }
 

--- a/src/components/cc-tile-scalability/cc-tile-scalability.js
+++ b/src/components/cc-tile-scalability/cc-tile-scalability.js
@@ -102,8 +102,8 @@ export class CcTileScalability extends LitElement {
       css`
         .tile_body {
           align-items: center;
-          grid-column-gap: 2rem;
-          grid-row-gap: 1rem;
+          grid-column-gap: 2em;
+          grid-row-gap: 1em;
           grid-template-columns: auto 1fr;
         }
 
@@ -117,7 +117,7 @@ export class CcTileScalability extends LitElement {
         .separator {
           border-top: 1px dashed #8C8C8C;
           flex: 1 1 0;
-          width: 1.5rem;
+          width: 1.5em;
         }
 
         [title] {

--- a/src/components/cc-tile-status-codes/cc-tile-status-codes.js
+++ b/src/components/cc-tile-status-codes/cc-tile-status-codes.js
@@ -246,8 +246,8 @@ export class CcTileStatusCodes extends LitElement {
         }
 
         .docs-toggle {
-          font-size: 1rem;
-          margin: 0 0 0 1rem;
+          font-size: 0.8em;
+          margin: 0 0 0 1em;
         }
 
         .tile_body {
@@ -275,7 +275,7 @@ export class CcTileStatusCodes extends LitElement {
 
         .tile_docs {
           align-self: center;
-          font-size: 0.9rem;
+          font-size: 0.9em;
           font-style: italic;
         }
 

--- a/src/components/cc-toaster/cc-toaster.stories.js
+++ b/src/components/cc-toaster/cc-toaster.stories.js
@@ -188,7 +188,7 @@ export const defaultStory = makeStory(conf, {
         <div class="knob">
           <cc-block class="buttons">
             <p>Click on buttons to trigger a toast</p>
-            <cc-flex-gap style="--cc-gap: 0.5rem;">${intents.map(_renderButton)}</cc-flex-gap>
+            <cc-flex-gap style="--cc-gap: 0.5em;">${intents.map(_renderButton)}</cc-flex-gap>
           </cc-block>
           
           <cc-block class="options">

--- a/src/components/cc-toggle/cc-toggle.stories.js
+++ b/src/components/cc-toggle/cc-toggle.stories.js
@@ -22,7 +22,6 @@ const conf = {
   css: `
     :host {
       display: grid;
-      gap: 1rem;
       grid-template-columns: repeat(var(--col-nb, 4), min-content);
     }
   `,

--- a/src/components/cc-zone-input/cc-zone-input.js
+++ b/src/components/cc-zone-input/cc-zone-input.js
@@ -247,7 +247,7 @@ export class CcZoneInput extends withResizeObserver(LitElement) {
         :host {
           background-color: var(--cc-color-bg-default, #fff);
           border: 1px solid #bcc2d1;
-          border-radius: 0.25rem;
+          border-radius: 0.25em;
           box-sizing: border-box;
           display: flex;
           overflow: hidden;
@@ -277,13 +277,13 @@ export class CcZoneInput extends withResizeObserver(LitElement) {
         }
 
         :host(:not([error])[w-gte-600]) .zone-list-wrapper {
-          flex-basis: 24rem;
-          max-width: 24rem;
+          flex-basis: 24em;
+          max-width: 24em;
         }
 
         :host([error]) .zone-list-wrapper {
           display: flex;
-          padding: 1rem;
+          padding: 1em;
         }
 
         :host([error]) cc-error {
@@ -291,11 +291,11 @@ export class CcZoneInput extends withResizeObserver(LitElement) {
         }
 
         .zone-list {
-          margin: 0.5rem;
+          margin: 0.5em;
         }
 
         .zone-list:not(:hover):focus-within {
-          border-radius: 0.25rem;
+          border-radius: 0.25em;
           box-shadow: 0 0 0 .2em rgba(50, 115, 220, .25);
           outline: 0;
         }
@@ -317,16 +317,16 @@ export class CcZoneInput extends withResizeObserver(LitElement) {
           border: 0;
           box-sizing: border-box;
           display: block;
-          margin: -0.5rem;
+          margin: -0.5em;
           outline: none;
         }
 
         .label {
           border: 2px solid var(--bd-color, transparent);
-          border-radius: 0.25rem;
+          border-radius: 0.25em;
           box-sizing: border-box;
           display: block;
-          padding: 0.5rem;
+          padding: 0.5em;
         }
 
         label {

--- a/src/components/cc-zone/cc-zone.js
+++ b/src/components/cc-zone/cc-zone.js
@@ -179,7 +179,6 @@ export class CcZone extends LitElement {
           background-color: var(--cc-zone-tag-bgcolor, var(--cc-color-bg-soft, #eeeeee));
           border: 1px solid var(--cc-zone-tag-bdcolor, transparent);
           border-radius: 0.25em;
-          border-radius: 0.25rem;
           box-sizing: border-box;
           font-family: var(--cc-ff-monospace);
           font-size: 0.8em;

--- a/src/mixins/with-resize-observer/with-resize-observer.stories.js
+++ b/src/mixins/with-resize-observer/with-resize-observer.stories.js
@@ -62,13 +62,13 @@ export const defaultStory = () => {
       }
       table {
         border-collapse: collapse;
-        margin-bottom: 1rem;
+        margin-bottom: 1em;
       }
       table,
       th,
       td {
         border: 1px solid #bbb;
-        padding: 0.5rem;
+        padding: 0.5em;
       }
       th {
         background-color: #f5f5f5;
@@ -81,18 +81,18 @@ export const defaultStory = () => {
       }
       
       .color {
-        border-radius: 0.25rem;
+        border-radius: 0.25em;
         display: inline-block;
-        height: 1rem;
-        margin-right: 0.5rem;
+        height: 1em;
+        margin-right: 0.5em;
         vertical-align: middle;
-        width: 1rem;
+        width: 1em;
       }
       
       pre {
         background-color: #f5f5f5;
-        border-radius: 0.25rem;
-        padding: 1rem;
+        border-radius: 0.25em;
+        padding: 1em;
       }
       
       .attributes {
@@ -104,7 +104,7 @@ export const defaultStory = () => {
         border: 1px solid #000;
         box-sizing: border-box;
         display: inline-block;
-        padding: 1rem;
+        padding: 1em;
         overflow: hidden;
       }
       

--- a/src/styles/info-tiles.js
+++ b/src/styles/info-tiles.js
@@ -5,19 +5,19 @@ export const tileStyles = css`
   :host {
     background-color: var(--cc-color-bg-default, #fff);
     border: 1px solid #bcc2d1;
-    border-radius: 0.25rem;
+    border-radius: 0.25em;
     box-sizing: border-box;
     display: grid;
-    grid-gap: 1rem;
+    grid-gap: 1em;
     grid-template-rows: auto 1fr;
-    min-height: 9rem;
+    min-height: 9em;
     overflow: hidden;
-    padding: 1rem;
+    padding: 1em;
   }
 
   .tile_title {
     color: var(--cc-color-text-weak);
-    font-size: 1.25rem;
+    font-size: 1.25em;
     text-align: center;
   }
   
@@ -39,19 +39,19 @@ export const tileStyles = css`
 // language=CSS
 export const instanceDetailsStyles = css`
   :host {
-    --bubble-d: 1.5rem;
+    --bubble-d: 1.5em;
     --bubble-r: calc(var(--bubble-d) / 2);
   }
 
   .size-label {
     background-color: var(--cc-color-bg-neutral);
     border: 1px solid #484848;
-    border-radius: 0.25rem;
+    border-radius: 0.25em;
     box-sizing: border-box;
     display: block;
     font-weight: bold;
-    height: 1.65rem;
-    line-height: 1.65rem;
+    height: 1.65em;
+    line-height: 1.65em;
     padding: 0 var(--bubble-r);
     text-align: center;
   }

--- a/src/styles/undefined-components.css
+++ b/src/styles/undefined-components.css
@@ -1,22 +1,22 @@
 /* This is a work in progress */
 
 cc-block:not(:defined) {
-  border-radius: .25rem;
+  border-radius: .25em;
   border: 1px solid #bcc2d1;
   display: grid;
-  grid-gap: 1rem;
-  padding: 1rem;
+  grid-gap: 1em;
+  padding: 1em;
 }
 
 cc-block:not(:defined) > [slot=title] {
   color: #3a3871;
-  font-size: 1.2rem;
+  font-size: 1.2em;
   font-weight: 700;
-  margin-bottom: .5rem;
+  margin-bottom: .5em;
 }
 
 cc-block[icon]:not(:defined) > [slot=title] {
-  padding-left: 2.5rem;
+  padding-left: 2.5em;
 }
 
 cc-flex-gap:not(:defined) {
@@ -27,26 +27,26 @@ cc-flex-gap:not(:defined) {
 
 cc-input-text:not(:defined) {
   background: #eee;
-  border-radius: .25rem;
+  border-radius: .25em;
   display: inline-block;
-  height: 2rem;
-  min-width: 18rem;
+  height: 2em;
+  min-width: 18em;
   vertical-align: top;
 }
 
 cc-tcp-redirection-form:not(:defined) {
   background: #eee;
-  border-radius: .25rem;
+  border-radius: .25em;
   display: block;
-  height: calc(3.8rem - 2px);
+  height: calc(3.8em - 2px);
 }
 
 cc-toggle:not(:defined) {
   background: #eee;
-  border-radius: .15rem;
+  border-radius: .15em;
   display: inline-block;
-  height: 2rem;
-  min-width: 10rem;
+  height: 2em;
+  min-width: 10em;
   vertical-align: top;
 }
 

--- a/src/templates/cc-link/cc-link.js
+++ b/src/templates/cc-link/cc-link.js
@@ -40,8 +40,8 @@ export const linkStyles = css`
   .sanitized-link:focus,
   .cc-link:focus {
     background-color: var(--cc-color-bg-default, #fff);
-    border-radius: 0.1rem;
-    box-shadow: 0 0 0 .1rem var(--cc-color-bg-default, #fff), 0 0 0 .3rem rgba(50, 115, 220, .25);
+    border-radius: 0.1em;
+    box-shadow: 0 0 0 .1em var(--cc-color-bg-default, #fff), 0 0 0 .3em rgba(50, 115, 220, .25);
     outline: 0;
   }
 

--- a/tasks/preview.js
+++ b/tasks/preview.js
@@ -144,11 +144,11 @@ async function updateListIndex (manifest) {
           margin: 0 auto;
           font-family: Arial, sans-serif;
           width: 100%;
-          max-width: 50rem;
+          max-width: 50em;
         }
         code {
           font-family: "SourceCodePro", "monaco", monospace;
-          font-size: 1rem;
+          font-size: 1em;
         }
         table {
           width: 100%;
@@ -158,7 +158,7 @@ async function updateListIndex (manifest) {
         }
         th,
         td {
-          padding: 0.25rem 0;
+          padding: 0.25em 0;
         }
       </style>
       <script src="https://components.clever-cloud.com/load.js?components=cc-datetime-relative" type="module"></script>


### PR DESCRIPTION
Fixes #126 

[Preview from rem to em](https://clever-components-preview.cellar-c2.services.clever-cloud.com/from-rem-to-em/index.html)

`cc-header-app` / `cc-header-addon` / `cc-header-orga` have very slight differences compared to before but only a few pixels.
This is because I rounded the `em` values to avoid having weird values.

I checked all the stories of all the components twice but considering how many there are, I may have missed something (bear in mind that I also had to check the responsive views for all of these :sweat_smile: )

I don't think we should all review all of the stories (+ responsive) for all of the components so I suggest the reviews focus on the components I list below.
These components set a `font-size` for some parts of their content, which means this is where `em` vs `rem` thingy comes into play.

Maybe each of you could pick a few components to review and comment to tell others what they are reviewing so we can split the effort ?

Most critical components to review:

@hsablonniere 
- [x] `cc-tcp-redirection-form`,
- [x] `cc-article-card`,
- [x] `cc-block`,
- [x] `cc-doc-card`,
- [x] `cc-env-var-form`,
- [x] `cc-env-var-input`,
- [x] `cc-header-addon`,
- [x] `cc-header-app`,
- [x] `cc-header-orga`,

@pdesoyres-cc 
- `cc-img`,
- `cc-input-number`,
- `cc-input-text`,
- `cc-input-number`,
- `cc-input-text`,
- `cc-map`,
- `cc-pricing-estimation`,
- `cc-pricing-product-consumption`,
- `cc-pricing-header`,
- `cc-pricing-table`,

@roberttran-cc 
- `cc-select`,
- `cc-button`,
- `cc-tile-instances`,
- `cc-tile-requests`,
- `cc-tile-status-code`,
- `cc-toggle`,
- `cc-zone`,
- `cc-zone-input`.

Note that pricing components were already using `em` but they rely on atom that were not using `em` before, so we'd better check anyway.

# TODO BEFORE MERGING

- [x] merge #512 and rebase on master