### PR TITLE
fix(i18n-sanitize): handle cases where origin equals empty string

### DIFF
--- a/src/lib/i18n-sanitize.js
+++ b/src/lib/i18n-sanitize.js
@@ -77,7 +77,9 @@ export function sanitize (statics, ...params) {
         // If link has href and external origin => force rel and target
         if (node.tagName === 'A' && node.getAttribute('href') != null) {
           node.classList.add('sanitized-link');
-          if (node.origin !== window.location.origin) {
+          // Chrome > 120 returns an empty string for an anchor element with an absolute url like `href=/foo` when it's in a template DOM element
+          // In such case, we need to test if it's an empty string to make sure absolute or relative urls are not considered external
+          if (node.origin?.length > 0 && node.origin !== window.location.origin) {
             node.setAttribute('rel', 'noopener noreferrer');
             node.setAttribute('target', '_blank');
           }


### PR DESCRIPTION
This fixes an issue with Chrome >= 120

Please read the issue for more info about the bug. This will make the solution easier to understand.

Fixes #906

## How to review?

- review the commit,
- run the tests locally with chrome >= 120 on this branch vs on the main branch.


Thanks @Galimede for your help when trying to reproduce this issue and for trying to find the reason in the chrome changelog :wink: 