### PR TITLE
fix(cc-pricing-product): filter out addon plans without zones

### DIFF
--- a/demo-smart/cc-pricing-page/index.html
+++ b/demo-smart/cc-pricing-page/index.html
@@ -127,6 +127,13 @@
         </div>
 
         <div class="product">
+          <cc-smart-container context='{"productId":"mongodb-addon"}'>
+            <h2>MongoDB</h2>
+            <cc-pricing-product mode="addon" action="add"></cc-pricing-product>
+          </cc-smart-container>
+        </div>
+
+        <div class="product">
             <cc-smart-container context='{ "productId": "cellar" }'>
               <h2>Cellar</h2>
               <cc-pricing-product-consumption></cc-pricing-product-consumption>

--- a/demo-smart/index.html
+++ b/demo-smart/index.html
@@ -107,9 +107,12 @@
   <li>
     <a class="definition-link" href="?definition=cc-ssh-key-list.smart">cc-ssh-key-list.smart</a>
   </li>
-    <li>
-      <a class="definition-link" href="?definition=cc-tile-metrics.smart">cc-tile-metrics.smart</a>
-    </li>
+  <li>
+    <a class="definition-link" href="?definition=cc-tile-metrics.smart">cc-tile-metrics.smart</a>
+  </li>
+  <li>
+    <a class="definition-link" href="/demo-smart/cc-pricing-page/">cc-pricing-page</a>
+  </li>
 </ul>
 
 <div class="context-buttons">

--- a/src/lib/product.js
+++ b/src/lib/product.js
@@ -1,8 +1,10 @@
 export function formatAddonProduct (addonProvider, priceSystem, selectedFeatures) {
+  // We filter out add-ons that are not attached to any zone. This is sometimes done on dev plans to disable them.
+  const addonPlansWithZones = addonProvider.plans.filter((plan) => plan.zones.length > 0);
   return {
     name: addonProvider.name,
     productFeatures: formatAddonFeatures(addonProvider.features, selectedFeatures),
-    plans: formatAddonPlans(addonProvider.plans, priceSystem, selectedFeatures),
+    plans: formatAddonPlans(addonPlansWithZones, priceSystem, selectedFeatures),
   };
 }
 


### PR DESCRIPTION
Fixes #858

## Context

We have disabled MongoDB dev plans but the pricing API still returns it.

In the console, we rely on the fact that this plan is no longer attached to any zone to filter it.

We want to do the same within our pricing components. If a plan has no zone, then we shouldn't display it.

## How to review?

- review the commit,
- run locally and go to [localhost:6006/demo-smart/cc-pricing-page/](http://localhost:6006/demo-smart/cc-pricing-page/). => The "MongoDB" section should no longer display the `dev` plan.
- 2 reviewers should be enough for this one.
