### PR TITLE
fix(cc-badge): use `iconA11yName` in `iconAccessibleName` getter/setter

### DIFF
--- a/src/components/cc-badge/cc-badge.js
+++ b/src/components/cc-badge/cc-badge.js
@@ -53,7 +53,7 @@ export class CcBadge extends LitElement {
   }
 
   get iconAccessibleName () {
-    return this.a11yName;
+    return this.iconA11yName;
   }
 
   /**
@@ -61,7 +61,7 @@ export class CcBadge extends LitElement {
    * @deprecated
    */
   set iconAccessibleName (value) {
-    this.a11yName = value;
+    this.iconA11yName = value;
   }
 
   render () {


### PR DESCRIPTION
Fixes #934

## How to review?

- Reviewing the commit should be enough,
- 1 reviewer should be enough.