### PR TITLE
Components/remove deprecated accessible name prop

### DIFF
--- a/docs/adr/adr-0022-new-icon-system.md
+++ b/docs/adr/adr-0022-new-icon-system.md
@@ -189,18 +189,18 @@ Using `role="img"` and `aria-label` attributes on a custom element does not seem
 
 Since we could not rely on the custom element itself, we had to rely on the `<svg>` element and manipulate it depending on its context.
 
-If the developer does not provide any `accessible-name` prop, the component adds an `aria-hidden="true"` attribute to the inner `<svg>` element.
-If the developer does provide an `accessible-name` prop, the component adds to the inner `<svg>` element:
+If the developer does not provide any `a11y-name` prop, the component adds an `aria-hidden="true"` attribute to the inner `<svg>` element.
+If the developer does provide an `a11y-name` prop, the component adds to the inner `<svg>` element:
 
 * A `role="img"` attribute,
-* An `aria-label` which value matches the value of the `accessible-name` prop,
-* A `<title>` element which value matches the value of the `accessible-name` prop.
+* An `aria-label` which value matches the value of the `a11y-name` prop,
+* A `<title>` element which value matches the value of the `a11y-name` prop.
 
 The addition of the `<title>` element is not necessary but this is the native HTML way for informative `<svg>` elements so we decided to keep it.
 
 Example of an informative `<cc-icon>`:
 ```html
-<cc-icon accessible-name="Caution">
+<cc-icon a11y-name="Caution">
   <svg role="img" aria-label="Caution">
     <title>Caution</title>
     ...
@@ -229,15 +229,15 @@ We considered using an `alt` prop and attribute to mimic the `<img>` API.
 
 We did not choose to go this way because we want to avoid using existing native attributes like `title` for instance.
 
-##### Using a custom accessible-name attribute
+##### Using a custom a11y-name attribute
 
-We chose to use a `accessible-name` attribute that should only be used if the icon conveys information.
+We chose to use a `a11y-name` attribute that should only be used if the icon conveys information.
 
 This simplifies the API for developers because:
 
 * In most cases, icons are decorative so there is nothing to do.
 * When the icon is informative, they only have one attribute to add.
-* We already use an `accessible-name` attribute on the `<cc-button>`. This means this attribute should be familiar for developers using our components. It is also a well-known concept for many people who have worked on accessibility before.
+* We already use an `a11y-name` attribute on the `<cc-button>`. This means this attribute should be familiar for developers using our components. It is also a well-known concept for many people who have worked on accessibility before.
 
 ## Limits and prospects
 

--- a/src/components/cc-badge/cc-badge.js
+++ b/src/components/cc-badge/cc-badge.js
@@ -22,7 +22,6 @@ export class CcBadge extends LitElement {
     return {
       circle: { type: Boolean },
       icon: { type: Object },
-      iconAccessibleName: { type: String, attribute: 'icon-accessible-name' },
       iconA11yName: { type: String, attribute: 'icon-a11y-name' },
       intent: { type: String },
       skeleton: { type: Boolean },
@@ -50,18 +49,6 @@ export class CcBadge extends LitElement {
 
     /** @type {BadgeWeight} Sets the style of the badge depending on how much one wants it to stand out. */
     this.weight = 'dimmed';
-  }
-
-  get iconAccessibleName () {
-    return this.iconA11yName;
-  }
-
-  /**
-   * Deprecated property. Use `iconA11yName` property or `icon-a11y-name` attribute instead.
-   * @deprecated
-   */
-  set iconAccessibleName (value) {
-    this.iconA11yName = value;
   }
 
   render () {

--- a/src/components/cc-button/cc-button.js
+++ b/src/components/cc-button/cc-button.js
@@ -48,7 +48,6 @@ export class CcButton extends LitElement {
 
   static get properties () {
     return {
-      accessibleName: { type: String, attribute: 'accessible-name' },
       a11yExpanded: { type: Boolean, attribute: 'a11y-expanded', reflect: true },
       a11yName: { type: String, attribute: 'a11y-name' },
       a11yPressed: { type: Boolean, attribute: 'a11y-pressed', reflect: true },
@@ -126,18 +125,6 @@ export class CcButton extends LitElement {
 
     /** @type {boolean} */
     this._cancelMode = false;
-  }
-
-  get accessibleName () {
-    return this.a11yName;
-  }
-
-  /**
-   * Deprecated property. Use `a11yName` property or `a11y-name` attribute instead.
-   * @deprecated
-   */
-  set accessibleName (value) {
-    this.a11yName = value;
   }
 
   focus () {

--- a/src/components/cc-button/cc-button.stories.js
+++ b/src/components/cc-button/cc-button.stories.js
@@ -166,7 +166,6 @@ export const accessibleName = makeStory(conf, {
   `,
   dom: (container) => {
     container.innerHTML = `
-        <cc-notice intent="warning"><span slot="message">The <code>accessible-name</code> attribute is deprecated in favor of <code>a11y-name</code></span></cc-notice>
         <p>The accessible name can be checked by using the accessibility inspector of your browser.</p>
         <p>You may also hover the buttons because we populate the <code>title</code> attribute with the same value.</p>
         

--- a/src/components/cc-icon/cc-icon.js
+++ b/src/components/cc-icon/cc-icon.js
@@ -31,7 +31,6 @@ import { skeletonStyles } from '../../styles/skeleton.js';
 export class CcIcon extends LitElement {
   static get properties () {
     return {
-      accessibleName: { type: String, attribute: 'accessible-name' },
       a11yName: { type: String, attribute: 'a11y-name' },
       icon: { type: Object },
       size: { type: String, reflect: true },
@@ -63,18 +62,6 @@ export class CcIcon extends LitElement {
 
     /** @type {boolean} Whether the icon should be displayed as skeleton. */
     this.skeleton = false;
-  }
-
-  get accessibleName () {
-    return this.a11yName;
-  }
-
-  /**
-   * Deprecated property. Use `a11yName` property or `a11y-name` attribute instead.
-   * @deprecated
-   */
-  set accessibleName (value) {
-    this.a11yName = value;
   }
 
   updated (changedProperties) {

--- a/src/components/cc-icon/cc-icon.stories.js
+++ b/src/components/cc-icon/cc-icon.stories.js
@@ -59,7 +59,6 @@ export const accessibleName = makeStory(conf, {
   `,
   dom: (container) => {
     const storyOutput = html`
-        <cc-notice intent="warning"><span slot="message">The <code>accessible-name</code> attribute is deprecated in favor of <code>a11y-name</code></span></cc-notice>
         <p>The accessible name can be checked by using the accessibility inspector of your browser.</p>
 
         <div>With <code>a11y-name</code> attribute:</div>

--- a/src/components/cc-img/cc-img.js
+++ b/src/components/cc-img/cc-img.js
@@ -18,7 +18,6 @@ export class CcImg extends LitElement {
 
   static get properties () {
     return {
-      accessibleName: { type: String, attribute: 'accessible-name' },
       a11yName: { type: String, attribute: 'a11y-name' },
       skeleton: { type: Boolean, reflect: true },
       src: { type: String },
@@ -44,18 +43,6 @@ export class CcImg extends LitElement {
 
     /** @type {boolean} */
     this._loaded = false;
-  }
-
-  get accessibleName () {
-    return this.a11yName;
-  }
-
-  /**
-   * Deprecated property. Use `a11yName` property or `a11y-name` attribute instead.
-   * @deprecated
-   */
-  set accessibleName (value) {
-    this.a11yName = value;
   }
 
   _onLoad (e) {

--- a/src/components/cc-popover/cc-popover.js
+++ b/src/components/cc-popover/cc-popover.js
@@ -55,7 +55,6 @@ import { dispatchCustomEvent, EventHandler } from '../../lib/events.js';
 export class CcPopover extends LitElement {
   static get properties () {
     return {
-      accessibleName: { type: String, attribute: 'accessible-name' },
       a11yName: { type: String, attribute: 'a11y-name' },
       hideText: { type: Boolean, attribute: 'hide-text' },
       icon: { type: Object },
@@ -119,18 +118,6 @@ export class CcPopover extends LitElement {
   }
 
   // region Public methods
-
-  get accessibleName () {
-    return this.a11yName;
-  }
-
-  /**
-   * Deprecated property. Use `a11yName` property or `a11y-name` attribute instead.
-   * @deprecated
-   */
-  set accessibleName (value) {
-    this.a11yName = value;
-  }
 
   /**
    * Opens the popover.


### PR DESCRIPTION
## Context

With the 12.0.0 release, we have decided to deprecate the `accessibleName` property & `accessible-name` attribute (see #894).

With the 13.0.0, we are now removing this prop / attribute.

This PR removes the prop / attribute from components.

## How to review?

- review every commit,
- 2 people should be enough for this one.

**Note**: I've checked the console project and there is no usage of `accessibleName` / `accessible-name`. This means that we don't need to adapt the console to this breaking change when integrating the `13.0.0` release @pdesoyres-cc :+1: 
