### PR TITLE
build(cdn): remove generated icon files from rollup config

### DIFF
--- a/rollup/rollup-common.js
+++ b/rollup/rollup-common.js
@@ -77,7 +77,6 @@ export function minifyStylesheet (stylesheet) {
 export function getMainFiles () {
 
   const mainFilesPatterns = [
-    `${SOURCE_DIR}/assets/*.icons.js`,
     `${SOURCE_DIR}/components/**/*.js`,
     `${SOURCE_DIR}/lib/i18n.js`,
     `${SOURCE_DIR}/lib/smart-manager.js`,


### PR DESCRIPTION
Fixes #898

# How to review

- Checkout branch
- Run `(export VERSION=12.0.0 && npm run cdn-release:build)` task
- Check the `dist-cdn/cc-remix.icons-{HASH}.js` file contents
- It should no more include all Remix icons and only include icons actually used in our Clever Components (43 icons)

# Related impacts

Also impacts the NPM build: remix icons are no more "officially" included. More precisely, they are still available but not at the project root. This behavior is intended.

# Reviewers

Two will be sufficient.