### PR TITLE
docs(wc-guidelines): add a section about component state

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -79,6 +79,10 @@
     margin: 1em 0;
   }
 
+  .markdown-body cc-notice {
+    margin-bottom: 1em;
+  }
+
   cc-toaster.main {
     position: fixed;
     top: 0;


### PR DESCRIPTION
## How to review

- Go to the ["wc-guidelines" preview page](https://clever-components-preview.cellar-c2.services.clever-cloud.com/docs/web-component-guidelines-state/index.html?path=/story/%F0%9F%91%8B-contributing-web-components-guidelines--page) and review the "How to deal with complex component states / data?" section