### PR TITLE
fix(cc-toggle): fix extra margin on top of cc-toggle

### DIFF
--- a/src/components/cc-toggle/cc-toggle.js
+++ b/src/components/cc-toggle/cc-toggle.js
@@ -15,7 +15,7 @@ import { dispatchCustomEvent } from '../../lib/events.js';
  *
  * * This component does not replace regular usage of radio/checkbox inputs in forms.
  * * It works well in toolbars or filter panels.
- * * The single mode mode (default) works well to toggle a component between two (or more) modes.
+ * * The single mode (default) works well to toggle a component between two (or more) modes.
  *
  * ## Details
  *
@@ -129,9 +129,11 @@ export class CcToggle extends LitElement {
         : this.value === value;
     };
 
+    const hasLegend = this.legend != null && this.legend.length > 0;
+
     return html`
-      <fieldset>
-        <legend>${this.legend}</legend>
+      <div role="group" aria-labelledby=${ifDefined(hasLegend ? 'legend' : undefined)} class="group">
+        ${hasLegend ? html`<div id="legend">${this.legend}</div>` : ''}
         <div class="toggle-group ${classMap(classes)}">
           ${repeat(this.choices, ({ value }) => value, ({ label, image, value }) => html`
             <!--
@@ -156,7 +158,7 @@ export class CcToggle extends LitElement {
             </label>
           `)}
         </div>
-      </fieldset>
+      </div>
     `;
   }
 
@@ -174,40 +176,21 @@ export class CcToggle extends LitElement {
 
           display: inline-flex;
         }
-
-        /* RESET */
-
-        fieldset {
-          display: inline-block;
-          min-width: 0;
-          padding: 0;
-          border: 0;
-          margin: 0;
+        
+        .group {
+          display: flex;
+          flex-direction: column;
+          gap: 0.35em;
         }
 
-        /* RESET */
-
-        legend {
-          max-width: 100%;
-          padding: 0;
-          color: inherit;
-          line-height: inherit;
-          white-space: normal;
+        :host([inline]) .group {
+          flex-direction: row;
+          align-items: center;
+          gap: 1em;
         }
-
-        legend:not(:empty) {
-          padding-bottom: 0.35em;
+        
+        #legend {
           line-height: 1.25em;
-        }
-
-        :host([inline]) legend {
-          width: max-content;
-          padding: 0;
-          margin-right: 1em;
-          /* cannot use flex to change legend position. Only solution is float. */
-          float: left;
-          /* used to vertically center the floated element. */
-          line-height: var(--height);
         }
 
         .toggle-group {


### PR DESCRIPTION
Fixes #896 

## What does this PR do?

Fixes the extra margin above the component when using `inline` and when inside a grid area.

## How to review?

You cannot see the problem until you use the component in the exactly explained situation.
See the issue details to have an example of code that reproduces the bug.

To help you, here is a story you can add to the code to see the problem, and to check if it has been fixed:
```javascript
export const grid = makeStory(conf, {
  // language=CSS
  css: `
    .grid {
      display: grid;
      grid-template-areas:
            'area1 area3'
            'area2 area3';
      grid-template-columns: 250px 1fr;
      grid-template-rows: max-content 1fr;
      gap: 1em;
    }

    .area1 {
      grid-area: area1;
      background-color: indianred;
    }
    .area2 {
      grid-area: area2;
      background-color: steelblue;
    }
    .area3 {
      grid-area: area3;
      background-color: darkseagreen;
    }
  `,
  dom: (container) => {
    container.innerHTML = `
        <div class="grid">
          <div class="area1"><cc-toggle inline legend="legend" choices='[{ "label": "on", "value": "on" },{ "label": "off", "value": "off" }]'></cc-toggle></div>
          <div class="area2"><cc-toggle legend="legend" choices='[{ "label": "on", "value": "on" },{ "label": "off", "value": "off" }]'></cc-toggle></div>
          <div class="area3"><cc-toggle inline choices='[{ "label": "on", "value": "on" },{ "label": "off", "value": "off" }]'></cc-toggle></div>
        </div>
    `;
  },
});
```

Also, check for regression on the following components:
```
─ cc-addon-option
│  ├─ cc-toggle
├─ cc-env-var-form
│  ├─ cc-toggle
├─ cc-invoice-list
│  ├─ cc-toggle
├─ cc-logsmap
│  ├─ cc-toggle
├─ cc-pricing-product-consumption
│  ├─ cc-toggle
```

Finally, check for legend alignment in the `All form controls` story.

2 reviewers should be enough.