### PR TITLE
cc-pricing-*: remove `apiConfig` from smart context parameters

### DIFF
--- a/demo-smart/cc-pricing-page/index.html
+++ b/demo-smart/cc-pricing-page/index.html
@@ -101,7 +101,7 @@
 </head>
 <body>
 
-<cc-smart-container context='{ "apiConfig": {}, "zoneId": "par", "addonFeatures":["cpu","memory","max-db-size","disk-size","connection-limit","version","databases","has-logs","has-metrics"]}'>
+<cc-smart-container context='{ "zoneId": "par", "addonFeatures":["cpu","memory","max-db-size","disk-size","connection-limit","version","databases","has-logs","has-metrics"]}'>
   <cc-pricing-page>
 
     <div class="header">

--- a/src/components/cc-pricing-header/cc-pricing-header.smart.js
+++ b/src/components/cc-pricing-header/cc-pricing-header.smart.js
@@ -8,12 +8,11 @@ import { sendToApi } from '../../lib/send-to-api.js';
 defineSmartComponent({
   selector: 'cc-pricing-header',
   params: {
-    apiConfig: { type: Object },
     zoneId: { type: String },
   },
   onContextUpdate ({ container, component, context, onEvent, updateComponent, signal }) {
 
-    const { apiConfig, zoneId } = context;
+    const { zoneId } = context;
 
     /**
      * This `cc-smart-container` is placed around the whole `cc-pricing-page` component.
@@ -37,7 +36,7 @@ defineSmartComponent({
      * we update `cc-pricing-header` accordingly.
      */
     if (component.zones.state === 'loading') {
-      fetchAllZones({ apiConfig, signal })
+      fetchAllZones({ signal })
         .then((zones) => {
           updateComponent('zones', {
             state: 'loaded',

--- a/src/components/cc-pricing-header/cc-pricing-header.smart.md
+++ b/src/components/cc-pricing-header/cc-pricing-header.smart.md
@@ -17,14 +17,7 @@ title: '💡 Smart'
 
 | Name        | Type        | Details                                                                          | Default |
 |-------------|-------------|----------------------------------------------------------------------------------|---------|
-| `apiConfig` | `ApiConfig` | Object with API configuration (only `API_HOST` is required for this component)   |         |
 | `zoneId`    | `string`    | Name from [`/v4/products/zones`](https://api.clever-cloud.com/v4/products/zones) | `par`   |
-
-```ts
-interface ApiConfig {
-    API_HOST: string,
-}
-```
 
 ## 🌐 API endpoints
 
@@ -36,9 +29,6 @@ interface ApiConfig {
 
 ```html
 <cc-smart-container context='{
-    "apiConfig": {
-      API_HOST: "",
-    },
     "zoneId": "mtl",
 }'>
   <cc-pricing-header></cc-pricing-header>

--- a/src/components/cc-pricing-product-consumption/cc-pricing-product-consumption.smart.js
+++ b/src/components/cc-pricing-product-consumption/cc-pricing-product-consumption.smart.js
@@ -7,17 +7,16 @@ import { formatAddonCellar, formatAddonFsbucket, formatAddonHeptapod, formatAddo
 defineSmartComponent({
   selector: 'cc-pricing-product-consumption',
   params: {
-    apiConfig: { type: Object },
     productId: { type: String },
     zoneId: { type: String },
   },
   onContextUpdate ({ updateComponent, context, signal }) {
-    const { apiConfig, productId, zoneId } = context;
+    const { productId, zoneId } = context;
 
     // Reset the component before loading
     updateComponent('product', { state: 'loading' });
 
-    fetchProduct({ apiConfig, productId, zoneId, signal })
+    fetchProduct({ productId, zoneId, signal })
       .then((product) => {
         updateComponent('product', {
           name: product.name,
@@ -32,8 +31,8 @@ defineSmartComponent({
   },
 });
 
-function fetchProduct ({ apiConfig, productId, zoneId, signal }) {
-  return fetchPriceSystem({ apiConfig, zoneId, signal })
+function fetchProduct ({ productId, zoneId, signal }) {
+  return fetchPriceSystem({ zoneId, signal })
     .then((priceSystem) => {
       if (productId === 'cellar') {
         return {

--- a/src/components/cc-pricing-product-consumption/cc-pricing-product-consumption.smart.md
+++ b/src/components/cc-pricing-product-consumption/cc-pricing-product-consumption.smart.md
@@ -17,15 +17,8 @@ title: '💡 Smart'
 
 | Name        | Type        | Details                                                                          | Default |
 |-------------|-------------|----------------------------------------------------------------------------------|---------|
-| `apiConfig` | `ApiConfig` | Object with API configuration (only `API_HOST` is required for this component)   |         |
 | `productId` | `string`    | `cellar`, `fsbucket`, `heptapod`, or `pulsar`                                    |         |
 | `zoneId`    | `string`    | Name from [`/v4/products/zones`](https://api.clever-cloud.com/v4/products/zones) | `par`   |
-
-```ts
-interface ApiConfig {
-    API_HOST: string,
-}
-```
 
 ## 🌐 API endpoints
 
@@ -41,9 +34,6 @@ Simple example for Cellar based on default zone.
 
 ```html
 <cc-smart-container context='{
-    "apiConfig": {
-      API_HOST: "",
-    },
     "productId": "cellar" }'>
   <cc-pricing-product-consumption></cc-pricing-product-consumption>
 </cc-smart-container>
@@ -55,9 +45,6 @@ Simple example for FS Bucket based on default zone.
 
 ```html
 <cc-smart-container context='{
-    "apiConfig": {
-      API_HOST: "",
-    },
     "productId": "fsbucket",
 }'>
   <cc-pricing-product-consumption></cc-pricing-product-consumption>
@@ -70,9 +57,6 @@ Simple example for FS Bucket based on default zone.
 
 ```html
 <cc-smart-container context='{
-    "apiConfig": {
-      API_HOST: "",
-    },
     "productId": "pulsar",
 }'>
   <cc-pricing-product-consumption></cc-pricing-product-consumption>
@@ -85,9 +69,6 @@ Simple example for Heptapod based on default zone.
 
 ```html
 <cc-smart-container context='{
-    "apiConfig": {
-      API_HOST: "",
-    },
     "productId": "heptapod",
 }'>
   <cc-pricing-product-consumption></cc-pricing-product-consumption>
@@ -102,9 +83,6 @@ NOTE: Prices are the same on all zones right now.
 
 ```html
 <cc-smart-container context='{
-    "apiConfig": {
-      API_HOST: "",
-    },
     "productId": "cellar",
     "zoneId": "rbx",
 }'>

--- a/src/components/cc-pricing-product/cc-pricing-product.smart-addon.js
+++ b/src/components/cc-pricing-product/cc-pricing-product.smart-addon.js
@@ -10,18 +10,17 @@ import { sendToApi } from '../../lib/send-to-api.js';
 defineSmartComponent({
   selector: 'cc-pricing-product[mode="addon"]',
   params: {
-    apiConfig: { type: Object },
     addonFeatures: { type: Array },
     productId: { type: String },
     zoneId: { type: String },
   },
   onContextUpdate ({ context, updateComponent, signal }) {
-    const { apiConfig, productId, zoneId, addonFeatures } = context;
+    const { productId, zoneId, addonFeatures } = context;
 
     // Reset the component before loading
     updateComponent('state', { state: 'loading' });
 
-    fetchAddonProduct({ apiConfig, zoneId, productId, addonFeatures, signal })
+    fetchAddonProduct({ zoneId, productId, addonFeatures, signal })
       .then((productDetails) => {
         updateComponent('product', {
           state: 'loaded',
@@ -37,16 +36,16 @@ defineSmartComponent({
   },
 });
 
-function fetchAddonProduct ({ apiConfig, productId, zoneId, addonFeatures, signal }) {
+function fetchAddonProduct ({ productId, zoneId, addonFeatures, signal }) {
   return Promise.all([
-    fetchAddonProvider({ apiConfig, productId, signal }),
-    fetchPriceSystem({ apiConfig, zoneId, signal }),
+    fetchAddonProvider({ productId, signal }),
+    fetchPriceSystem({ zoneId, signal }),
   ]).then(([addonProvider, priceSystem]) => formatAddonProduct(addonProvider, priceSystem, addonFeatures));
 }
 
-function fetchAddonProvider ({ apiConfig, signal, productId }) {
+function fetchAddonProvider ({ signal, productId }) {
   return getAllAddonProviders()
-    .then(sendToApi({ apiConfig, cacheDelay: ONE_DAY, signal }))
+    .then(sendToApi({ cacheDelay: ONE_DAY, signal }))
     .then((allAddonProviders) => {
       const addonProvider = allAddonProviders.find((ap) => ap.id === productId);
       if (addonProvider == null) {

--- a/src/components/cc-pricing-product/cc-pricing-product.smart-addon.md
+++ b/src/components/cc-pricing-product/cc-pricing-product.smart-addon.md
@@ -16,17 +16,9 @@ title: '💡 Smart (add-on)'
 
 | Name            | Type        | Details                                                                                          | Default |
 |-----------------|-------------|--------------------------------------------------------------------------------------------------|---------|
-| `apiConfig`     | `ApiConfig` | Object with API configuration (only `API_HOST` is required for this component)                   |         |
 | `productId`     | `string`    | id from [`/v2/products/addonproviders`](https://api.clever-cloud.com/v2/products/addonproviders) |         |
 | `zoneId`        | `string`    | Name from [`/v4/products/zones`](https://api.clever-cloud.com/v4/products/zones)                 | `par`   |
 | `addonFeatures` | `string[]`  | List of feature codes as describe in the component API.                                          |         |
-
-
-```ts
-interface ApiConfig {
-  API_HOST: string,
-}
-```
 
 * When `addonFeatures` is not specified, all product features are listed in the order of the API.
 * Setting `addonFeatures` allows you to filter the features you want to display.
@@ -47,9 +39,6 @@ Simple example based on default zone.
 
 ```html
 <cc-smart-container context='{
-    "apiConfig": {
-      API_HOST: "",
-    },
     "productId": "postgresql-addon",
 }'>
   <cc-pricing-product mode="addon"></cc-pricing-product>
@@ -64,9 +53,6 @@ NOTE: Prices are the same on all zones right now.
 
 ```html
 <cc-smart-container context='{
-    "apiConfig": {
-      API_HOST: "",
-    },
     "productId": "postgresql-addon",
     "zoneId": "rbx",
 }'>
@@ -81,9 +67,6 @@ It's also a good way to filter features.
 
 ```html
 <cc-smart-container context='{
-    "apiConfig": {
-      API_HOST: "",
-    },
     "productId": "postgresql-addon",
     "addonFeatures": ["cpu", "memory", "disk-size"],
 }'>

--- a/src/components/cc-pricing-product/cc-pricing-product.smart-runtime.js
+++ b/src/components/cc-pricing-product/cc-pricing-product.smart-runtime.js
@@ -10,17 +10,16 @@ import './cc-pricing-product.js';
 defineSmartComponent({
   selector: 'cc-pricing-product[mode="runtime"]',
   params: {
-    apiConfig: { type: Object },
     productId: { type: String },
     zoneId: { type: String },
   },
   onContextUpdate ({ context, updateComponent, signal }) {
-    const { apiConfig, productId, zoneId } = context;
+    const { productId, zoneId } = context;
 
     // Reset the component before loading
     updateComponent('state', { state: 'loading' });
 
-    fetchRuntimeProduct({ apiConfig, productId, zoneId, signal })
+    fetchRuntimeProduct({ productId, zoneId, signal })
       .then((productDetails) => {
         updateComponent('product', {
           state: 'loaded',
@@ -36,16 +35,16 @@ defineSmartComponent({
   },
 });
 
-function fetchRuntimeProduct ({ apiConfig, productId, zoneId, signal }) {
+function fetchRuntimeProduct ({ productId, zoneId, signal }) {
   return Promise.all([
-    fetchRuntime({ apiConfig, productId, signal }),
+    fetchRuntime({ productId, signal }),
     fetchPriceSystem({ zoneId, signal }),
   ]).then(([runtime, priceSystem]) => formatRuntimeProduct(runtime, priceSystem));
 }
 
-function fetchRuntime ({ apiConfig, productId, signal }) {
+function fetchRuntime ({ productId, signal }) {
   return getAvailableInstances()
-    .then(sendToApi({ apiConfig, cacheDelay: ONE_DAY, signal }))
+    .then(sendToApi({ cacheDelay: ONE_DAY, signal }))
     .then((allRuntimes) => {
       const runtime = allRuntimes.find((f) => f.variant.slug === productId);
       if (runtime == null) {

--- a/src/components/cc-pricing-product/cc-pricing-product.smart-runtime.md
+++ b/src/components/cc-pricing-product/cc-pricing-product.smart-runtime.md
@@ -16,15 +16,8 @@ title: '💡 Smart (runtime)'
 
 | Name        | Type        | Details                                                                                          | Default |
 |-------------|-------------|--------------------------------------------------------------------------------------------------|---------|
-| `apiConfig` | `ApiConfig` | Object with API configuration (only `API_HOST` is required for this component)                   |         |
 | `productId` | `string`    | Variant slug from [`/v2/products/instances`](https://api.clever-cloud.com/v2/products/instances) |         |
 | `zoneId`    | `string`    | Name from [`/v4/products/zones`](https://api.clever-cloud.com/v4/products/zones)                 | `par`   |
-
-```ts
-interface ApiConfig {
-  API_HOST: string,
-}
-```
 
 ## 🌐 API endpoints
 
@@ -41,9 +34,6 @@ Simple example based on default zone.
 
 ```html
 <cc-smart-container context='{
-    "apiConfig": {
-      API_HOST: "",
-    },
     "productId": "node",
 }'>
   <cc-pricing-product mode="runtime"></cc-pricing-product>
@@ -54,9 +44,6 @@ Simple example based on default zone.
 
 ```html
 <cc-smart-container context='{
-    "apiConfig": {
-      API_HOST: "",
-    },
     "productId": "jenkins-runner",
 }'>
   <cc-pricing-product mode="runtime" action="none" temporalities='[{"type":"minute","digits":5}]'></cc-pricing-product>
@@ -67,9 +54,6 @@ Simple example based on default zone.
 
 ```html
 <cc-smart-container context='{
-    "apiConfig": {
-      API_HOST: "",
-    },
     "productId": "heptapod-runner",
 }'>
   <cc-pricing-product mode="runtime" action="none" temporalities='[{"type":"minute","digits":5}]'></cc-pricing-product>
@@ -84,9 +68,6 @@ NOTE: Prices are the same on all zones right now.
 
 ```html
 <cc-smart-container context='{
-    "apiConfig": {
-      API_HOST: "",
-    },
     "productId": "node",
     "zoneId": "rbx",
 }'>


### PR DESCRIPTION
Fixes #798 

## What does this PR do?

- Removes all `apiConfig` parameters from the newly updated pricing smart components.

## How to review

- Review every commit.
@pdesoyres-cc I used `chore` as commit types because I did not want these to be part of the changelog (because we haven't released the changes I'm rolling back with this PR so it would be confusing to include these commits in the changelog).
=> Is there a better way to do this?