### PR TITLE
cc-env-var-form: fix toggling to JSON mode while in skeleton state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ title: Changelog
 
 ## Unreleased (????-??-??)
 
+### Components
+
+* `<cc-env-var-form>`: fix toggling to JSON mode while in skeleton state.
+
 ### ⚠️ BREAKING CHANGES
 
 * `<cc-toggle>`: update component host default `display` CSS property (BREAKING CHANGE).

--- a/src/components/cc-env-var-form/cc-env-var-form.js
+++ b/src/components/cc-env-var-form/cc-env-var-form.js
@@ -156,7 +156,7 @@ export class CcEnvVarForm extends LitElement {
     }
     else if (mode === 'JSON') {
       // clone to force an update/reset of the json form
-      this._jsonVariables = [...this._currentVariables];
+      this._jsonVariables = this._currentVariables != null ? [...this._currentVariables] : null;
     }
     this._mode = mode;
   }


### PR DESCRIPTION
Fix #543.

Initial code was using array spreading on a variable (when the user toggles to JSON mode). But this variable can be `null` when the component is in skeleton state.

The fix is checking the variable value and spreading only if it is not null.