### PR TITLE
Add "WONTPAY" to pending statuses.

### DIFF
--- a/src/components/cc-invoice-table/cc-invoice-table.js
+++ b/src/components/cc-invoice-table/cc-invoice-table.js
@@ -11,7 +11,7 @@ import { ccLink, linkStyles } from '../../templates/cc-link/cc-link.js';
 const fileSvg = new URL('../../assets/file.svg', import.meta.url).href;
 
 // TODO: Move to clever-client
-export const PENDING_STATUSES = ['PENDING', 'PAYMENTHELD'];
+export const PENDING_STATUSES = ['PENDING', 'PAYMENTHELD', 'WONTPAY'];
 export const PROCESSING_STATUS = 'PROCESSING';
 export const PROCESSED_STATUSES = ['PAID', 'CANCELED', 'REFUNDED'];
 


### PR DESCRIPTION
Fixes #686 

When we flag an invoice as "wontpay" (meaning we stopped trying to get the money and considered the fight lost), it disappears from the displayed invoices entirely. The WONTPAY invoices should just be considered as pending ones.