### PR TITLE
markdown: disable sanitizer for stories doc markdown

### DIFF
--- a/src/stories/lib/markdown.cjs
+++ b/src/stories/lib/markdown.cjs
@@ -49,7 +49,7 @@ function markdownToCsfWithDocsPage (markdownText) {
     .use(remarkGfm)
     .use(frontmatter, ['yaml'])
     .use(highlight)
-    .use(remark2Html);
+    .use(remark2Html, { sanitize: false });
 
   const markdownAst = processor.parse(markdownText);
 


### PR DESCRIPTION
Since our dependency update, `remark-html` has been updated to `13.0.2`.
This version introduces a breaking change by sanitizing markdown content it handles.

Since we need to add web components inside our "smart" stories to test them, we need to disable this sanitizing.