### PR TITLE
fix(cc-select): add red border / focus ring when error slot is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ title: Changelog
 * `<cc-select>`: 
   * remove the unique id generation technique and rely on Shadow DOM isolation instead.
   * only disable the placeholder option if the component is in required mode.
+  * add red border and redish focus ring when error slot is used.
 * `<cc-toggle>`: remove the unique name generation technique and rely on Shadow DOM isolation instead.
 * `accessibility Styles`: add new `accessibilityStyles` containing a `visually-hidden` class to hide content visually but not from assistive technologies.
 * `<cc-env-var-create>`: add visually hidden label for all input fields so that these fields can be identified by assistive technologies.

--- a/src/components/cc-select/cc-select.js
+++ b/src/components/cc-select/cc-select.js
@@ -34,9 +34,7 @@ export class CcSelect extends LitElement {
       placeholder: { type: String },
       required: { type: Boolean },
       value: { type: String },
-      _uniqueErrorId: { type: String, state: true },
-      _uniqueHelpId: { type: String, state: true },
-      _uniqueInputId: { type: String, state: true },
+      _hasError: { type: Boolean, state: true },
     };
   }
 
@@ -71,6 +69,8 @@ export class CcSelect extends LitElement {
 
     /** @type {string|null} Sets the selected value of the element. This prop should always be set. It should always match one of the option values. */
     this.value = null;
+
+    this._hasError = false;
   }
 
   updated (changedProperties) {
@@ -96,6 +96,10 @@ export class CcSelect extends LitElement {
     dispatchCustomEvent(this, 'input', this.value);
   }
 
+  _onErrorSlotChanged (event) {
+    this._hasError = event.target.assignedNodes()?.length > 0;
+  }
+
   render () {
     return html`
       <label for="input-id">
@@ -107,6 +111,7 @@ export class CcSelect extends LitElement {
       <div class="selectWrapper ${classMap({ disabled: this.disabled })}">
         <select
           id="input-id"
+          class="${classMap({ error: this._hasError })}"
           ?disabled=${this.disabled}
           aria-describedby="help-id error-id"
           @input=${this._onSelectInput}
@@ -126,7 +131,7 @@ export class CcSelect extends LitElement {
       </div>
 
       <div class="error-container" id="error-id">
-        <slot name="error"></slot>
+        <slot name="error" @slotchange="${this._onErrorSlotChanged}"></slot>
       </div>
     `;
   }
@@ -234,6 +239,14 @@ export class CcSelect extends LitElement {
           border-color: #777;
           box-shadow: 0 0 0 .2em rgba(50, 115, 220, .25);
           outline: 0;
+        }
+        
+        select.error {
+          border-color: var(--cc-color-border-danger) !important;
+        }
+        
+        select.error:focus {
+          box-shadow: 0 0 0 .2em var(--cc-color-border-danger-weak);
         }
 
         .selectWrapper {

--- a/src/components/cc-select/cc-select.stories.js
+++ b/src/components/cc-select/cc-select.stories.js
@@ -1,6 +1,6 @@
 import './cc-select.js';
 import { allFormControlsStory } from '../../stories/all-form-controls.js';
-import { makeStory } from '../../stories/lib/make-story.js';
+import { makeStory, storyWait } from '../../stories/lib/make-story.js';
 import { enhanceStoriesNames } from '../../stories/lib/story-names.js';
 
 const baseOptions = [
@@ -203,6 +203,41 @@ export const longContentWihFixedWidth = makeStory(
   },
 );
 
+export const simulation = makeStory(conf, {
+  items: [{
+    label: 'Favourite artist',
+    placeholder: '-- Select an artist --',
+    value: '',
+    options: baseOptions,
+  }],
+  simulations: [
+    storyWait(0, ([component]) => {
+      component.innerHTML = `
+        <p slot="help">No error slot, no focus</p>
+      `;
+    }),
+    storyWait(2000, ([component]) => {
+      component.innerHTML = `
+        <p slot="help">With error, no focus</p>
+        <p slot="error">This is an error message</p>
+      `;
+    }),
+    storyWait(2000, ([component]) => {
+      component.innerHTML = `
+        <p slot="help">With error, with focus</p>
+        <p slot="error">This is an error message</p>
+      `;
+      component.focus();
+    }),
+    storyWait(2000, ([component]) => {
+      component.innerHTML = `
+        <p slot="help">No error slot, with focus</p>
+      `;
+      component.focus();
+    }),
+  ],
+});
+
 export const allFormControls = allFormControlsStory;
 
 enhanceStoriesNames({
@@ -216,5 +251,6 @@ enhanceStoriesNames({
   inlineWithRequired,
   inlineWithErrorAndHelpMessages,
   longContentWihFixedWidth,
+  simulation,
   allFormControls,
 });


### PR DESCRIPTION
Fixes #587 

The whole code is basically a copy / paste from what @pdesoyres-cc has done for `cc-input-` a few weeks ago :wink:.

[Preview](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-select/fix-red-border-when-error/index.html?path=/story/%F0%9F%A7%AC-atoms-cc-select--simulation)

# TODO

- [x] rebase after merging #605 