### PR TITLE
fix(cc-invoice): `<template>` content is erased

### DIFF
--- a/src/components/cc-invoice/cc-invoice.js
+++ b/src/components/cc-invoice/cc-invoice.js
@@ -67,9 +67,9 @@ export class CcInvoice extends LitElement {
           <div slot="button">${ccLink(invoice.downloadUrl, i18n('cc-invoice.download-pdf'), skeleton)}</div>
           <div class="info"><em class=${classMap({ skeleton })}>${i18n('cc-invoice.info', { date, amount })}</em></div>
           <cc-html-frame class="frame" ?loading="${skeleton}" iframe-title="${i18n('cc-invoice.title')} ${number}">
-            ${!skeleton ? html`
-              <template>${unsafeHTML(this.invoice.invoiceHtml)}</template>
-            ` : ''}
+            ${!skeleton ? unsafeHTML(`
+              <template>${this.invoice.invoiceHtml}</template>
+            `) : ''}
           </cc-html-frame>
         ` : ''}
         ${this.error ? html`


### PR DESCRIPTION
Fixes #784

## What does this PR do?

Move the `<template>` tag used within `cc-invoice` inside the `unsafeHTML` expression because Lit won't allow using expressions inside a `<template>` tag.

## What to review?

- code
- UI (in prod, invoice content = blank, in preview, invoice content = heading and text).


<details>
<summary>More info about the issue and the solution</summary>

The `<cc-invoice>` component allows developers to pass HTML through the `invoice.invoiceHtml` prop.
This feature used to work with Lit 1.X but it has been broken since we've migrated to Lit 2.X (components version 10 and upper).

The HTML fragment is supposed to be handled by `<cc-html-frame>` inside the `<cc-invoice>` component.

To pass HTML to `<cc-html-frame>`, you need to `slot` it inside a `<template>` tag like this:
```html
<cc-html-frame>
  <template>your html</template>
</cc-html-frame>
```

In `<cc-invoice>` we used to do it like this:
```html
<cc-html-frame>
  <template>${unsafeHTML(this.invoice.invoiceHtml)}</template>
</cc-html-frame>
```

But it does not work anymore because you cannot use expressions within a `<template>` tag (see [Lit docs - Invalid locations](https://lit.dev/docs/templates/expressions/#invalid-locations)).
Trying to use `unsafeHTML` expression within a `<template>` tag on Lit playground results in the following error:
![Uncaught (in promise) Error: Expressions are not supported inside `template` elements. See https://lit.dev/msg/expression-in-template for more information.](https://github.com/CleverCloud/clever-components/assets/100240294/69e36549-d556-4a4d-ba57-5ef12e1da352)
</details>