### PR TITLE
fix(cc-ssh-key-list): creation form mistakenly updated

### DIFF
--- a/src/components/cc-ssh-key-list/cc-ssh-key-list.js
+++ b/src/components/cc-ssh-key-list/cc-ssh-key-list.js
@@ -7,7 +7,6 @@ import '../cc-block/cc-block.js';
 import '../cc-block-section/cc-block-section.js';
 import { css, html, LitElement } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
-import { live } from 'lit/directives/live.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { repeat } from 'lit/directives/repeat.js';
 import {
@@ -167,6 +166,26 @@ export class CcSshKeyList extends LitElement {
     dispatchCustomEvent(this, 'import', sshKey);
   }
 
+  _onNameInput ({ detail: name }) {
+    this.createSshKeyForm = {
+      ...this.createSshKeyForm,
+      name: {
+        ...this.createSshKeyForm.name,
+        value: name,
+      },
+    };
+  }
+
+  _onPublicKeyInput ({ detail: publicKey }) {
+    this.createSshKeyForm = {
+      ...this.createSshKeyForm,
+      publicKey: {
+        ...this.createSshKeyForm.publicKey,
+        value: publicKey,
+      },
+    };
+  }
+
   render () {
     const state = this.keyData.state;
 
@@ -257,8 +276,9 @@ export class CcSshKeyList extends LitElement {
       <div class="create-form">
         <cc-input-text
           ?disabled=${this.createSshKeyForm.state === 'creating'}
+          @cc-input-text:input=${this._onNameInput}
           @cc-input-text:requestimplicitsubmit=${this._onCreateKey}
-          .value="${live(this.createSshKeyForm.name?.value)}"
+          .value="${this.createSshKeyForm.name?.value}"
           class="create-form__name"
           label=${i18n('cc-ssh-key-list.add.name')}
           required
@@ -270,8 +290,9 @@ export class CcSshKeyList extends LitElement {
         </cc-input-text>
         <cc-input-text
           ?disabled=${this.createSshKeyForm.state === 'creating'}
+          @cc-input-text:input=${this._onPublicKeyInput}
           @cc-input-text:requestimplicitsubmit=${this._onCreateKey}
-          .value="${live(this.createSshKeyForm.publicKey?.value)}"
+          .value="${this.createSshKeyForm.publicKey?.value}"
           class="create-form__public-key"
           label=${i18n('cc-ssh-key-list.add.public-key')}
           required


### PR DESCRIPTION
Fixes #703

## How the fix works

Removing the `live()` directive and manually synchronizing the view and model does the job.

## How to review

You'll have to checkout the branch to test locally with real data as you need to perform the delete or import action. Check the issue #703 for details on how to reproduce.

