### PR TITLE
fix: match typecheck tsconfig with typescript dependency version

### DIFF
--- a/tsconfig-typecheck-jsdoc.json
+++ b/tsconfig-typecheck-jsdoc.json
@@ -8,7 +8,6 @@
     "allowUnusedLabels": false,
     "alwaysStrict": true,
     "checkJs": true,
-    "exactOptionalPropertyTypes": false,
     "noEmit": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitAny": true,
@@ -17,6 +16,6 @@
     "noImplicitThis": true,
     "noPropertyAccessFromIndexSignature": false,
     "target": "ESNext",
-    "moduleResolution": "NodeNext"
+    "moduleResolution": "node"
   }
 }


### PR DESCRIPTION
Fix #620.

Remove and update config properties not yet available in the current typescript version `~4.3.2`.