### PR TITLE
refactor(cc-addon-linked-apps): migrate to the new smart component design

### DIFF
--- a/demo-smart/index.html
+++ b/demo-smart/index.html
@@ -53,9 +53,9 @@
 <body>
 
 <ul class="definition-list">
-  <!--  <li>-->
-  <!--    <a class="definition-link" href="?definition=cc-addon-linked-apps.smart">cc-addon-linked-apps.smart</a>-->
-  <!--  </li>-->
+    <li>
+      <a class="definition-link" href="?definition=cc-addon-linked-apps.smart">cc-addon-linked-apps.smart</a>
+    </li>
   <!--  <li>-->
   <!--    <a class="definition-link" href="?definition=cc-article-list.smart">cc-article-list.smart</a>-->
   <!--  </li>-->
@@ -124,6 +124,7 @@
   <button data-context='{"ownerId":"orga_3547a882-d464-4c34-8168-add4b3e0c135","currentUserId":"user_d3d02829-8847-40ea-ab76-ada4e2f026c0"}'>ACME BAR</button>
   <button data-context='{"ownerId":"orga_540caeb6-521c-4a19-a955-efe6da35d142","currentUserId":"user_d3d02829-8847-40ea-ab76-ada4e2f026c0"}'>ACME FOO</button>
   <button data-context='{"ownerId":"orga_3547a882-d464-4c34-8168-add4b3e0c135","addonId":"addon_53167b5a-3290-430d-912a-a084b6e905e7"}'>addon-elastic</button>
+  <button data-context='{"ownerId":"orga_3547a882-d464-4c34-8168-add4b3e0c135","addonId":"addon_1eef66a7-6840-4050-a484-2f7dc14dfded"}'>addon-config</button>
   <button data-context='{"ownerId":"orga_3547a882-d464-4c34-8168-add4b3e0c135","addonId":"addon_795d2901-f7be-4c5e-8401-73f180a6d5d2"}'>addon-pg</button>
   <button data-context='{"ownerId":"orga_3547a882-d464-4c34-8168-add4b3e0c135","addonId":"addon_7bfe6a42-4cb8-488e-96db-77c8da4627d2"}'>addon-jenkins</button>
   <button data-context='{"ownerId":"orga_2eb942c9-ae24-40fe-9e4c-53c9982a02b1","appId":"app_ea67204f-6a09-433d-a1a9-c0a46592545c", "consoleGrafanaLink":"https://console.clever-cloud.com", "grafanaBaseLink":"https://grafana.services.clever-cloud.com/"}'>cpu-load-bench</button>

--- a/src/components/cc-addon-linked-apps/cc-addon-linked-apps.js
+++ b/src/components/cc-addon-linked-apps/cc-addon-linked-apps.js
@@ -8,23 +8,19 @@ import { i18n } from '../../lib/i18n.js';
 import { skeletonStyles } from '../../styles/skeleton.js';
 import { ccLink, linkStyles } from '../../templates/cc-link/cc-link.js';
 
-/** @type {Application[]} */
+/** @type {LinkedApplication[]} */
 const SKELETON_APPLICATIONS = [
-  { name: '??????????????????', link: '', instance: { variant: {} } },
-  { name: '???????????????????????', link: '', instance: { variant: {} } },
-  { name: '????????????????????', link: '', instance: { variant: {} } },
+  { name: '??????????????????', link: '' },
+  { name: '???????????????????????', link: '' },
+  { name: '????????????????????', link: '' },
 ];
 
 /**
- * @typedef {import('../common.types.js').Application} Application
+ * @typedef {import('./cc-addon-linked-apps.types.js').AddonLinkedAppsState} AddonLinkedAppsState
  */
 
 /**
  * A component to display applications linked to an add-on.
- *
- * ## Details
- *
- * * When applications is nullish, a skeleton screen UI pattern is displayed (loading hint).
  *
  * @cssdisplay block
  */
@@ -32,58 +28,69 @@ export class CcAddonLinkedApps extends LitElement {
 
   static get properties () {
     return {
-      applications: { type: Array },
-      error: { type: Boolean },
+      state: { type: Object },
     };
   }
 
   constructor () {
     super();
 
-    /** @type {Application[]|null} Sets the linked applications. */
-    this.applications = null;
+    /** @type {AddonLinkedAppsState} Sets the linked applications state. */
+    this.state = { type: 'loading' };
+  }
 
-    /** @type {boolean} Displays an error message. */
-    this.error = false;
+  _getErrorContent () {
+    return html`
+      <cc-notice intent="warning" message="${i18n('cc-addon-linked-apps.loading-error')}"></cc-notice>
+    `;
+  }
+
+  _getEmptyContent () {
+    return html`
+      <div>${i18n('cc-addon-linked-apps.details')}</div>
+      <div class="cc-block_empty-msg">${i18n('cc-addon-linked-apps.no-linked-applications')}</div>
+    `;
   }
 
   render () {
+    if (this.state.type === 'error') {
+      return this._renderView(this._getErrorContent());
+    }
 
-    const skeleton = (this.applications == null);
-    const applications = skeleton ? SKELETON_APPLICATIONS : this.applications;
-    const hasData = (!this.error && (applications.length > 0));
-    const emptyData = (!this.error && (applications.length === 0));
+    const skeleton = (this.state.type === 'loading');
+    const linkedApps = skeleton ? SKELETON_APPLICATIONS : this.state.linkedApplications;
+    const hasData = (linkedApps.length > 0);
 
+    if (!hasData) {
+      return this._renderView(this._getEmptyContent());
+    }
+
+    const content = html`
+      <div>${i18n('cc-addon-linked-apps.details')}</div>
+
+      ${linkedApps.map((linkedApp) => html`
+        <div class="application">
+          <cc-img class="logo"
+            ?skeleton=${skeleton}
+            src=${ifDefined(linkedApp.variantLogoUrl)}
+            title="${ifDefined(linkedApp.variantName)}"
+          ></cc-img>
+          <div class="details">
+            <span class="name">${ccLink(linkedApp.link, linkedApp.name, skeleton)}</span>
+            <cc-zone mode="small" .zone="${linkedApp.zone}"></cc-zone>
+          </div>
+        </div>
+      `)}
+    `;
+
+    return this._renderView(content);
+  }
+
+  _renderView (content) {
     return html`
       <cc-block>
         <div slot="title">${i18n('cc-addon-linked-apps.title')}</div>
-
-        ${hasData ? html`
-          <div>${i18n('cc-addon-linked-apps.details')}</div>
-
-          ${applications.map((application) => html`
-            <div class="application">
-              <cc-img class="logo"
-                ?skeleton=${skeleton}
-                src=${ifDefined(application.instance.variant.logo)}
-                title="${ifDefined(application.instance.variant.name)}"
-              ></cc-img>
-              <div class="details">
-                <span class="name">${ccLink(application.link, application.name, skeleton)}</span>
-                <cc-zone mode="small" .zone="${application.zone}"></cc-zone>
-              </div>
-            </div>
-          `)}
-        ` : ''}
-
-        ${emptyData ? html`
-          <div>${i18n('cc-addon-linked-apps.details')}</div>
-          <div class="cc-block_empty-msg">${i18n('cc-addon-linked-apps.no-linked-applications')}</div>
-        ` : ''}
-
-        ${this.error ? html`
-          <cc-notice intent="warning" message="${i18n('cc-addon-linked-apps.loading-error')}"></cc-notice>
-        ` : ''}
+        ${content}
       </cc-block>
     `;
   }

--- a/src/components/cc-addon-linked-apps/cc-addon-linked-apps.stories.js
+++ b/src/components/cc-addon-linked-apps/cc-addon-linked-apps.stories.js
@@ -22,45 +22,33 @@ const ZONE_MTL = {
   tags: ['infra:ovh'],
 };
 
-const applications = [
+const linkedApplications = [
   {
     name: 'My Node JS Prod Application',
     link: '/organisations/uuid_foo/applications/uuid_bar',
-    instance: {
-      variant: {
-        name: 'Node', logo: 'https://assets.clever-cloud.com/logos/nodejs.svg',
-      },
-    },
+    variantName: 'Node',
+    variantLogoUrl: 'https://assets.clever-cloud.com/logos/nodejs.svg',
     zone: ZONE_PAR,
   },
   {
     name: 'My Awesome Java app for my API',
     link: '/organisations/uuid_foo/applications/uuid_bar',
-    instance: {
-      variant: {
-        name: 'Java + Maven', logo: 'https://assets.clever-cloud.com/logos/maven.svg',
-      },
-    },
+    variantName: 'Java + Maven',
+    variantLogoUrl: 'https://assets.clever-cloud.com/logos/maven.svg',
     zone: ZONE_PAR,
   },
   {
     name: 'My Dev PHP frontend',
     link: '/organisations/uuid_foo/applications/uuid_bar',
-    instance: {
-      variant: {
-        name: 'PHP', logo: 'https://assets.clever-cloud.com/logos/php.svg',
-      },
-    },
+    variantName: 'PHP',
+    variantLogoUrl: 'https://assets.clever-cloud.com/logos/php.svg',
     zone: ZONE_MTL,
   },
   {
     name: 'My Awesome Scala API',
     link: '/organisations/uuid_foo/applications/uuid_bar',
-    instance: {
-      variant: {
-        name: 'Scala + SBT', logo: 'https://assets.clever-cloud.com/logos/scala.svg',
-      },
-    },
+    variantName: 'Scala + SBT',
+    variantLogoUrl: 'https://assets.clever-cloud.com/logos/scala.svg',
     zone: ZONE_MTL,
   },
 ];
@@ -75,43 +63,48 @@ const conf = {
 };
 
 export const defaultStory = makeStory(conf, {
-  items: [{ applications }],
+  items: [{ state: { type: 'loaded', linkedApplications } }],
 });
 
 export const skeleton = makeStory(conf, {
-  items: [{}],
+  items: [{ state: { type: 'loading' } }],
 });
 
 export const error = makeStory(conf, {
-  items: [{ error: true }],
+  items: [{ state: { type: 'error' } }],
 });
 
 export const empty = makeStory(conf, {
-  items: [{ applications: [] }],
+  items: [{ state: { type: 'loaded', linkedApplications: [] } }],
 });
 
 export const dataLoaded = makeStory(conf, {
-  items: [{ applications }],
+  items: [{ state: { type: 'loaded', linkedApplications } }],
 });
 
 export const dataLoadedWithLongName = makeStory(conf, {
-  items: [{
-    applications: applications.map((app) => {
-      return {
-        ...app,
-        name: app.name + ' very very very very very long',
-      };
-    }),
-  }],
+  items: [
+    {
+      state: {
+        type: 'loaded',
+        linkedApplications: linkedApplications.map((app) => {
+          return {
+            ...app,
+            name: app.name + ' very very very very very long',
+          };
+        }),
+      },
+    },
+  ],
 });
 
 export const simulations = makeStory(conf, {
-  items: [{}, {}, {}],
+  items: [{ state: { type: 'loading' } }, { state: { type: 'loading' } }, { state: { type: 'loading' } }],
   simulations: [
     storyWait(2000, ([component, componentNone, componentError]) => {
-      component.applications = applications;
-      componentNone.applications = [];
-      componentError.error = true;
+      component.state = { type: 'loaded', linkedApplications };
+      componentNone.state = { type: 'loaded', linkedApplications: [] };
+      componentError.state = { type: 'error' };
     }),
   ],
 });

--- a/src/components/cc-addon-linked-apps/cc-addon-linked-apps.types.d.ts
+++ b/src/components/cc-addon-linked-apps/cc-addon-linked-apps.types.d.ts
@@ -1,0 +1,24 @@
+import { Zone } from "../common.types";
+
+export type AddonLinkedAppsState = AddonLinkedAppsStateLoading | AddonLinkedAppsStateLoaded | AddonLinkedAppsStateError;
+
+interface AddonLinkedAppsStateLoading {
+  type: 'loading';
+}
+
+interface AddonLinkedAppsStateLoaded {
+  type: 'loaded';
+  linkedApplications: Array<LinkedApplication>;
+}
+
+interface AddonLinkedAppsStateError {
+  type: 'error';
+}
+
+export interface LinkedApplication {
+  name: string;
+  link: string;
+  variantName?: string;
+  variantLogoUrl?: string;
+  zone?: Zone;
+}

--- a/src/components/common.types.d.ts
+++ b/src/components/common.types.d.ts
@@ -163,13 +163,6 @@ interface Zone {
 
 type ToggleStateType = 'off' | 'open' | 'close';
 
-interface Application {
-  name: string;
-  link: string;
-  instance: Instance;
-  zone: Zone;
-}
-
 interface Instance {
   flavourName: string;
   count: number;


### PR DESCRIPTION
Fixes #918 (which is part of #708)
Also fixes a part of #917.

## What is this?

* rework the properties to use our new way of implementing component states (this is a breaking change)
* migration of the smart component with the new design (no RxJs)
* remove incoming confusion with Instance type (see #917).

## How to review?

* code
* check for regressions
