### PR TITLE
ci(test): upgrade volta github action from version 1 to version 4

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: volta-cli/action@v1
+      - uses: volta-cli/action@v4
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
The version 1 of `volta-cli/action` github action is so old that it doesn't work anymore: Running action fails with:
```
Run volta-cli/action@v1
  with:
downloading volta@1.1.0
Object prototype may only be an Object or null: undefined
Waiting 18 seconds before trying again
Object prototype may only be an Object or null: undefined
Waiting 15 seconds before trying again
Error: Object prototype may only be an Object or null: undefined
```
Upgrading to version 4 resolve the issue. see [changelog](https://github.com/volta-cli/action/releases)