### PR TITLE
Resize controller: implement lit-labs `resizeController`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@clevercloud/client": "^7.11.0",
         "@lit-labs/motion": "^1.0.3",
+        "@lit-labs/observers": "^2.0.0",
         "@shoelace-style/shoelace": "^2.5.0",
         "chart.js": "^3.5.0",
         "chartjs-plugin-datalabels": "^2.0.0",
@@ -4006,6 +4007,14 @@
       "integrity": "sha512-y62SxlUTeFtoQTS8/KqAnOnOTdm0FpB23PgFFc99lPj9T5Gg0uktzRmmmqxPaGoNeRg2cLcPpbvK8iEo8CWMoQ==",
       "dependencies": {
         "lit": "^2.0.0"
+      }
+    },
+    "node_modules/@lit-labs/observers": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/observers/-/observers-2.0.0.tgz",
+      "integrity": "sha512-NMbCjJEqp8V9TpTtt8HhzFVymx/WGpTD7iU+FMKSis4u3iBWwu2UYh6KChwFTEPW9xMum70r2IBnaViBINaGTA==",
+      "dependencies": {
+        "@lit/reactive-element": "^1.1.0"
       }
     },
     "node_modules/@lit-labs/react": {
@@ -21630,6 +21639,14 @@
       "integrity": "sha512-y62SxlUTeFtoQTS8/KqAnOnOTdm0FpB23PgFFc99lPj9T5Gg0uktzRmmmqxPaGoNeRg2cLcPpbvK8iEo8CWMoQ==",
       "requires": {
         "lit": "^2.0.0"
+      }
+    },
+    "@lit-labs/observers": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@lit-labs/observers/-/observers-2.0.0.tgz",
+      "integrity": "sha512-NMbCjJEqp8V9TpTtt8HhzFVymx/WGpTD7iU+FMKSis4u3iBWwu2UYh6KChwFTEPW9xMum70r2IBnaViBINaGTA==",
+      "requires": {
+        "@lit/reactive-element": "^1.1.0"
       }
     },
     "@lit-labs/react": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   "dependencies": {
     "@clevercloud/client": "^7.11.0",
     "@lit-labs/motion": "^1.0.3",
+    "@lit-labs/observers": "^2.0.0",
     "@shoelace-style/shoelace": "^2.5.0",
     "chart.js": "^3.5.0",
     "chartjs-plugin-datalabels": "^2.0.0",

--- a/src/components/cc-orga-member-card/cc-orga-member-card.js
+++ b/src/components/cc-orga-member-card/cc-orga-member-card.js
@@ -1,3 +1,4 @@
+import { ResizeController } from '@lit-labs/observers/resize-controller.js';
 import { css, html, LitElement } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
@@ -10,9 +11,9 @@ import {
   iconRemixDeleteBin_5Fill as iconBin,
   iconRemixAccountCircleFill as iconAvatar,
 } from '../../assets/cc-remix.icons.js';
-import { ResizeObserverController } from '../../controllers/resize-observer-controller.js';
 import { dispatchCustomEvent } from '../../lib/events.js';
 import { i18n } from '../../lib/i18n.js';
+import { resizeCallback } from '../../lib/resize-callback.js';
 import '../cc-button/cc-button.js';
 import '../cc-img/cc-img.js';
 import '../cc-icon/cc-icon.js';
@@ -93,7 +94,9 @@ export class CcOrgaMemberCard extends LitElement {
       width: [BREAKPOINT_TINY, BREAKPOINT_SMALL, BREAKPOINT_MEDIUM],
     };
 
-    new ResizeObserverController(this);
+    new ResizeController(this, {
+      callback: resizeCallback,
+    });
 
     /** @type {Ref<CcInputText>} */
     this._deleteButtonRef = createRef();

--- a/src/components/cc-orga-member-card/cc-orga-member-card.js
+++ b/src/components/cc-orga-member-card/cc-orga-member-card.js
@@ -10,9 +10,9 @@ import {
   iconRemixDeleteBin_5Fill as iconBin,
   iconRemixAccountCircleFill as iconAvatar,
 } from '../../assets/cc-remix.icons.js';
+import { ResizeObserverController } from '../../controllers/resize-observer-controller.js';
 import { dispatchCustomEvent } from '../../lib/events.js';
 import { i18n } from '../../lib/i18n.js';
-import { withResizeObserver } from '../../mixins/with-resize-observer/with-resize-observer.js';
 import '../cc-button/cc-button.js';
 import '../cc-img/cc-img.js';
 import '../cc-icon/cc-icon.js';
@@ -51,7 +51,7 @@ const BREAKPOINT_TINY = 350;
  * We don't fire a delete event so that it can be processed differently by the smart component (leaving the org means the user has to be redirected).
  * @event {CustomEvent<UpdateMember>} cc-orga-member-card:update - Fires when the user clicks on a validate button after editing member role.
  */
-export class CcOrgaMemberCard extends withResizeObserver(LitElement) {
+export class CcOrgaMemberCard extends LitElement {
 
   static get properties () {
     return {
@@ -92,6 +92,8 @@ export class CcOrgaMemberCard extends withResizeObserver(LitElement) {
     this.breakpoints = {
       width: [BREAKPOINT_TINY, BREAKPOINT_SMALL, BREAKPOINT_MEDIUM],
     };
+
+    new ResizeObserverController(this);
 
     /** @type {Ref<CcInputText>} */
     this._deleteButtonRef = createRef();

--- a/src/controllers/resize-observer-controller.js
+++ b/src/controllers/resize-observer-controller.js
@@ -1,0 +1,60 @@
+/**
+ * For this reactive controller to work, the component it is attached must have at least one of the following:
+ *
+ * - a public `onResize` method with `{ width: number }` as its parameter. It is called everytime a resize happens, with the current width of the component.
+ * - a public `breakpoints` property whose type matches the following @type {{ width: number[] }}.
+ *
+ * This reactive controller sets up a resize observer to do the following everytime the element is resized:
+ *
+ * - call the `onResize` with the current `width` of the component.
+ * - adds / removes the `w-lt-${breakpoint}` or `w-gte-${breakpoint}` attributes to the component depending its current `width`.
+ *
+ * @param {LitElement} host - the lit element to be observed
+ */
+export class ResizeObserverController {
+  constructor (host) {
+    host.addController(this);
+
+    this.host = host;
+
+    if (!window.ResizeObserver) {
+      console.warn(
+        `ResizeController error: browser does not support ResizeObserver.`,
+      );
+      return;
+    }
+
+    this._observer = new ResizeObserver(() => this._onResize);
+  }
+
+  _onResize () {
+    const { width } = this.host.getBoundingClientRect();
+
+    if (this.host.onResize != null) {
+      this.host.onResize({ width });
+    }
+
+    if (this.host.breakpoints != null) {
+      this.host.breakpoints.width.forEach((breakpoint) => {
+
+        const gteAttr = 'w-gte-' + breakpoint;
+        (breakpoint <= width)
+          ? this.host.setAttribute(gteAttr, '')
+          : this.host.removeAttribute(gteAttr);
+
+        const ltAttr = 'w-lt-' + breakpoint;
+        (width < breakpoint)
+          ? this.host.setAttribute(ltAttr, '')
+          : this.host.removeAttribute(ltAttr);
+      });
+    }
+  }
+
+  hostConnected () {
+    this._observer?.observe(this.host);
+  }
+
+  hostDisconnected () {
+    this._observer?.disconnect();
+  }
+}

--- a/src/lib/get-width-on-resize.js
+++ b/src/lib/get-width-on-resize.js
@@ -1,0 +1,17 @@
+/**
+ * Function to be used as a callback of the `lib-labs resizeController`.
+ * For better browser compatibility, it extracts the `width` of the observed element using `getBoundingClientRect()`.
+ * The `width` is then stored inside the `value` property of the `resizeController`.
+ *
+ * @param {ResizeObserverEntry[]} entries - the resize observer entries.
+ * @return {number|null} the current width of the observed element or `null` if no entries.
+ */
+export function getWidthOnResize (entries) {
+  if (entries == null || entries?.length === 0) {
+    return null;
+  }
+
+  const { width } = entries[0].target.getBoundingClientRect();
+
+  return width;
+}

--- a/src/lib/resize-callback.js
+++ b/src/lib/resize-callback.js
@@ -11,6 +11,7 @@
  * - adds / removes the `w-lt-${breakpoint}` or `w-gte-${breakpoint}` attributes to the component depending its current `width`.
  *
  * @param {ResizeObserverEntry[]} entries - the resize observer entries
+ * @param {breakpoints} breakpoints - breakpoints
  */
 export function resizeCallback (entries) {
   if (entries.length === 0) {

--- a/src/lib/resize-callback.js
+++ b/src/lib/resize-callback.js
@@ -1,0 +1,41 @@
+/**
+ * To be used as a callback of Lit-Labs `ResizeController` or `ResizeObserver`.
+ * For this to work, the component needs to have AT LEAST ONE of the following:
+ *
+ * - a public `onResize` method with `{ width: number }` as its parameter. It is called everytime a resize happens, with the current width of the component.
+ * - a public `breakpoints` property whose type matches the following @type {{ width: number[] }}.
+ *
+ * This callback does the following everytime the element is resized:
+ *
+ * - calls the `onResize` with the current `width` of the component.
+ * - adds / removes the `w-lt-${breakpoint}` or `w-gte-${breakpoint}` attributes to the component depending its current `width`.
+ *
+ * @param {ResizeObserverEntry[]} entries - the resize observer entries
+ */
+export function resizeCallback (entries) {
+  if (entries.length === 0) {
+    return;
+  }
+
+  const component = entries[0].target;
+  const { width } = component.getBoundingClientRect();
+
+  if (component.onResize != null) {
+    component.onResize({ width });
+  }
+
+  if (component.breakpoints != null) {
+    component.breakpoints.width.forEach((breakpoint) => {
+
+      const gteAttr = 'w-gte-' + breakpoint;
+      (breakpoint <= width)
+        ? component.setAttribute(gteAttr, '')
+        : component.removeAttribute(gteAttr);
+
+      const ltAttr = 'w-lt-' + breakpoint;
+      (width < breakpoint)
+        ? component.setAttribute(ltAttr, '')
+        : component.removeAttribute(ltAttr);
+    });
+  }
+}

--- a/src/lib/set-size-attributes.js
+++ b/src/lib/set-size-attributes.js
@@ -1,0 +1,35 @@
+/**
+ * @typedef {{ width: number[] }} Breakpoints
+ */
+
+/**
+ * For each given breakpoint, this function sets the following attributes:
+ *
+ * - `w-gte-${breakpoint}` if the element's width >= the breakpoint
+ * - `w-lt-${breakpoint}` if the element's width is < the breakpoint
+ *
+ * @param {HTMLElement} element - the element to which you want to add / remove the attributes
+ * @param {number} width - the current width of the element
+ * @param {Breakpoints} breakpoints - the breakpoints
+ */
+export function setSizeAttributes (element, width, breakpoints) {
+  if (breakpoints != null) {
+    breakpoints.width.forEach((breakpoint) => {
+
+>>>>>>>> a567e84f (feat(resize-controller): test lit-labs way):src/lib/set-size-attributes.js
+      const gteAttr = 'w-gte-' + breakpoint;
+      (breakpoint <= width)
+        ? element.setAttribute(gteAttr, '')
+        : element.removeAttribute(gteAttr);
+
+      const ltAttr = 'w-lt-' + breakpoint;
+      (width < breakpoint)
+        ? element.setAttribute(ltAttr, '')
+        : element.removeAttribute(ltAttr);
+    });
+  }
+
+  if (component.onResize != null) {
+    component.onResize({ width });
+  }
+}


### PR DESCRIPTION
## Context

In #551, we decided to rewrite the `resizeObserver` mixin and use a reactive controller instead.

The `resizeObserver` mixin has two features that we need:

- update the component internal `_size` prop with the current `width` of the component, everytime it is resized (we rely on a public `onResize` method to do so),
- set and remove attributes based on publicly declared `breakpoints` on the component everytime it is resized.

We want the `resizeController` to be able to do at least the same.

There are several ways to do so:

- building our own `resizeController` and using the component public methods and properties like we do with the mixin (first commit),
- relying on the lit-labs `resizeController` and using the component public methods and properties (second commit).
- relying on the lit-labs `resizeController` and using its API (`value` property of the observer + `willUpdate` lifecycle hook) (third commit).

All these options work, you can check the `cc-orga-member-card` / `cc-orga-member-list` (data loaded stories) since this component relies on both features (attribute & size prop).