### PR TITLE
docs(jsdoc): use the jsdoc syntax to flag optional parameters

### DIFF
--- a/src/lib/define-smart-component-with-observables.js
+++ b/src/lib/define-smart-component-with-observables.js
@@ -15,9 +15,9 @@ const META = Symbol('META');
 /**
  * @param {object} definition
  * @param {string} definition.selector
- * @param {object?} definition.params
+ * @param {object} [definition.params]
  * @param {(container: SmartContainer, component: Element, context$: Observable<object>, signal: AbortSignal) => void} definition.onConnect
- * @param {AbortSignal?} signal
+ * @param {AbortSignal} [signal]
  */
 export function defineSmartComponentWithObservables (definition, signal) {
 

--- a/src/lib/define-smart-component.js
+++ b/src/lib/define-smart-component.js
@@ -27,7 +27,7 @@ const META = Symbol('META');
  *   ) => void,
  *   signal?: AbortSignal,
  * }) => void} definition.onContextUpdate
- * @param {AbortSignal?} signal
+ * @param {AbortSignal} [signal]
  */
 export function defineSmartComponent (definition, signal) {
 

--- a/src/lib/events.js
+++ b/src/lib/events.js
@@ -2,7 +2,7 @@
  * Send a custom event in the format node => tagName:eventSuffix
  * @param {Window|Node} node
  * @param {String} eventNameOrSuffix - In case of an eventName it will dispatch the event associated to the node or dispatch the event directly if there's a suffix in the eventName
- * @param {any?} detail
+ * @param {any} [detail]
  * @return {CustomEvent} the event that has been dispatched.
  */
 export function dispatchCustomEvent (node, eventNameOrSuffix, detail) {

--- a/src/lib/i18n.js
+++ b/src/lib/i18n.js
@@ -1,6 +1,6 @@
 /**
  * @param {string} key - The translation key
- * @param {object?} data - The translation data
+ * @param {object} [data] - The translation data
  * @returns {string} - The translated
  */
 export function i18n (key, data) {

--- a/src/lib/notifications.js
+++ b/src/lib/notifications.js
@@ -15,7 +15,7 @@ export function notify (notification, target = window) {
 
 /**
  * @param {string} message
- * @param {string?} title
+ * @param {string} [title]
  * @return {CustomEvent} the <code>cc:notify</code> event that has been dispatched.
  */
 export function notifyError (message, title) {
@@ -28,7 +28,7 @@ export function notifyError (message, title) {
 
 /**
  * @param {string} message
- * @param {string?} title
+ * @param {string} [title]
  * @return {CustomEvent} the <code>cc:notify</code> event that has been dispatched.
  */
 export function notifySuccess (message, title) {

--- a/src/lib/send-to-api.js
+++ b/src/lib/send-to-api.js
@@ -14,7 +14,7 @@ import { withOptions } from '@clevercloud/client/esm/with-options.js';
  * @param {String} apiConfig.OAUTH_CONSUMER_KEY
  * @param {String} apiConfig.OAUTH_CONSUMER_SECRET
  * @param {AbortSignal} signal
- * @param {Number?} cacheDelay
+ * @param {Number} [cacheDelay]
  * @return {function(*=): (any | undefined)}
  */
 export function sendToApi ({ apiConfig = {}, signal, cacheDelay, timeout }) {
@@ -38,7 +38,7 @@ export function sendToApi ({ apiConfig = {}, signal, cacheDelay, timeout }) {
  * @param {Object} apiConfig
  * @param {String} apiConfig.WARP_10_HOST
  * @param {AbortSignal} signal
- * @param {Number?} cacheDelay
+ * @param {Number} [cacheDelay]
  * @return {function(*=): (any | undefined)}
  */
 export function sendToWarp ({ apiConfig = {}, signal, cacheDelay, timeout }) {

--- a/src/lib/smart-manager.js
+++ b/src/lib/smart-manager.js
@@ -15,10 +15,10 @@ import { objectEquals } from './utils.js';
 /**
  * @typedef SmartComponentDefinition
  * @property {String} selector
- * @property {Object?} params
- * @property {Function?} onConnect
- * @property {Function?} onContextUpdate
- * @property {Function?} onDisconnect
+ * @property {Object} [params]
+ * @property {Function} [onConnect]
+ * @property {Function} [onContextUpdate]
+ * @property {Function} [onDisconnect]
  */
 
 const COMPONENTS = Symbol('COMPONENTS');
@@ -62,7 +62,7 @@ export function observeContainer (container, signal) {
 
 /**
  * @param {SmartComponentDefinition} definition
- * @param {AbortSignal?} signal
+ * @param {AbortSignal} [signal]
  */
 export function defineSmartComponentCore (definition, signal) {
 


### PR DESCRIPTION
Fixes #746 

## How to review?

- review all files changed (changes are very simple so you can use the GitHub UI)
- 2 reviewers should be enough for this.