### PR TITLE
Changelog: add `7.13.0` and `7.13.1` versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -266,6 +266,18 @@ title: Changelog
 * `<cc-toggle>`: add `inline` prop to place the label on the left of the group of radio input elements. Add new `inline` story to show this behavior.
 * `<cc-invoice-list>`: inline year filters (`<cc-toggle>` for desktop and `<cc-select>` for mobile).
 
+## 7.13.1 (2023-06-23)
+
+**⚠️ Caution:**
+
+The goal of this release is to fix issues with the version 7.12 of the `pricing` components for our Website (see [#791](https://github.com/CleverCloud/clever-components/issues/791) [#787](https://github.com/CleverCloud/clever-components/issues/787) [#781](https://github.com/CleverCloud/clever-components/issues/781)).
+Changes described below are specific to this version.
+They are not part of versions between `8.0.0` and `11.0.0`.
+
+If you need to use the `pricing` components, please update to a version >= `11.0.0` of our components that contains a rework of these components.
+
+* `<cc-pricing-header>`: make sure the initial value of the zones dropdown is set after loading the zones.
+
 ## 7.13.0 (2023-06-23)
 
 **⚠️ Caution:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -266,6 +266,19 @@ title: Changelog
 * `<cc-toggle>`: add `inline` prop to place the label on the left of the group of radio input elements. Add new `inline` story to show this behavior.
 * `<cc-invoice-list>`: inline year filters (`<cc-toggle>` for desktop and `<cc-select>` for mobile).
 
+## 7.13.0 (2023-06-23)
+
+**⚠️ Caution:**
+
+The goal of this release is to fix issues with the version 7.12 of the `pricing` components for our Website (see [#787](https://github.com/CleverCloud/clever-components/issues/787) [#781](https://github.com/CleverCloud/clever-components/issues/781)).
+Changes described below are specific to this version.
+They are not part of versions between `8.0.0` and `11.0.0`.
+
+If you need to use the `pricing` components, please update to a version >= `11.0.0` of our components that contains a rework of these components.
+
+* update `Shoelace` dependency from `2.0.0-beta.47` to `2.5.0` to fix an issue with Chrome > 114.
+* `<cc-pricing-table>`: make it possible to add custom features. Stop filtering out features that have no registered translation.
+
 ## 7.12.0 (2022-05-20)
 
 * `cc-link`: remove `defaultThemeStyles` insertion in CSS.


### PR DESCRIPTION
Fixes #793 

## What does this PR do?

- Updates the changelog to retrieve entries from `7.13.0` and `7.13.1` versions.
- Adds a note to warn about the specificity of these versions. (Not sure about this message, feel free to suggest improvements as usual :hugs:)