### PR TITLE
tokens: add border radius custom props and use them

### DIFF
--- a/demo-smart/index.html
+++ b/demo-smart/index.html
@@ -31,7 +31,7 @@
     display: block;
     background-color: #eee;
     padding: 0.25em 0.5em;
-    border-radius: 0.25em;
+    border-radius: var(--cc-border-radius-default, 0.25em);
   }
 
   .context-buttons {

--- a/src/components/cc-action-dispatcher/cc-action-dispatcher.js
+++ b/src/components/cc-action-dispatcher/cc-action-dispatcher.js
@@ -128,7 +128,7 @@ export class CcActionDispatcher extends LitElement {
         .number-block {
           padding: 1em;
           background-color: var(--cc-color-bg-neutral);
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
           text-align: center;
         }
 

--- a/src/components/cc-addon-linked-apps/cc-addon-linked-apps.js
+++ b/src/components/cc-addon-linked-apps/cc-addon-linked-apps.js
@@ -108,7 +108,7 @@ export class CcAddonLinkedApps extends LitElement {
           width: 1.6em;
           height: 1.6em;
           flex: 0 0 auto;
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
         }
 
         .details {

--- a/src/components/cc-addon-option/cc-addon-option.js
+++ b/src/components/cc-addon-option/cc-addon-option.js
@@ -70,7 +70,7 @@ export class CcAddonOption extends LitElement {
           display: grid;
           padding: 1em;
           background-color: var(--cc-color-bg-default, #fff);
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
           grid-gap: 1em;
           grid-template-columns: min-content 1fr;
         }
@@ -103,7 +103,7 @@ export class CcAddonOption extends LitElement {
         .logo {
           width: 1.6em;
           height: 1.6em;
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
         }
 
         cc-toggle {

--- a/src/components/cc-article-card/cc-article-card.js
+++ b/src/components/cc-article-card/cc-article-card.js
@@ -91,7 +91,7 @@ export class CcArticleCard extends LitElement {
           padding: 1em;
           border: 1px solid #bcc2d1;
           background-color: var(--cc-color-bg-default, #fff);
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
           gap: 1em;
           grid-template-columns: 1fr;
           grid-template-rows: min-content min-content 1fr min-content;

--- a/src/components/cc-article-list/cc-article-list.js
+++ b/src/components/cc-article-list/cc-article-list.js
@@ -80,7 +80,7 @@ export class CcArticleList extends LitElement {
           padding: 1em;
           border: 1px solid #bcc2d1;
           background-color: var(--cc-color-bg-default, #fff);
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
           text-align: center;
         }
       `,

--- a/src/components/cc-block/cc-block.js
+++ b/src/components/cc-block/cc-block.js
@@ -131,7 +131,7 @@ export class CcBlock extends LitElement {
           box-sizing: border-box;
           border: 1px solid #bcc2d1;
           background-color: var(--cc-color-bg-default, #fff);
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
         }
 
         .head {
@@ -155,7 +155,7 @@ export class CcBlock extends LitElement {
           height: 1.5em;
           align-self: flex-start;
           margin-right: 1em;
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
         }
 
         ::slotted([slot='title']) {

--- a/src/components/cc-doc-card/cc-doc-card.js
+++ b/src/components/cc-doc-card/cc-doc-card.js
@@ -86,7 +86,7 @@ export class CcDocCard extends LitElement {
           padding: 1em;
           border: 1px solid #bcc2d1;
           background-color: var(--cc-color-bg-default, #fff);
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
           gap: 1em;
           grid-template-areas: 
             'img title'
@@ -105,7 +105,7 @@ export class CcDocCard extends LitElement {
         cc-img {
           width: 2em;
           height: 2em;
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
         }
 
         .title {

--- a/src/components/cc-doc-list/cc-doc-list.js
+++ b/src/components/cc-doc-list/cc-doc-list.js
@@ -79,7 +79,7 @@ export class CcDocList extends LitElement {
           padding: 1em;
           border: 1px solid #bcc2d1;
           background-color: var(--cc-color-bg-default, #fff);
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
           text-align: center;
         }
 

--- a/src/components/cc-elasticsearch-info/cc-elasticsearch-info.js
+++ b/src/components/cc-elasticsearch-info/cc-elasticsearch-info.js
@@ -117,7 +117,7 @@ export class CcElasticsearchInfo extends LitElement {
           height: 1.5em;
           flex: 0 0 auto;
           margin-right: 0.5em;
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
         }
 
         /* SKELETON */

--- a/src/components/cc-env-var-create/cc-env-var-create.js
+++ b/src/components/cc-env-var-create/cc-env-var-create.js
@@ -194,7 +194,7 @@ export class CcEnvVarCreate extends LitElement {
         cc-error code {
           padding: 0.15em 0.3em;
           background-color: var(--cc-color-bg-neutral, #eee);
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
           font-family: var(--cc-ff-monospace, monospace);
         }
       `,

--- a/src/components/cc-env-var-editor-expert/cc-env-var-editor-expert.js
+++ b/src/components/cc-env-var-editor-expert/cc-env-var-editor-expert.js
@@ -199,7 +199,7 @@ export class CcEnvVarEditorExpert extends LitElement {
         .example code {
           padding: 0.15em 0.3em;
           background-color: var(--cc-color-bg-neutral, #eee);
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
           font-family: var(--cc-ff-monospace, monospace);
         }
 

--- a/src/components/cc-env-var-editor-json/cc-env-var-editor-json.js
+++ b/src/components/cc-env-var-editor-json/cc-env-var-editor-json.js
@@ -199,7 +199,7 @@ export class CcEnvVarEditorJson extends LitElement {
         .example code {
           padding: 0.15em 0.3em;
           background-color: var(--cc-color-bg-neutral, #eee);
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
           font-family: var(--cc-ff-monospace, monospace);
         }
 

--- a/src/components/cc-env-var-form/cc-env-var-form.js
+++ b/src/components/cc-env-var-form/cc-env-var-form.js
@@ -317,7 +317,7 @@ export class CcEnvVarForm extends LitElement {
           padding: 0.5em 1em;
           border: 1px solid #bcc2d1;
           background-color: var(--cc-color-bg-default, #fff);
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
         }
 
         .header {

--- a/src/components/cc-env-var-linked-services/cc-env-var-linked-services.js
+++ b/src/components/cc-env-var-linked-services/cc-env-var-linked-services.js
@@ -155,7 +155,7 @@ export class CcEnvVarLinkedServices extends LitElement {
           padding: 1em;
           border: 1px solid #bcc2d1;
           background-color: var(--cc-color-bg-default, #fff);
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
         }
 
         .loading {

--- a/src/components/cc-error/cc-error.js
+++ b/src/components/cc-error/cc-error.js
@@ -79,7 +79,7 @@ export class CcError extends LitElement {
             padding: 1em;
             border: 1px solid #bcc2d1;
             background-color: var(--cc-color-bg-default, #fff);
-            border-radius: 0.25em;
+            border-radius: var(--cc-border-radius-default, 0.25em);
             box-shadow: 0 0 1em rgb(0 0 0 / 40%);
             grid-gap: 1em;
             justify-items: center;

--- a/src/components/cc-flex-gap/cc-flex-gap.stories.js
+++ b/src/components/cc-flex-gap/cc-flex-gap.stories.js
@@ -16,7 +16,7 @@ const conf = {
     }
     
     cc-flex-gap > * {
-      border-radius: 0.25em;
+      border-radius: var(--cc-border-radius-default, 0.25em);
       border: 1px solid #000;
       flex: 1 1 0;
       padding: 0.5em 1em;

--- a/src/components/cc-grafana-info/cc-grafana-info.js
+++ b/src/components/cc-grafana-info/cc-grafana-info.js
@@ -224,7 +224,7 @@ export class CcGrafanaInfo extends LitElement {
           height: 1.5em;
           flex: 0 0 auto;
           margin-right: 0.5em;
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
         }
 
         .cc-link {
@@ -235,7 +235,7 @@ export class CcGrafanaInfo extends LitElement {
         .dashboard-screenshot {
           width: 100%;
           max-width: 50em;
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
         }
 
         p {

--- a/src/components/cc-header-addon/cc-header-addon.js
+++ b/src/components/cc-header-addon/cc-header-addon.js
@@ -132,7 +132,7 @@ export class CcHeaderAddon extends LitElement {
           overflow: hidden;
           border: 1px solid #bcc2d1;
           background-color: var(--cc-color-bg-default, #fff);
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
         }
 
         .main {
@@ -142,7 +142,7 @@ export class CcHeaderAddon extends LitElement {
         .logo {
           width: 3.25em;
           height: 3.25em;
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
         }
 
         .details {

--- a/src/components/cc-header-app/cc-header-app.js
+++ b/src/components/cc-header-app/cc-header-app.js
@@ -328,7 +328,7 @@ export class CcHeaderApp extends LitElement {
           overflow: hidden;
           border: 1px solid #bcc2d1;
           background-color: var(--cc-color-bg-default, #fff);
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
         }
 
         cc-error {
@@ -345,7 +345,7 @@ export class CcHeaderApp extends LitElement {
           width: 3.25em;
           height: 3.25em;
           align-self: flex-start;
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
         }
 
         .flavor-logo_img {

--- a/src/components/cc-header-orga/cc-header-orga.js
+++ b/src/components/cc-header-orga/cc-header-orga.js
@@ -104,7 +104,7 @@ export class CcHeaderOrga extends LitElement {
           padding: var(--cc-gap);
           border: 1px solid #bcc2d1;
           background-color: var(--cc-color-bg-default, #fff);
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
         }
 
         .wrapper.enterprise {
@@ -115,7 +115,7 @@ export class CcHeaderOrga extends LitElement {
         .logo {
           width: 3.25em;
           height: 3.25em;
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
         }
 
         .details,

--- a/src/components/cc-input-number/cc-input-number.js
+++ b/src/components/cc-input-number/cc-input-number.js
@@ -463,7 +463,7 @@ export class CcInputNumber extends LitElement {
           height: 1.6em;
           flex-shrink: 0;
           margin: 0.2em;
-          border-radius: 0.15em;
+          border-radius: var(--cc-border-radius-small, 0.15em);
           cursor: pointer;
         }
 

--- a/src/components/cc-input-number/cc-input-number.js
+++ b/src/components/cc-input-number/cc-input-number.js
@@ -399,7 +399,7 @@ export class CcInputNumber extends LitElement {
           overflow: hidden;
           border: 1px solid #aaa;
           background: var(--cc-color-bg-default, #fff);
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
           box-shadow: 0 0 0 0 rgb(255 255 255 / 0%);
         }
 

--- a/src/components/cc-input-text/cc-input-text.js
+++ b/src/components/cc-input-text/cc-input-text.js
@@ -551,7 +551,7 @@ export class CcInputText extends LitElement {
           overflow: hidden;
           border: 1px solid #aaa;
           background: var(--cc-color-bg-default, #fff);
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
           box-shadow: 0 0 0 0 rgb(255 255 255 / 0%);
         }
         

--- a/src/components/cc-input-text/cc-input-text.js
+++ b/src/components/cc-input-text/cc-input-text.js
@@ -616,7 +616,7 @@ export class CcInputText extends LitElement {
           height: 1.6em;
           flex-shrink: 0;
           margin: 0.2em 0.2em 0.2em 0;
-          border-radius: 0.15em;
+          border-radius: var(--cc-border-radius-small, 0.15em);
           cursor: pointer;
         }
 

--- a/src/components/cc-jenkins-info/cc-jenkins-info.js
+++ b/src/components/cc-jenkins-info/cc-jenkins-info.js
@@ -123,7 +123,7 @@ export class CcJenkinsInfo extends LitElement {
           height: 1.5em;
           flex: 0 0 auto;
           margin-right: 0.5em;
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
         }
 
         /* SKELETON */

--- a/src/components/cc-logsmap/cc-logsmap.js
+++ b/src/components/cc-logsmap/cc-logsmap.js
@@ -210,7 +210,7 @@ export class CcLogsMap extends LitElement {
         height: 15em;
         border: 1px solid #ccc;
         background-color: var(--cc-color-bg-default, #fff);
-        border-radius: 0.25em;
+        border-radius: var(--cc-border-radius-default, 0.25em);
       }
 
       cc-toggle {

--- a/src/components/cc-map/cc-map.js
+++ b/src/components/cc-map/cc-map.js
@@ -421,7 +421,7 @@ export class CcMap extends withResizeObserver(LitElement) {
           padding: 1em;
           border: 1px solid #bcc2d1;
           background-color: var(--cc-color-bg-default, #fff);
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
           box-shadow: 0 0 1em rgb(0 0 0 / 40%);
         }
 

--- a/src/components/cc-matomo-info/cc-matomo-info.js
+++ b/src/components/cc-matomo-info/cc-matomo-info.js
@@ -132,7 +132,7 @@ export class CcMatomoInfo extends LitElement {
           height: 1.5em;
           flex: 0 0 auto;
           margin-right: 0.5em;
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
         }
 
         .application-list > * {

--- a/src/components/cc-notice/cc-notice.js
+++ b/src/components/cc-notice/cc-notice.js
@@ -141,7 +141,7 @@ export class CcNotice extends LitElement {
           display: grid;
           align-items: center;
           padding: 0.75em;
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
           gap: 0.5em;
           grid-template-areas: 
             'icon heading'

--- a/src/components/cc-notice/cc-notice.js
+++ b/src/components/cc-notice/cc-notice.js
@@ -221,7 +221,7 @@ export class CcNotice extends LitElement {
           padding: 0.2em;
           border: none;
           background-color: transparent;
-          border-radius: 0.15em;
+          border-radius: var(--cc-border-radius-small, 0.15em);
           cursor: pointer;
         }
         

--- a/src/components/cc-pricing-product-consumption/cc-pricing-product-consumption.js
+++ b/src/components/cc-pricing-product-consumption/cc-pricing-product-consumption.js
@@ -507,7 +507,7 @@ export class CcPricingProductConsumption extends withResizeObserver(LitElement) 
         .head {
           display: grid;
           padding: 1em 1em 0;
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
           gap: 1em;
           grid-auto-rows: min-content;
         }
@@ -535,7 +535,7 @@ export class CcPricingProductConsumption extends withResizeObserver(LitElement) 
           display: block;
           width: 3em;
           height: 3em;
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
         }
 
         .name-wrapper {

--- a/src/components/cc-pricing-product/cc-pricing-product.js
+++ b/src/components/cc-pricing-product/cc-pricing-product.js
@@ -189,7 +189,7 @@ export class CcPricingProduct extends LitElement {
           display: block;
           width: 3em;
           height: 3em;
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
         }
 
         .name {

--- a/src/components/cc-select/cc-select.js
+++ b/src/components/cc-select/cc-select.js
@@ -231,7 +231,7 @@ export class CcSelect extends LitElement {
           padding: 0 3em 0 0.5em;
           border: 1px solid #aaa;
           background-color: var(--cc-color-bg-default, #fff);
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
           grid-area: input;
         }
 

--- a/src/components/cc-ssh-key-list/cc-ssh-key-list.js
+++ b/src/components/cc-ssh-key-list/cc-ssh-key-list.js
@@ -506,7 +506,7 @@ export class CcSshKeyList extends LitElement {
           padding: 0.25em 0.75em;
           border: 1px solid #d9d9d9;
           background-color: var(--cc-color-bg-neutral);
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
           font-family: var(--cc-ff-monospace);
           font-size: 0.9em;
           line-height: 2;

--- a/src/components/cc-tcp-redirection-form/cc-tcp-redirection-form.js
+++ b/src/components/cc-tcp-redirection-form/cc-tcp-redirection-form.js
@@ -123,7 +123,7 @@ export class CcTcpRedirectionForm extends LitElement {
         .description code {
           padding: 0.15em 0.3em;
           background-color: var(--cc-color-bg-neutral);
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
           font-family: var(--cc-ff-monospace);
         }
       `,

--- a/src/components/cc-tcp-redirection/cc-tcp-redirection.js
+++ b/src/components/cc-tcp-redirection/cc-tcp-redirection.js
@@ -184,7 +184,7 @@ export class CcTcpRedirection extends LitElement {
         .text:not(.skeleton) code {
           padding: 0.15em 0.3em;
           background-color: var(--cc-color-bg-neutral);
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
           font-family: var(--cc-ff-monospace);
         }
 

--- a/src/components/cc-tile-metrics/cc-tile-metrics.js
+++ b/src/components/cc-tile-metrics/cc-tile-metrics.js
@@ -379,7 +379,7 @@ export class CcTileMetrics extends withResizeObserver(LitElement) {
           justify-content: center;
           /* TODO: Change variable when we have proper border token */
           border: 1px solid var(--cc-color-bg-strong);
-          border-radius: 0.15em;
+          border-radius: var(--cc-border-radius-small, 0.15em);
           box-shadow: rgb(255 255 255 / 0%) 0 0 0 0;
           transition: box-shadow 75ms ease-in-out 0s;
         }

--- a/src/components/cc-toast/cc-toast.js
+++ b/src/components/cc-toast/cc-toast.js
@@ -276,7 +276,7 @@ export class CcToast extends LitElement {
           border: none;
           margin: 0.25em;
           background-color: transparent;
-          border-radius: 0.15em;
+          border-radius: var(--cc-border-radius-small, 0.15em);
           cursor: pointer;
         }
 

--- a/src/components/cc-toggle/cc-toggle.js
+++ b/src/components/cc-toggle/cc-toggle.js
@@ -208,7 +208,7 @@ export class CcToggle extends LitElement {
           height: var(--height);
           box-sizing: border-box;
           background-color: var(--cc-color-bg-default, #fff);
-          border-radius: 0.15em;
+          border-radius: var(--cc-border-radius-small, 0.15em);
           line-height: 1.25;
         }
 
@@ -279,7 +279,7 @@ export class CcToggle extends LitElement {
           left: var(--space);
           display: block;
           background-color: var(--cc-color-bg);
-          border-radius: 0.15em;
+          border-radius: var(--cc-border-radius-small, 0.15em);
           content: '';
         }
 

--- a/src/components/cc-zone-input/cc-zone-input.js
+++ b/src/components/cc-zone-input/cc-zone-input.js
@@ -250,7 +250,7 @@ export class CcZoneInput extends withResizeObserver(LitElement) {
           box-sizing: border-box;
           border: 1px solid #bcc2d1;
           background-color: var(--cc-color-bg-default, #fff);
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
         }
 
         cc-map,
@@ -295,7 +295,7 @@ export class CcZoneInput extends withResizeObserver(LitElement) {
         }
 
         .zone-list:not(:hover):focus-within {
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
           outline: var(--cc-focus-outline, #000 solid 2px);
           outline-offset: var(--cc-focus-outline-offset, 2px);
         }
@@ -326,7 +326,7 @@ export class CcZoneInput extends withResizeObserver(LitElement) {
           box-sizing: border-box;
           padding: 0.5em;
           border: 2px solid var(--bd-color, transparent);
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
         }
 
         label {

--- a/src/components/cc-zone/cc-zone.js
+++ b/src/components/cc-zone/cc-zone.js
@@ -192,7 +192,7 @@ export class CcZone extends LitElement {
           border: 1px solid var(--cc-zone-tag-bdcolor, transparent);
           margin-top: 0.5em;
           background-color: var(--cc-zone-tag-bgcolor, var(--cc-color-bg-soft, #eee));
-          border-radius: 0.25em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
           font-family: var(--cc-ff-monospace);
           font-size: 0.8em;
           line-height: 1.5;

--- a/src/components/cc-zone/cc-zone.js
+++ b/src/components/cc-zone/cc-zone.js
@@ -128,7 +128,7 @@ export class CcZone extends LitElement {
           width: 2em;
           height: var(--lh);
           margin-right: 1em;
-          border-radius: 0.15em;
+          border-radius: var(--cc-border-radius-small, 0.15em);
           box-shadow: 0 0 3px rgb(0 0 0 / 40%);
         }
 

--- a/src/mixins/with-resize-observer/with-resize-observer.stories.js
+++ b/src/mixins/with-resize-observer/with-resize-observer.stories.js
@@ -93,7 +93,7 @@ export const defaultStory = () => {
       }
       
       .color {
-        border-radius: 0.25em;
+        border-radius: var(--cc-border-radius-default, 0.25em);
         display: inline-block;
         height: 1em;
         margin-right: 0.5em;
@@ -103,7 +103,7 @@ export const defaultStory = () => {
       
       pre {
         background-color: #f5f5f5;
-        border-radius: 0.25em;
+        border-radius: var(--cc-border-radius-default, 0.25em);
         padding: 1em;
       }
       

--- a/src/styles/default-theme.css
+++ b/src/styles/default-theme.css
@@ -246,6 +246,11 @@
   --cc-focus-outline-offset: 2px;
   /*endregion*/
 
+  /*region border radius */
+  /* Beware: since we use `em` units, the computed value of these tokens might vary even within the same component */
+  --cc-border-radius-default: 0.25em;
+  /*endregion */
+
   /*region Miscellaneous*/
   /**
    * An opacity value that passes a11y tests.

--- a/src/styles/default-theme.css
+++ b/src/styles/default-theme.css
@@ -249,6 +249,7 @@
   /*region border radius */
   /* Beware: since we use `em` units, the computed value of these tokens might vary even within the same component */
   --cc-border-radius-default: 0.25em;
+  --cc-border-radius-small: 0.15em;
   /*endregion */
 
   /*region Miscellaneous*/

--- a/src/styles/info-tiles.js
+++ b/src/styles/info-tiles.js
@@ -3,16 +3,16 @@ import { css } from 'lit';
 // language=CSS
 export const tileStyles = css`
   :host {
-    background-color: var(--cc-color-bg-default, #fff);
-    border: 1px solid #bcc2d1;
-    border-radius: 0.25em;
-    box-sizing: border-box;
     display: grid;
+    overflow: hidden;
+    min-height: 9em;
+    box-sizing: border-box;
+    padding: 1em;
+    border: 1px solid #bcc2d1;
+    background-color: var(--cc-color-bg-default, #fff);
+    border-radius: var(--cc-border-radius-default, 0.25em);
     grid-gap: 1em;
     grid-template-rows: auto 1fr;
-    min-height: 9em;
-    overflow: hidden;
-    padding: 1em;
   }
 
   .tile_title {
@@ -26,8 +26,8 @@ export const tileStyles = css`
   }
 
   .tile_body {
-    align-content: center;
     display: grid;
+    align-content: center;
   }
 
   .tile_message {
@@ -44,27 +44,27 @@ export const instanceDetailsStyles = css`
   }
 
   .size-label {
-    background-color: var(--cc-color-bg-neutral);
-    border: 1px solid #484848;
-    border-radius: 0.25em;
-    box-sizing: border-box;
     display: block;
-    font-weight: bold;
     height: 1.65em;
-    line-height: 1.65em;
+    box-sizing: border-box;
     padding: 0 var(--bubble-r);
+    border: 1px solid #484848;
+    background-color: var(--cc-color-bg-neutral);
+    border-radius: var(--cc-border-radius-default, 0.25em);
+    font-weight: bold;
+    line-height: 1.65em;
     text-align: center;
   }
 
   .count-bubble {
+    display: block;
+    width: var(--bubble-d);
+    height: var(--bubble-d);
     background-color: var(--color-legacy-grey, #000);
     border-radius: 50%;
     color: var(--cc-color-text-inverted, #fff);
-    display: block;
     font-weight: bold;
-    height: var(--bubble-d);
     line-height: var(--bubble-d);
     text-align: center;
-    width: var(--bubble-d);
   }
 `;


### PR DESCRIPTION
Fixes #734 

## How to review?

- check both commits (using GitHub should be enough),
- check stories of all the components impacted (nothing should change compared to prod):

  - `cc-action-dispatcher`
  - `cc-addon-linked-apps`
  - `cc-addon-option`
  - `cc-article-card`
  - `cc-article-list`
  - `cc-block`
  - `cc-doc-card`
  - `cc-doc-list`
  - `cc-elasticsearch-info`
  - `cc-env-var-create`
  - `cc-env-var-editor-expert`
  - `cc-env-var-editor-json`
  - `cc-env-var-form`
  - `cc-env-var-linked-services`
  - `cc-error`
  - `cc-grafana-info`
  - `cc-header-addon`
  - `cc-header-app`
  - `cc-header-orga`
  - `cc-input-number`
  - `cc-input-text`
  - `cc-jenkins-info`
  - `cc-logsmap`
  - `cc-map`
  - `cc-matomo-info`
  - `cc-notice`
  - `cc-select`
  - `cc-ssh-key-list`
  - `cc-tcp-redirection`
  - `cc-tcp-redirection-form`
  - `cc-zone`
  - `cc-zone-input`
  - `cc-tile-metrics`
  - `cc-toast`
  - `cc-toggle`