### PR TITLE
fix(cc-select): disable placeholder option only when field is required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,9 @@ title: Changelog
   * add `alt` attribute values for controls (+ / -) so that they can be identified by assistive technologies.
   * add `hiddenLabel` prop to allow the label to be visually hidden in some cases.
   * add red border and redish focus ring when error slot is used
-* `<cc-select>`: remove the unique id generation technique and rely on Shadow DOM isolation instead.
+* `<cc-select>`: 
+  * remove the unique id generation technique and rely on Shadow DOM isolation instead.
+  * only disable the placeholder option if the component is in required mode.
 * `<cc-toggle>`: remove the unique name generation technique and rely on Shadow DOM isolation instead.
 * `accessibility Styles`: add new `accessibilityStyles` containing a `visually-hidden` class to hide content visually but not from assistive technologies.
 * `<cc-env-var-create>`: add visually hidden label for all input fields so that these fields can be identified by assistive technologies.

--- a/src/components/cc-select/cc-select.js
+++ b/src/components/cc-select/cc-select.js
@@ -60,10 +60,13 @@ export class CcSelect extends LitElement {
     /** @type {Option[]|[]} Sets the list of options displayed inside the select element. */
     this.options = [];
 
-    /** @type {string|null} Sets a disabled option with empty value. This option will always be the first of the list. It can be selected by default by setting `value=''`. */
+    /** @type {string|null} Sets a disabled option with empty value.
+     * This option will always be the first of the list. It can be selected by default by setting `value=''`.
+     * This option is only selectable by the user if the field is optional (`required=false`).
+     */
     this.placeholder = null;
 
-    /** @type {boolean} Sets the "required" text inside the label */
+    /** @type {boolean} Sets the "required" text inside the label. If a placeholder is set, it won't be selectable by the user, it may only be selected as a default value. */
     this.required = false;
 
     /** @type {string|null} Sets the selected value of the element. This prop should always be set. It should always match one of the option values. */
@@ -110,7 +113,7 @@ export class CcSelect extends LitElement {
           .value=${this.value}
         >
           ${this.placeholder != null && this.placeholder !== '' ? html`
-            <option value="" disabled>${this.placeholder}</option>
+            <option value="" ?disabled=${this.required}>${this.placeholder}</option>
           ` : ''}
           ${this.options.map((option) => html`
             <option value=${option.value}>${option.label}</option>


### PR DESCRIPTION
Fixes #604 

# How to test

In the [Default Story - Select component - Preview](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-select/fix-disabled-placeholder/index.html?path=/story/%F0%9F%A7%AC-atoms-cc-select--default-story), you should be able to select a value from the first select, and then switch back to the placeholder. In other words, the placeholder is selectable.

In the [Required Story - Select component - Preview](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-select/fix-disabled-placeholder/index.html?path=/story/%F0%9F%A7%AC-atoms-cc-select--required), if you select a value, then you should not be able to switch back to the placeholder value. In other words, the placeholder is not selectable / disabled.