### PR TITLE
tokens: add neutral border colors and use them when relevant

### DIFF
--- a/src/components/cc-addon-option/cc-addon-option.js
+++ b/src/components/cc-addon-option/cc-addon-option.js
@@ -92,7 +92,7 @@ export class CcAddonOption extends LitElement {
         }
 
         :host(:not([enabled])) {
-          border: 2px solid #f8f8f8;
+          border: 2px solid var(--cc-color-border-neutral-weak, #eee);
           background-color: var(--cc-color-bg-neutral);
         }
 

--- a/src/components/cc-article-card/cc-article-card.js
+++ b/src/components/cc-article-card/cc-article-card.js
@@ -89,7 +89,7 @@ export class CcArticleCard extends LitElement {
           overflow: hidden;
           box-sizing: border-box;
           padding: 1em;
-          border: 1px solid #bcc2d1;
+          border: 1px solid var(--cc-color-border-neutral, #aaa);
           background-color: var(--cc-color-bg-default, #fff);
           border-radius: var(--cc-border-radius-default, 0.25em);
           gap: 1em;
@@ -100,7 +100,7 @@ export class CcArticleCard extends LitElement {
         .image {
           display: block;
           height: 8em;
-          border-bottom: 1px solid #bcc2d1;
+          border-bottom: 1px solid var(--cc-color-border-neutral, #aaa);
           margin: -1em -1em 0;
           justify-self: stretch;
         }

--- a/src/components/cc-article-list/cc-article-list.js
+++ b/src/components/cc-article-list/cc-article-list.js
@@ -78,7 +78,7 @@ export class CcArticleList extends LitElement {
 
         cc-error {
           padding: 1em;
-          border: 1px solid #bcc2d1;
+          border: 1px solid var(--cc-color-border-neutral, #aaa);
           background-color: var(--cc-color-bg-default, #fff);
           border-radius: var(--cc-border-radius-default, 0.25em);
           text-align: center;

--- a/src/components/cc-block-section/cc-block-section.js
+++ b/src/components/cc-block-section/cc-block-section.js
@@ -51,7 +51,7 @@ export class CcBlockSection extends LitElement {
 
         :host(:not(:first-of-type)) {
           padding-top: 2em;
-          border-top: 1px solid #bcc2d1;
+          border-top: 1px solid var(--cc-color-border-neutral-weak, #eee);
           margin-top: 1em;
         }
 

--- a/src/components/cc-block/cc-block.js
+++ b/src/components/cc-block/cc-block.js
@@ -129,7 +129,7 @@ export class CcBlock extends LitElement {
           display: grid;
           overflow: hidden;
           box-sizing: border-box;
-          border: 1px solid #bcc2d1;
+          border: 1px solid var(--cc-color-border-neutral, #aaa);
           background-color: var(--cc-color-bg-default, #fff);
           border-radius: var(--cc-border-radius-default, 0.25em);
         }

--- a/src/components/cc-doc-card/cc-doc-card.js
+++ b/src/components/cc-doc-card/cc-doc-card.js
@@ -84,7 +84,7 @@ export class CcDocCard extends LitElement {
           display: grid;
           box-sizing: border-box;
           padding: 1em;
-          border: 1px solid #bcc2d1;
+          border: 1px solid var(--cc-color-border-neutral, #aaa);
           background-color: var(--cc-color-bg-default, #fff);
           border-radius: var(--cc-border-radius-default, 0.25em);
           gap: 1em;

--- a/src/components/cc-doc-list/cc-doc-list.js
+++ b/src/components/cc-doc-list/cc-doc-list.js
@@ -77,7 +77,7 @@ export class CcDocList extends LitElement {
 
         cc-error {
           padding: 1em;
-          border: 1px solid #bcc2d1;
+          border: 1px solid var(--cc-color-border-neutral, #aaa);
           background-color: var(--cc-color-bg-default, #fff);
           border-radius: var(--cc-border-radius-default, 0.25em);
           text-align: center;

--- a/src/components/cc-env-var-form/cc-env-var-form.js
+++ b/src/components/cc-env-var-form/cc-env-var-form.js
@@ -315,7 +315,7 @@ export class CcEnvVarForm extends LitElement {
         :host {
           display: block;
           padding: 0.5em 1em;
-          border: 1px solid #bcc2d1;
+          border: 1px solid var(--cc-color-border-neutral, #aaa);
           background-color: var(--cc-color-bg-default, #fff);
           border-radius: var(--cc-border-radius-default, 0.25em);
         }

--- a/src/components/cc-env-var-linked-services/cc-env-var-linked-services.js
+++ b/src/components/cc-env-var-linked-services/cc-env-var-linked-services.js
@@ -153,7 +153,7 @@ export class CcEnvVarLinkedServices extends LitElement {
         .error {
           box-sizing: border-box;
           padding: 1em;
-          border: 1px solid #bcc2d1;
+          border: 1px solid var(--cc-color-border-neutral, #aaa);
           background-color: var(--cc-color-bg-default, #fff);
           border-radius: var(--cc-border-radius-default, 0.25em);
         }

--- a/src/components/cc-error/cc-error.js
+++ b/src/components/cc-error/cc-error.js
@@ -77,7 +77,7 @@ export class CcError extends LitElement {
             align-items: center;
             justify-content: center;
             padding: 1em;
-            border: 1px solid #bcc2d1;
+            border: 1px solid var(--cc-color-border-neutral, #aaa);
             background-color: var(--cc-color-bg-default, #fff);
             border-radius: var(--cc-border-radius-default, 0.25em);
             box-shadow: 0 0 1em rgb(0 0 0 / 40%);

--- a/src/components/cc-header-addon/cc-header-addon.js
+++ b/src/components/cc-header-addon/cc-header-addon.js
@@ -130,7 +130,7 @@ export class CcHeaderAddon extends LitElement {
 
           display: block;
           overflow: hidden;
-          border: 1px solid #bcc2d1;
+          border: 1px solid var(--cc-color-border-neutral, #aaa);
           background-color: var(--cc-color-bg-default, #fff);
           border-radius: var(--cc-border-radius-default, 0.25em);
         }

--- a/src/components/cc-header-app/cc-header-app.js
+++ b/src/components/cc-header-app/cc-header-app.js
@@ -326,7 +326,7 @@ export class CcHeaderApp extends LitElement {
 
           display: block;
           overflow: hidden;
-          border: 1px solid #bcc2d1;
+          border: 1px solid var(--cc-color-border-neutral, #aaa);
           background-color: var(--cc-color-bg-default, #fff);
           border-radius: var(--cc-border-radius-default, 0.25em);
         }

--- a/src/components/cc-header-orga/cc-header-orga.js
+++ b/src/components/cc-header-orga/cc-header-orga.js
@@ -102,7 +102,7 @@ export class CcHeaderOrga extends LitElement {
           display: block;
           overflow: hidden;
           padding: var(--cc-gap);
-          border: 1px solid #bcc2d1;
+          border: 1px solid var(--cc-color-border-neutral, #aaa);
           background-color: var(--cc-color-bg-default, #fff);
           border-radius: var(--cc-border-radius-default, 0.25em);
         }

--- a/src/components/cc-input-number/cc-input-number.js
+++ b/src/components/cc-input-number/cc-input-number.js
@@ -397,7 +397,7 @@ export class CcInputNumber extends LitElement {
           bottom: 0;
           left: 0;
           overflow: hidden;
-          border: 1px solid #aaa;
+          border: 1px solid var(--cc-color-border-neutral-strong, #aaa);
           background: var(--cc-color-bg-default, #fff);
           border-radius: var(--cc-border-radius-default, 0.25em);
           box-shadow: 0 0 0 0 rgb(255 255 255 / 0%);

--- a/src/components/cc-input-text/cc-input-text.js
+++ b/src/components/cc-input-text/cc-input-text.js
@@ -549,7 +549,7 @@ export class CcInputText extends LitElement {
           bottom: 0;
           left: 0;
           overflow: hidden;
-          border: 1px solid #aaa;
+          border: 1px solid var(--cc-color-border-neutral-strong, #aaa);
           background: var(--cc-color-bg-default, #fff);
           border-radius: var(--cc-border-radius-default, 0.25em);
           box-shadow: 0 0 0 0 rgb(255 255 255 / 0%);

--- a/src/components/cc-invoice-table/cc-invoice-table.js
+++ b/src/components/cc-invoice-table/cc-invoice-table.js
@@ -244,7 +244,7 @@ export class CcInvoiceTable extends withResizeObserver(LitElement) {
         }
 
         tr:not(:last-child) td {
-          border-bottom: 1px solid #ddd;
+          border-bottom: 1px solid var(--cc-color-border-neutral-weak, #eee);
         }
 
         /* applied on th and td */

--- a/src/components/cc-logsmap/cc-logsmap.js
+++ b/src/components/cc-logsmap/cc-logsmap.js
@@ -208,7 +208,7 @@ export class CcLogsMap extends LitElement {
         overflow: hidden;
         width: 20em;
         height: 15em;
-        border: 1px solid #ccc;
+        border: 1px solid var(--cc-color-border-neutral, #aaa);
         background-color: var(--cc-color-bg-default, #fff);
         border-radius: var(--cc-border-radius-default, 0.25em);
       }

--- a/src/components/cc-map/cc-map.js
+++ b/src/components/cc-map/cc-map.js
@@ -419,7 +419,7 @@ export class CcMap extends withResizeObserver(LitElement) {
           align-items: center;
           justify-content: center;
           padding: 1em;
-          border: 1px solid #bcc2d1;
+          border: 1px solid var(--cc-color-border-neutral, #aaa);
           background-color: var(--cc-color-bg-default, #fff);
           border-radius: var(--cc-border-radius-default, 0.25em);
           box-shadow: 0 0 1em rgb(0 0 0 / 40%);

--- a/src/components/cc-select/cc-select.js
+++ b/src/components/cc-select/cc-select.js
@@ -229,7 +229,7 @@ export class CcSelect extends LitElement {
           height: 2em;
           box-sizing: border-box;
           padding: 0 3em 0 0.5em;
-          border: 1px solid #aaa;
+          border: 1px solid var(--cc-color-border-neutral-strong, #aaa);
           background-color: var(--cc-color-bg-default, #fff);
           border-radius: var(--cc-border-radius-default, 0.25em);
           grid-area: input;

--- a/src/components/cc-ssh-key-list/cc-ssh-key-list.js
+++ b/src/components/cc-ssh-key-list/cc-ssh-key-list.js
@@ -504,7 +504,7 @@ export class CcSshKeyList extends LitElement {
         [slot='info'] code {
           display: inline-block;
           padding: 0.25em 0.75em;
-          border: 1px solid #d9d9d9;
+          border: 1px solid var(--cc-color-border-neutral-weak, #eee);
           background-color: var(--cc-color-bg-neutral);
           border-radius: var(--cc-border-radius-default, 0.25em);
           font-family: var(--cc-ff-monospace);

--- a/src/components/cc-tile-consumption/cc-tile-consumption.js
+++ b/src/components/cc-tile-consumption/cc-tile-consumption.js
@@ -87,7 +87,7 @@ export class CcTileConsumption extends LitElement {
 
         .separator {
           flex: 1 1 0;
-          border-top: 1px dotted #8c8c8c;
+          border-top: 1px dotted var(--cc-color-border-neutral-strong, #8c8c8c);
           margin: 0 10px;
         }
 

--- a/src/components/cc-tile-scalability/cc-tile-scalability.js
+++ b/src/components/cc-tile-scalability/cc-tile-scalability.js
@@ -117,7 +117,7 @@ export class CcTileScalability extends LitElement {
         .separator {
           width: 1.5em;
           flex: 1 1 0;
-          border-top: 1px dashed #8c8c8c;
+          border-top: 1px dashed var(--cc-color-border-neutral-strong, #8c8c8c);
         }
 
         [title] {

--- a/src/components/cc-zone-input/cc-zone-input.js
+++ b/src/components/cc-zone-input/cc-zone-input.js
@@ -248,7 +248,7 @@ export class CcZoneInput extends withResizeObserver(LitElement) {
           display: flex;
           overflow: hidden;
           box-sizing: border-box;
-          border: 1px solid #bcc2d1;
+          border: 1px solid var(--cc-color-border-neutral, #aaa);
           background-color: var(--cc-color-bg-default, #fff);
           border-radius: var(--cc-border-radius-default, 0.25em);
         }
@@ -262,7 +262,7 @@ export class CcZoneInput extends withResizeObserver(LitElement) {
           width: 100%;
           height: 100%;
           flex-basis: 0;
-          border-right: 1px solid #bcc2d1;
+          border-right: 1px solid var(--cc-color-border-neutral, #aaa);
         }
 
         :host([w-lt-600]) cc-map,

--- a/src/styles/default-theme.css
+++ b/src/styles/default-theme.css
@@ -1,6 +1,8 @@
 :root {
   --cc-ff-monospace: "SourceCodePro", "monaco", monospace;
-/* All custom properties are sorted alphabetically within each region. */
+  
+  /* All custom properties are sorted alphabetically within each region. */
+  
   /*region Color choices*/
   /* color choices - these should not be referenced inside components (use decisions below instead)
     tool used for grey shades: https://mdigi.tools/color-shades/#333333 (10 or 11 steps)
@@ -52,17 +54,13 @@
   /* Usage: Sensitive information that require attention.
   For instance: error messages */
   --cc-color-text-danger: var(--color-red-100);
-  /* Usage: regular text.
-  -- Not used at the moment - will be when we allow theme override. -- */
+  
+  /* Usage: regular text. */
   --cc-color-text-default: var(--color-grey-90);
 
   /* Usage: Opposite of default text color - use this with plain backgrounds like primary / success / danger, etc.
   For instance: text inside primary cc-button. */
   --cc-color-text-inverted: var(--color-white);
-
-  /* Usage: text less important than normal text.
-  For instance: sidenotes, the required mention inside forms. */
-  --cc-color-text-weak: var(--color-grey-80);
 
   /* Usage: info, main color used through the application.
   For instance: text color inside outlined primary cc-button. */
@@ -91,6 +89,10 @@
   /* Usage: cautionnary text.
   For instance: text saying an app is stopped. */
   --cc-color-text-warning: var(--color-orange-100);
+
+  /* Usage: text less important than normal text.
+  For instance: sidenotes, the required mention inside forms. */
+  --cc-color-text-weak: var(--color-grey-80);
   /*endregion*/
 
   /*region Color Decisions (background)*/
@@ -211,6 +213,12 @@
 
   /*region Color Decisions(border)*/
 
+  /* Usage: for danger border */
+  --cc-color-border-danger: var(--color-red-100);
+
+  /* Usage: for danger border */
+  --cc-color-border-danger-weak: var(--color-red-20);
+
   /* Usage: for primary border */
   --cc-color-border-primary-weak: var(--color-blue-20);
 
@@ -220,11 +228,6 @@
   /* Usage: for warning border */
   --cc-color-border-warning-weak: var(--color-orange-20);
 
-  /* Usage: for danger border */
-  --cc-color-border-danger: var(--color-red-100);
-
-  /* Usage: for danger border */
-  --cc-color-border-danger-weak: var(--color-red-20);
   /*endregion*/
 
   /*region Margin Decisions*/

--- a/src/styles/default-theme.css
+++ b/src/styles/default-theme.css
@@ -219,6 +219,10 @@
   /* Usage: for danger border */
   --cc-color-border-danger-weak: var(--color-red-20);
 
+  /* Usage: for contrasted borders.
+  * For instance: click targets like input fields */
+  --cc-color-border-neutral-strong: var(--color-grey-50);
+
   /* Usage: for primary border */
   --cc-color-border-primary-weak: var(--color-blue-20);
 

--- a/src/styles/default-theme.css
+++ b/src/styles/default-theme.css
@@ -227,6 +227,10 @@
   * For instance: click targets like input fields */
   --cc-color-border-neutral-strong: var(--color-grey-50);
 
+  /* Usage: for very subtle decorative borders
+  * For instance: row separators within a table. */
+  --cc-color-border-neutral-weak: var(--color-grey-15);
+
   /* Usage: for primary border */
   --cc-color-border-primary-weak: var(--color-blue-20);
 

--- a/src/styles/default-theme.css
+++ b/src/styles/default-theme.css
@@ -219,6 +219,10 @@
   /* Usage: for danger border */
   --cc-color-border-danger-weak: var(--color-red-20);
 
+  /* Usage: for subtle decorative borders
+  * For instance: block & card borders */
+  --cc-color-border-neutral: var(--color-grey-30);
+
   /* Usage: for contrasted borders.
   * For instance: click targets like input fields */
   --cc-color-border-neutral-strong: var(--color-grey-50);

--- a/src/styles/info-tiles.js
+++ b/src/styles/info-tiles.js
@@ -8,7 +8,7 @@ export const tileStyles = css`
     min-height: 9em;
     box-sizing: border-box;
     padding: 1em;
-    border: 1px solid #bcc2d1;
+    border: 1px solid var(--cc-color-border-neutral, #aaa);
     background-color: var(--cc-color-bg-default, #fff);
     border-radius: var(--cc-border-radius-default, 0.25em);
     grid-gap: 1em;
@@ -48,7 +48,7 @@ export const instanceDetailsStyles = css`
     height: 1.65em;
     box-sizing: border-box;
     padding: 0 var(--bubble-r);
-    border: 1px solid #484848;
+    border: 1px solid var(--cc-color-border-neutral, #aaa);
     background-color: var(--cc-color-bg-neutral);
     border-radius: var(--cc-border-radius-default, 0.25em);
     font-weight: bold;


### PR DESCRIPTION
Fixes #733


## TODO

- [x] decide on how many tokens we want
- [x] decide on colors used by each of the tokens we introduce
- [x] decide on token naming strategy
- [x] rebase

## How to review?

- check the commits (using GitHub should be enough),
- check all the components impacted (do the new border colors work for all of them?):

  - `cc-addon-option.js`,
  - `cc-article-card.js`,
  - `cc-article-list.js`,
  - `cc-block.js`,
  - `cc-block-section.js`,
  - `cc-doc-card.js`,
  - `cc-doc-list.js`,
  - `cc-env-var-form.js`,
  - `cc-env-var-linked-services.js`,
  - `cc-error.js`,
  - `cc-header-addon.js`,
  - `cc-header-app.js`,
  - `cc-header-orga.js`,
  - `cc-input-number.js`,
  - `cc-input-text.js`,
  - `cc-invoice-table.js`,
  - `cc-logsmap.js`,
  - `cc-map.js`,
  - `cc-select.js`,
  - `cc-ssh-key-list.js`,
  - `cc-tile-consumption.js`,
  - `cc-tile-scalability.js`,
  - `cc-zone-input.js`,
  - (all tiles).


<details>
<summary>Archived discussion</summary>

## Questions

### Two tokens 
This one was a little bit trickier than anticipated in the issue.

We can distinguish at least two types of "neutral" borders:

- **strong borders**, usually for interactive controls (form controls). For these, we want users to clearly visualize the boundaries of the control because they need to click inside it. => **need at least `3:1` of contrast ratio**.
- **subtle borders**, usually to suggest boundaries that already are visible through the layout & spacing. For instance cards, table rows, etc. These are somewhat "decorative" (it's definitely debatable). They are not essential to the interface but they emphasize something that should already stand out (with good use of spacing and visual headings). => **no minimum contrast ratio** 

This means we probably need not one but two different tokens.

### Token naming

Working on this made me realize that most of the "neutral" borders we use are subtle (card borders, separators).

Strong borders are only required in a few of our components.

I suggest we change the naming of the `default` token since it's actually not going to be used that often:
`--cc-color-border-strong`.

Also, I wonder if we should mention "neutral" in their name like we do for background tokens?
`--cc-color-border-neutral-strong`
`--cc-color-border-neutral-weak`

### Do we need a 3rd token?

For subtle borders, we have different cases that may require different tokens.

Card & block borders, where we currently have fairly visible (although < 3:1 of contrast ratio) border:
![the cc-block component](https://user-images.githubusercontent.com/100240294/230382754-e846eeec-0553-40a8-b2a6-c90d8d4b620b.png)

Separators, where we currently have less visible borders:
![image](https://user-images.githubusercontent.com/100240294/230383164-cc2d4e88-af17-4b8f-b349-cf4693317dc5.png)

Check out these 3 previews to see our options:

- [one accessible token to rule them all](https://clever-components-preview.cellar-c2.services.clever-cloud.com/tokens/add-border-colors-full-default/index.html?path=/story/%F0%9F%A7%AC-molecules-cc-block-section--default-story)
- [two tokens (strong for input borders, weak for everything else like card borders and separators)](https://clever-components-preview.cellar-c2.services.clever-cloud.com/tokens/add-border-colors/index.html?path=/story/%F0%9F%A7%AC-molecules-cc-block-section--default-story)
- [three tokens (strong for input borders, weak for card borders, weaker for separators](https://clever-components-preview.cellar-c2.services.clever-cloud.com/tokens/add-border-colors-three-shades/index.html?path=/story/%F0%9F%A7%AC-molecules-cc-block-section--default-story)

If we use a very subtle grey for both, or we go with 3 tokens:

- `--cc-color-border-neutral-strong` => for input, select, etc.
- `--cc-color-border-neutral` => for cards etc.
- `--cc-color-border-neutral-weak` => for row separators for instance.

or, if we consider `default` should mean it's accessible, we could go for:

- `--cc-color-border-neutral-default` => for input, select, etc.
- `--cc-color-border-neutral-weak` => for cards etc.
- `--cc-color-border-neutral-weaker` => for row separators for instance.

## Meeting about this subject

During the meeting, we discussed how important it was to ensure the token system remain as simple as possible by limiting how many tokens we introduce.
We all agreed that 3 tokens was the best option for "design" as it allows for more subtle design choices.
Some of us felt like 2 tokens were also enough for decent design and that it may not be worth it to add a third token.

In the end, I chose to go with 3 tokens because:

- before introducing tokens, it seems we were mostly relying on 3 shades of grey anyway, which means there was a need for these 3 shades,
- generating grey shades is fairly easy to do so later on, we may easily "hide" the complexity of overriding the border colors by letting developers only select the strongest grey and compute other shades from there (for grey shades, HSL system is ok),
- while we all agreed on the benefits of having 3 shades, it seemed we did not all agree that we could make it work with only two shades.

</details>