### PR TITLE
fix(focus outline): use contrasted focus outline

### DIFF
--- a/src/components/cc-button/cc-button.js
+++ b/src/components/cc-button/cc-button.js
@@ -378,9 +378,9 @@ export class CcButton extends LitElement {
 
         /* STATES */
 
-        .btn:not([aria-disabled='true']):focus {
-          box-shadow: 0 0 0 0.2em rgb(50 115 220 / 25%);
-          outline: 0;
+        .btn:focus {
+          outline: var(--cc-focus-outline, #000 solid 2px);
+          outline-offset: var(--cc-focus-outline-offset, 2px);
         }
 
         .btn:not([aria-disabled='true']):hover {

--- a/src/components/cc-header-orga/cc-header-orga.js
+++ b/src/components/cc-header-orga/cc-header-orga.js
@@ -155,7 +155,8 @@ export class CcHeaderOrga extends LitElement {
         }
 
         .hotline_number:focus {
-          box-shadow: 0 0 0 0.2em rgb(50 115 220 / 25%);
+          outline: var(--cc-focus-outline, #000 solid 2px);
+          outline-offset: var(--cc-focus-outline-offset, 2px);
         }
 
         .hotline_number:hover {

--- a/src/components/cc-input-number/cc-input-number.js
+++ b/src/components/cc-input-number/cc-input-number.js
@@ -405,15 +405,17 @@ export class CcInputNumber extends LitElement {
 
         input:focus + .ring {
           border-color: #777;
-          box-shadow: 0 0 0 0.2em rgb(50 115 220 / 25%);
-        }
-
-        input:focus.error + .ring {
-          box-shadow: 0 0 0 0.2em var(--cc-color-border-danger-weak);
+          outline: var(--cc-focus-outline, #000 solid 2px);
+          outline-offset: var(--cc-focus-outline-offset, 2px);
         }
 
         input.error + .ring {
           border-color: var(--cc-color-border-danger) !important;
+        }
+
+        input.error:focus + .ring {
+          outline: var(--cc-focus-outline-error, #000 solid 2px);
+          outline-offset: var(--cc-focus-outline-offset, 2px);
         }
 
         input:hover + .ring {
@@ -466,8 +468,8 @@ export class CcInputNumber extends LitElement {
         }
 
         .btn:focus {
-          box-shadow: 0 0 0 0.2em rgb(50 115 220 / 25%);
-          outline: 0;
+          outline: var(--cc-focus-outline, #000 solid 2px);
+          outline-offset: var(--cc-focus-outline-offset, 2px);
         }
 
         .btn:active,

--- a/src/components/cc-input-text/cc-input-text.js
+++ b/src/components/cc-input-text/cc-input-text.js
@@ -561,11 +561,13 @@ export class CcInputText extends LitElement {
 
         .input:focus + .ring {
           border-color: #777;
-          box-shadow: 0 0 0 0.2em rgb(50 115 220 / 25%);
+          outline: var(--cc-focus-outline, #000 solid 2px);
+          outline-offset: var(--cc-focus-outline-offset, 2px);
         }
-
-        .input:focus.error + .ring {
-          box-shadow: 0 0 0 0.2em var(--cc-color-border-danger-weak);
+        
+        input.error:focus + .ring {
+          outline: var(--cc-focus-outline-error, #000 solid 2px);
+          outline-offset: var(--cc-focus-outline-offset, 2px);
         }
 
         .input:hover + .ring {
@@ -619,8 +621,8 @@ export class CcInputText extends LitElement {
         }
 
         .btn:focus {
-          box-shadow: 0 0 0 0.2em rgb(50 115 220 / 25%);
-          outline: 0;
+          outline: var(--cc-focus-outline, #000 solid 2px);
+          outline-offset: var(--cc-focus-outline-offset, 2px);
         }
 
         .btn:active,

--- a/src/components/cc-notice/cc-notice.js
+++ b/src/components/cc-notice/cc-notice.js
@@ -242,8 +242,8 @@ export class CcNotice extends LitElement {
         }
         
         .close-button:focus {
-          box-shadow: 0 0 0 0.15em rgb(50 115 220 / 25%);
-          outline: 0;
+          outline: var(--cc-focus-outline, #000 solid 2px);
+          outline-offset: var(--cc-focus-outline-offset, 2px);
         }
 
         .close-button img {

--- a/src/components/cc-pricing-estimation/cc-pricing-estimation.js
+++ b/src/components/cc-pricing-estimation/cc-pricing-estimation.js
@@ -318,8 +318,8 @@ export class CcPricingEstimation extends withResizeObserver(LitElement) {
         }
 
         .cc-link:focus {
-          box-shadow: 0 0 0 0.2em rgb(0 0 0 / 40%);
-          outline: 0;
+          outline: var(--cc-focus-outline, #000 solid 2px);
+          outline-offset: var(--cc-focus-outline-offset, 2px);
         }
 
         .cc-link::-moz-focus-inner {

--- a/src/components/cc-select/cc-select.js
+++ b/src/components/cc-select/cc-select.js
@@ -242,8 +242,8 @@ export class CcSelect extends LitElement {
 
         select:focus {
           border-color: #777;
-          box-shadow: 0 0 0 0.2em rgb(50 115 220 / 25%);
-          outline: 0;
+          outline: var(--cc-focus-outline, #000 solid 2px);
+          outline-offset: var(--cc-focus-outline-offset, 2px);
         }
         
         select.error {
@@ -251,7 +251,8 @@ export class CcSelect extends LitElement {
         }
         
         select.error:focus {
-          box-shadow: 0 0 0 0.2em var(--cc-color-border-danger-weak);
+          outline: var(--cc-focus-outline-error, #000 solid 2px);
+          outline-offset: var(--cc-focus-outline-offset, 2px);
         }
 
         .select-wrapper {

--- a/src/components/cc-toast/cc-toast.js
+++ b/src/components/cc-toast/cc-toast.js
@@ -291,8 +291,8 @@ export class CcToast extends LitElement {
         }
         
         .close-button:enabled:focus {
-          box-shadow: 0 0 0 0.15em rgb(50 115 220 / 25%);
-          outline: 0;
+          outline: var(--cc-focus-outline, #000 solid 2px);
+          outline-offset: var(--cc-focus-outline-offset, 2px);
         }
         /* endregion */
 

--- a/src/components/cc-toggle/cc-toggle.js
+++ b/src/components/cc-toggle/cc-toggle.js
@@ -340,8 +340,8 @@ export class CcToggle extends LitElement {
 
         .toggle-group.mode-single.enabled:not(:hover):focus-within,
         .toggle-group.mode-multiple.enabled:not(:hover) input:enabled:focus + label {
-          box-shadow: 0 0 0 0.2em rgb(50 115 220 / 25%);
-          outline: 0;
+          outline: var(--cc-focus-outline, #000 solid 2px);
+          outline-offset: var(--cc-focus-outline-offset, 2px);
         }
 
         .toggle-group.mode-multiple.enabled:not(:hover) input:enabled:focus + label {

--- a/src/components/cc-zone-input/cc-zone-input.js
+++ b/src/components/cc-zone-input/cc-zone-input.js
@@ -296,8 +296,8 @@ export class CcZoneInput extends withResizeObserver(LitElement) {
 
         .zone-list:not(:hover):focus-within {
           border-radius: 0.25em;
-          box-shadow: 0 0 0 0.2em rgb(50 115 220 / 25%);
-          outline: 0;
+          outline: var(--cc-focus-outline, #000 solid 2px);
+          outline-offset: var(--cc-focus-outline-offset, 2px);
         }
 
         .zone-choice {

--- a/src/styles/default-theme.css
+++ b/src/styles/default-theme.css
@@ -235,6 +235,12 @@
   --cc-margin-top-btn-horizontal-form: 1.6em;
   /*endregion*/
 
+  /*region Focus Outline*/
+  --cc-focus-outline: var(--color-blue-60) solid 2px;
+  --cc-focus-outline-error: var(--color-red-100) solid 2px;
+  --cc-focus-outline-offset: 2px;
+  /*endregion*/
+
   /*region Miscellaneous*/
   /**
    * An opacity value that passes a11y tests.

--- a/src/templates/cc-link/cc-link.js
+++ b/src/templates/cc-link/cc-link.js
@@ -41,8 +41,8 @@ export const linkStyles = css`
   .cc-link:focus {
     background-color: var(--cc-color-bg-default, #fff);
     border-radius: 0.1em;
-    box-shadow: 0 0 0 .1em var(--cc-color-bg-default, #fff), 0 0 0 .3em rgba(50, 115, 220, .25);
-    outline: 0;
+    outline: var(--cc-focus-outline, #000000 solid 2px);
+    outline-offset: var(--cc-focus-outline-offset, 2px);
   }
 
   .sanitized-link::-moz-focus-inner,


### PR DESCRIPTION
Fixes #281

# How to review

:tada: You may now review the code.
:monocle_face: You should also review most of the stories simply by tabbing through their content: the focus should always look like below
![Focus outline example on a cc-input-text. A blue outline with some offset so that we can see the border of the input as well as the outline at the same time](https://user-images.githubusercontent.com/100240294/212939762-dd3bc865-fe5e-4f93-aea8-513962801b2a.png)
:art: If you don't like the styling of the focus outline, feel free to say so in a comment !


# What we discussed

There are several ways to standardize our focus styling and I'm not sure which way to go.

The styling is made of two rules:
```css
outline: var(--color-blue-60) solid 2px;
outline-offset: 2px;
```

We'd like to apply these rules to every focusable element (minus some exceptions).

Currently, we use explicit selectors inside components like:
```css
.btn:not([aria-disabled='true']):focus {
   outline: var(--cc-focus-outline);
   outline-offset: var(--cc-focus-outline-offset);
}
```

The drawback is that it's easy to forget it, for instance when you implement a component and you use a simple button, a link, a checkbox, an input without using one of our custom components (like the close buttons in `cc-notice` / `cc-toast`).

We could rely on a general selector like:
```css
*:focus {
  outline: var(--cc-focus-outline);
  outline-offset: var(--cc-focus-outline-offset);
}
```

This is what I would do for a website with a stylesheet but when it comes to components, I'm not sure how to make this work because we don't have a global stylesheet (unless we rely on the `default-theme.css` but it's not really it's purpose so that would be weird).

Should every component import a `a11y-styling.js` that would contain this selector?
Do we stick to what we currently have (explicit selectors inside individual components, relying on CSS custom properties)?

## Decision

Go for explicit selectors inside individual components for now and discuss the idea of a common shared style module (see #690).

# TODO

Following a discussion with @hsablonniere It looks like I forgot to add fallbacks for focus styles in case the theme is not loaded.

- [x] add fallback