### PR TITLE
chore(eslint): update `no-new` rule to "off"

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -48,6 +48,7 @@ module.exports = {
     'lit/no-useless-template-literals': 'error',
     'lit/no-value-attribute': 'error',
     'multiline-ternary': 'off',
+    'no-new': 'off',
     'operator-linebreak': ['error', 'before'],
     'padded-blocks': 'off',
     'quotes': ['error', 'single', { 'allowTemplateLiterals': true }],

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ title: Changelog
 * Add new dependency `@web/test-runner-commands` so that Web Test Runner can test both on desktop and mobile.
 * Add new helpers to extract stories and run accessibility test on them.
 * Add new test files in most of the component folders. These test files only contain accessibility tests for the moment.
+* Update eslint `no-new` rule from "error" to "off".
 * `<cc-tcp-redirection-form>`: rework state, types and smart for TCP redirection components
 
 ## 9.0.0 (2022-07-19)

--- a/src/controllers/lost-focus-controller.stories.js
+++ b/src/controllers/lost-focus-controller.stories.js
@@ -16,7 +16,6 @@ class MyList extends LitElement {
     super();
     this.items = [];
 
-    // eslint-disable-next-line no-new
     new LostFocusController(this, '.item', ({ suggestedElement }) => {
       suggestedElement?.querySelector('cc-button').focus();
     });

--- a/test/controller/lost-focus-controller.test.js
+++ b/test/controller/lost-focus-controller.test.js
@@ -20,7 +20,6 @@ describe('lost-focus-controller', () => {
         super();
         this.items = ['1', '2', '3'];
 
-        // eslint-disable-next-line no-new
         new LostFocusController(this, '.item', (event) => {
           dispatchCustomEvent(this, 'my-element:lostFocus', event);
         });


### PR DESCRIPTION
Fixes #597.

We choose to deactivate the `no-new` rule.