### PR TITLE
fix(cc-ssh-key-list): improve UX when adding a new key

### DIFF
--- a/src/components/cc-ssh-key-list/cc-ssh-key-list.smart.js
+++ b/src/components/cc-ssh-key-list/cc-ssh-key-list.smart.js
@@ -51,9 +51,11 @@ defineSmartComponent({
 
       addKey({ apiConfig, key: { name, key: publicKey } })
         .then(() => {
-          updateComponent('createSshKeyForm', CcSshKeyList.CREATE_FORM_INIT_STATE);
           // re-fetching keys because we need fingerprint info sent from API to properly display newly created keys
-          refreshList().then(() => notifySuccess(component, i18n('cc-ssh-key-list.success.add', { name })));
+          refreshList().then(() => {
+            notifySuccess(component, i18n('cc-ssh-key-list.success.add', { name }));
+            updateComponent('createSshKeyForm', CcSshKeyList.CREATE_FORM_INIT_STATE);
+          });
         })
         .catch((error) => {
           console.error(error);


### PR DESCRIPTION
Improve UX with a better correlation between UI and API requests.

Previous behavior:
- request new key addition
- creation form disabled
- key successfully added
- creation form enabled
- request key lists refresh silently (ie. without skeleton state)
- key lists successfully refreshed

New behavior :
- request new key addition
- creation form disabled
- key successfully added
- request key lists refresh silently (ie. without skeleton state)
- key lists successfully refreshed
- creation form enabled