### PR TITLE
Web Dev Server: enable development mode for our dependencies

### DIFF
--- a/web-dev-server.config.js
+++ b/web-dev-server.config.js
@@ -109,7 +109,11 @@ const injectAuthForSmartComponentsPlugin = {
 
 export default {
   port: 6006,
-  nodeResolve: true,
+  // There is a PR to include this in the default config of Web Dev Server (https://github.com/modernweb-dev/web/pull/2109)
+  // Once it's merged, we may revert this part of the config to `nodeResolve: true`
+  nodeResolve: {
+    exportConditions: ['development'],
+  },
   // watch: true,
   mimeTypes: {
     '**/*.md': 'js',


### PR DESCRIPTION
Fixes #801

## How to review?

- Check the commit,
- Pull the branch, run `npm run storybook:dev` and check some of the stories like `cc-html-frame`. Open your dev tools console and you should see warnings like this:

![Lit warning about dev mode and mutating a reactive property inside the update hook](https://github.com/CleverCloud/clever-components/assets/100240294/f8106369-8ad2-478a-92d3-891e636a9010)
