### PR TITLE
Add label style customization for cc-input-text & similar components

### DIFF
--- a/src/components/cc-input-date/cc-input-date.js
+++ b/src/components/cc-input-date/cc-input-date.js
@@ -98,6 +98,9 @@ function invalid (code) {
  * @fires {CustomEvent} cc-input-date:requestimplicitsubmit - Fires when enter key is pressed.
  *
  * @cssprop {FontFamily} --cc-input-font-family - The font-family for the input content (defaults: `inherit`).
+ * @cssprop {Color} --cc-input-label-color - The color for the input's label (defaults: `inherit`).
+ * @cssprop {FontSize} --cc-input-label-font-size - The font-size for the input's label (defaults: `inherit`).
+ * @cssprop {FontWeight} --cc-input-label-font-weight - The font-weight for the input's label (defaults: `normal`).
  *
  * @slot error - The error message to be displayed below the `<input>` element or below the help text. Please use a `<p>` tag.
  * @slot help - The help message to be displayed right below the `<input>` element. Please use a `<p>` tag.
@@ -405,7 +408,7 @@ export class CcInputDate extends LitElement {
     return html`
       ${this.label != null ? html`
         <label class=${classMap({ 'visually-hidden': this.hiddenLabel })} for="input-id">
-          <span>${this.label}</span>
+          <span class="label-text">${this.label}</span>
           ${this.required ? html`
             <span class="required">${i18n('cc-input-date.required')}</span>
           ` : ''}
@@ -480,11 +483,13 @@ export class CcInputDate extends LitElement {
 
         :host([inline]) {
           display: inline-grid;
+          align-items: baseline;
           gap: 0 1em;
-          grid-template-areas: 
+          grid-auto-rows: min-content;
+          grid-template-areas:
             'label input'
-            '. help'
-            '. error';
+            'label help'
+            'label error';
           grid-template-columns: auto 1fr;
         }
 
@@ -506,9 +511,14 @@ export class CcInputDate extends LitElement {
           line-height: 1.25em;
         }
 
+        label .label-text {
+          color: var(--cc-input-label-color, inherit);
+          font-size: var(--cc-input-label-font-size, inherit);
+          font-weight: var(--cc-input-label-font-weight, normal);
+        }
+
         :host([inline]) label {
           flex-direction: column;
-          justify-content: center;
           padding: 0;
           gap: 0;
           grid-area: label;

--- a/src/components/cc-input-date/cc-input-date.stories.js
+++ b/src/components/cc-input-date/cc-input-date.stories.js
@@ -108,6 +108,7 @@ export const timezone = makeStory(conf, {
 
 const date = new Date();
 export const customWidth = makeStory(conf, {
+  // language=CSS
   css: `
     cc-input-date {
       display: block;
@@ -124,6 +125,61 @@ export const customWidth = makeStory(conf, {
         value: new Date(date.getTime() + i * 60_000),
       };
     }),
+});
+
+const customBaseItems = [
+  { label: 'The label' },
+  { label: 'The label', required: true },
+];
+
+export const customLabelStyle = makeStory({ ...conf, displayMode: 'block' }, {
+  // language=CSS
+  css: `
+    cc-input-date {
+      --cc-input-label-color: #475569;
+      --cc-input-label-font-size: 1.2em;
+      --cc-input-label-font-weight: bold;
+      font-size: 1.25em;
+      max-width: 32em;
+    }
+    cc-input-date:nth-of-type(${customBaseItems.length + 'n'}) {
+      margin-block-end: 2em;
+    }
+  `,
+  items: [
+    ...customBaseItems,
+    ...customBaseItems.map((item) => ({
+      ...item,
+      innerHTML: `<p slot="help">Must be a date</p>`,
+    })),
+    ...customBaseItems.map((item) => ({
+      ...item,
+      innerHTML: `<p slot="error">You must enter a value</p>`,
+    })),
+    ...customBaseItems.map((item) => ({
+      ...item,
+      innerHTML: `<p slot="help">Must be a date</p><p slot="error">You must enter a value</p>`,
+    })),
+    ...customBaseItems.map((item) => ({
+      ...item,
+      inline: true,
+    })),
+    ...customBaseItems.map((item) => ({
+      ...item,
+      inline: true,
+      innerHTML: `<p slot="help">Must be a date</p>`,
+    })),
+    ...customBaseItems.map((item) => ({
+      ...item,
+      inline: true,
+      innerHTML: `<p slot="error">You must enter a value</p>`,
+    })),
+    ...customBaseItems.map((item) => ({
+      ...item,
+      inline: true,
+      innerHTML: `<p slot="help">Must be a date</p><p slot="error">You must enter a value</p>`,
+    })),
+  ],
 });
 
 export const allFormControls = allFormControlsStory;

--- a/src/components/cc-input-number/cc-input-number.js
+++ b/src/components/cc-input-number/cc-input-number.js
@@ -27,6 +27,9 @@ import '../cc-icon/cc-icon.js';
  * @cssprop {Align} --cc-input-number-align - Change the alignment of the number present in the input (defaults: `right`).
  * @cssprop {Color} --cc-input-btn-icon-color - The color for the icon within the +/- buttons (defaults: `#595959`).
  * @cssprop {FontFamily} --cc-input-font-family - The font-family for the input content (defaults: `inherit`).
+ * @cssprop {Color} --cc-input-label-color - The color for the input's label (defaults: `inherit`).
+ * @cssprop {FontSize} --cc-input-label-font-size - The font-size for the input's label (defaults: `inherit`).
+ * @cssprop {FontWeight} --cc-input-label-font-weight - The font-weight for the input's label (defaults: `normal`).
  *
  * @slot error - The error message to be displayed below the `<input>` element or below the help text. Please use a `<p>` tag.
  * @slot help - The help message to be displayed right below the `<input>` element. Please use a `<p>` tag.
@@ -178,7 +181,7 @@ export class CcInputNumber extends LitElement {
 
       ${this.label != null ? html`
         <label class=${classMap({ 'visually-hidden': this.hiddenLabel })} for="input-id">
-          <span>${this.label}</span>
+          <span class="label-text">${this.label}</span>
           ${this.required ? html`
             <span class="required">${i18n('cc-input-number.required')}</span>
           ` : ''}
@@ -246,11 +249,13 @@ export class CcInputNumber extends LitElement {
 
         :host([inline]) {
           display: inline-grid;
+          align-items: baseline;
           gap: 0 1em;
-          grid-template-areas: 
+          grid-auto-rows: min-content;
+          grid-template-areas:
             'label input'
-            '. help'
-            '. error';
+            'label help'
+            'label error';
           grid-template-columns: auto 1fr;
         }
 
@@ -272,9 +277,14 @@ export class CcInputNumber extends LitElement {
           line-height: 1.25em;
         }
 
+        label .label-text {
+          color: var(--cc-input-label-color, inherit);
+          font-size: var(--cc-input-label-font-size, inherit);
+          font-weight: var(--cc-input-label-font-weight, normal);
+        }
+
         :host([inline]) label {
           flex-direction: column;
-          justify-content: center;
           padding: 0;
           gap: 0;
           grid-area: label;

--- a/src/components/cc-input-number/cc-input-number.stories.js
+++ b/src/components/cc-input-number/cc-input-number.stories.js
@@ -172,6 +172,63 @@ export const customWidth = makeStory(conf, {
     }),
 });
 
+const customBaseItems = [
+  { label: 'The label', value: 100 },
+  { label: 'The label', value: 100, required: true },
+  { label: 'The label', value: 100, controls: true },
+  { label: 'The label', value: 100, required: true, controls: true },
+];
+
+export const customLabelStyle = makeStory({ ...conf, displayMode: 'block' }, {
+  // language=CSS
+  css: `
+    cc-input-number {
+      --cc-input-label-color: #475569;
+      --cc-input-label-font-size: 1.2em;
+      --cc-input-label-font-weight: bold;
+      font-size: 1.25em;
+      max-width: 32em;
+    }
+    cc-input-number:nth-of-type(${customBaseItems.length + 'n'}) {
+      margin-block-end: 2em;
+    }
+  `,
+  items: [
+    ...customBaseItems,
+    ...customBaseItems.map((item) => ({
+      ...item,
+      innerHTML: `<p slot="help">Must be an integer</p>`,
+    })),
+    ...customBaseItems.map((item) => ({
+      ...item,
+      innerHTML: `<p slot="error">You must enter a value</p>`,
+    })),
+    ...customBaseItems.map((item) => ({
+      ...item,
+      innerHTML: `<p slot="help">Must be an integer</p><p slot="error">You must enter a value</p>`,
+    })),
+    ...customBaseItems.map((item) => ({
+      ...item,
+      inline: true,
+    })),
+    ...customBaseItems.map((item) => ({
+      ...item,
+      inline: true,
+      innerHTML: `<p slot="help">Must be an integer</p>`,
+    })),
+    ...customBaseItems.map((item) => ({
+      ...item,
+      inline: true,
+      innerHTML: `<p slot="error">You must enter a value</p>`,
+    })),
+    ...customBaseItems.map((item) => ({
+      ...item,
+      inline: true,
+      innerHTML: `<p slot="help">Must be an integer</p><p slot="error">You must enter a value</p>`,
+    })),
+  ],
+});
+
 export const allFormControls = allFormControlsStory;
 
 export const simulation = makeStory(conf, {

--- a/src/components/cc-input-text/cc-input-text.js
+++ b/src/components/cc-input-text/cc-input-text.js
@@ -35,6 +35,9 @@ const TAG_SEPARATOR = ' ';
  *
  * @cssprop {Color} --cc-input-btn-icon-color - The color for the icon within the clipboard/secret button (defaults: `#595959`).
  * @cssprop {FontFamily} --cc-input-font-family - The font-family for the input content (defaults: `inherit` or `--cc-ff-monospace` when using the tags mode).
+ * @cssprop {Color} --cc-input-label-color - The color for the input's label (defaults: `inherit`).
+ * @cssprop {FontSize} --cc-input-label-font-size - The font-size for the input's label (defaults: `inherit`).
+ * @cssprop {FontWeight} --cc-input-label-font-weight - The font-weight for the input's label (defaults: `normal`).
  *
  * @slot error - The error message to be displayed below the `<input>` element or below the help text. Please use a `<p>` tag.
  * @slot help - The help message to be displayed right below the `<input>` element. Please use a `<p>` tag.
@@ -228,7 +231,7 @@ export class CcInputText extends LitElement {
 
       ${this.label != null ? html`
         <label class=${classMap({ 'visually-hidden': this.hiddenLabel })} for="input-id">
-          <span>${this.label}</span>
+          <span class="label-text">${this.label}</span>
           ${this.required ? html`
             <span class="required">${i18n('cc-input-text.required')}</span>
           ` : ''}
@@ -351,11 +354,13 @@ export class CcInputText extends LitElement {
 
         :host([inline]) {
           display: inline-grid;
+          align-items: baseline;
           gap: 0 1em;
-          grid-template-areas: 
+          grid-auto-rows: min-content;
+          grid-template-areas:
             'label input'
-            '. help'
-            '. error';
+            'label help'
+            'label error';
           grid-template-columns: auto 1fr;
         }
 
@@ -381,18 +386,18 @@ export class CcInputText extends LitElement {
           line-height: 1.25em;
         }
 
+        label .label-text {
+          color: var(--cc-input-label-color, inherit);
+          font-size: var(--cc-input-label-font-size, inherit);
+          font-weight: var(--cc-input-label-font-weight, normal);
+        }
+
         :host([inline]) label {
           flex-direction: column;
-          justify-content: center;
           padding: 0;
           gap: 0;
           grid-area: label;
           line-height: normal;
-        }
-        
-        :host([inline][multi]) label {
-          /* Allows the label text to be aligned with the first line of the input. */
-          height: 2em;
         }
 
         .required {

--- a/src/components/cc-input-text/cc-input-text.stories.js
+++ b/src/components/cc-input-text/cc-input-text.stories.js
@@ -226,6 +226,68 @@ export const tagsWithClipboard = makeStory(conf, {
   items: tagsItems.map((p) => ({ ...p, clipboard: true })),
 });
 
+const customBaseItems = [
+  { label: 'The label', placeholder: 'No value yet...' },
+  { label: 'The label', placeholder: 'No value yet...', required: true },
+  { label: 'The label', placeholder: 'No value yet...', multi: true },
+  { label: 'The label', placeholder: 'No value yet...', multi: true, required: true },
+  { label: 'The label', placeholder: 'No value yet...', multi: true, value: 'Simple value\nOther lines...' },
+  { label: 'The label', placeholder: 'No value yet...', multi: true, required: true, value: 'Simple value\nOther lines...' },
+];
+
+export const customLabelStyle = makeStory(conf, {
+  // language=CSS
+  css: `
+    cc-input-text {
+      --cc-input-label-color: #475569;
+      --cc-input-label-font-size: 1.2em;
+      --cc-input-label-font-weight: bold;
+      font-size: 1.25em;
+    }
+    cc-input-text:nth-of-type(${customBaseItems.length + 'n'}) {
+      margin-block-end: 2em;
+    }
+    cc-input-text[multi] {
+      /* Necessary because the container is a display:flex */
+      width: 100%;
+    }
+  `,
+  items: [
+    ...customBaseItems,
+    ...customBaseItems.map((item) => ({
+      ...item,
+      innerHTML: `<p slot="help">Must be at least 7 characters long</p>`,
+    })),
+    ...customBaseItems.map((item) => ({
+      ...item,
+      innerHTML: `<p slot="error">You must enter a value</p>`,
+    })),
+    ...customBaseItems.map((item) => ({
+      ...item,
+      innerHTML: `<p slot="help">Must be at least 7 characters long</p><p slot="error">You must enter a value</p>`,
+    })),
+    ...customBaseItems.map((item) => ({
+      ...item,
+      inline: true,
+    })),
+    ...customBaseItems.map((item) => ({
+      ...item,
+      inline: true,
+      innerHTML: `<p slot="help">Must be at least 7 characters long</p>`,
+    })),
+    ...customBaseItems.map((item) => ({
+      ...item,
+      inline: true,
+      innerHTML: `<p slot="error">You must enter a value</p>`,
+    })),
+    ...customBaseItems.map((item) => ({
+      ...item,
+      inline: true,
+      innerHTML: `<p slot="help">Must be at least 7 characters long</p><p slot="error">You must enter a value</p>`,
+    })),
+  ],
+});
+
 export const allFormControls = allFormControlsStory;
 
 export const simulation = makeStory(conf, {

--- a/src/components/cc-select/cc-select.js
+++ b/src/components/cc-select/cc-select.js
@@ -20,6 +20,10 @@ import { i18n } from '../../lib/i18n.js';
  *
  * @fires {CustomEvent<string>} cc-select:input - Fires the `value` whenever the `value` changes.
  *
+ * @cssprop {Color} --cc-select-label-color - The color for the select's label (defaults: `inherit`).
+ * @cssprop {FontSize} --cc-select-label-font-size - The font-size for the select's label (defaults: `inherit`).
+ * @cssprop {FontWeight} --cc-select-label-font-weight - The font-weight for the select's label (defaults: `normal`).
+ *
  * @slot error - The error message to be displayed below the `<select>` element or below the help text. Please use a `<p>` tag.
  * @slot help - The help message to be displayed right below the `<select>` element. Please use a `<p>` tag.
  */
@@ -104,7 +108,7 @@ export class CcSelect extends LitElement {
   render () {
     return html`
       <label for="input-id">
-        <span>${this.label}</span>
+        <span class="label-text">${this.label}</span>
         ${this.required ? html`
           <span class="required">${i18n('cc-select.required')}</span>
         ` : ''}
@@ -152,11 +156,13 @@ export class CcSelect extends LitElement {
 
         :host([inline]) {
           display: inline-grid;
+          align-items: baseline;
           gap: 0 1em;
-          grid-template-areas: 
+          grid-auto-rows: min-content;
+          grid-template-areas:
             'label input'
-            '. help'
-            '. error';
+            'label help'
+            'label error';
           grid-template-columns: auto 1fr;
         }
 
@@ -178,9 +184,14 @@ export class CcSelect extends LitElement {
           line-height: 1.25em;
         }
 
+        label .label-text {
+          color: var(--cc-select-label-color, inherit);
+          font-size: var(--cc-select-label-font-size, inherit);
+          font-weight: var(--cc-select-label-font-weight, normal);
+        }
+
         :host([inline]) label {
           flex-direction: column;
-          justify-content: center;
           padding: 0;
           gap: 0;
           grid-area: label;
@@ -273,6 +284,7 @@ export class CcSelect extends LitElement {
           background-color: var(--cc-color-bg-primary, #000);
           clip-path: polygon(100% 0%, 0 0%, 50% 100%);
           content: '';
+          pointer-events: none;
           transform: translateY(-50%);
         }
 

--- a/src/components/cc-select/cc-select.stories.js
+++ b/src/components/cc-select/cc-select.stories.js
@@ -203,6 +203,63 @@ export const longContentWihFixedWidth = makeStory(
   },
 );
 
+const customBaseItems = [
+  { label: 'Favourite artist', value: 'LENNON', options: baseOptions },
+  { label: 'Favourite artist', value: 'LENNON', options: baseOptions, required: true },
+];
+
+export const customLabelStyle = makeStory({ ...conf, displayMode: 'block' }, {
+  // language=CSS
+  css: `
+    cc-select {
+      --cc-select-label-color: #475569;
+      --cc-select-label-font-size: 1.2em;
+      --cc-select-label-font-weight: bold;
+      font-size: 1.25em;
+      max-width: 32em;
+    }
+    cc-select:nth-of-type(${customBaseItems.length + 'n'}) {
+      margin-block-end: 2em;
+    }
+  `,
+  items: [
+    ...customBaseItems,
+    ...customBaseItems.map((item) => ({
+      ...item,
+      innerHTML: `<p slot="help">There can be only one.</p>`,
+    })),
+    ...customBaseItems.map((item) => ({
+      ...item,
+      innerHTML: `<p slot="error">A value must be selected.</p>`,
+    })),
+    ...customBaseItems.map((item) => ({
+      ...item,
+      innerHTML: `<p slot="help">There can be only one.</p><p slot="error">A value must be selected.</p>`,
+    })),
+    ...customBaseItems.map((item) => ({
+      ...item,
+      inline: true,
+    })),
+    ...customBaseItems.map((item) => ({
+      ...item,
+      inline: true,
+      innerHTML: `<p slot="help">There can be only one.</p>`,
+    })),
+    ...customBaseItems.map((item) => ({
+      ...item,
+      inline: true,
+      innerHTML: `<p slot="error">A value must be selected.</p>`,
+    })),
+    ...customBaseItems.map((item) => ({
+      ...item,
+      inline: true,
+      innerHTML: `<p slot="help">There can be only one.</p><p slot="error">A value must be selected.</p>`,
+    })),
+  ],
+});
+
+export const allFormControls = allFormControlsStory;
+
 export const simulation = makeStory(conf, {
   items: [{
     label: 'Favourite artist',
@@ -237,5 +294,3 @@ export const simulation = makeStory(conf, {
     }),
   ],
 });
-
-export const allFormControls = allFormControlsStory;

--- a/src/components/cc-toggle/cc-toggle.js
+++ b/src/components/cc-toggle/cc-toggle.js
@@ -38,6 +38,9 @@ import { dispatchCustomEvent } from '../../lib/events.js';
  * @cssprop {FontWeight} --cc-toggle-font-weight - Sets the value of the font weight CSS property (defaults: `bold`).
  * @cssprop {Filter} --cc-toggle-img-filter - A CSS filter to apply on images of all choices (defaults: `none`). It must be defined directly on the element.
  * @cssprop {Filter} --cc-toggle-img-filter-selected - A CSS filter to apply on images of selected choices (defaults: `none`). It must be defined directly on the element.
+ * @cssprop {Color} --cc-toggle-legend-color - The color for the group's legend (defaults: `inherit`).
+ * @cssprop {FontSize} --cc-toggle-legend-font-size - The font-size for the group's legend (defaults: `inherit`).
+ * @cssprop {FontWeight} --cc-toggle-legend-font-weight - The font-weight for the group's legend (defaults: `normal`).
  * @cssprop {TextTransform} --cc-toggle-text-transform - Sets the value of the text transform CSS property (defaults: `uppercase`).
  */
 export class CcToggle extends LitElement {
@@ -69,7 +72,7 @@ export class CcToggle extends LitElement {
     /** @type {boolean} Hides the text and only displays the image specified with `choices[i].image`. The text will be added as `title` on the inner `<label>` and an `aria-label` on the inner `<input>`. */
     this.hideText = false;
 
-    /** @type {boolean} Sets the `<label>` on the left of the `<select>` element.
+    /** @type {boolean} Sets the legend on the left of the `<select>` element.
      * Only use this if your form contains 1 or 2 fields and your labels are short.
      */
     this.inline = false;
@@ -190,6 +193,9 @@ export class CcToggle extends LitElement {
         }
         
         #legend {
+          color: var(--cc-toggle-legend-color, inherit);
+          font-size: var(--cc-toggle-legend-font-size, inherit);
+          font-weight: var(--cc-toggle-legend-font-weight, normal);
           line-height: 1.25em;
         }
 

--- a/src/components/cc-toggle/cc-toggle.stories.js
+++ b/src/components/cc-toggle/cc-toggle.stories.js
@@ -243,4 +243,23 @@ Here you can see a series of toolbar examples using CSS custom propreties of the
   ],
 });
 
+export const customLegendStyle = makeStory({ ...conf, displayMode: 'block' }, {
+  // language=CSS
+  css: `
+    cc-toggle {
+      --cc-toggle-legend-color: #475569;
+      --cc-toggle-legend-font-size: 1.2em;
+      --cc-toggle-legend-font-weight: bold;
+      font-size: 1.25em;
+    }
+    cc-toggle:nth-of-type(${normalAndSubtleItems.length + 'n'}) {
+      margin-block-end: 2em;
+    }
+  `,
+  items: [
+    ...normalAndSubtleItems.map((p) => ({ ...p, legend: 'The legend' })),
+    ...normalAndSubtleItems.map((p) => ({ ...p, legend: 'The legend', inline: true })),
+  ],
+});
+
 export const allFormControls = allFormControlsStory;

--- a/src/stories/all-form-controls.js
+++ b/src/stories/all-form-controls.js
@@ -1,4 +1,5 @@
 import '../components/cc-button/cc-button.js';
+import '../components/cc-input-date/cc-input-date.js';
 import '../components/cc-input-number/cc-input-number.js';
 import '../components/cc-input-text/cc-input-text.js';
 import '../components/cc-select/cc-select.js';


### PR DESCRIPTION
Fixes #888.

# What to review

Is the feature properly working & rendered on screen.
Does the feature introduces visual regression (excluding "Visual breaking changes").

# How to review

Updated components:
- `cc-input-text`
- `cc-input-number`
- `cc-input-date`
- `cc-select`
- `cc-toggle`

UI review:
- for the introduced feature, a dedicated story "Custom label style" has been added, displaying relevant cases ;
- for regression check, compare stories between the preview & the current release.

Code review: there is one commit per component so it's quite straightforward.

<details>
<summary>(previous topic on "visual breaking changes")</summary>
# Visual breaking changes

Actually, this feature needed a change in the component global layout, impacting many cases but especially when label is displayed inline.

Thus introducing potential "visual breaking changes" (to be discussed).

## The root cause

In inline mode, when the label part (including the "required" text) is big enough, it introduces a gap between the input and the content below (either the help or the error text).

![image](https://github.com/CleverCloud/clever-components/assets/102976382/7ec41346-b566-47fc-9046-be9dd6bf2cd8)

## The fix

The solution was to change the grid `grid-template-areas` property from...

```css
  grid-template-areas: 
    'label input'
    '. help'
    '. error';
```
...to
```css
  grid-template-areas: 
    'label input'
    'label help'
    'label error';
```

## The impacts

But to ensure a relatively homogeneous layout in all cases, the `grid` layout in inline mode is now based on the following rule:

```css
:host([inline]) {
  align-items: baseline;
}
```

Causing a slight difference in the "Inline" and "Inline (error and help messages)" stories:

[inline.webm](https://github.com/CleverCloud/clever-components/assets/102976382/f2b0c452-3db3-463f-8f65-04b467e26b2e)

[inline-with-error-and-help-messages.webm](https://github.com/CleverCloud/clever-components/assets/102976382/1584411e-d071-4358-ad12-9d337e78a36d)

But causing a significant difference in the "Inline (required)" story, the overall component taking ultimately more height:

[inline-with-required.webm](https://github.com/CleverCloud/clever-components/assets/102976382/b6857761-8b3f-418f-84df-072e1065cfca)

> [!IMPORTANT]  
> WDYT?

# What's left to do

Maybe consider adding a custom property for the label color.

If the feature is validated, the same feature should also be implemented in the following components:

- [x] cc-input-date
- [x] cc-input-number
- [x] cc-select
- [x] cc-toggle

Also test on each browser.
</details>