### PR TITLE
refactor(cc-tcp-redirection-form): rework state, types and smart for TCP redirection components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ title: Changelog
 * Add new dependency `@web/test-runner-commands` so that Web Test Runner can test both on desktop and mobile.
 * Add new helpers to extract stories and run accessibility test on them.
 * Add new test files in most of the component folders. These test files only contain accessibility tests for the moment.
+* `<cc-tcp-redirection-form>`: rework state, types and smart for TCP redirection components
 
 ## 9.0.0 (2022-07-19)
 

--- a/demo-smart/index.html
+++ b/demo-smart/index.html
@@ -61,9 +61,9 @@
   <!--  <li>-->
   <!--    <a class="definition-link" href="?definition=cc-env-var-form.smart-env-var-addon&context=env-var-addon">cc-env-var-form.smart-env-var-addon</a>-->
   <!--  </li>-->
-    <li>
-      <a class="definition-link" href="?definition=cc-env-var-form.smart-exposed-config&context=exposed-config">cc-env-var-form.smart-exposed-config</a>
-    </li>
+  <li>
+    <a class="definition-link" href="?definition=cc-env-var-form.smart-exposed-config&context=exposed-config">cc-env-var-form.smart-exposed-config</a>
+  </li>
   <!--  <li>-->
   <!--    <a class="definition-link" href="?definition=cc-grafana-info.smart&grafanaBaseLink=http%3A%2F%2Fexample.com"">cc-grafana-info.smart</a>-->
   <!--  </li>-->
@@ -89,7 +89,7 @@
   <!--    <a class="definition-link" href="?definition=cc-pricing-product.smart-runtime">cc-pricing-product.smart-runtime</a>-->
   <!--  </li>-->
     <li>
-      <a class="definition-link" href="?definition=cc-tcp-redirection-form.smart">cc-tcp-redirection-form.smart</a>
+    <a class="definition-link" href="?definition=cc-tcp-redirection-form.smart">cc-tcp-redirection-form.smart</a>
     </li>
   <!--  <li>-->
   <!--    <a class="definition-link" href="?definition=cc-tile-status-codes.smart">cc-tile-status-codes.smart</a>-->

--- a/src/components/cc-tcp-redirection-form/cc-tcp-redirection-form.js
+++ b/src/components/cc-tcp-redirection-form/cc-tcp-redirection-form.js
@@ -7,14 +7,13 @@ import { i18n } from '../../lib/i18n.js';
 import { linkStyles } from '../../templates/cc-link/cc-link.js';
 
 const SKELETON_REDIRECTIONS = [
-  { namespace: 'default', sourcePort: 1234 },
-  { namespace: 'cleverapps' },
+  { state: 'loading' },
+  { state: 'loading' },
 ];
 
 /**
- * @typedef {import('./cc-tcp-redirection-form.types.js').ContextRedirectionType} ContextRedirectionType
- * @typedef {import('./cc-tcp-redirection-form.types.js').Redirection} Redirection
- * @typedef {import('./cc-tcp-redirection-form.types.js').RedirectionNamespace} RedirectionNamespace
+ * @typedef {import('./cc-tcp-redirection-form.types.js').TcpRedirectionFormContextType} TcpRedirectionFormContextType
+ * @typedef {import('./cc-tcp-redirection-form.types.js').TcpRedirectionFormState} TcpRedirectionFormState
  */
 
 /**
@@ -22,72 +21,78 @@ const SKELETON_REDIRECTIONS = [
  *
  * @cssdisplay block
  *
- * @event {CustomEvent<RedirectionNamespace>} cc-tcp-redirection:create - Fires a redirection namespace whenever the create button is clicked.
- * @event {CustomEvent<Redirection>} cc-tcp-redirection:delete - Fires a redirection whenever the delete button is clicked.
+ * @event {CustomEvent<CreateTcpRedirection>} cc-tcp-redirection:create - Fires a redirection namespace whenever the create button is clicked.
+ * @event {CustomEvent<DeleteTcpRedirection>} cc-tcp-redirection:delete - Fires a redirection whenever the delete button is clicked.
  */
 export class CcTcpRedirectionForm extends LitElement {
 
   static get properties () {
     return {
       context: { type: String },
-      error: { type: Boolean },
-      redirections: { type: Array },
+      redirections: { type: Object },
     };
   }
 
   constructor () {
     super();
 
-    /** @type {ContextRedirectionType} Defines in which context the form is used so it can show the appropriate description or lack thereof (defaults to user). */
+    /** @type {TcpRedirectionFormContextType} Defines in which context the form is used so it can show the appropriate description or lack thereof (defaults to user). */
     this.context = 'user';
 
-    /** @type {boolean} Sets a loading error state. */
-    this.error = false;
-
-    /** @type {Redirection[]|null} Sets the list of redirections. */
-    this.redirections = null;
-  }
-
-  _getRedirectionCount () {
-    if (this.context === 'admin' && this.redirections != null) {
-      const howManyRedirections = this.redirections.filter(({ sourcePort }) => sourcePort != null).length;
-      if (howManyRedirections >= 1) {
-        return html`<cc-badge circle weight="strong">${howManyRedirections}</cc-badge>`;
-      }
-    }
-    return '';
+    /** @type {TcpRedirectionFormState} Sets the list of redirections. */
+    this.redirections = { state: 'loading' };
   }
 
   render () {
-    const skeleton = (this.redirections == null);
-    const redirections = skeleton ? SKELETON_REDIRECTIONS : this.redirections;
+
+    const state = this.redirections.state;
     const blockState = (this.context === 'admin') ? 'close' : 'off';
 
     return html`
       <cc-block state="${blockState}">
-        <div slot="title">${i18n('cc-tcp-redirection-form.title')}${this._getRedirectionCount()}</div>
+
+        <div slot="title">
+          ${i18n('cc-tcp-redirection-form.title')}
+          ${this._renderRedirectionCountBadge()}
+        </div>
+
         ${this.context === 'user' ? html`
           <div class="description">${i18n('cc-tcp-redirection-form.description')}</div>
         ` : ''}
-        ${!this.error && redirections.length > 0 ? html`
-          ${redirections.map((redirection) => html`
-            <cc-tcp-redirection
-              namespace=${redirection.namespace}
-              .sourcePort=${redirection.sourcePort}
-              ?skeleton=${skeleton}
-              ?waiting=${redirection.waiting}
-              ?private=${redirection.private}
-            ></cc-tcp-redirection>
+
+        ${state === 'loading' ? html`
+          ${SKELETON_REDIRECTIONS.map((redirection) => html`
+            <cc-tcp-redirection .redirection=${redirection}></cc-tcp-redirection>
           `)}
         ` : ''}
-        ${!this.error && redirections.length === 0 ? html`
-          <div class="cc-block_empty-msg">${i18n('cc-tcp-redirection-form.empty')}</div>
+
+        ${state === 'loaded' ? html`
+          ${this.redirections.value.map((redirection) => html`
+            <cc-tcp-redirection .redirection=${redirection}></cc-tcp-redirection>
+          `)}
+          ${this.redirections.value.length === 0 ? html`
+            <div class="cc-block_empty-msg">${i18n('cc-tcp-redirection-form.empty')}</div>
+          ` : ''}
         ` : ''}
-        ${this.error ? html`
+
+        ${state === 'error' ? html`
           <cc-error>${i18n('cc-tcp-redirection-form.error')}</cc-error>
         ` : ''}
+
       </cc-block>
     `;
+  }
+
+  _renderRedirectionCountBadge () {
+    if (this.context === 'admin' && this.redirections.state === 'loaded') {
+      const redirectionCount = this.redirections.value.filter(({ sourcePort }) => sourcePort != null).length;
+      if (redirectionCount >= 1) {
+        return html`
+          <cc-badge circle weight="strong">${redirectionCount}</cc-badge>
+        `;
+      }
+    }
+    return '';
   }
 
   static get styles () {

--- a/src/components/cc-tcp-redirection-form/cc-tcp-redirection-form.stories.js
+++ b/src/components/cc-tcp-redirection-form/cc-tcp-redirection-form.stories.js
@@ -13,142 +13,182 @@ const conf = {
 };
 
 export const defaultStory = makeStory(conf, {
-  items: [
-    {
-      redirections: [
-        { namespace: 'default', sourcePort: 5220 },
-        { namespace: 'cleverapps' },
+  items: [{
+    redirections: {
+      state: 'loaded',
+      value: [
+        { state: 'loaded', namespace: 'default', sourcePort: 5220 },
+        { state: 'loaded', namespace: 'cleverapps' },
       ],
     },
-  ],
+  }],
 });
 
 export const empty = makeStory(conf, {
-  items: [{ redirections: [] }],
+  items: [{
+    redirections: {
+      state: 'loaded',
+      value: [],
+    },
+  }],
 });
 
 export const loading = makeStory(conf, {
-  items: [{}],
+  items: [{
+    redirections: {
+      state: 'loading',
+    },
+  }],
 });
 
-export const loadingError = makeStory(conf, {
-  items: [{ error: true }],
+export const errorWithLoading = makeStory(conf, {
+  items: [{
+    redirections: {
+      state: 'error',
+    },
+  }],
 });
 
 export const dataLoaded = makeStory(conf, {
-  items: [
-    {
-      redirections: [
-        { namespace: 'default', sourcePort: 5220 },
-        { namespace: 'cleverapps' },
-        { namespace: 'customer-name', sourcePort: 6440, private: true },
+  items: [{
+    redirections: {
+      state: 'loaded',
+      value: [
+        { state: 'loaded', namespace: 'default', sourcePort: 5220 },
+        { state: 'loaded', namespace: 'cleverapps' },
+        { state: 'loaded', namespace: 'customer-name', sourcePort: 6440, private: true },
       ],
     },
-  ],
+  }],
 });
 
 export const dataLoadedWithContextAdmin = makeStory(conf, {
   docs: 'When `context="admin"` is used, the component description is hidden, the block is collapsed and a redirection counter bubble is be displayed.',
-  items: [
-    {
-      redirections: [
-        { namespace: 'default', sourcePort: 5220 },
-        { namespace: 'cleverapps' },
-        { namespace: 'customer-name', sourcePort: 6440, private: true },
+  items: [{
+    redirections: {
+      state: 'loaded',
+      value: [
+        { state: 'loaded', namespace: 'default', sourcePort: 5220 },
+        { state: 'loaded', namespace: 'cleverapps' },
+        { state: 'loaded', namespace: 'customer-name', sourcePort: 6440, private: true },
       ],
-      context: 'admin',
     },
-  ],
+    context: 'admin',
+  }],
 });
 
 export const dataLoadedWithContextAdminAndNoRedirections = makeStory(conf, {
   docs: 'When `context="admin"` is used, the counter bubble is not displayed if there is no redirection.',
-  items: [
-    {
-      redirections: [
-        { namespace: 'default' },
-        { namespace: 'cleverapps' },
-        { namespace: 'customer-name', private: true },
+  items: [{
+    redirections: {
+      state: 'loaded',
+      value: [
+        { state: 'loaded', namespace: 'default' },
+        { state: 'loaded', namespace: 'cleverapps' },
+        { state: 'loaded', namespace: 'customer-name', private: true },
       ],
-      context: 'admin',
     },
-  ],
+    context: 'admin',
+  }],
 });
 
 export const dataLoadedWithCreatingRedirection = makeStory(conf, {
-  items: [
-    {
-      redirections: [
-        { namespace: 'default', sourcePort: 5220 },
-        { namespace: 'cleverapps', waiting: true },
-        { namespace: 'customer-name', sourcePort: 6440, private: true },
+  items: [{
+    redirections: {
+      state: 'loaded',
+      value: [
+        { state: 'loaded', namespace: 'default', sourcePort: 5220 },
+        { state: 'waiting', namespace: 'cleverapps' },
+        { state: 'loaded', namespace: 'customer-name', sourcePort: 6440, private: true },
       ],
     },
-  ],
+  }],
 });
 
 export const dataLoadedWithDeletingRedirection = makeStory(conf, {
-  items: [
-    {
-      redirections: [
-        { namespace: 'default', sourcePort: 5220 },
-        { namespace: 'cleverapps', sourcePort: 3821 },
-        { namespace: 'customer-name', sourcePort: 6440, waiting: true, private: true },
+  items: [{
+    redirections: {
+      state: 'loaded',
+      value: [
+        { state: 'loaded', namespace: 'default', sourcePort: 5220 },
+        { state: 'loaded', namespace: 'cleverapps', sourcePort: 3821 },
+        { state: 'waiting', namespace: 'customer-name', sourcePort: 6440, private: true },
       ],
     },
-  ],
+  }],
 });
 
 export const dataLoadedWithManyNamespaces = makeStory(conf, {
-  items: [
-    {
-      redirections: [
-        { namespace: 'default', sourcePort: 874 },
-        { namespace: 'cleverapps', sourcePort: 12345 },
-        { namespace: 'secondary', sourcePort: 99 },
-        { namespace: 'customer-name-one', sourcePort: 1234 },
-        { namespace: 'customer-name-two', sourcePort: 4321 },
-        { namespace: 'customer-name-three' },
-        { namespace: 'customer-name-four', sourcePort: 7531 },
-        { namespace: 'customer-name-five' },
-        { namespace: 'customer-name-six' },
-        { namespace: 'customer-name-seven', sourcePort: 3456 },
+  items: [{
+    redirections: {
+      state: 'loaded',
+      value: [
+        { state: 'loaded', namespace: 'default', sourcePort: 874 },
+        { state: 'loaded', namespace: 'cleverapps', sourcePort: 12345 },
+        { state: 'loaded', namespace: 'secondary', sourcePort: 99 },
+        { state: 'loaded', namespace: 'customer-name-one', sourcePort: 1234 },
+        { state: 'loaded', namespace: 'customer-name-two', sourcePort: 4321 },
+        { state: 'loaded', namespace: 'customer-name-three' },
+        { state: 'loaded', namespace: 'customer-name-four', sourcePort: 7531 },
+        { state: 'loaded', namespace: 'customer-name-five' },
+        { state: 'loaded', namespace: 'customer-name-six' },
+        { state: 'loaded', namespace: 'customer-name-seven', sourcePort: 3456 },
       ],
     },
-  ],
+  }],
 });
 
 export const simulation = makeStory(conf, {
-  items: [{}, {}],
+  items: [
+    { redirections: { state: 'loading' } },
+    { redirections: { state: 'loading' } },
+  ],
   simulations: [
     storyWait(2000, ([component, componentError]) => {
-      component.redirections = [
-        { namespace: 'default', sourcePort: 5220 },
-        { namespace: 'cleverapps' },
-        { namespace: 'customer-name', sourcePort: 6440, private: true },
-      ];
-      componentError.error = true;
+      component.redirections = {
+        state: 'loaded',
+        value: [
+          { state: 'loaded', namespace: 'default', sourcePort: 5220 },
+          { state: 'loaded', namespace: 'cleverapps' },
+        ],
+      };
+      componentError.redirections = { state: 'error' };
     }),
     storyWait(1000, ([component, componentError]) => {
-      component.redirections = [
-        { namespace: 'default', sourcePort: 5220 },
-        { namespace: 'cleverapps', waiting: true },
-        { namespace: 'customer-name', sourcePort: 6440, private: true },
-      ];
+      component.redirections = {
+        state: 'loaded',
+        value: [
+          { state: 'loaded', namespace: 'default', sourcePort: 5220 },
+          { state: 'waiting', namespace: 'cleverapps' },
+        ],
+      };
     }),
     storyWait(1500, ([component, componentError]) => {
-      component.redirections = [
-        { namespace: 'default', sourcePort: 5220 },
-        { namespace: 'cleverapps', waiting: true },
-        { namespace: 'customer-name', sourcePort: 6440, private: true, waiting: true },
-      ];
+      component.redirections = {
+        state: 'loaded',
+        value: [
+          { state: 'waiting', namespace: 'default', sourcePort: 5220 },
+          { state: 'waiting', namespace: 'cleverapps' },
+        ],
+      };
     }),
     storyWait(1500, ([component, componentError]) => {
-      component.redirections = [
-        { namespace: 'default', sourcePort: 5220 },
-        { namespace: 'cleverapps', sourcePort: 4242 },
-        { namespace: 'customer-name', private: true },
-      ];
+      component.redirections = {
+        state: 'loaded',
+        value: [
+          { state: 'waiting', namespace: 'default', sourcePort: 5220 },
+          { state: 'loaded', namespace: 'cleverapps', sourcePort: 4242 },
+        ],
+      };
+    }),
+    storyWait(1500, ([component, componentError]) => {
+      component.redirections = {
+        state: 'loaded',
+        value: [
+          { state: 'loaded', namespace: 'default' },
+          { state: 'loaded', namespace: 'cleverapps', sourcePort: 4242 },
+        ],
+      };
     }),
   ],
 });
@@ -157,7 +197,7 @@ enhanceStoriesNames({
   defaultStory,
   empty,
   loading,
-  loadingError,
+  errorWithLoading,
   dataLoaded,
   dataLoadedWithContextAdmin,
   dataLoadedWithContextAdminAndNoRedirections,

--- a/src/components/cc-tcp-redirection-form/cc-tcp-redirection-form.types.d.ts
+++ b/src/components/cc-tcp-redirection-form/cc-tcp-redirection-form.types.d.ts
@@ -1,10 +1,22 @@
-export interface RedirectionNamespace {
-  namespace: string,
+import { TcpRedirectionState } from "../cc-tcp-redirection/cc-tcp-redirection.types";
+
+export type TcpRedirectionFormContextType = "user" | "admin";
+
+export type TcpRedirectionFormState =
+  TcpRedirectionFormStateLoading
+  | TcpRedirectionFormStateLoaded
+  | TcpRedirectionFormStateError;
+
+interface TcpRedirectionFormStateLoading {
+  state: "loading";
 }
 
-export interface Redirection {
-  namespace: string,
-  sourcePort: number,
+interface TcpRedirectionFormStateLoaded {
+  state: "loaded";
+  value: TcpRedirectionState[]
 }
 
-export type ContextRedirectionType = "user" | "admin";
+interface TcpRedirectionFormStateError {
+  state: "error";
+}
+

--- a/src/components/cc-tcp-redirection/cc-tcp-redirection.stories.js
+++ b/src/components/cc-tcp-redirection/cc-tcp-redirection.stories.js
@@ -2,6 +2,17 @@ import './cc-tcp-redirection.js';
 import { makeStory } from '../../stories/lib/make-story.js';
 import { enhanceStoriesNames } from '../../stories/lib/story-names.js';
 
+const baseItems = [
+  { redirection: { state: 'loaded', namespace: 'customer-name', isPrivate: true } },
+  { redirection: { state: 'loaded', namespace: 'default' } },
+  { redirection: { state: 'loaded', namespace: 'cleverapps' } },
+  { redirection: { state: 'loaded', namespace: 'alternative' } },
+];
+
+const baseItemsWithRedirection = baseItems.map((item, i) => {
+  return { redirection: { ...item.redirection, sourcePort: 1000 + i } };
+});
+
 export default {
   title: '🛠 TCP Redirections/<cc-tcp-redirection>',
   component: 'cc-tcp-redirection',
@@ -13,25 +24,16 @@ const conf = {
 
 export const defaultStory = makeStory(conf, {
   items: [
-    { namespace: 'default', sourcePort: 5220 },
-    { namespace: 'cleverapps' },
+    { redirection: { state: 'loaded', namespace: 'default', sourcePort: 5220 } },
+    { redirection: { state: 'loaded', namespace: 'cleverapps' } },
   ],
 });
 
-const baseItems = [
-  { namespace: 'customer-name', private: true },
-  { namespace: 'default' },
-  { namespace: 'cleverapps' },
-  { namespace: 'alternative' },
-];
-
-const baseItemsWithRedirection = baseItems.map((p, i) => ({ ...p, sourcePort: 1000 + i }));
-
 export const loading = makeStory(conf, {
   items: [
-    { skeleton: true, namespace: 'customer-name', sourcePort: 1234, private: true },
-    { skeleton: true, namespace: 'default' },
-    { skeleton: true, namespace: 'cleverapps' },
+    { redirection: { state: 'loading' } },
+    { redirection: { state: 'loading' } },
+    { redirection: { state: 'loading' } },
   ],
 });
 
@@ -44,11 +46,15 @@ export const dataLoadedWithNoRedirection = makeStory(conf, {
 });
 
 export const waitingWithRedirection = makeStory(conf, {
-  items: baseItemsWithRedirection.map((p) => ({ ...p, waiting: true })),
+  items: baseItemsWithRedirection.map((item) => {
+    return { redirection: { ...item.redirection, state: 'waiting' } };
+  }),
 });
 
 export const waitingWithNoRedirection = makeStory(conf, {
-  items: baseItems.map((p) => ({ ...p, waiting: true })),
+  items: baseItems.map((item) => {
+    return { redirection: { ...item.redirection, state: 'waiting' } };
+  }),
 });
 
 enhanceStoriesNames({

--- a/src/components/cc-tcp-redirection/cc-tcp-redirection.types.d.ts
+++ b/src/components/cc-tcp-redirection/cc-tcp-redirection.types.d.ts
@@ -1,10 +1,28 @@
-export interface RedirectionNamespace {
+interface TcpRedirection {
   namespace: string,
+  isPrivate: boolean,
+  sourcePort?: number,
 }
 
-export interface Redirection {
-  namespace: string,
-  sourcePort: number,
+export type TcpRedirectionState = TcpRedirectionStateLoading | TcpRedirectionStateLoaded | TcpRedirectionStateWaiting;
+
+interface TcpRedirectionStateLoading {
+  state: "loading";
 }
 
-export type ContextRedirectionType = "user" | "admin";
+interface TcpRedirectionStateLoaded extends TcpRedirection {
+  state: "loaded";
+}
+
+interface TcpRedirectionStateWaiting extends TcpRedirection {
+  state: "waiting";
+}
+
+interface CreateTcpRedirection {
+  namespace: string;
+}
+
+interface DeleteTcpRedirection {
+  namespace: string;
+  sourcePort: number;
+}


### PR DESCRIPTION
* apply the new design for component properties with typed states
* use the new defineSmartComponent for the smart definition
* move the skeleton logic to the cc-tcp-redirection component