### PR TITLE
fix(tests): add another resize loop error message to the ignore list

### DIFF
--- a/src/components/cc-tile-metrics/cc-tile-metrics.js
+++ b/src/components/cc-tile-metrics/cc-tile-metrics.js
@@ -1,4 +1,4 @@
-import { BarController, BarElement, CategoryScale, Chart, LinearScale, Title, Tooltip } from 'chart.js';
+import { BarController, BarElement, CategoryScale, Chart, LinearScale, Title, Tooltip, Filler } from 'chart.js';
 import { css, html, LitElement } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { createRef, ref } from 'lit/directives/ref.js';
@@ -21,7 +21,7 @@ import { ccLink, linkStyles } from '../../templates/cc-link/cc-link.js';
 import '../cc-button/cc-button.js';
 import '../cc-icon/cc-icon.js';
 
-Chart.register(BarController, BarElement, Tooltip, CategoryScale, LinearScale, Title);
+Chart.register(BarController, BarElement, Tooltip, CategoryScale, LinearScale, Title, Filler);
 
 const TOP_COLOR_CHART = 'rgb(190, 52, 97)';
 const MIDDLE_COLOR_CHART = 'rgb(78, 100, 234)';

--- a/test/helpers/accessibility.js
+++ b/test/helpers/accessibility.js
@@ -29,7 +29,8 @@ before(() => {
   window.onerror = function (err) {
     switch (err) {
       case 'ResizeObserver loop limit exceeded':
-        console.warn('Ignored: ResizeObserver loop limit exceeded');
+        return false;
+      case 'ResizeObserver loop completed with undelivered notifications.':
         return false;
       case 'Uncaught IndexSizeError: Failed to execute \'getImageData\' on \'CanvasRenderingContext2D\': The source width is 0.':
         return false;


### PR DESCRIPTION
Fixes #821
Fixes #822

## How to review?
 
**Disclaimer:** the browser still logs `null` everytime a resize loop error happens. I tried to remove it but failed because we're patching the fake `window.onerror` of `Mocha` and it seems tricky. I stopped searching for a solution since we have a proper fix on its way and I don't think it's worth more efforts in the meantime as long as tests are fixed.

- 2 reviewers should be enough for this one,
- review the commits,
- check in local if tests are running fine (still verbose but I have no solutions for this),
- check that `cc-tile-metrics` is the same as in prod. 
