### PR TITLE
ci: replace volta-cli/action by actions/setup-node

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -31,7 +31,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: '[Prepare] Setup Node.js'
-        uses: volta-cli/action@v4
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: 'package.json'
       - name: '[Prepare] Install dependencies'
         run: npm ci
       - name: '[Prepare] Check if a preview already exists'
@@ -83,7 +85,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: '[Prepare] Setup Node.js'
-        uses: volta-cli/action@v4
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: 'package.json'
       - name: '[Prepare] Install dependencies'
         run: npm ci
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,9 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.ref_name }}
       - name: '[Prepare] Setup Node.js'
-        uses: volta-cli/action@v4
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: 'package.json'
       - name: '[Prepare] Extract NPM tag'
         id: npm_tag
         run: p=${{ needs.pre-publish.outputs.prerelease }} && echo "tag=${p:-latest}" >> $GITHUB_OUTPUT
@@ -62,7 +64,9 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.ref_name }}
       - name: '[Prepare] Setup Node.js'
-        uses: volta-cli/action@v4
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: 'package.json'
       - name: '[Prepare] Install dependencies'
         run: npm ci
       - name: '[Build]'

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -17,7 +17,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: '[Prepare] Setup Node.js'
-        uses: volta-cli/action@v4
+        uses: actions/setup-node@v3
+        with:
+          node-version-file: 'package.json'
       - name: '[Prepare] Install dependencies'
         run: npm ci
 


### PR DESCRIPTION
Fixes #874

As per https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#node-version-file, we can easily move from `volta-cli/action` to `actions/setup-node`.