### PR TITLE
Tokens: add new neutral border colors for component states (disabled, hovered, focused)

### DIFF
--- a/src/components/cc-input-number/cc-input-number.js
+++ b/src/components/cc-input-number/cc-input-number.js
@@ -419,7 +419,7 @@ export class CcInputNumber extends LitElement {
         }
 
         input:hover + .ring {
-          border-color: #777;
+          border-color: var(--cc-color-border-neutral-hovered, #777);
         }
 
         :host([disabled]) .ring {

--- a/src/components/cc-input-number/cc-input-number.js
+++ b/src/components/cc-input-number/cc-input-number.js
@@ -423,7 +423,7 @@ export class CcInputNumber extends LitElement {
         }
 
         :host([disabled]) .ring {
-          border-color: var(--cc-color-bg-neutral-disabled);
+          border-color: var(--cc-color-border-neutral-disabled, #777);
           background: var(--cc-color-bg-neutral-disabled);
         }
 
@@ -436,7 +436,7 @@ export class CcInputNumber extends LitElement {
         .skeleton .ring,
         .skeleton:hover .ring,
         .skeleton input:hover + .ring {
-          border-color: #eee;
+          border-color: var(--cc-color-border-neutral-disabled, #777);
           background-color: var(--cc-color-bg-neutral-disabled);
           cursor: progress;
         }

--- a/src/components/cc-input-number/cc-input-number.js
+++ b/src/components/cc-input-number/cc-input-number.js
@@ -404,7 +404,7 @@ export class CcInputNumber extends LitElement {
         }
 
         input:focus + .ring {
-          border-color: #777;
+          border-color: var(--cc-color-border-neutral-focused, #777);
           outline: var(--cc-focus-outline, #000 solid 2px);
           outline-offset: var(--cc-focus-outline-offset, 2px);
         }

--- a/src/components/cc-input-number/cc-input-number.js
+++ b/src/components/cc-input-number/cc-input-number.js
@@ -428,7 +428,7 @@ export class CcInputNumber extends LitElement {
         }
 
         :host([readonly]) .ring {
-          background: var(--cc-color-bg-neutral-readonly);
+          background: var(--cc-color-bg-neutral-readonly, #aaa);
         }
 
         /* SKELETON */

--- a/src/components/cc-input-text/cc-input-text.js
+++ b/src/components/cc-input-text/cc-input-text.js
@@ -575,7 +575,7 @@ export class CcInputText extends LitElement {
         }
 
         :host([disabled]) .ring {
-          border-color: #eee;
+          border-color: var(--cc-color-border-neutral-disabled, #eee);
           background: var(--cc-color-bg-neutral-disabled);
         }
 
@@ -588,7 +588,7 @@ export class CcInputText extends LitElement {
         .skeleton .ring,
         .skeleton:hover .ring,
         .skeleton .input:hover + .ring {
-          border-color: #eee;
+          border-color: var(--cc-color-border-neutral-disabled, #eee);
           background-color: var(--cc-color-bg-neutral-disabled);
           cursor: progress;
         }

--- a/src/components/cc-input-text/cc-input-text.js
+++ b/src/components/cc-input-text/cc-input-text.js
@@ -560,7 +560,7 @@ export class CcInputText extends LitElement {
         }
 
         .input:focus + .ring {
-          border-color: #777;
+          border-color: var(--cc-color-border-neutral-focused, #777);
           outline: var(--cc-focus-outline, #000 solid 2px);
           outline-offset: var(--cc-focus-outline-offset, 2px);
         }

--- a/src/components/cc-input-text/cc-input-text.js
+++ b/src/components/cc-input-text/cc-input-text.js
@@ -571,7 +571,7 @@ export class CcInputText extends LitElement {
         }
 
         .input:hover + .ring {
-          border-color: #777;
+          border-color: var(--cc-color-border-neutral-hovered, #777);
         }
 
         :host([disabled]) .ring {

--- a/src/components/cc-input-text/cc-input-text.js
+++ b/src/components/cc-input-text/cc-input-text.js
@@ -580,7 +580,7 @@ export class CcInputText extends LitElement {
         }
 
         :host([readonly]) .ring {
-          background: var(--cc-color-bg-neutral-hovered);
+          background: var(--cc-color-bg-neutral-readonly, #aaa);
         }
 
         /* SKELETON */

--- a/src/components/cc-select/cc-select.js
+++ b/src/components/cc-select/cc-select.js
@@ -279,7 +279,7 @@ export class CcSelect extends LitElement {
         }
 
         select[disabled] {
-          border-color: var(--cc-color-bg-neutral-disabled);
+          border-color: var(--cc-color-border-neutral-disabled, #777);
           background: var(--cc-color-bg-neutral-disabled);
           color: var(--cc-color-text-weak);
           opacity: 1;

--- a/src/components/cc-select/cc-select.js
+++ b/src/components/cc-select/cc-select.js
@@ -236,7 +236,7 @@ export class CcSelect extends LitElement {
         }
 
         select:hover {
-          border-color: #777;
+          border-color: var(--cc-color-border-neutral-hovered, #777);
           cursor: pointer;
         }
 

--- a/src/components/cc-select/cc-select.js
+++ b/src/components/cc-select/cc-select.js
@@ -241,7 +241,7 @@ export class CcSelect extends LitElement {
         }
 
         select:focus {
-          border-color: #777;
+          border-color: var(--cc-color-border-neutral-focused, #777);
           outline: var(--cc-focus-outline, #000 solid 2px);
           outline-offset: var(--cc-focus-outline-offset, 2px);
         }

--- a/src/styles/default-theme.css
+++ b/src/styles/default-theme.css
@@ -223,6 +223,10 @@
   * For instance: block & card borders */
   --cc-color-border-neutral: var(--color-grey-30);
 
+  /* Usage: for disabled borders
+  * For instance: disabled input / select borders */
+  --cc-color-border-neutral-disabled: var(--color-grey-15);
+
   /* Usage: for contrasted borders.
   * For instance: click targets like input fields */
   --cc-color-border-neutral-strong: var(--color-grey-50);

--- a/src/styles/default-theme.css
+++ b/src/styles/default-theme.css
@@ -227,6 +227,10 @@
   * For instance: disabled input / select borders */
   --cc-color-border-neutral-disabled: var(--color-grey-15);
 
+  /* Usage: for focused borders
+  * For instance: focused input / select borders */
+  --cc-color-border-neutral-focused: var(--color-grey-70);
+
   /* Usage: for contrasted borders.
   * For instance: click targets like input fields */
   --cc-color-border-neutral-strong: var(--color-grey-50);

--- a/src/styles/default-theme.css
+++ b/src/styles/default-theme.css
@@ -231,6 +231,10 @@
   * For instance: focused input / select borders */
   --cc-color-border-neutral-focused: var(--color-grey-70);
 
+  /* Usage: for borders on hover
+  * For instance: input / select borders on hover */
+  --cc-color-border-neutral-hovered: var(--color-grey-70);
+
   /* Usage: for contrasted borders.
   * For instance: click targets like input fields */
   --cc-color-border-neutral-strong: var(--color-grey-50);


### PR DESCRIPTION
Fixes #511 
Fixes #749 

## How to review

This PR is fairly simple.

- review every commit
- check `cc-input-*` & `cc-select` stories (new very subtle change of border on hover, focus)
- check one of the `all form controls` stories and compare to prod to see the fix for readonly bg color.