### PR TITLE
refactor: rollback the smart-manager to the old low level API and move the observable API to a different module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ title: Changelog
 * Upgrade from `@custom-elements-manifest/analyzer@0.4.1` to `@custom-elements-manifest/analyzer@0.6.4`.
 * Fix Custom Element Manifest generation web dev server plugin: disable caching
 * Add JSDoc based typechecking with TypeScript's CLI (just utils.js for now)
+* Rollback the smart-manager to the old low level API and move the observable API to a different module
 
 ## 9.0.0 (2022-07-19)
 

--- a/src/components/cc-addon-linked-apps/cc-addon-linked-apps.smart.js
+++ b/src/components/cc-addon-linked-apps/cc-addon-linked-apps.smart.js
@@ -3,11 +3,11 @@ import '../cc-smart-container/cc-smart-container.js';
 import { getLinkedApplications } from '@clevercloud/client/esm/api/v2/addon.js';
 import { getAllZones } from '@clevercloud/client/esm/api/v4/product.js';
 import { ONE_DAY } from '@clevercloud/client/esm/with-cache.js';
+import { defineSmartComponentWithObservables } from '../../lib/define-smart-component-with-observables.js';
 import { LastPromise, unsubscribeWithSignal } from '../../lib/observables.js';
 import { sendToApi } from '../../lib/send-to-api.js';
-import { defineComponent } from '../../lib/smart-manager.js';
 
-defineComponent({
+defineSmartComponentWithObservables({
   selector: 'cc-addon-linked-apps',
   params: {
     apiConfig: { type: Object },

--- a/src/components/cc-article-list/cc-article-list.smart.js
+++ b/src/components/cc-article-list/cc-article-list.smart.js
@@ -2,13 +2,13 @@ import './cc-article-list.js';
 import '../cc-smart-container/cc-smart-container.js';
 import { request } from '@clevercloud/client/esm/request.fetch.js';
 import { withCache } from '@clevercloud/client/esm/with-cache.js';
+import { defineSmartComponentWithObservables } from '../../lib/define-smart-component-with-observables.js';
 import { LastPromise, unsubscribeWithSignal } from '../../lib/observables.js';
-import { defineComponent } from '../../lib/smart-manager.js';
 import { parseRssFeed } from '../../lib/xml-parser.js';
 
 const FOUR_HOURS = 1000 * 60 * 60 * 4;
 
-defineComponent({
+defineSmartComponentWithObservables({
   selector: 'cc-article-list',
   params: {
     lang: { type: String },

--- a/src/components/cc-env-var-form/cc-env-var-form.smart-config-provider.js
+++ b/src/components/cc-env-var-form/cc-env-var-form.smart-config-provider.js
@@ -1,13 +1,20 @@
 import './cc-env-var-form.js';
 import '../cc-smart-container/cc-smart-container.js';
 import { get as getAddon } from '@clevercloud/client/esm/api/v2/addon.js';
+import { defineSmartComponentWithObservables } from '../../lib/define-smart-component-with-observables.js';
 import { i18n } from '../../lib/i18n.js';
 import { notifyError, notifySuccess } from '../../lib/notifications.js';
-import { fromCustomEvent, LastPromise, map, merge, unsubscribeWithSignal, withLatestFrom } from '../../lib/observables.js';
+import {
+  fromCustomEvent,
+  LastPromise,
+  map,
+  merge,
+  unsubscribeWithSignal,
+  withLatestFrom,
+} from '../../lib/observables.js';
 import { sendToApi } from '../../lib/send-to-api.js';
-import { defineComponent } from '../../lib/smart-manager.js';
 
-defineComponent({
+defineSmartComponentWithObservables({
   selector: 'cc-env-var-form[context="config-provider"]',
   params: {
     apiConfig: { type: Object },

--- a/src/components/cc-env-var-form/cc-env-var-form.smart-env-var-addon.js
+++ b/src/components/cc-env-var-form/cc-env-var-form.smart-env-var-addon.js
@@ -1,11 +1,11 @@
 import './cc-env-var-form.js';
 import '../cc-smart-container/cc-smart-container.js';
 import { getAllEnvVars } from '@clevercloud/client/esm/api/v2/addon.js';
+import { defineSmartComponentWithObservables } from '../../lib/define-smart-component-with-observables.js';
 import { LastPromise, unsubscribeWithSignal } from '../../lib/observables.js';
 import { sendToApi } from '../../lib/send-to-api.js';
-import { defineComponent } from '../../lib/smart-manager.js';
 
-defineComponent({
+defineSmartComponentWithObservables({
   selector: 'cc-env-var-form[context="env-var-addon"]',
   params: {
     apiConfig: { type: Object },

--- a/src/components/cc-env-var-form/cc-env-var-form.smart-exposed-config.js
+++ b/src/components/cc-env-var-form/cc-env-var-form.smart-exposed-config.js
@@ -3,13 +3,13 @@ import '../cc-smart-container/cc-smart-container.js';
 import { getAllExposedEnvVars, updateAllExposedEnvVars } from '@clevercloud/client/esm/api/v2/application.js';
 import { toNameValueObject } from '@clevercloud/client/esm/utils/env-vars.js';
 import { fetchApp } from '../../lib/api-helpers.js';
+import { defineSmartComponentWithObservables } from '../../lib/define-smart-component-with-observables.js';
 import { i18n } from '../../lib/i18n.js';
 import { notifyError, notifySuccess } from '../../lib/notifications.js';
 import { fromCustomEvent, LastPromise, merge, unsubscribeWithSignal, withLatestFrom } from '../../lib/observables.js';
 import { sendToApi } from '../../lib/send-to-api.js';
-import { defineComponent } from '../../lib/smart-manager.js';
 
-defineComponent({
+defineSmartComponentWithObservables({
   selector: 'cc-env-var-form[context="exposed-config"]',
   params: {
     apiConfig: { type: Object },

--- a/src/components/cc-grafana-info/cc-grafana-info.smart.js
+++ b/src/components/cc-grafana-info/cc-grafana-info.smart.js
@@ -6,14 +6,14 @@ import {
   getGrafanaOrganisation,
   resetGrafanaOrganisation,
 } from '../../lib/api-helpers.js';
+import { defineSmartComponentWithObservables } from '../../lib/define-smart-component-with-observables.js';
 import { i18n } from '../../lib/i18n.js';
 import { notifyError, notifySuccess } from '../../lib/notifications.js';
 import { fromCustomEvent, LastPromise, unsubscribeWithSignal, withLatestFrom } from '../../lib/observables.js';
 import { sendToApi } from '../../lib/send-to-api.js';
-import { defineComponent } from '../../lib/smart-manager.js';
 
 // TODO, we need to refactor this one to make it more like the others
-defineComponent({
+defineSmartComponentWithObservables({
   selector: 'cc-grafana-info',
   params: {
     apiConfig: { type: Object },

--- a/src/components/cc-invoice-list/cc-invoice-list.smart.js
+++ b/src/components/cc-invoice-list/cc-invoice-list.smart.js
@@ -1,10 +1,10 @@
 import './cc-invoice-list.js';
 import '../cc-smart-container/cc-smart-container.js';
 import { fetchAllInvoices } from '../../lib/api-helpers.js';
+import { defineSmartComponentWithObservables } from '../../lib/define-smart-component-with-observables.js';
 import { LastPromise, unsubscribeWithSignal } from '../../lib/observables.js';
-import { defineComponent } from '../../lib/smart-manager.js';
 
-defineComponent({
+defineSmartComponentWithObservables({
   selector: 'cc-invoice-list',
   params: {
     apiConfig: { type: Object },

--- a/src/components/cc-invoice/cc-invoice.smart.js
+++ b/src/components/cc-invoice/cc-invoice.smart.js
@@ -1,10 +1,10 @@
 import './cc-invoice.js';
 import '../cc-smart-container/cc-smart-container.js';
 import { fetchInvoice, fetchInvoiceHtml } from '../../lib/api-helpers.js';
+import { defineSmartComponentWithObservables } from '../../lib/define-smart-component-with-observables.js';
 import { LastPromise, unsubscribeWithSignal } from '../../lib/observables.js';
-import { defineComponent } from '../../lib/smart-manager.js';
 
-defineComponent({
+defineSmartComponentWithObservables({
   selector: 'cc-invoice',
   params: {
     apiConfig: { type: Object },

--- a/src/components/cc-jenkins-info/cc-jenkins-info.smart.js
+++ b/src/components/cc-jenkins-info/cc-jenkins-info.smart.js
@@ -1,11 +1,11 @@
 import './cc-jenkins-info.js';
 import '../cc-smart-container/cc-smart-container.js';
 import { getAddon, getJenkinsUpdates } from '@clevercloud/client/esm/api/v4/addon-providers.js';
+import { defineSmartComponentWithObservables } from '../../lib/define-smart-component-with-observables.js';
 import { LastPromise, unsubscribeWithSignal } from '../../lib/observables.js';
 import { sendToApi } from '../../lib/send-to-api.js';
-import { defineComponent } from '../../lib/smart-manager.js';
 
-defineComponent({
+defineSmartComponentWithObservables({
   selector: 'cc-jenkins-info',
   params: {
     apiConfig: { type: Object },

--- a/src/components/cc-pricing-page/cc-pricing-page.smart.js
+++ b/src/components/cc-pricing-page/cc-pricing-page.smart.js
@@ -1,10 +1,10 @@
 import './cc-pricing-page.js';
 import '../cc-smart-container/cc-smart-container.js';
 import { fetchAllZones } from '../../lib/api-helpers.js';
+import { defineSmartComponentWithObservables } from '../../lib/define-smart-component-with-observables.js';
 import { fromCustomEvent, LastPromise, unsubscribeWithSignal } from '../../lib/observables.js';
-import { defineComponent } from '../../lib/smart-manager.js';
 
-defineComponent({
+defineSmartComponentWithObservables({
   selector: 'cc-pricing-page',
   params: {
     currency: { type: Object },

--- a/src/components/cc-pricing-product-consumption/cc-pricing-product-consumption.smart.js
+++ b/src/components/cc-pricing-product-consumption/cc-pricing-product-consumption.smart.js
@@ -1,9 +1,9 @@
 import './cc-pricing-product-consumption.js';
 import '../cc-smart-container/cc-smart-container.js';
 import { fetchPriceSystem } from '../../lib/api-helpers.js';
+import { defineSmartComponentWithObservables } from '../../lib/define-smart-component-with-observables.js';
 import { LastPromise, unsubscribeWithSignal } from '../../lib/observables.js';
 import { formatAddonCellar, formatAddonFsbucket, formatAddonHeptapod, formatAddonPulsar } from '../../lib/product.js';
-import { defineComponent } from '../../lib/smart-manager.js';
 
 const PRODUCTS = {
   cellar: {
@@ -41,7 +41,7 @@ const PRODUCTS = {
   },
 };
 
-defineComponent({
+defineSmartComponentWithObservables({
   selector: 'cc-pricing-product-consumption',
   params: {
     currency: { type: Object },

--- a/src/components/cc-pricing-product/cc-pricing-product.smart-addon.js
+++ b/src/components/cc-pricing-product/cc-pricing-product.smart-addon.js
@@ -3,12 +3,12 @@ import '../cc-smart-container/cc-smart-container.js';
 import { getAllAddonProviders } from '@clevercloud/client/esm/api/v2/product.js';
 import { ONE_DAY } from '@clevercloud/client/esm/with-cache.js';
 import { fetchPriceSystem } from '../../lib/api-helpers.js';
+import { defineSmartComponentWithObservables } from '../../lib/define-smart-component-with-observables.js';
 import { LastPromise, unsubscribeWithSignal } from '../../lib/observables.js';
 import { formatAddonProduct } from '../../lib/product.js';
 import { sendToApi } from '../../lib/send-to-api.js';
-import { defineComponent } from '../../lib/smart-manager.js';
 
-defineComponent({
+defineSmartComponentWithObservables({
   selector: 'cc-pricing-product[mode="addon"]',
   params: {
     productId: { type: String },

--- a/src/components/cc-pricing-product/cc-pricing-product.smart-runtime.js
+++ b/src/components/cc-pricing-product/cc-pricing-product.smart-runtime.js
@@ -3,12 +3,12 @@ import '../cc-smart-container/cc-smart-container.js';
 import { getAvailableInstances } from '@clevercloud/client/esm/api/v2/product.js';
 import { ONE_DAY } from '@clevercloud/client/esm/with-cache.js';
 import { fetchPriceSystem } from '../../lib/api-helpers.js';
+import { defineSmartComponentWithObservables } from '../../lib/define-smart-component-with-observables.js';
 import { LastPromise, unsubscribeWithSignal } from '../../lib/observables.js';
 import { formatRuntimeProduct, getRunnerProduct } from '../../lib/product.js';
 import { sendToApi } from '../../lib/send-to-api.js';
-import { defineComponent } from '../../lib/smart-manager.js';
 
-defineComponent({
+defineSmartComponentWithObservables({
   selector: 'cc-pricing-product[mode="runtime"]',
   params: {
     productId: { type: String },

--- a/src/components/cc-smart-container/cc-smart-container.js
+++ b/src/components/cc-smart-container/cc-smart-container.js
@@ -1,16 +1,11 @@
 import { css, html, LitElement } from 'lit';
-import { unsubscribeWithSignal } from '../../lib/observables.js';
-import { defineComponent, observeContainer, updateContext } from '../../lib/smart-manager.js';
+import { defineSmartComponentCore, observeContainer, updateContext } from '../../lib/smart-manager.js';
 
 // Special case to propagate/merge contexts trough containers
-defineComponent({
+defineSmartComponentCore({
   selector: 'cc-smart-container',
-  onConnect (container, component, context$, disconnectSignal) {
-    unsubscribeWithSignal(disconnectSignal, [
-      context$.subscribe((context) => {
-        component.parentContext = context;
-      }),
-    ]);
+  onContextUpdate (container, component, context) {
+    component.parentContext = context;
   },
 });
 

--- a/src/components/cc-tcp-redirection-form/cc-tcp-redirection-form.smart.js
+++ b/src/components/cc-tcp-redirection-form/cc-tcp-redirection-form.smart.js
@@ -2,13 +2,13 @@ import './cc-tcp-redirection-form.js';
 import '../cc-smart-container/cc-smart-container.js';
 import { addTcpRedir, getTcpRedirs, removeTcpRedir } from '@clevercloud/client/esm/api/v2/application.js';
 import { getNamespaces } from '@clevercloud/client/esm/api/v2/organisation.js';
+import { defineSmartComponentWithObservables } from '../../lib/define-smart-component-with-observables.js';
 import { i18n } from '../../lib/i18n.js';
 import { notifyError, notifySuccess } from '../../lib/notifications.js';
 import { fromCustomEvent, LastPromise, unsubscribeWithSignal, withLatestFrom } from '../../lib/observables.js';
 import { sendToApi } from '../../lib/send-to-api.js';
-import { defineComponent } from '../../lib/smart-manager.js';
 
-defineComponent({
+defineSmartComponentWithObservables({
   selector: 'cc-tcp-redirection-form',
   params: {
     apiConfig: { type: Object },

--- a/src/components/cc-tile-status-codes/cc-tile-status-codes.smart.js
+++ b/src/components/cc-tile-status-codes/cc-tile-status-codes.smart.js
@@ -4,11 +4,11 @@ import { getStatusCodesFromWarp10 } from '@clevercloud/client/esm/access-logs.js
 import { getWarp10AccessLogsToken } from '@clevercloud/client/esm/api/v2/warp-10.js';
 import { THIRTY_SECONDS } from '@clevercloud/client/esm/request.fetch-with-timeout.js';
 import { ONE_DAY } from '@clevercloud/client/esm/with-cache.js';
+import { defineSmartComponentWithObservables } from '../../lib/define-smart-component-with-observables.js';
 import { LastPromise, unsubscribeWithSignal } from '../../lib/observables.js';
 import { sendToApi, sendToWarp } from '../../lib/send-to-api.js';
-import { defineComponent } from '../../lib/smart-manager.js';
 
-defineComponent({
+defineSmartComponentWithObservables({
   selector: 'cc-tile-status-codes',
   params: {
     apiConfig: { type: Object },

--- a/src/lib/define-smart-component-with-observables.js
+++ b/src/lib/define-smart-component-with-observables.js
@@ -1,0 +1,47 @@
+import { Subject } from './observables.js';
+import { defineSmartComponentCore } from './smart-manager.js';
+
+const META = Symbol('META');
+
+/**
+ * @typedef {import('rxjs').Subject} Subject
+ */
+
+/**
+ * @typedef {Element} SmartContainer
+ * @param {object} context
+ */
+
+/**
+ * @param {object} definition
+ * @param {string} definition.selector
+ * @param {object?} definition.params
+ * @param {(container: SmartContainer, component: Element, context$: Observable<object>, signal: AbortSignal) => void} definition.onConnect
+ * @param {AbortSignal?} signal
+ */
+export function defineSmartComponentWithObservables (definition, signal) {
+
+  defineSmartComponentCore({
+    selector: definition.selector,
+    params: definition.params,
+    onConnect (container, component) {
+
+      const context$ = new Subject();
+      const disconnectionController = new AbortController();
+
+      if (component[META] == null) {
+        component[META] = new Map();
+      }
+      component[META].set(definition, { context$, disconnectionController });
+
+      definition.onConnect(container, component, context$, disconnectionController.signal);
+    },
+    onContextUpdate (container, component, context) {
+      component[META].get(definition).context$.next(context);
+    },
+    onDisconnect (container, component) {
+      component[META].get(definition).disconnectionController.abort();
+      component[META].delete(definition);
+    },
+  }, signal);
+}

--- a/src/lib/smart-manager.js
+++ b/src/lib/smart-manager.js
@@ -1,6 +1,19 @@
 import { Subject } from './observables.js';
 import { objectEquals } from './utils.js';
 
+// In the global space of this module (for any module importing it), we maintain:
+// * a rootContext object
+// * a smartContainers Set with all containers currently in the page
+// * a smartComponentDefinitions Set with all definitions currently in the page
+
+// On each container, we maintain:
+// * a Map on container[COMPONENTS] with all components keyed by definition object
+// * an object with the current context on container[CURRENT_CONTEXT]
+
+// On each component, we maintain:
+// * a map on component[META] with pointers to context$, disconnectionController keyed by definition object
+// * an object with the last context on component[LAST_CONTEXT]
+
 /**
  * @typedef SmartComponentDefinition
  * @property {String} selector


### PR DESCRIPTION
Hey folks,

We're going to deprecate (and then remove) the current `defineComponent` function from the smart manager which is based on Observables and RxJS.

In this PR:

* add some comments (just the first step)
* rollback the `defineComponent` function to the previous low level API with 3 callbacks `onConnect`, `onContextUpdate` and `onDisconnect`
* reimplement the current `defineComponent` function (based on just one `onConnect` callback and a `context$` observable) with the "new" low level API in a different file `smart-manager-observables.js`
* cleanup the test suite
  * BTW the test suite was kinda still testing the low level API with a dirty hack, it's better now

Next steps

* Define a new high level API (not based on observables) with a bit more magic
* Write some more comments, JSDoc and documentation