### PR TITLE
cc-pricing-product: allow custom (not translated) features

### DIFF
--- a/src/components/cc-pricing-estimation/cc-pricing-estimation.js
+++ b/src/components/cc-pricing-estimation/cc-pricing-estimation.js
@@ -149,8 +149,16 @@ export class CcPricingEstimation extends LitElement {
    * @return {string|void} the translated feature name if a translation exists or nothing if the translation does not exist
    */
   _getFeatureName (feature) {
-    if (feature != null && FEATURES_I18N[feature.code] != null) {
+    if (feature == null) {
+      return '';
+    }
+
+    if (FEATURES_I18N[feature.code] != null) {
       return FEATURES_I18N[feature.code]();
+    }
+
+    if (feature.name != null) {
+      return i18n('cc-pricing-estimation.feature.custom', { featureName: feature.name });
     }
   }
 
@@ -471,16 +479,15 @@ export class CcPricingEstimation extends LitElement {
           </summary>
           ${hasFeatures ? html`
             <dl class="plan__features">
-              ${plan.features?.map((feature) => {
-                if (AVAILABLE_FEATURES.includes(feature.code)) {
+              ${plan.features
+                ?.filter((feature) => AVAILABLE_FEATURES.includes(feature.code) || feature.name != null)
+                ?.map((feature) => {
                   return html`
                     <div class="plan__features__feature">
                       <dt>${this._getFeatureName(feature)}</dt>
                       <dd>${this._getFeatureValue(feature)}</dd>
                     </div>
                   `;
-                }
-                return '';
               })}
             </dl>
           ` : ''}

--- a/src/components/cc-pricing-page/cc-pricing-page.stories.js
+++ b/src/components/cc-pricing-page/cc-pricing-page.stories.js
@@ -12,6 +12,7 @@ import {
   dataLoadedWithHeptapod as heptapodStory,
 } from '../cc-pricing-product-consumption/cc-pricing-product-consumption.stories.js';
 import {
+  dataLoadedWithFakeProduct as fakeProductStory,
   dataLoadedWithAddonMongodb as mongoStory,
   dataLoadedWithRuntimeNode as nodeStory,
   dataLoadedWithAddonPostgresql as postgresqlStory,
@@ -216,6 +217,12 @@ function renderBaseStory ({
             ${state === 'loading' ? createStoryItem(heptapodStory, { product: { state: 'loading' } }) : ''}
             ${state === 'error' ? createStoryItem(heptapodStory, { product: { state: 'error' } }) : ''}
             ${state === 'loaded' ? createStoryItem(heptapodStory) : ''}
+          </div>
+          <div class="product">
+            <h3>Fake product</h3>
+            ${state === 'loading' ? createStoryItem(fakeProductStory, { product: { state: 'loading' } }) : ''}
+            ${state === 'error' ? createStoryItem(fakeProductStory, { product: { state: 'error' } }) : ''}
+            ${state === 'loaded' ? createStoryItem(fakeProductStory) : ''}
           </div>
         </div>
       </div>

--- a/src/components/cc-pricing-page/cc-pricing-page.stories.js
+++ b/src/components/cc-pricing-page/cc-pricing-page.stories.js
@@ -250,7 +250,7 @@ export const error = makeStory(conf, {
 
 export const dataLoadedWithDollars = makeStory(conf, {
   dom: (container) => {
-    renderBaseStory({ selectedCurrency: currencies.dollar }, container);
+    renderBaseStory({ selectedCurrency: currencies.usd }, container);
   },
 });
 

--- a/src/components/cc-pricing-page/cc-pricing-page.stories.js
+++ b/src/components/cc-pricing-page/cc-pricing-page.stories.js
@@ -47,6 +47,7 @@ const conf = {
       position: sticky;
       z-index: 10;
       top: 0;
+      overflow: auto;
       height: max-content;
       max-height: 80vh;
       flex: 0 1 25em;

--- a/src/components/cc-pricing-product-consumption/cc-pricing-product-consumption.js
+++ b/src/components/cc-pricing-product-consumption/cc-pricing-product-consumption.js
@@ -463,13 +463,13 @@ export class CcPricingProductConsumption extends withResizeObserver(LitElement) 
       return html`
         <cc-input-number
           label=${i18n('cc-pricing-product-consumption.size', { bytes: unitValue })}
-          hidden-label
           class="input-quantity"
           value=${quantity}
           min="0"
           @cc-input-number:input=${(e) => this._onInputValue(type, e.detail)}
         ></cc-input-number>
         <cc-toggle
+          legend=${i18n('cc-pricing-product-consumption.unit')}
           class="input-unit"
           value=${unitValue}
           .choices=${this._getUnits()}
@@ -481,7 +481,6 @@ export class CcPricingProductConsumption extends withResizeObserver(LitElement) 
       return html`
         <cc-input-number
           label=${i18n('cc-pricing-product-consumption.quantity')}
-          hidden-label
           class="input-quantity"
           value=${quantity}
           min="0"

--- a/src/components/cc-pricing-product/cc-pricing-product.js
+++ b/src/components/cc-pricing-product/cc-pricing-product.js
@@ -111,8 +111,16 @@ export class CcPricingProduct extends withResizeObserver(LitElement) {
    * @return {string|undefined} the translated feature name if a translation exists or nothing if the translation does not exist
    */
   _getFeatureName (feature) {
-    if (feature != null && FEATURES_I18N[feature.code] != null) {
+    if (feature == null) {
+      return '';
+    }
+
+    if (FEATURES_I18N[feature.code] != null) {
       return FEATURES_I18N[feature.code]();
+    }
+
+    if (feature.name != null) {
+      return feature.name;
     }
   }
 
@@ -254,7 +262,7 @@ export class CcPricingProduct extends withResizeObserver(LitElement) {
   _renderProductPlans (productName, productPlans, productFeatures) {
     // this component is not rerendering very often so we consider we can afford to sort plans and filter the features here.
     const sortedPlans = [...productPlans].sort((a, b) => a.price - b.price);
-    const filteredProductFeatures = [...productFeatures].filter((feature) => AVAILABLE_FEATURES.includes(feature.code) || feature.name != null);
+    const filteredProductFeatures = productFeatures.filter((feature) => AVAILABLE_FEATURES.includes(feature.code) || feature.name != null);
 
     // We don't really have a good way to detect when the component should switch between big and small mode.
     // Also, when this component is used several times in the page, it's better if all instances switch at the same breakpoint.

--- a/src/components/cc-pricing-product/cc-pricing-product.js
+++ b/src/components/cc-pricing-product/cc-pricing-product.js
@@ -130,7 +130,7 @@ export class CcPricingProduct extends withResizeObserver(LitElement) {
       case 'boolean':
         return i18n('cc-pricing-product.type.boolean', { boolean: feature.value === 'true' });
       case 'boolean-shared':
-        return i18n('cc-pricing-product.type.boolean-shared', { boolean: feature.value === 'shared' });
+        return i18n('cc-pricing-product.type.boolean-shared', { shared: feature.value === 'shared' });
       case 'bytes':
         return (feature.code === 'memory' && feature.value === '0')
           ? i18n('cc-pricing-product.type.boolean-shared', { shared: true })

--- a/src/components/cc-pricing-product/cc-pricing-product.js
+++ b/src/components/cc-pricing-product/cc-pricing-product.js
@@ -223,10 +223,10 @@ export class CcPricingProduct extends withResizeObserver(LitElement) {
    * Adds the product name to the given plan.
    * Dispatches a `cc-pricing-product:add-plan` event with the plan as its payload.
    *
+   * @param {string} productName - the name of the product to which the plan is attached
    * @param {Plan} plan - the plan to be added to the estimation
    */
-  _onAddPlan (plan) {
-    const productName = this.product.name;
+  _onAddPlan (productName, plan) {
     dispatchCustomEvent(this, 'add-plan', { productName, ...plan });
   }
 
@@ -240,42 +240,44 @@ export class CcPricingProduct extends withResizeObserver(LitElement) {
       ${this.product.state === 'loading' ? html`
         <cc-loader></cc-loader>
       ` : ''}
-      ${this.product.state === 'loaded' ? this._renderProductPlans(this.product) : ''}
+      ${this.product.state === 'loaded'
+        ? this._renderProductPlans(this.product.name, this.product.plans, this.product.productFeatures)
+        : ''}
     `;
   }
 
   /**
-   * @param {PricingProductState} product
+   * @param {string} productName - the name of the product
+   * @param {Plan[]} productPlans - the list of plans attached to this product
+   * @param {Feature[]} productFeatures - the list of features to display
    */
-  _renderProductPlans (product) {
+  _renderProductPlans (productName, productPlans, productFeatures) {
     // this component is not rerendering very often so we consider we can afford to sort plans and filter the features here.
-    const sortedPlans = [...product.plans].sort((a, b) => a.price - b.price);
-    const filteredProductFeatures = product.productFeatures
-      .filter((feature) => AVAILABLE_FEATURES.includes(feature.code));
+    const sortedPlans = [...productPlans].sort((a, b) => a.price - b.price);
+    const filteredProductFeatures = [...productFeatures].filter((feature) => AVAILABLE_FEATURES.includes(feature.code) || feature.name != null);
 
     // We don't really have a good way to detect when the component should switch between big and small mode.
     // Also, when this component is used several times in the page, it's better if all instances switch at the same breakpoint.
     return (this._size > BREAKPOINT)
-      ? this._renderBigPlans(product, sortedPlans, filteredProductFeatures)
-      : this._renderSmallPlans(product, sortedPlans, filteredProductFeatures);
+      ? this._renderBigPlans(productName, sortedPlans, filteredProductFeatures)
+      : this._renderSmallPlans(productName, sortedPlans, filteredProductFeatures);
   }
 
   /**
-   * @param {PricingProductState} product
+   * @param {string} productName
    * @param {Plan[]} sortedPlans
-   * @param {Feature[]} filteredProductFeatures
+   * @param {Feature[]} productFeatures
    */
-  _renderBigPlans (product, sortedPlans, filteredProductFeatures) {
+  _renderBigPlans (productName, sortedPlans, productFeatures) {
     const temporality = this.temporalities ?? DEFAULT_TEMPORALITY_LIST;
-    const productName = product.name;
 
     return html`
       <table>
-        <caption class="visually-hidden">${product.name}</caption>
+        <caption class="visually-hidden">${productName}</caption>
         <thead>
           <tr>
             <th>${i18n('cc-pricing-product.plan')}</th>
-            ${filteredProductFeatures.map((feature) => html`
+            ${productFeatures.map((feature) => html`
               <th class=${classMap({ 'number-align': NUMBER_FEATURE_TYPES.includes(feature.type) })}>${this._getFeatureName(feature)}</th>
             `)}
             ${temporality.map(({ type }) => html`
@@ -290,13 +292,13 @@ export class CcPricingProduct extends withResizeObserver(LitElement) {
         ${sortedPlans.map((plan) => html`
           <tr>
             <td>${plan.name}</td>
-            ${this._renderBigPlanFeatures(plan.features, filteredProductFeatures)}
+            ${this._renderBigPlanFeatures(plan.features, productFeatures)}
             ${temporality.map(({ type, digits }) => html`
               <td class="number-align">${this._getPriceValue(type, plan.price, digits)}</td>
             `)}
             ${this.action === 'add' ? html`
               <td class="btn-col">
-                <button class="btn" @click="${() => this._onAddPlan(plan)}" title="${i18n('cc-pricing-product.add-button', { productName, size: plan.name })}">
+                <button class="btn" @click="${() => this._onAddPlan(productName, plan)}" title="${i18n('cc-pricing-product.add-button', { productName, size: plan.name })}">
                   <cc-icon
                     .icon=${iconAdd}
                     accessible-name=${i18n('cc-pricing-product.add-button', { productName, size: plan.name })}
@@ -313,10 +315,10 @@ export class CcPricingProduct extends withResizeObserver(LitElement) {
 
   /**
    * @param {Feature[]} planFeatures
-   * @param {Feature[]} filteredProductFeatures
+   * @param {Feature[]} productFeatures
    */
-  _renderBigPlanFeatures (planFeatures, filteredProductFeatures) {
-    return filteredProductFeatures.map((feature) => {
+  _renderBigPlanFeatures (planFeatures, productFeatures) {
+    return productFeatures.map((feature) => {
       const currentPlanFeature = planFeatures.find((f) => feature.code === f.code);
       return html`
         <td class=${classMap({ 'number-align': NUMBER_FEATURE_TYPES.includes(feature.type) })}>${this._getFeatureValue(currentPlanFeature)}</td>
@@ -325,23 +327,23 @@ export class CcPricingProduct extends withResizeObserver(LitElement) {
   }
 
   /**
-   * @param {PricingProductState} product
+   * @param {string} productName
    * @param {Plan[]} sortedPlans
-   * @param {Feature[]} filteredProductFeatures
+   * @param {Feature[]} productFeatures
    */
-  _renderSmallPlans (product, sortedPlans, filteredProductFeatures) {
+  _renderSmallPlans (productName, sortedPlans, productFeatures) {
     const temporality = this.temporalities ?? DEFAULT_TEMPORALITY_LIST;
-    const productName = product.name;
 
     return html`
       <div>
+        <div class="visually-hidden">${productName}</div>
         ${sortedPlans.map((plan) => html`
           <div class="plan">
 
             <div class="plan-name">
               <span>${plan.name}</span>
               ${this.action === 'add' ? html`
-                <button class="btn" @click="${() => this._onAddPlan(plan)}" title="${i18n('cc-pricing-product.add-button', { productName, size: plan.name })}">
+                <button class="btn" @click="${() => this._onAddPlan(productName, plan)}" title="${i18n('cc-pricing-product.add-button', { productName, size: plan.name })}">
                   <cc-icon
                     .icon=${iconAdd}
                     accessible-name=${i18n('cc-pricing-product.add-button', { productName, size: plan.name })}
@@ -351,7 +353,7 @@ export class CcPricingProduct extends withResizeObserver(LitElement) {
             </div>
 
             <dl class="feature-list">
-              ${this._renderSmallPlanFeatures(plan.features, filteredProductFeatures)}
+              ${this._renderSmallPlanFeatures(plan.features, productFeatures)}
               ${temporality.map(({ type, digits }) => html`
                 <div class="price-small">
                   <dt class="feature-name">${this._getPriceLabel(type)}</dt>
@@ -367,10 +369,10 @@ export class CcPricingProduct extends withResizeObserver(LitElement) {
 
   /**
    * @param {Feature[]} planFeatures
-   * @param {Feature[]} filteredProductFeatures
+   * @param {Feature[]} productFeatures
    */
-  _renderSmallPlanFeatures (planFeatures, filteredProductFeatures) {
-    return filteredProductFeatures.map((feature) => {
+  _renderSmallPlanFeatures (planFeatures, productFeatures) {
+    return productFeatures.map((feature) => {
       const currentPlanFeature = planFeatures.find((f) => feature.code === f.code);
       return html`
         <div>

--- a/src/components/cc-pricing-product/cc-pricing-product.stories.js
+++ b/src/components/cc-pricing-product/cc-pricing-product.stories.js
@@ -4,15 +4,17 @@ import { getFullProductRuntime } from '../../stories/fixtures/runtime-plans.js';
 import { makeStory, storyWait } from '../../stories/lib/make-story.js';
 import { enhanceStoriesNames } from '../../stories/lib/story-names.js';
 
+const addonFeatures = ['connection-limit', 'cpu', 'databases', 'disk-size', 'gpu', 'has-logs', 'has-metrics', 'memory', 'version'];
+
 // Feature order is not the same between plans
-// Some features will be ignored because they cannot be translated
 // Some features will be ignored because they are not listed
 // Some features are missing for some plans
 const fakeProductPlans = [
   {
     name: 'ONE',
     features: [
-      { code: 'connection-limit', type: 'number', value: '20' },
+      { code: 'databases', type: 'number', value: '1' },
+      { code: 'connection-limit', type: 'number', value: '10' },
       { code: 'disk-size', type: 'bytes', value: String(5 * 1024 ** 3) },
       { code: 'version', type: 'string', value: '1.2.3' },
       { code: 'gpu', type: 'number', value: '2' },
@@ -21,13 +23,14 @@ const fakeProductPlans = [
       { code: 'has-metrics', type: 'boolean', value: 'false' },
       { code: 'memory', type: 'bytes', value: String(256 * 1024 ** 2) },
       { code: 'has-logs', type: 'boolean', value: 'true' },
-      { code: 'ignored-because-not-translated', type: 'string', value: 'ignore this' },
+      { code: 'custom-feature', type: 'string', name: 'Custom Feature', value: 'Custom value 1' },
     ],
     price: 0,
   },
   {
     name: 'TWO',
     features: [
+      { code: 'connection-limit', type: 'number', value: '20' },
       { code: 'databases', type: 'number', value: '20' },
       { code: 'ignored-because-not-listed', type: 'string', value: 'ignore this' },
       { code: 'cpu', type: 'number', value: '2' },
@@ -35,7 +38,7 @@ const fakeProductPlans = [
       { code: 'gpu', type: 'number', value: '4' },
       { code: 'memory', type: 'bytes', value: String(512 * 1024 ** 2) },
       { code: 'has-metrics', type: 'boolean', value: 'true' },
-      { code: 'ignored-because-not-translated', type: 'string', value: 'ignore this' },
+      { code: 'custom-feature', type: 'string', name: 'Custom Feature', value: 'Custom value 2' },
       { code: 'version', type: 'string', value: '1.2.3' },
       { code: 'has-logs', type: 'boolean', value: 'true' },
     ],
@@ -50,7 +53,8 @@ const fakeProductPlans = [
       { code: 'connection-limit', type: 'number', value: '100' },
       { code: 'gpu', type: 'number', value: '8' },
       { code: 'has-logs', type: 'boolean', value: 'true' },
-      { code: 'ignored-because-not-translated', type: 'string', value: 'ignore this' },
+      { code: 'has-metrics', type: 'boolean', value: 'true' },
+      { code: 'custom-feature', type: 'string', name: 'Custom Feature', value: 'Custom value 3' },
       { code: 'memory', type: 'bytes', value: String(5 * 1024 ** 2) },
       { code: 'version', type: 'string', value: '1.2.3' },
     ],
@@ -95,14 +99,11 @@ export const dataLoadedWithFakeProduct = makeStory(conf, {
       productFeatures: [
         { code: 'connection-limit', type: 'number' },
         { code: 'cpu', type: 'number' },
-        { code: 'databases', type: 'number' },
         { code: 'disk-size', type: 'bytes' },
         { code: 'gpu', type: 'number' },
         { code: 'has-logs', type: 'boolean' },
-        { code: 'has-metrics', type: 'boolean' },
         { code: 'memory', type: 'bytes' },
-        { code: 'version', type: 'string' },
-        { code: 'ignored-because-not-translated', type: 'number' },
+        { code: 'custom-feature', type: 'string', name: 'Custom Feature' },
       ],
     },
   },
@@ -120,8 +121,7 @@ export const dataLoadedWithFakeProduct = makeStory(conf, {
         { code: 'databases', type: 'number' },
         { code: 'version', type: 'string' },
         { code: 'has-logs', type: 'boolean' },
-        { code: 'has-metrics', type: 'boolean' },
-        { code: 'ignored-because-not-translated', type: 'number' },
+        { code: 'custom-feature', type: 'string', name: 'Custom Feature' },
       ],
     },
   }],
@@ -158,7 +158,7 @@ export const dataLoadedWithAddonElasticsearch = makeStory(conf, {
   items: [{
     product: {
       state: 'loaded',
-      ...getFullProductAddon('es-addon'),
+      ...getFullProductAddon('es-addon', addonFeatures),
     },
   }],
 });
@@ -167,7 +167,7 @@ export const dataLoadedWithAddonMongodb = makeStory(conf, {
   items: [{
     product: {
       state: 'loaded',
-      ...getFullProductAddon('mongodb-addon'),
+      ...getFullProductAddon('mongodb-addon', addonFeatures),
     },
   }],
 });
@@ -176,7 +176,7 @@ export const dataLoadedWithAddonMysql = makeStory(conf, {
   items: [{
     product: {
       state: 'loaded',
-      ...getFullProductAddon('mysql-addon'),
+      ...getFullProductAddon('mysql-addon', addonFeatures),
     },
   }],
 });
@@ -185,7 +185,7 @@ export const dataLoadedWithAddonPostgresql = makeStory(conf, {
   items: [{
     product: {
       state: 'loaded',
-      ...getFullProductAddon('postgresql-addon'),
+      ...getFullProductAddon('postgresql-addon', addonFeatures),
     },
   }],
 });
@@ -194,7 +194,7 @@ export const dataLoadedWithAddonRedis = makeStory(conf, {
   items: [{
     product: {
       state: 'loaded',
-      ...getFullProductAddon('redis-addon'),
+      ...getFullProductAddon('redis-addon', addonFeatures),
     },
   }],
 });
@@ -204,7 +204,7 @@ export const dataLoadedWithNoAction = makeStory(conf, {
     action: 'none',
     product: {
       state: 'loaded',
-      ...getFullProductAddon('postgresql-addon'),
+      ...getFullProductAddon('postgresql-addon', addonFeatures),
     },
   }],
 });
@@ -215,7 +215,7 @@ export const dataLoadedWithDollars = makeStory(conf, {
       currency: { code: 'USD', changeRate: 1.1802 },
       product: {
         state: 'loaded',
-        ...getFullProductAddon('postgresql-addon'),
+        ...getFullProductAddon('postgresql-addon', addonFeatures),
       },
     },
   ],

--- a/src/components/common.types.d.ts
+++ b/src/components/common.types.d.ts
@@ -119,6 +119,7 @@ interface Feature {
   code: "connection-limit" | "cpu" | "databases" | "disk-size" | "gpu" | "has-logs" | "has-metrics" | "max-db-size" | "memory" | "version";
   type: "boolean" | "shared" | "bytes" | "number" | "runtime" | "string";
   value?: number | string; // Only required for a plan feature
+  name?: string;
 }
 
 interface PricingSection {

--- a/src/lib/product.js
+++ b/src/lib/product.js
@@ -121,6 +121,7 @@ function formatAddonFeatures (providerFeatures, selectedFeatures) {
         type: feature.type.toLowerCase(),
         // Only used when we format plan features
         value: feature.computable_value ?? '',
+        name: feature.name,
       };
     });
 }

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -600,7 +600,7 @@ export const translations = {
   'cc-pricing-estimation.heading': `My selection`,
   'cc-pricing-estimation.hide': `Hide`,
   'cc-pricing-estimation.label.currency': `Currency: `,
-  'cc-pricing-estimation.label.temporality': `Temporality: `,
+  'cc-pricing-estimation.label.temporality': `Unit of time: `,
   'cc-pricing-estimation.plan.delete': ({ productName, planName }) => `Remove ${productName} - ${planName}`,
   'cc-pricing-estimation.plan.qty.btn.decrease': ({ productName, planName }) => `Decrease quantity - ${productName} (${planName})`,
   'cc-pricing-estimation.plan.qty.btn.increase': ({ productName, planName }) => `Increase quantity - ${productName} (${planName})`,
@@ -633,7 +633,7 @@ export const translations = {
   //#endregion
   //#region cc-pricing-header
   'cc-pricing-header.label.currency': `Currency`,
-  'cc-pricing-header.label.temporality': `Temporality`,
+  'cc-pricing-header.label.temporality': `Unit of time`,
   'cc-pricing-header.label.zone': `Zone`,
   'cc-pricing-header.price-name.1000-minutes': `Price (${formatNumber(lang, 1000)} minutes)`,
   'cc-pricing-header.price-name.30-days': () => sanitize`Price/30&nbsp;days`,

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -706,12 +706,13 @@ export const translations = {
   'cc-pricing-product-consumption.public-users.label': `public users`,
   'cc-pricing-product-consumption.public-users.title': `Public users:`,
   'cc-pricing-product-consumption.quantity': `Quantity`,
-  'cc-pricing-product-consumption.size': ({ bytes }) => `Size in ${getUnit(bytes)}`,
+  'cc-pricing-product-consumption.size': ({ bytes }) => `Size (in ${getUnit(bytes)})`,
   'cc-pricing-product-consumption.storage.label': `storage`,
   'cc-pricing-product-consumption.storage.title': `Storage:`,
   'cc-pricing-product-consumption.subtotal.title': `Subtotal (30 days):`,
   'cc-pricing-product-consumption.toggle-btn.label': `Show more details`,
   'cc-pricing-product-consumption.total.title': `Estimated total (30 days):`,
+  'cc-pricing-product-consumption.unit': `Unit`,
   //#endregion
   //#region cc-select
   'cc-select.required': `required`,

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -588,6 +588,7 @@ export const translations = {
   'cc-pricing-estimation.estimated-price-name.second': `estimated/Second`,
   'cc-pricing-estimation.feature.connection-limit': `Connection limit: `,
   'cc-pricing-estimation.feature.cpu': `vCPUs: `,
+  'cc-pricing-estimation.feature.custom': ({ featureName }) => `${featureName}: `,
   'cc-pricing-estimation.feature.databases': `Databases: `,
   'cc-pricing-estimation.feature.disk-size': `Disk size: `,
   'cc-pricing-estimation.feature.gpu': `GPUs: `,

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -601,6 +601,7 @@ export const translations = {
   'cc-pricing-estimation.estimated-price-name.second': `estimé/seconde`,
   'cc-pricing-estimation.feature.connection-limit': () => sanitize`Limite de connexions&nbsp;: `,
   'cc-pricing-estimation.feature.cpu': () => sanitize`vCPUs&nbsp;: `,
+  'cc-pricing-estimation.feature.custom': ({ featureName }) => sanitize`${featureName}&nbsp;: `,
   'cc-pricing-estimation.feature.databases': () => sanitize`Bases de données&nbsp;: `,
   'cc-pricing-estimation.feature.disk-size': () => sanitize`Taille du disque&nbsp;: `,
   'cc-pricing-estimation.feature.gpu': () => sanitize`GPUs&nbsp;: `,

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -719,12 +719,13 @@ export const translations = {
   'cc-pricing-product-consumption.public-users.label': `utilisateurs publics`,
   'cc-pricing-product-consumption.public-users.title': `Utilisateurs publics :`,
   'cc-pricing-product-consumption.quantity': `Quantité`,
-  'cc-pricing-product-consumption.size': ({ bytes }) => `Taille en ${getUnit(bytes)}`,
+  'cc-pricing-product-consumption.size': ({ bytes }) => `Taille (en ${getUnit(bytes)})`,
   'cc-pricing-product-consumption.storage.label': `stockage`,
   'cc-pricing-product-consumption.storage.title': `Stockage :`,
   'cc-pricing-product-consumption.subtotal.title': `Sous-total (30 jours) :`,
   'cc-pricing-product-consumption.toggle-btn.label': `Afficher plus de details`,
   'cc-pricing-product-consumption.total.title': `Total estimé (30 jours) :`,
+  'cc-pricing-product-consumption.unit': `Unité`,
   //#endregion
   //#region cc-select
   'cc-select.required': `obligatoire`,


### PR DESCRIPTION
Fixes #796 

## What does this PR do?

- Tweaks the code of `cc-pricing-product` to benefit from type checking and states.
- Updates the `cc-pricing-product` and `cc-pricing-estimation` components to use the `name` property if the feature code is not associated with a translation.
- Updates the `fake product` story to reflect this change.
- Updates all other product stories to filter features displayed (since features not translated used to be hidden, we did not have to explicitly filter them out before this change).
- Changes the `temporality` translation in English ("temporality" does not really mean what we wanted to convey here. I left it within the code to avoid an unnecessary breaking change, it's understandable for devs I think).
- Adds `Fake product` to the list of products displayed in the `cc-pricing-page` stories.
- Fixes the dollar story of pricing page.
- Adds a visible label + legend in the `cc-pricing-product-consumption` component.
- Fixes content overflowing from `cc-pricing-estimation` in the `cc-pricing-page` stories.

## How to review?

- Check both commits,
- Check the [preview](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-pricing-new/allow-custom-product-features/index.html) (all pricing product stories + all the pricing page stories) : 
  - the `fake plan` story should now display new features but other stories should be the same as before.
  - the `dollar` pricing page story should now have a pricing header select set to dollar instead of euro.
  - the `cc-pricing-product-consumption` component (bottom of the stories) should have visible labels and legends for quantity/size and units (these should also be translated).
  - the label for the temporality dropdown in `cc-pricing-header` should now be `Unit of time` in English.
  - when you add many different products to the estimation, the content is not overflowing anymore within the `cc-pricing-estimation`, it's scrollable.

<details>
<summary>Archived - Issue with plan features vs product features when used without the smart component</summary>

> ## Questions/Notes
> 
> If you add a custom product to the estimation the custom features are not displayed in the estimation.
> You can test this by adding a plan from the `fake product` at the bottom of a pricing page story.
> 
> 
> I tried to make these part of the estimation details but it's tricky because:
> 
> - We manipulate two pieces of data related to features:
>   - `productFeatures` which is the list of features we want to display. It does not contain values, only the features code, type and name.
>   - plan `features` which are the actual features related to a plan. It contains features code, type, value and maybe a name (or maybe not). => When products are set from the API, plan features always have a `name`. When they are set manually (custom product), developers are allowed not to set any `name` (the reason for that is that if we force devs to set a name both in `productFeatures` and `plan` features, they may set different name for the same feature code by mistake...).
> - We display custom features within the `cc-pricing-product` component if they have a `name` property with a value.
> - We check whether the feature has a name by checking the `productFeatures` since plan `features` may not have a `name`.
> - The list of plans that `cc-pricing-estimation` manages come from plan `features`.
> - This component does not have any access to `productFeatures`.
> 
> This raises two issues:
>   - The `cc-pricing-estimation` cannot use the same strategy as `cc-pricing-product` and check if the feature is translated or has a name because custom product plan `features` may not have a name.
>   - The `cc-pricing-estimation` does not filter features based on `productFeatures` because it does not have any access to it.
>     - => we could add `productFeatures` to its properties but it would have to be set manually because it's not watched by any smart component.
>     - => we could filter plan `features` based on `productFeatures` before sending them to `cc-pricing-estimation` but this is not the most readable pattern (so many places to filter these: within render, sub-renders, right before adding plan...).
>     - => this is only an issue with custom products. Products coming from the API are formatted by methods within `product.js` and we filter plan features from there so `cc-pricing-product` and `cc-pricing-estimation` only deal with features that have already been filtered.

=> We decided to force the use of a `name` property on plan features as well as product features because:
  - this is what the API already does,
  - this means we don't have to change the current code,
  - the issue only happens when using the `cc-pricing-product` without a smart component and setting custom features, which should be very uncommon.
If the issue turns out to be an actual problem, we discussed a solution that would consist in:
- changing plan features into a key (code) value model
- relying on the `productFeatures` to get the `name` and the `type`.
- adding `name` and `type` to the info that is passed to `cc-pricing-estimation` upon adding a plan to it.
</details>
