### PR TITLE
Add a FocusLostController

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -22,7 +22,7 @@ Array
 
 // Use emojis to sort story categories/kinds
 // Docs, then components, then stuffs for devs (mixins and inner styles)
-const EMOJI_SORT = ['🏠', '📌', '🧬', '🛠', '🔀', '♻️'];
+const EMOJI_SORT = ['🏠', '📌', '🧬', '🛠', '🔀', '🕹', '♻️'];
 
 export const parameters = {
   options: {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ title: Changelog
 * Add JSDoc based typechecking with TypeScript's CLI (just utils.js for now)
 * Rollback the smart-manager to the old low level API and move the observable API to a different module
 * Introduce a new defineSmartComponent function
+* Add `FocusLostController`, a Lit Reactive Controller that helps manage focus loss.
 
 ## 9.0.0 (2022-07-19)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@bundled-es-modules/chai": "^4.2.2",
         "@custom-elements-manifest/analyzer": "^0.6.4",
         "@open-wc/dev-server-hmr": "^0.1.3",
+        "@open-wc/testing": "^3.1.6",
         "@rollup/plugin-alias": "^3.1.2",
         "@rollup/plugin-commonjs": "^18.1.0",
         "@rollup/plugin-json": "^4.1.0",
@@ -3105,6 +3106,15 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/@esm-bundle/chai": {
+      "version": "4.3.4-fix.0",
+      "resolved": "https://registry.npmjs.org/@esm-bundle/chai/-/chai-4.3.4-fix.0.tgz",
+      "integrity": "sha512-26SKdM4uvDWlY8/OOOxSB1AqQWeBosCX3wRYUZO7enTAj03CtVxIiCimYVG2WpULcyV51qapK4qTovwkUr5Mlw==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^4.2.12"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
@@ -3433,6 +3443,22 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@open-wc/chai-dom-equals": {
+      "version": "0.12.36",
+      "resolved": "https://registry.npmjs.org/@open-wc/chai-dom-equals/-/chai-dom-equals-0.12.36.tgz",
+      "integrity": "sha512-Gt1fa37h4rtWPQGETSU4n1L678NmMi9KwHM1sH+JCGcz45rs8DBPx7MUVeGZ+HxRlbEI5t9LU2RGGv6xT2OlyA==",
+      "dev": true,
+      "dependencies": {
+        "@open-wc/semantic-dom-diff": "^0.13.16",
+        "@types/chai": "^4.1.7"
+      }
+    },
+    "node_modules/@open-wc/chai-dom-equals/node_modules/@open-wc/semantic-dom-diff": {
+      "version": "0.13.21",
+      "resolved": "https://registry.npmjs.org/@open-wc/semantic-dom-diff/-/semantic-dom-diff-0.13.21.tgz",
+      "integrity": "sha512-BONpjHcGX2zFa9mfnwBCLEmlDsOHzT+j6Qt1yfK3MzFXFtAykfzFjAgaxPetu0YbBlCfXuMlfxI4vlRGCGMvFg==",
+      "dev": true
+    },
     "node_modules/@open-wc/dedupe-mixin": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@open-wc/dedupe-mixin/-/dedupe-mixin-1.3.1.tgz",
@@ -3462,6 +3488,43 @@
       "dependencies": {
         "@lit/reactive-element": "^1.0.0",
         "@open-wc/dedupe-mixin": "^1.3.0"
+      }
+    },
+    "node_modules/@open-wc/semantic-dom-diff": {
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@open-wc/semantic-dom-diff/-/semantic-dom-diff-0.19.7.tgz",
+      "integrity": "sha512-ahwHb7arQXXnkIGCrOsM895FJQrU47VWZryCsSSzl5nB3tJKcJ8yjzQ3D/yqZn6v8atqOz61vaY05aNsqoz3oA==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^4.3.1",
+        "@web/test-runner-commands": "^0.6.1"
+      }
+    },
+    "node_modules/@open-wc/testing": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@open-wc/testing/-/testing-3.1.6.tgz",
+      "integrity": "sha512-MIf9cBtac4/UBE5a+R5cXiRhOGfzetsV+ZPFc188AfkPDPbmffHqjrRoCyk4B/qS6fLEulSBMLSaQ+6ze971gQ==",
+      "dev": true,
+      "dependencies": {
+        "@esm-bundle/chai": "^4.3.4-fix.0",
+        "@open-wc/chai-dom-equals": "^0.12.36",
+        "@open-wc/semantic-dom-diff": "^0.19.7",
+        "@open-wc/testing-helpers": "^2.1.2",
+        "@types/chai": "^4.2.11",
+        "@types/chai-dom": "^0.0.12",
+        "@types/sinon-chai": "^3.2.3",
+        "chai-a11y-axe": "^1.3.2"
+      }
+    },
+    "node_modules/@open-wc/testing-helpers": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@open-wc/testing-helpers/-/testing-helpers-2.1.3.tgz",
+      "integrity": "sha512-hQujGaWncmWLx/974jq5yf2jydBNNTwnkISw2wLGiYgX34+3R6/ns301Oi9S3Il96Kzd8B7avdExp/gDgqcF5w==",
+      "dev": true,
+      "dependencies": {
+        "@open-wc/scoped-elements": "^2.1.3",
+        "lit": "^2.0.0",
+        "lit-html": "^2.0.0"
       }
     },
     "node_modules/@popperjs/core": {
@@ -3704,6 +3767,21 @@
       "dependencies": {
         "@types/connect": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.3.tgz",
+      "integrity": "sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==",
+      "dev": true
+    },
+    "node_modules/@types/chai-dom": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@types/chai-dom/-/chai-dom-0.0.12.tgz",
+      "integrity": "sha512-4rE7sDw713cV61TYzQbMrPjC4DjNk3x4vk9nAVRNXcSD4p0/5lEEfm0OgoCz5eNuWUXNKA0YiKiH/JDTuKivkA==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "*"
       }
     },
     "node_modules/@types/co-body": {
@@ -3978,6 +4056,31 @@
         "@types/mime": "^1",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/sinon": {
+      "version": "10.0.13",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.13.tgz",
+      "integrity": "sha512-UVjDqJblVNQYvVNUsj0PuYYw0ELRmgt1Nt5Vk0pT5f16ROGfcKJY8o1HVuMOJOpD727RrGB9EGvoaTQE5tgxZQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinon-chai": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.8.tgz",
+      "integrity": "sha512-d4ImIQbT/rKMG8+AXpmcan5T2/PNeSjrYhvkwet6z0p8kzYtfgA32xzOBlbU0yqJfq+/0Ml805iFoODO0LP5/g==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "*",
+        "@types/sinon": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz",
+      "integrity": "sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==",
+      "dev": true
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.2",
@@ -4970,6 +5073,15 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "dev": true
     },
+    "node_modules/axe-core": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.3.tgz",
+      "integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/axios": {
       "version": "0.21.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
@@ -5848,6 +5960,15 @@
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.1.0.tgz",
       "integrity": "sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==",
       "dev": true
+    },
+    "node_modules/chai-a11y-axe": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/chai-a11y-axe/-/chai-a11y-axe-1.4.0.tgz",
+      "integrity": "sha512-m7J6DVAl1ePL2ifPKHmwQyHXdCZ+Qfv+qduh6ScqcDfBnJEzpV1K49TblujM45j1XciZOFeFNqMb2sShXMg/mw==",
+      "dev": true,
+      "dependencies": {
+        "axe-core": "^4.3.3"
+      }
     },
     "node_modules/chainsaw": {
       "version": "0.1.0",
@@ -18888,6 +19009,15 @@
         }
       }
     },
+    "@esm-bundle/chai": {
+      "version": "4.3.4-fix.0",
+      "resolved": "https://registry.npmjs.org/@esm-bundle/chai/-/chai-4.3.4-fix.0.tgz",
+      "integrity": "sha512-26SKdM4uvDWlY8/OOOxSB1AqQWeBosCX3wRYUZO7enTAj03CtVxIiCimYVG2WpULcyV51qapK4qTovwkUr5Mlw==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "^4.2.12"
+      }
+    },
     "@jridgewell/gen-mapping": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
@@ -19158,6 +19288,24 @@
         "fastq": "^1.6.0"
       }
     },
+    "@open-wc/chai-dom-equals": {
+      "version": "0.12.36",
+      "resolved": "https://registry.npmjs.org/@open-wc/chai-dom-equals/-/chai-dom-equals-0.12.36.tgz",
+      "integrity": "sha512-Gt1fa37h4rtWPQGETSU4n1L678NmMi9KwHM1sH+JCGcz45rs8DBPx7MUVeGZ+HxRlbEI5t9LU2RGGv6xT2OlyA==",
+      "dev": true,
+      "requires": {
+        "@open-wc/semantic-dom-diff": "^0.13.16",
+        "@types/chai": "^4.1.7"
+      },
+      "dependencies": {
+        "@open-wc/semantic-dom-diff": {
+          "version": "0.13.21",
+          "resolved": "https://registry.npmjs.org/@open-wc/semantic-dom-diff/-/semantic-dom-diff-0.13.21.tgz",
+          "integrity": "sha512-BONpjHcGX2zFa9mfnwBCLEmlDsOHzT+j6Qt1yfK3MzFXFtAykfzFjAgaxPetu0YbBlCfXuMlfxI4vlRGCGMvFg==",
+          "dev": true
+        }
+      }
+    },
     "@open-wc/dedupe-mixin": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@open-wc/dedupe-mixin/-/dedupe-mixin-1.3.1.tgz",
@@ -19187,6 +19335,43 @@
       "requires": {
         "@lit/reactive-element": "^1.0.0",
         "@open-wc/dedupe-mixin": "^1.3.0"
+      }
+    },
+    "@open-wc/semantic-dom-diff": {
+      "version": "0.19.7",
+      "resolved": "https://registry.npmjs.org/@open-wc/semantic-dom-diff/-/semantic-dom-diff-0.19.7.tgz",
+      "integrity": "sha512-ahwHb7arQXXnkIGCrOsM895FJQrU47VWZryCsSSzl5nB3tJKcJ8yjzQ3D/yqZn6v8atqOz61vaY05aNsqoz3oA==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "^4.3.1",
+        "@web/test-runner-commands": "^0.6.1"
+      }
+    },
+    "@open-wc/testing": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@open-wc/testing/-/testing-3.1.6.tgz",
+      "integrity": "sha512-MIf9cBtac4/UBE5a+R5cXiRhOGfzetsV+ZPFc188AfkPDPbmffHqjrRoCyk4B/qS6fLEulSBMLSaQ+6ze971gQ==",
+      "dev": true,
+      "requires": {
+        "@esm-bundle/chai": "^4.3.4-fix.0",
+        "@open-wc/chai-dom-equals": "^0.12.36",
+        "@open-wc/semantic-dom-diff": "^0.19.7",
+        "@open-wc/testing-helpers": "^2.1.2",
+        "@types/chai": "^4.2.11",
+        "@types/chai-dom": "^0.0.12",
+        "@types/sinon-chai": "^3.2.3",
+        "chai-a11y-axe": "^1.3.2"
+      }
+    },
+    "@open-wc/testing-helpers": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@open-wc/testing-helpers/-/testing-helpers-2.1.3.tgz",
+      "integrity": "sha512-hQujGaWncmWLx/974jq5yf2jydBNNTwnkISw2wLGiYgX34+3R6/ns301Oi9S3Il96Kzd8B7avdExp/gDgqcF5w==",
+      "dev": true,
+      "requires": {
+        "@open-wc/scoped-elements": "^2.1.3",
+        "lit": "^2.0.0",
+        "lit-html": "^2.0.0"
       }
     },
     "@popperjs/core": {
@@ -19393,6 +19578,21 @@
       "requires": {
         "@types/connect": "*",
         "@types/node": "*"
+      }
+    },
+    "@types/chai": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.3.tgz",
+      "integrity": "sha512-hC7OMnszpxhZPduX+m+nrx+uFoLkWOMiR4oa/AZF3MuSETYTZmFfJAHqZEM8MVlvfG7BEUcgvtwoCTxBp6hm3g==",
+      "dev": true
+    },
+    "@types/chai-dom": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/@types/chai-dom/-/chai-dom-0.0.12.tgz",
+      "integrity": "sha512-4rE7sDw713cV61TYzQbMrPjC4DjNk3x4vk9nAVRNXcSD4p0/5lEEfm0OgoCz5eNuWUXNKA0YiKiH/JDTuKivkA==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "*"
       }
     },
     "@types/co-body": {
@@ -19667,6 +19867,31 @@
         "@types/mime": "^1",
         "@types/node": "*"
       }
+    },
+    "@types/sinon": {
+      "version": "10.0.13",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.13.tgz",
+      "integrity": "sha512-UVjDqJblVNQYvVNUsj0PuYYw0ELRmgt1Nt5Vk0pT5f16ROGfcKJY8o1HVuMOJOpD727RrGB9EGvoaTQE5tgxZQ==",
+      "dev": true,
+      "requires": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "@types/sinon-chai": {
+      "version": "3.2.8",
+      "resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.8.tgz",
+      "integrity": "sha512-d4ImIQbT/rKMG8+AXpmcan5T2/PNeSjrYhvkwet6z0p8kzYtfgA32xzOBlbU0yqJfq+/0Ml805iFoODO0LP5/g==",
+      "dev": true,
+      "requires": {
+        "@types/chai": "*",
+        "@types/sinon": "*"
+      }
+    },
+    "@types/sinonjs__fake-timers": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz",
+      "integrity": "sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==",
+      "dev": true
     },
     "@types/trusted-types": {
       "version": "2.0.2",
@@ -20442,6 +20667,12 @@
       "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "dev": true
     },
+    "axe-core": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.3.tgz",
+      "integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==",
+      "dev": true
+    },
     "axios": {
       "version": "0.21.1",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
@@ -21161,6 +21392,15 @@
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.1.0.tgz",
       "integrity": "sha512-vlNK021QdI7PNeiUh/lKkC/mNHHfV0m/Ad5JoI0TYtlBnJAslM/JIkm/tGC88bkLIwO6OQ5uV6ztS6kVAtCDlg==",
       "dev": true
+    },
+    "chai-a11y-axe": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/chai-a11y-axe/-/chai-a11y-axe-1.4.0.tgz",
+      "integrity": "sha512-m7J6DVAl1ePL2ifPKHmwQyHXdCZ+Qfv+qduh6ScqcDfBnJEzpV1K49TblujM45j1XciZOFeFNqMb2sShXMg/mw==",
+      "dev": true,
+      "requires": {
+        "axe-core": "^4.3.3"
+      }
     },
     "chainsaw": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@bundled-es-modules/chai": "^4.2.2",
     "@custom-elements-manifest/analyzer": "^0.6.4",
     "@open-wc/dev-server-hmr": "^0.1.3",
+    "@open-wc/testing": "^3.1.6",
     "@rollup/plugin-alias": "^3.1.2",
     "@rollup/plugin-commonjs": "^18.1.0",
     "@rollup/plugin-json": "^4.1.0",

--- a/src/controllers/lost-focus-controller.js
+++ b/src/controllers/lost-focus-controller.js
@@ -1,0 +1,70 @@
+import { findActiveElement, isParentOf } from '../lib/shadow-dom-utils.js';
+
+/**
+ * @callback LostFocusCallback
+ * @param {LostFocusEvent} event
+ * @returns {void}
+ */
+
+/**
+ * @typedef {Object} LostFocusEvent
+ * @property {Element} removedElement the element that has been removed from DOM
+ * @property {Element} focusedElement the element that had focus just before removal (can be the removedElement itself or one of its children)
+ * @property {number} index the index of the removedElement (before removal)
+ * @property {Element|null} suggestedElement the element that we suggest to gain focus
+ */
+
+/**
+ * This Reactive controller helps detect a focus lost situation that can occur when the focused element is removed from the DOM.
+ *
+ * You provide a query selector which will select the elements for which you're tracking removal.
+ *
+ * You provide a callback that will be fired when one of these elements is removed from the DOM.
+ * The callback is fired only if the deleted element had focus (or one of its children had focus)
+ *
+ * The callback will suggest a new element to focus. It suggests the nearest element matching the same query selector.
+ */
+export class LostFocusController {
+  /**
+   * @param {LitElement} host the custom element
+   * @param {string} selector the query selector that will select the elements we want to listen to
+   * @param {LostFocusCallback} callback
+   */
+  constructor (host, selector, callback) {
+    host.addController(this);
+    this.host = host;
+    this.selector = selector;
+    this.elements = [];
+    this.callback = callback;
+  }
+
+  hostUpdate () {
+    // memorize the active element so that we are able to check if a deleted element was a parent of the focused element.
+    this.activeElement = findActiveElement();
+  }
+
+  hostUpdated () {
+    // keep the previous elements because we will want to compare with the new ones
+    const previousElements = this.elements;
+    // get the elements we are interested in
+    this.elements = Array.from(this.host.shadowRoot.querySelectorAll(this.selector));
+
+    // compare elements to the previous one and check if some elements have been removed
+    const removedElements = previousElements.filter((e) => !this.elements.includes(e));
+    if (removedElements.length > 0) {
+      // among these removed elements, find the one containing the focused element
+      // elementWithFocus may not be the focused element itself, it can be the element matching the query selector containing the focused element.
+      const elementWithFocus = removedElements.find((e) => e === this.activeElement || isParentOf(e, this.activeElement));
+      if (elementWithFocus != null) {
+        // we find the index of the removed element in the previous list
+        const index = previousElements.indexOf(elementWithFocus);
+
+        // we suggest a new element to have the focus
+        const suggestedElementIndex = Math.min(this.elements.length - 1, index);
+        const suggestedElement = suggestedElementIndex > -1 ? this.elements[suggestedElementIndex] : null;
+
+        this.callback({ removedElement: elementWithFocus, focusedElement: this.activeElement, index: index, suggestedElement });
+      }
+    }
+  }
+}

--- a/src/controllers/lost-focus-controller.md
+++ b/src/controllers/lost-focus-controller.md
@@ -1,0 +1,81 @@
+# LostFocusController
+
+This Reactive controller helps detect a focus lost situation that can occur when the focused element is detached from the DOM.
+
+* You provide a query selector which will select the elements for which you're tracking removal.
+* You provide a callback that will be fired when one of these elements is removed from the DOM. 
+  The callback is fired only if the deleted element had focus (or one of its children had focus)
+* The callback will suggest a new element to focus. It suggests the nearest element matching the same query selector.
+
+## Usage
+
+* To use this controller, you have to instantiate it in the constructor of your `LitElement`.
+
+Example:
+
+```js
+class MyElement extends LitElement {
+  constructor () {
+    super();
+    new LostFocusController(this, 'query_selector_to_elements_you_track', () => {
+      // react to focus loss
+    });
+  }
+}
+```
+
+The `LostFocusController` constructor takes the following parameters:
+
+1. the instance of your LitElement based component.
+2. the query selector that will be used to track which item was removed.
+3. the function that will be called when a focus lost is detected. This function is called with one object parameter made of:
+  * `removedElement`: the element that has been removed from DOM.
+  * `focusedElement`: the element that had focus just before removal (can be the `removedElement` itself or one of its children).
+  * `index`: the index of the `removedElement` within the list of elements matching the query selector (before removal).
+  * `suggestedElement`: the element that we suggest to gain focus. It may be `null` if the removed element was the last one matching the query selector.
+
+## Full example
+
+The next example shows a list of items where each item is removable with a button.
+Once an item is removed, we want to focus on the remove button of the next item.
+The example below shows how to do that using the LostFocusController:
+
+```javascript
+import { html, LitElement } from 'lit';
+import { repeat } from 'lit/directives/repeat.js';
+
+class ListOfElements extends LitElement {
+  static get properties () {
+    return {
+      items: {type: Array},
+    };
+  }
+
+  constructor () {
+    super();
+    /**
+     * @type {{id: string, name: string}[]}
+     */
+    this.items = [];
+
+    new LostFocusController(this, '.item', ({suggestedElement}) => {
+      suggestedElement?.querySelector('button').focus();
+    });
+  }
+
+  _onRemove (id) {
+    this.items = this.items.filter((item) => item.id !== id);
+  }
+
+  render () {
+    return repeat(this.items, (item) => item.id, (item) => {
+      return html`
+        <div class="item">
+          <button @click=${() => this._onRemove(item.id)}>Remove</button>
+          <span>${item.name}</span>  
+        </div>
+      `;
+    });
+  }
+}
+```

--- a/src/controllers/lost-focus-controller.stories.js
+++ b/src/controllers/lost-focus-controller.stories.js
@@ -1,0 +1,101 @@
+import { css, html, LitElement, render } from 'lit';
+import { repeat } from 'lit/directives/repeat.js';
+import { enhanceStoriesNames } from '../stories/lib/story-names.js';
+import { LostFocusController } from './lost-focus-controller.js';
+import docsPage from './lost-focus-controller.md';
+import '../components/cc-button/cc-button.js';
+
+class MyList extends LitElement {
+  static get properties () {
+    return {
+      items: { type: Array },
+    };
+  }
+
+  constructor () {
+    super();
+    this.items = [];
+
+    // eslint-disable-next-line no-new
+    new LostFocusController(this, '.item', ({ suggestedElement }) => {
+      suggestedElement?.querySelector('cc-button').focus();
+    });
+  }
+
+  _onRemove (event) {
+    const item = event.currentTarget.dataset.name;
+    event.currentTarget.waiting = true;
+    setTimeout(() => {
+      this.items = this.items.filter((e) => e !== item);
+    }, 2000);
+  }
+
+  focus () {
+    this.shadowRoot.querySelector('cc-button').focus();
+  }
+
+  firstUpdated (_changedProperties) {
+    setTimeout(() => this.focus());
+  }
+
+  render () {
+    return repeat(this.items, (item) => item, (item) => {
+      return html`
+        <div class="item">
+          <cc-button @cc-button:click=${this._onRemove} data-name="${item}">Remove</cc-button>
+          <span>${item}</span>  
+        </div>
+      `;
+    });
+  }
+
+  static get styles () {
+    return [
+      // language=CSS
+      css`
+        div {
+          margin-bottom: 0.2em;
+        }
+      `,
+    ];
+  }
+}
+window.customElements.define('my-list', MyList);
+
+export default {
+  title: '🕹️ Controllers/LostFocusController',
+  parameters: { docs: { page: docsPage.parameters.docs.page } },
+};
+
+export const defaultStory = () => {
+  const storyDom = document.createElement('div');
+  const items = Array.from({ length: 10 }, (_, i) => `Item ${i + 1}`);
+
+  const onReset = () => {
+    render(template, storyDom);
+    setTimeout(() => storyDom.querySelector('my-list').focus(), 10);
+  };
+
+  const template = html`
+    <style>
+      .main {
+        margin: 1em;
+      }
+      cc-button {
+        margin-top: 0.3em;
+      }
+    </style>
+    <div class="main">
+      <div class="title">Try deleting item and see the focus automatically placed on the next button</div>
+      <my-list .items=${items}></my-list>
+      <div class="title">Click the button below to reset the list items</div>
+      <cc-button @cc-button:click=${onReset}>reset</cc-button>
+    </div>
+  `;
+
+  render(template, storyDom);
+
+  return storyDom;
+};
+
+enhanceStoriesNames({ defaultStory });

--- a/src/lib/shadow-dom-utils.js
+++ b/src/lib/shadow-dom-utils.js
@@ -1,0 +1,47 @@
+
+/**
+ * Finds the active element (the element currently focused). It handles the case where the focused element is
+ * inside a custom element.
+ *
+ * @param {Document | ShadowRoot} root
+ * @return {null | Element}
+ */
+export function findActiveElement (root = document) {
+  const activeElement = root.activeElement;
+
+  if (activeElement == null) {
+    return null;
+  }
+
+  if (activeElement.shadowRoot != null) {
+    return findActiveElement(activeElement.shadowRoot);
+  }
+  else {
+    return activeElement;
+  }
+}
+
+/**
+ * Check whether the given parent node is an ancestor of the given child node. It traverses custom elements shadow DOM.
+ *
+ * @param {Node} parent
+ * @param {Node} child
+ * @return {boolean}
+ */
+export function isParentOf (parent, child) {
+  if (parent == null || child == null) {
+    return false;
+  }
+
+  let currentElement = child;
+
+  while (currentElement != null) {
+    currentElement = currentElement instanceof ShadowRoot ? currentElement.host : currentElement.parentNode;
+
+    if (currentElement === parent) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/test/controller/lost-focus-controller.test.js
+++ b/test/controller/lost-focus-controller.test.js
@@ -1,0 +1,190 @@
+import { expect } from '@bundled-es-modules/chai';
+import { fixture, defineCE, nextFrame } from '@open-wc/testing';
+import * as hanbi from 'hanbi';
+import { html, LitElement } from 'lit';
+import { repeat } from 'lit/directives/repeat.js';
+import { LostFocusController } from '../../src/controllers/lost-focus-controller.js';
+import { dispatchCustomEvent } from '../../src/lib/events.js';
+
+describe('lost-focus-controller', () => {
+
+  const ce = defineCE(
+    class extends LitElement {
+      static get properties () {
+        return {
+          items: { type: Array },
+        };
+      }
+
+      constructor () {
+        super();
+        this.items = ['1', '2', '3'];
+
+        // eslint-disable-next-line no-new
+        new LostFocusController(this, '.item', (event) => {
+          dispatchCustomEvent(this, 'my-element:lostFocus', event);
+        });
+      }
+
+      removeItem (it) {
+        this.items = this.items.filter((item) => item !== it);
+      }
+
+      clear () {
+        this.items = [];
+      }
+
+      focusHeader () {
+        this.shadowRoot.querySelector('.header').focus();
+      }
+
+      focusItem (it) {
+        this.getItemElement(it)?.focus();
+      }
+
+      focusItemButton (it) {
+        this.getItemElement(it)?.querySelector('button').focus();
+      }
+
+      getItemElement (it) {
+        return this.shadowRoot.querySelector(`[data-item="${it}"]`);
+      }
+
+      render () {
+        return html`
+          <div class="header"></div>
+          ${repeat(this.items, (item) => item, (item) => {
+            return html`
+              <div tabindex="0" class="item" data-item="${item}"><button>${item}</button></div>
+            `;
+          })}
+        `;
+      }
+    },
+  );
+
+  /**
+   * @return {Promise<{element: Element, spy: Stub}>}
+   */
+  const createElement = async () => {
+    const element = await fixture(`<${ce}></${ce}>`);
+
+    const spy = hanbi.spy();
+    element.addEventListener('my-element:lostFocus', (e) => spy.handler(e.detail));
+
+    return { element, spy };
+  };
+
+  it('should notify focus lost when an item is focused', async () => {
+    const { element, spy } = await createElement();
+
+    element.focusItem('2');
+    element.removeItem('2');
+
+    await nextFrame();
+
+    expect(spy.called).to.equal(true);
+  });
+
+  it('should notify focus lost when a child of item is focused', async () => {
+    const { element, spy } = await createElement();
+
+    element.focusItemButton('2');
+    element.removeItem('2');
+
+    await nextFrame();
+
+    expect(spy.called).to.equal(true);
+  });
+
+  it('should not notify focus lost when an item is not focused', async () => {
+    const { element, spy } = await createElement();
+
+    element.focusItem('1');
+    element.removeItem('2');
+
+    await nextFrame();
+
+    expect(spy.called).to.equal(false);
+  });
+
+  it('should not notify focus lost when no items is not focused', async () => {
+    const { element, spy } = await createElement();
+
+    element.focusHeader();
+    element.removeItem('2');
+
+    await nextFrame();
+
+    expect(spy.called).to.equal(false);
+  });
+
+  it('should not notify focus lost when an item is not focused', async () => {
+    const { element, spy } = await createElement();
+
+    element.focusHeader();
+    element.removeItem('2');
+
+    await nextFrame();
+
+    expect(spy.called).to.equal(false);
+  });
+
+  it('should identify the deleted and focused item properly', async () => {
+    const { element, spy } = await createElement();
+
+    const expectedRemovedItem = element.getItemElement('2');
+    const expectedFocusedItem = expectedRemovedItem.querySelector('button');
+
+    element.focusItemButton('2');
+    element.removeItem('2');
+
+    await nextFrame();
+
+    const event = spy.lastCall.args[0];
+    expect(event.index).to.equal(1);
+    expect(event.removedElement).to.equal(expectedRemovedItem);
+    expect(event.focusedElement).to.equal(expectedFocusedItem);
+  });
+
+  it('should suggest the next item', async () => {
+    const { element, spy } = await createElement();
+
+    const expectedSuggestedItem = element.getItemElement('3');
+
+    element.focusItemButton('2');
+    element.removeItem('2');
+
+    await nextFrame();
+
+    const event = spy.lastCall.args[0];
+    expect(event.suggestedElement).to.equal(expectedSuggestedItem);
+  });
+
+  it('should suggest the previous item when the removed element was the last one', async () => {
+    const { element, spy } = await createElement();
+
+    const expectedSuggestedItem = element.getItemElement('2');
+
+    element.focusItemButton('3');
+    element.removeItem('3');
+
+    await nextFrame();
+
+    const event = spy.lastCall.args[0];
+    expect(event.suggestedElement).to.equal(expectedSuggestedItem);
+  });
+
+  it('should suggest nothing if there was no element left', async () => {
+    const { element, spy } = await createElement();
+
+    element.focusItemButton('2');
+    element.clear();
+
+    await nextFrame();
+
+    const event = spy.lastCall.args[0];
+    expect(event.suggestedElement).to.equal(null);
+  });
+
+});

--- a/test/shadow-dom-utils.test.js
+++ b/test/shadow-dom-utils.test.js
@@ -1,0 +1,87 @@
+import { expect } from '@bundled-es-modules/chai';
+import { fixture, defineCE } from '@open-wc/testing-helpers';
+import { html, LitElement } from 'lit';
+import { findActiveElement, isParentOf } from '../src/lib/shadow-dom-utils.js';
+
+describe('shadow-dom-utils', () => {
+
+  const ce = defineCE(
+    class extends LitElement {
+      getButtonElement () {
+        return this.shadowRoot.querySelector('button');
+      }
+
+      render () {
+        return html`<button>button</button><slot></slot>`;
+      }
+    },
+  );
+
+  describe('findActiveElement', () => {
+    it('should return button inside custom element', async () => {
+      const element = await fixture(`<${ce}></${ce}>`);
+
+      const elementInsideCustomElement = element.getButtonElement();
+      elementInsideCustomElement.focus();
+      expect(findActiveElement()).to.equal(elementInsideCustomElement);
+      // the next line is just to demonstrate that document.activeElement stops to the custom element host (because of shadow dom isolation)
+      expect(document.activeElement).to.equal(element);
+    });
+
+    it('should return button when deep inside custom element', async () => {
+      await fixture(`<${ce}><${ce}><${ce} id="deepChild"></${ce}></${ce}></${ce}>`);
+      const elementInsideCustomElement = document.querySelector('#deepChild').getButtonElement();
+      elementInsideCustomElement.focus();
+      expect(findActiveElement()).to.equal(elementInsideCustomElement);
+    });
+
+    it('should return button', async () => {
+      const element = await fixture(`<button></button>`);
+      element.focus();
+      expect(findActiveElement()).to.equal(element);
+    });
+
+    it('should return null when focus it not a descendant', async () => {
+      const element = await fixture(`<div id="child1"></div><button id="child2">button</button>`);
+      document.querySelector('#child2').focus();
+      expect(findActiveElement(element)).to.equal(null);
+    });
+  });
+
+  describe('isParentOf', () => {
+    it('should return false when child is the parent itself', async () => {
+      const element = await fixture(`<div></div>`);
+      expect(isParentOf(element, element)).to.equal(false);
+    });
+
+    it('should return true when child is first descendant of parent', async () => {
+      const element = await fixture(`<div><span id="child"></span></div>`);
+      expect(isParentOf(element, document.querySelector('#child'))).to.equal(true);
+    });
+
+    it('should return true when child is deep descendant of parent', async () => {
+      const element = await fixture(`<div><div><div><span id="child"></span></div></div></div>`);
+      expect(isParentOf(element, document.querySelector('#child'))).to.equal(true);
+    });
+
+    it('should return false when child is not a descendant', async () => {
+      await fixture(`<div id="child1"></div><div id="child2"></div>`);
+      expect(isParentOf(document.querySelector('#child1'), document.querySelector('#child2'))).to.equal(false);
+    });
+
+    it('should return true when child is a custom element', async () => {
+      const element = await fixture(`<div><${ce} id="child"></${ce}></div>`);
+      expect(isParentOf(element, document.querySelector('#child'))).to.equal(true);
+    });
+
+    it('should return true when child is inside a custom element', async () => {
+      const element = await fixture(`<${ce} id="child"></${ce}>`);
+      expect(isParentOf(element, document.querySelector('#child').getButtonElement())).to.equal(true);
+    });
+
+    it('should return true when child is deep inside a custom element', async () => {
+      const element = await fixture(`<${ce}><${ce}><${ce} id="child"></${ce}></${ce}></${ce}>`);
+      expect(isParentOf(element, document.querySelector('#child').getButtonElement())).to.equal(true);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #575 

## implementation

* This Reactive controller helps detect a focus loss situation when the focused element is removed from the DOM.
* You provide a query selector which will select the elements for which you're tracking removal.
* You provide a callback that will be fired when one of these elements is removed from the DOM. The callback is fired only if the deleted element had focus (or one of its children had focus)
* The callback will suggest a new element to focus on. It suggests the nearest element matching the same query selector.

## review

Preview is [here](https://clever-components-preview.cellar-c2.services.clever-cloud.com/focus-lost-ctrl/index.html?path=/story/%F0%9F%95%B9%EF%B8%8F-controllers-focuslostcontroller--default-story)

* check the code
* check the story
* check the storybook doc tab