### PR TITLE
docs: update documentation links to reflect incoming new site

### DIFF
--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -744,7 +744,7 @@ export const translations = {
   'cc-ssh-key-list.add.name': `Name`,
   'cc-ssh-key-list.add.public-key': `Public key`,
   'cc-ssh-key-list.add.title': `Add a new key`,
-  'cc-ssh-key-list.doc.info': () => sanitize`If you need any help, head up to our <a href="https://www.clever-cloud.com/doc/admin-console/ssh-keys/">documentation</a>.`,
+  'cc-ssh-key-list.doc.info': () => sanitize`If you need any help, head up to our <a href="https://developers.clever-cloud.com/doc/account/ssh-keys-management/">documentation</a>.`,
   'cc-ssh-key-list.error.add': ({ name }) => `An error occurred while adding your new personal key "${name}".`,
   'cc-ssh-key-list.error.delete': ({ name }) => `An error occurred while deleting your personal key "${name}".`,
   'cc-ssh-key-list.error.import': ({ name }) => `An error occurred while importing your GitHub key "${name}".`,

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -757,7 +757,7 @@ export const translations = {
   'cc-ssh-key-list.add.name': `Nom`,
   'cc-ssh-key-list.add.public-key': `Clé publique`,
   'cc-ssh-key-list.add.title': `Ajouter une nouvelle clé`,
-  'cc-ssh-key-list.doc.info': () => sanitize`Pour plus d'aide, vous pouvez consulter notre <a href="https://www.clever-cloud.com/doc/admin-console/ssh-keys/">documentation (en anglais)</a>.`,
+  'cc-ssh-key-list.doc.info': () => sanitize`Pour plus d'aide, vous pouvez consulter notre <a href="https://developers.clever-cloud.com/doc/account/ssh-keys-management/">documentation (en anglais)</a>.`,
   'cc-ssh-key-list.error.add': ({ name }) => `Une erreur est survenue pendant l'ajout de votre nouvelle clé personnelle "${name}".`,
   'cc-ssh-key-list.error.delete': ({ name }) => `Une erreur est survenue pendant la suppression de votre clé personnelle "${name}".`,
   'cc-ssh-key-list.error.import': ({ name }) => `Une erreur est survenue pendant l'import de votre clé personnelle "${name}".`,


### PR DESCRIPTION
Fixes #880

Also update an old redirection and fix a typo (missing word).

- [x] Wait the new documentation site to go live.