### PR TITLE
chore(cc-addon-features types): rename `Feature` to `AddonFeature`

### DIFF
--- a/src/components/cc-addon-features/cc-addon-features.js
+++ b/src/components/cc-addon-features/cc-addon-features.js
@@ -23,7 +23,7 @@ const featureIcons = {
 
 const SORT_FEATURES = ['cpus', 'vcpus', 'memory', 'disk'];
 
-/** @type {Feature[]} */
+/** @type {AddonFeature[]} */
 const SKELETON_FEATURES = [
   { name: '??????', value: '????????' },
   { name: '????', value: '??' },
@@ -32,7 +32,7 @@ const SKELETON_FEATURES = [
 ];
 
 /**
- * @typedef {import('./cc-addon-features.types.js').Feature} Feature
+ * @typedef {import('./cc-addon-features.types.js').AddonFeature} AddonFeature
  */
 
 /**
@@ -61,7 +61,7 @@ export class CcAddonFeatures extends LitElement {
     /** @type {boolean} Displays an error message. */
     this.error = false;
 
-    /** @type {Feature[]} Sets the list features. */
+    /** @type {AddonFeature[]} Sets the list features. */
     this.features = [];
   }
 

--- a/src/components/cc-addon-features/cc-addon-features.types.d.ts
+++ b/src/components/cc-addon-features/cc-addon-features.types.d.ts
@@ -1,4 +1,4 @@
-interface Feature {
+interface AddonFeature {
   name: string;
   value: string;
 }


### PR DESCRIPTION
Fixes #815

2 reviewers should be enough.

Low priority, this change does not have to be released with `11.0.0` since it's just to fix a Webstorm issue.