### PR TITLE
cc-badge: add skeleton mode / impl 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ title: Changelog
 * `<cc-zone-input>`: make server markers not focusable.
 * `<cc-addon-admin>`: fix skeleton mode
 * `<cc-env-var-form>`: fix toggling to JSON mode while in skeleton state.
+* `<cc-badge>`: add skeleton mode
 * New component:
   * `<cc-action-dispatcher>`
 

--- a/src/components/cc-badge/cc-badge.js
+++ b/src/components/cc-badge/cc-badge.js
@@ -1,4 +1,6 @@
 import { css, html, LitElement } from 'lit';
+import { classMap } from 'lit/directives/class-map.js';
+import { skeletonStyles } from '../../styles/skeleton.js';
 
 /**
  * @typedef {import('./cc-badge.types.js').BadgeIntent} BadgeIntent
@@ -8,16 +10,17 @@ import { css, html, LitElement } from 'lit';
 /**
  * A component to highlight a small chunk of text.
  *
- * @cssdisplay inline-flex
+ * @cssdisplay inline-block
  */
 export class CcBadge extends LitElement {
   static get properties () {
     return {
-      circle: { type: Boolean, reflect: true },
+      circle: { type: Boolean },
       iconAlt: { type: String, attribute: 'icon-alt' },
       iconSrc: { type: String, attribute: 'icon-src' },
-      intent: { type: String, reflect: true },
-      weight: { type: String, reflect: true },
+      intent: { type: String },
+      skeleton: { type: Boolean },
+      weight: { type: String },
     };
   }
 
@@ -36,26 +39,49 @@ export class CcBadge extends LitElement {
     /** @type {BadgeIntent} Sets the accent color used for the badge. */
     this.intent = 'neutral';
 
+    /** @type {boolean} Whether the component should be displayed as skeleton. */
+    this.skeleton = false;
+
     /** @type {BadgeWeight} Sets the style of the badge depending on how much one wants it to stand out. */
     this.weight = 'dimmed';
   }
 
   render () {
+    const modes = {
+      dimmed: this.weight == null || this.weight === 'dimmed',
+      strong: this.weight === 'strong',
+      outlined: this.weight === 'outlined',
+      neutral: this.intent == null || this.intent === 'neutral',
+      info: this.intent === 'info',
+      success: this.intent === 'success',
+      warning: this.intent === 'warning',
+      danger: this.intent === 'danger',
+      skeleton: this.skeleton,
+      circle: this.circle,
+    };
+
     return html`
-      ${this.iconSrc != null ? html`
-        <img src=${this.iconSrc} alt=${this.iconAlt ?? ''}>
-      ` : ''}
-      <span>
-        <slot></slot>
+      <span class="cc-badge ${classMap(modes)}">
+        ${this.iconSrc != null ? html`
+          <img src=${this.iconSrc} alt=${this.iconAlt ?? ''}>
+        ` : ''}
+        <span>
+          <slot></slot>
+        </span>
       </span>
     `;
   }
 
   static get styles () {
     return [
+      skeletonStyles,
       // language=CSS
       css`
         :host {
+          display: inline-block;
+        }
+
+        .cc-badge {
           align-items: center;
           border-radius: 1em;
           display: inline-flex;
@@ -64,7 +90,21 @@ export class CcBadge extends LitElement {
           padding: 0.2em 0.8em;
         }
 
-        :host([circle]) {
+        /* skeleton is more important */
+        .skeleton {
+          background-color: #bbb !important;
+          color: transparent !important;
+        }
+
+        .skeleton.outlined {
+          box-shadow: inset 0 0 0 0.06em #777 !important;
+        }
+
+        .skeleton img {
+          visibility: hidden !important;
+        }
+
+        .circle {
           border-radius: 50%;
           font-size: 1em;
           height: 1.5em;
@@ -74,16 +114,16 @@ export class CcBadge extends LitElement {
           width: 1.5em;
         }
 
-        :host([weight="dimmed"]) {
+        .dimmed {
           background-color: var(--accent-color, #ccc);
         }
 
-        :host([weight="strong"]) {
+        .strong {
           background-color: var(--accent-color, #777);
           color: var(--cc-color-text-inverted, #fff);
         }
 
-        :host([weight="outlined"]) {
+        .outlined {
           background-color: transparent;
           /* roughly 1px. We want the border to scale with the font size so that outlined
           badges still stand out as they should when font-size is increased. */
@@ -91,43 +131,43 @@ export class CcBadge extends LitElement {
           color: var(--accent-color, #777);
         }
 
-        :host([intent="info"]) {
+        .info {
           --accent-color: var(--cc-color-bg-primary);
         }
 
-        :host([intent="info"][weight="dimmed"]) {
+        .info.dimmed {
           --accent-color: var(--cc-color-bg-primary-weak);
         }
 
-        :host([intent="success"]) {
+        .success {
           --accent-color: var(--cc-color-bg-success);
         }
 
-        :host([intent="success"][weight="dimmed"]) {
+        .success.dimmed {
           --accent-color: var(--cc-color-bg-success-weak);
         }
 
-        :host([intent="danger"]) {
+        .danger {
           --accent-color: var(--cc-color-bg-danger);
         }
 
-        :host([intent="danger"][weight="dimmed"]) {
+        .danger.dimmed {
           --accent-color: var(--cc-color-bg-danger-weak);
         }
 
-        :host([intent="warning"]) {
+        .warning {
           --accent-color: var(--cc-color-bg-warning);
         }
 
-        :host([intent="warning"][weight="dimmed"]) {
+        .warning.dimmed {
           --accent-color: var(--cc-color-bg-warning-weak);
         }
 
-        :host([intent="neutral"]) {
+        .neutral {
           --accent-color: var(--cc-color-bg-strong);
         }
 
-        :host([intent="neutral"][weight="dimmed"]) {
+        .neutral.dimmed {
           --accent-color: var(--cc-color-bg-neutral-alt);
         }
 

--- a/src/components/cc-badge/cc-badge.stories.js
+++ b/src/components/cc-badge/cc-badge.stories.js
@@ -36,6 +36,76 @@ const baseItems = [
   },
 ];
 
+const iconsItems = [
+  {
+    intent: 'info',
+    weight: 'dimmed',
+    innerHTML: 'this is info',
+    iconSrc: infoSvg,
+    iconAlt: 'Info',
+  },
+  {
+    intent: 'success',
+    weight: 'outlined',
+    innerHTML: 'this is success',
+    iconSrc: tickSvg,
+    iconAlt: 'Success',
+  },
+  {
+    intent: 'danger',
+    weight: 'outlined',
+    innerHTML: 'this is danger',
+    iconSrc: errorSvg,
+    iconAlt: 'Error',
+  },
+  {
+    intent: 'warning',
+    weight: 'strong',
+    innerHTML: 'this is warning',
+    iconSrc: warningSvg,
+    iconAlt: 'Warning',
+  },
+  {
+    intent: 'neutral',
+    weight: 'strong',
+    innerHTML: 'this is neutral',
+    iconSrc: badgeSvg,
+  },
+];
+
+const circleItems = [
+  {
+    intent: 'info',
+    weight: 'dimmed',
+    innerHTML: '1',
+    circle: true,
+  },
+  {
+    intent: 'success',
+    weight: 'outlined',
+    innerHTML: '2',
+    circle: true,
+  },
+  {
+    intent: 'danger',
+    weight: 'outlined',
+    innerHTML: '10',
+    circle: true,
+  },
+  {
+    intent: 'warning',
+    weight: 'strong',
+    innerHTML: '5',
+    circle: true,
+  },
+  {
+    intent: 'neutral',
+    weight: 'strong',
+    innerHTML: '1',
+    circle: true,
+  },
+];
+
 export default {
   title: '🧬 Atoms/<cc-badge>',
   component: 'cc-badge',
@@ -50,92 +120,51 @@ export const dimmed = makeStory(conf, {
   items: baseItems,
 });
 
+export const dimmedWithSkeleton = makeStory(conf, {
+  items: baseItems.map((badge) => ({ ...badge, skeleton: true })),
+});
+
 export const outlined = makeStory(conf, {
   items: baseItems.map((badge) => ({ ...badge, weight: 'outlined' })),
+});
+
+export const outlinedWithSkeleton = makeStory(conf, {
+  items: baseItems.map((badge) => ({ ...badge, weight: 'outlined', skeleton: true })),
 });
 
 export const strong = makeStory(conf, {
   items: baseItems.map((badge) => ({ ...badge, weight: 'strong' })),
 });
 
+export const strongWithSkeleton = makeStory(conf, {
+  items: baseItems.map((badge) => ({ ...badge, weight: 'strong', skeleton: true })),
+});
+
 export const icons = makeStory(conf, {
-  items: [
-    {
-      intent: 'info',
-      weight: 'dimmed',
-      innerHTML: 'this is info',
-      iconSrc: infoSvg,
-      iconAlt: 'Info',
-    },
-    {
-      intent: 'success',
-      weight: 'outlined',
-      innerHTML: 'this is success',
-      iconSrc: tickSvg,
-      iconAlt: 'Success',
-    },
-    {
-      intent: 'danger',
-      weight: 'outlined',
-      innerHTML: 'this is danger',
-      iconSrc: errorSvg,
-      iconAlt: 'Error',
-    },
-    {
-      intent: 'warning',
-      weight: 'strong',
-      innerHTML: 'this is warning',
-      iconSrc: warningSvg,
-      iconAlt: 'Warning',
-    },
-    {
-      intent: 'neutral',
-      weight: 'strong',
-      innerHTML: 'this is neutral',
-      iconSrc: badgeSvg,
-    },
-  ],
+  items: iconsItems,
+});
+
+export const iconsWithSkeleton = makeStory(conf, {
+  items: iconsItems.map((badge) => ({ ...badge, skeleton: true })),
 });
 
 export const circleWithNumber = makeStory(conf, {
-  items: [
-    {
-      intent: 'info',
-      weight: 'dimmed',
-      innerHTML: '1',
-      circle: true,
-    },
-    {
-      intent: 'success',
-      weight: 'outlined',
-      innerHTML: '2',
-      circle: true,
-    },
-    {
-      intent: 'danger',
-      weight: 'outlined',
-      innerHTML: '10',
-      circle: true,
-    },
-    {
-      intent: 'warning',
-      weight: 'strong',
-      innerHTML: '5',
-      circle: true,
-    },
-    {
-      intent: 'neutral',
-      weight: 'strong',
-      innerHTML: '1',
-      circle: true,
-    },
-  ],
+  items: circleItems,
+});
+
+export const circleWithNumberWithSkeleton = makeStory(conf, {
+  items: circleItems.map((badge) => ({ ...badge, skeleton: true })),
 });
 
 enhanceStoriesNames({
   dimmed,
+  dimmedWithSkeleton,
   outlined,
+  outlinedWithSkeleton,
   strong,
+  strongWithSkeleton,
   icons,
+  iconsWithSkeleton,
   circleWithNumber,
+  circleWithNumberWithSkeleton,
 });


### PR DESCRIPTION
Fixes #521 

## UI

Visually there is no difference but I added the preview so that you can compare the DOM which differs from the first implementation: https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-badge-skeleton-impl-2/index.html

## Implementation

This implementation breaks the initial philosophy which is based on the `:host` CSS selector to apply styles. Instead, it adds a root `<div>` tag which receives all the CSS classes needed to apply style for the different modes (intent, weight, ...)

I add the modify all the CSS selectors to be based on classes instead of `host:`.

Adding the skeleton mode is straightforward as it uses the `skeleton.js` in the same way as usual.