### PR TITLE
fix(cc-icon): force svg size to resolve safari 15 issue

### DIFF
--- a/src/components/cc-icon/cc-icon.js
+++ b/src/components/cc-icon/cc-icon.js
@@ -132,9 +132,11 @@ export class CcIcon extends LitElement {
         }
 
         svg {
+          width: 100%;
+          height: 100%;
           fill: var(--cc-icon-color, currentColor);
         }
-        
+
         .skeleton {
           width: var(--size, 1em);
           height: var(--size, 1em);


### PR DESCRIPTION
Fixes #681

# What does this PR do & how to review?

* 2 reviewers should be enough for this
- [x] check on every browser that `cc-icon` stories are still displayed normally.
- [x] If you have a Safari 15 available, check the the icons are displayed as they should.

# More info about the bug and this fix

The bug seems to correspond to what is described here:
https://bugs.webkit.org/show_bug.cgi?id=221234

The reduced test case can be found here: https://codepen.io/florian-sanders-cc/pen/OJwXxpW
If you check this on Safari 15, the `<svg>` element is not visible unless you uncomment the `flex-direction` rule or the `width` rule.

To fix this in the `cc-icon` I went for the explicit `width: 100%;` and `height: 100%` rules because I think it feels less magical than setting a different `flex-direction`.

# TODO

- [x] Should we report on the webkit tracker that this issue seems to be fixed with safari 16? 
edit: after checking with @roberttran-cc, the WebKit issue is not fixed with Safari 16 but our issue is. It might not be the same issue after all so let's not comment the WebKit issue.