### PR TITLE
chore: handle beta components when firing custom events 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@commitlint/cli": "^17.1.2",
         "@commitlint/config-conventional": "^17.1.0",
         "@custom-elements-manifest/analyzer": "^0.6.4",
+        "@esm-bundle/chai-as-promised": "^7.1.1",
         "@open-wc/dev-server-hmr": "^0.1.3",
         "@open-wc/testing": "^3.1.6",
         "@rollup/plugin-alias": "^3.1.2",
@@ -49,6 +50,7 @@
         "babel-plugin-inline-svg": "^1.2.0",
         "babel-plugin-template-html-minifier": "^4.1.0",
         "chai": "^4.3.6",
+        "chai-as-promised": "^7.1.1",
         "chalk": "^2.4.2",
         "clean-css": "^4.2.1",
         "dependency-graph": "^0.11.0",
@@ -3965,6 +3967,12 @@
         "@types/chai": "^4.2.12"
       }
     },
+    "node_modules/@esm-bundle/chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@esm-bundle/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-qhDeW3gK3ITAzzhZj8QfvuhX7iNqyzooVZJnoW5bjIotxxJM92O9EKxdxBg4B35hjh3tV1chlEgC/pfR9cVRlA==",
+      "dev": true
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.5.tgz",
@@ -7488,6 +7496,18 @@
       "dev": true,
       "dependencies": {
         "axe-core": "^4.3.3"
+      }
+    },
+    "node_modules/chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "dev": true,
+      "dependencies": {
+        "check-error": "^1.0.2"
+      },
+      "peerDependencies": {
+        "chai": ">= 2.1.2 < 5"
       }
     },
     "node_modules/chainsaw": {
@@ -21949,6 +21969,12 @@
         "@types/chai": "^4.2.12"
       }
     },
+    "@esm-bundle/chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@esm-bundle/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-qhDeW3gK3ITAzzhZj8QfvuhX7iNqyzooVZJnoW5bjIotxxJM92O9EKxdxBg4B35hjh3tV1chlEgC/pfR9cVRlA==",
+      "dev": true
+    },
     "@floating-ui/core": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.2.5.tgz",
@@ -24852,6 +24878,15 @@
       "dev": true,
       "requires": {
         "axe-core": "^4.3.3"
+      }
+    },
+    "chai-as-promised": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+      "dev": true,
+      "requires": {
+        "check-error": "^1.0.2"
       }
     },
     "chainsaw": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@commitlint/cli": "^17.1.2",
     "@commitlint/config-conventional": "^17.1.0",
     "@custom-elements-manifest/analyzer": "^0.6.4",
+    "@esm-bundle/chai-as-promised": "^7.1.1",
     "@open-wc/dev-server-hmr": "^0.1.3",
     "@open-wc/testing": "^3.1.6",
     "@rollup/plugin-alias": "^3.1.2",

--- a/src/lib/events.js
+++ b/src/lib/events.js
@@ -1,21 +1,41 @@
 /**
  * Send a custom event in the format node => tagName:eventSuffix
  * @param {Window|Node} node
- * @param {String} eventNameOrSuffix - In case of an eventName it will dispatch the event associated to the node or dispatch the event directly if there's a suffix in the eventName
+ * @param {string} eventNameOrSuffix - In case of an eventName it will dispatch the event associated to the node or dispatch the event directly if there's a suffix in the eventName
  * @param {any} [detail]
  * @return {CustomEvent} the event that has been dispatched.
  */
 export function dispatchCustomEvent (node, eventNameOrSuffix, detail) {
-  const eventName = eventNameOrSuffix.includes(':')
-    ? eventNameOrSuffix
-    : `${node.nodeName?.toLocaleLowerCase()}:${eventNameOrSuffix}`;
+  const eventName = getEventName(node, eventNameOrSuffix);
   const event = new CustomEvent(eventName, { detail, bubbles: true, composed: true });
   node.dispatchEvent(event);
   return event;
 }
 
+const betaComponentNodeNameRegex = /^(cc-.+?)-beta$/;
+
 /**
- * This a utility handler that will help adding and removing an event listener from a DOM Element.
+ *
+ * @param {Window|Node} node
+ * @param {string} eventNameOrSuffix
+ * @return {string}
+ */
+function getEventName (node, eventNameOrSuffix) {
+  if (eventNameOrSuffix.includes(':')) {
+    return eventNameOrSuffix;
+  }
+
+  const nodeName = node.nodeName?.toLocaleLowerCase();
+  const match = nodeName.match(betaComponentNodeNameRegex);
+  const isBetaComponent = match != null;
+
+  const prefix = isBetaComponent ? match[1] : nodeName;
+
+  return `${prefix}:${eventNameOrSuffix}`;
+}
+
+/**
+ * This is a utility handler that will help adding and removing an event listener from a DOM Element.
  */
 export class EventHandler {
   /**

--- a/test/event.test.js
+++ b/test/event.test.js
@@ -1,0 +1,52 @@
+import { chai, expect } from '@bundled-es-modules/chai';
+import chaiAsPromised from '@esm-bundle/chai-as-promised';
+import { dispatchCustomEvent } from '../src/lib/events.js';
+
+chai.use(chaiAsPromised);
+
+/**
+ * @param nodeName
+ * @param eventNameToDispatch
+ * @param eventNameToListen
+ * @param detail
+ * @return {Promise<CustomEvent>}
+ */
+function fireEvent (nodeName, eventNameToDispatch, eventNameToListen, detail) {
+  return new Promise((resolve, reject) => {
+    const htmlElement = document.createElement(nodeName);
+    document.body.appendChild(htmlElement);
+    htmlElement.addEventListener(eventNameToListen, resolve);
+    dispatchCustomEvent(htmlElement, eventNameToDispatch, detail);
+    reject(new Error('event not received'));
+  });
+}
+
+describe('dispatchCustomEvent', () => {
+  it('should dispatch custom event', async () => {
+    await fireEvent('cc-component', 'myEvent', 'cc-component:myEvent', 'detail');
+  });
+
+  it('should not receive event when listening on wrong event', async () => {
+    expect(fireEvent('cc-component', 'myEvent', 'wrongEvent', 'detail'))
+      .to.eventually.be.rejectedWith('event not received');
+  });
+
+  it('should dispatch custom event on the right element', async () => {
+    const event = await fireEvent('cc-component', 'myEvent', 'cc-component:myEvent', 'detail');
+    expect(event.target?.nodeName?.toLowerCase()).to.equal('cc-component');
+  });
+
+  it('should dispatch custom event with the right type', async () => {
+    const event = await fireEvent('cc-component', 'myEvent', 'cc-component:myEvent', 'detail');
+    expect(event.type).to.equal('cc-component:myEvent');
+  });
+
+  it('should dispatch custom event with the given detail', async () => {
+    const event = await fireEvent('cc-component', 'myEvent', 'cc-component:myEvent', 'detail');
+    expect(event.detail).to.equal('detail');
+  });
+
+  it('should dispatch custom event with full event name', async () => {
+    await fireEvent('cc-component', 'full:name', 'full:name', 'detail');
+  });
+});

--- a/test/event.test.js
+++ b/test/event.test.js
@@ -49,4 +49,8 @@ describe('dispatchCustomEvent', () => {
   it('should dispatch custom event with full event name', async () => {
     await fireEvent('cc-component', 'full:name', 'full:name', 'detail');
   });
+
+  it('should dispatch custom event with beta component', async () => {
+    await fireEvent('cc-component-beta', 'myEvent', 'cc-component:myEvent', 'detail');
+  });
 });


### PR DESCRIPTION
Fixes #902 

### What does this PR do?

When dispatching custom events, we check if the element is a beta component (`^cc-.+-beta$`).
If it the case, the name of the event will be prefixed by the component name **without** the `-beta` suffix.

There are 2 commits:

* The first one adds unit tests on `dispatchCustomEvent` function.
* The second one implements the feature itself.

### How to review?

* check the code
* With Storybook, with Action addon, check that [this <cc-logs-beta> story](https://clever-components-preview.cellar-c2.services.clever-cloud.com/event-beta/index.html?path=/story/%F0%9F%9A%A7-beta-%F0%9F%9B%A0-logs-cc-logs-beta--data-loaded-with-many-metadata-with-wrap-lines) emits the right events when
  * scrolling to the bottom: `onCcLogsFollowChange: "false"`
  * scrolling up: `onCcLogsFollowChange: "true"`

2 reviewers should be enough.