### PR TITLE
chore(package-lock): update lock file following dependency addition

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,6 @@
         "babel-plugin-inline-svg": "^1.2.0",
         "babel-plugin-template-html-minifier": "^4.1.0",
         "chai": "^4.3.6",
-        "chai-as-promised": "^7.1.1",
         "chalk": "^2.4.2",
         "clean-css": "^4.2.1",
         "dependency-graph": "^0.11.0",
@@ -7496,18 +7495,6 @@
       "dev": true,
       "dependencies": {
         "axe-core": "^4.3.3"
-      }
-    },
-    "node_modules/chai-as-promised": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
-      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
-      "dev": true,
-      "dependencies": {
-        "check-error": "^1.0.2"
-      },
-      "peerDependencies": {
-        "chai": ">= 2.1.2 < 5"
       }
     },
     "node_modules/chainsaw": {
@@ -24878,15 +24865,6 @@
       "dev": true,
       "requires": {
         "axe-core": "^4.3.3"
-      }
-    },
-    "chai-as-promised": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
-      "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
-      "dev": true,
-      "requires": {
-        "check-error": "^1.0.2"
       }
     },
     "chainsaw": {


### PR DESCRIPTION
Small bump to the package lock that we had forgotten following the addition of the `chai-as-promised` dependency.