### PR TITLE
cc-badge: add skeleton mode / impl 1

### DIFF
--- a/src/components/cc-badge/cc-badge.js
+++ b/src/components/cc-badge/cc-badge.js
@@ -1,4 +1,5 @@
 import { css, html, LitElement } from 'lit';
+import { innerSkeletonStyles, skeletonPulseStyles } from '../../styles/skeleton.js';
 
 /**
  * @typedef {import('./cc-badge.types.js').BadgeIntent} BadgeIntent
@@ -17,6 +18,7 @@ export class CcBadge extends LitElement {
       iconAlt: { type: String, attribute: 'icon-alt' },
       iconSrc: { type: String, attribute: 'icon-src' },
       intent: { type: String, reflect: true },
+      skeleton: { type: Boolean, reflect: true },
       weight: { type: String, reflect: true },
     };
   }
@@ -36,6 +38,9 @@ export class CcBadge extends LitElement {
     /** @type {BadgeIntent} Sets the accent color used for the badge. */
     this.intent = 'neutral';
 
+    /** @type {boolean} Whether the component should be displayed as skeleton. */
+    this.skeleton = false;
+
     /** @type {BadgeWeight} Sets the style of the badge depending on how much one wants it to stand out. */
     this.weight = 'dimmed';
   }
@@ -53,6 +58,7 @@ export class CcBadge extends LitElement {
 
   static get styles () {
     return [
+      skeletonPulseStyles,
       // language=CSS
       css`
         :host {
@@ -62,6 +68,19 @@ export class CcBadge extends LitElement {
           font-size: 0.8em;
           gap: 0.3em;
           padding: 0.2em 0.8em;
+        }
+        
+        :host([skeleton]) {
+          background-color: #bbb !important;
+          ${innerSkeletonStyles};
+        }
+        
+        :host([skeleton][weight="outlined"]) {
+          box-shadow: inset 0 0 0 0.06em #777;
+        }
+        
+        :host([skeleton]) img {
+          visibility: hidden;
         }
 
         :host([circle]) {

--- a/src/components/cc-badge/cc-badge.stories.js
+++ b/src/components/cc-badge/cc-badge.stories.js
@@ -36,6 +36,76 @@ const baseItems = [
   },
 ];
 
+const iconsItems = [
+  {
+    intent: 'info',
+    weight: 'dimmed',
+    innerHTML: 'this is info',
+    iconSrc: infoSvg,
+    iconAlt: 'Info',
+  },
+  {
+    intent: 'success',
+    weight: 'outlined',
+    innerHTML: 'this is success',
+    iconSrc: tickSvg,
+    iconAlt: 'Success',
+  },
+  {
+    intent: 'danger',
+    weight: 'outlined',
+    innerHTML: 'this is danger',
+    iconSrc: errorSvg,
+    iconAlt: 'Error',
+  },
+  {
+    intent: 'warning',
+    weight: 'strong',
+    innerHTML: 'this is warning',
+    iconSrc: warningSvg,
+    iconAlt: 'Warning',
+  },
+  {
+    intent: 'neutral',
+    weight: 'strong',
+    innerHTML: 'this is neutral',
+    iconSrc: badgeSvg,
+  },
+];
+
+const circleItems = [
+  {
+    intent: 'info',
+    weight: 'dimmed',
+    innerHTML: '1',
+    circle: true,
+  },
+  {
+    intent: 'success',
+    weight: 'outlined',
+    innerHTML: '2',
+    circle: true,
+  },
+  {
+    intent: 'danger',
+    weight: 'outlined',
+    innerHTML: '10',
+    circle: true,
+  },
+  {
+    intent: 'warning',
+    weight: 'strong',
+    innerHTML: '5',
+    circle: true,
+  },
+  {
+    intent: 'neutral',
+    weight: 'strong',
+    innerHTML: '1',
+    circle: true,
+  },
+];
+
 export default {
   title: '🧬 Atoms/<cc-badge>',
   component: 'cc-badge',
@@ -50,92 +120,51 @@ export const dimmed = makeStory(conf, {
   items: baseItems,
 });
 
+export const dimmedWithSkeleton = makeStory(conf, {
+  items: baseItems.map((badge) => ({ ...badge, skeleton: true })),
+});
+
 export const outlined = makeStory(conf, {
   items: baseItems.map((badge) => ({ ...badge, weight: 'outlined' })),
+});
+
+export const outlinedWithSkeleton = makeStory(conf, {
+  items: baseItems.map((badge) => ({ ...badge, weight: 'outlined', skeleton: true })),
 });
 
 export const strong = makeStory(conf, {
   items: baseItems.map((badge) => ({ ...badge, weight: 'strong' })),
 });
 
+export const strongWithSkeleton = makeStory(conf, {
+  items: baseItems.map((badge) => ({ ...badge, weight: 'strong', skeleton: true })),
+});
+
 export const icons = makeStory(conf, {
-  items: [
-    {
-      intent: 'info',
-      weight: 'dimmed',
-      innerHTML: 'this is info',
-      iconSrc: infoSvg,
-      iconAlt: 'Info',
-    },
-    {
-      intent: 'success',
-      weight: 'outlined',
-      innerHTML: 'this is success',
-      iconSrc: tickSvg,
-      iconAlt: 'Success',
-    },
-    {
-      intent: 'danger',
-      weight: 'outlined',
-      innerHTML: 'this is danger',
-      iconSrc: errorSvg,
-      iconAlt: 'Error',
-    },
-    {
-      intent: 'warning',
-      weight: 'strong',
-      innerHTML: 'this is warning',
-      iconSrc: warningSvg,
-      iconAlt: 'Warning',
-    },
-    {
-      intent: 'neutral',
-      weight: 'strong',
-      innerHTML: 'this is neutral',
-      iconSrc: badgeSvg,
-    },
-  ],
+  items: iconsItems,
+});
+
+export const iconsWithSkeleton = makeStory(conf, {
+  items: iconsItems.map((badge) => ({ ...badge, skeleton: true })),
 });
 
 export const circleWithNumber = makeStory(conf, {
-  items: [
-    {
-      intent: 'info',
-      weight: 'dimmed',
-      innerHTML: '1',
-      circle: true,
-    },
-    {
-      intent: 'success',
-      weight: 'outlined',
-      innerHTML: '2',
-      circle: true,
-    },
-    {
-      intent: 'danger',
-      weight: 'outlined',
-      innerHTML: '10',
-      circle: true,
-    },
-    {
-      intent: 'warning',
-      weight: 'strong',
-      innerHTML: '5',
-      circle: true,
-    },
-    {
-      intent: 'neutral',
-      weight: 'strong',
-      innerHTML: '1',
-      circle: true,
-    },
-  ],
+  items: circleItems,
+});
+
+export const circleWithNumberWithSkeleton = makeStory(conf, {
+  items: circleItems.map((badge) => ({ ...badge, skeleton: true })),
 });
 
 enhanceStoriesNames({
   dimmed,
+  dimmedWithSkeleton,
   outlined,
+  outlinedWithSkeleton,
   strong,
+  strongWithSkeleton,
   icons,
+  iconsWithSkeleton,
   circleWithNumber,
+  circleWithNumberWithSkeleton,
 });

--- a/src/styles/skeleton.js
+++ b/src/styles/skeleton.js
@@ -1,8 +1,21 @@
 import { css } from 'lit';
 
-// language=CSS
-export const skeletonStyles = css`
+export const innerSkeletonStyles = css`
+  animation-direction: alternate;
+  animation-duration: 500ms;
+  animation-iteration-count: infinite;
+  animation-name: skeleton-pulse;
+  animation-play-state: var(--cc-skeleton-state, running);
+  color: transparent !important;
+  cursor: progress;
+  -moz-user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+`;
 
+// language=CSS
+export const skeletonPulseStyles = css`
   @keyframes skeleton-pulse {
     from {
       opacity: 0.85;
@@ -12,18 +25,13 @@ export const skeletonStyles = css`
       opacity: 0.45;
     }
   }
+`;
+
+// language=CSS
+export const skeletonStyles = css`
+  ${skeletonPulseStyles}
 
   .skeleton {
-    animation-direction: alternate;
-    animation-duration: 500ms;
-    animation-iteration-count: infinite;
-    animation-name: skeleton-pulse;
-    animation-play-state: var(--cc-skeleton-state, running);
-    color: transparent;
-    cursor: progress;
-    -moz-user-select: none;
-    -webkit-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
+    ${innerSkeletonStyles}
   }
 `;

--- a/src/styles/skeleton.js
+++ b/src/styles/skeleton.js
@@ -1,6 +1,6 @@
-import { css } from 'lit';
+import { css, unsafeCSS } from 'lit';
 
-export const innerSkeletonStyles = css`
+export const innerSkeletonStyles = unsafeCSS(`
   animation-direction: alternate;
   animation-duration: 500ms;
   animation-iteration-count: infinite;
@@ -12,7 +12,7 @@ export const innerSkeletonStyles = css`
   -webkit-user-select: none;
   -ms-user-select: none;
   user-select: none;
-`;
+`);
 
 // language=CSS
 export const skeletonPulseStyles = css`
@@ -32,6 +32,6 @@ export const skeletonStyles = css`
   ${skeletonPulseStyles}
 
   .skeleton {
-    ${innerSkeletonStyles}
+    ${innerSkeletonStyles};
   }
 `;


### PR DESCRIPTION
Fixes #521

## UI

On the UI part, I used the same colors as `<cc-button>`.

Preview is available here: https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-badge-skeleton-impl-1/index.html

:thinking: Maybe, we would like to put these gray colors (background, border) into the theme.

## Implementation

I tried two implementations as I need your thought about what I encountered. (See another PR for second implementation #548) 

In this implementation, I tried to follow the same philosophy already present: there is no `<div>` tag encapsulating the whole component. Instead, it uses directly the `:host` CSS selector to apply styles for the different modes (weight, intent, ...).

In order to add the skeleton mode to our components, we use `skeleton.js` which exports a `skeletonStyles` constant that can be added to the `static get styles()` array of our component.

But here, I don't want this full `skeletonStyles` provided by `skeleton.js`. I just want a part of it and apply some pieces to a `:host([skeleton])` CSS selector.

That is what I did in this implementation: I split the `skeletonStyles` provided by `skeleton.js` into multiple parts.

And then, I used those parts like that:
```javascript

import { innerSkeletonStyles, skeletonPulseStyles } from '../../styles/skeleton.js';

// ...

  static get styles () {
    return [
      skeletonPulseStyles,
      // language=CSS
      css`
        :host([skeleton]) {
          background-color: #bbb !important;
          ${innerSkeletonStyles};
        }
      `,
    ];
  }
```

