### PR TITLE
chore: protect master branch from push

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+protected_branch='master'
+current_branch=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
+
+if [ "$protected_branch" = "$current_branch" ]
+then
+    read -p "You're about to push to ${protected_branch} branch, is that what you intended? [y|n] " -n 1 -r < /dev/tty
+    echo
+    if echo "$REPLY" | grep -E '^[Yy]$' > /dev/null
+    then
+        exit 0
+    fi
+    exit 1
+else
+    exit 0
+fi


### PR DESCRIPTION
This PR adds protection on direct push on the master branch. It doesn't prevent developers from doing it (it can sometimes be necessary). But a confirmation will be required when pushing on the master branch.