### PR TITLE
Storybook (dev server): refresh CEM when a component is updated

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -42,24 +42,40 @@ const config = {
   },
   // index markdown stories so they can be part of the generated menu and lazy loaded
   experimental_indexers: async (existingIndexers) => {
-    return [markdownIndexer, ...existingIndexers]
+    return [markdownIndexer, ...existingIndexers ?? []]
   },
-  viteFinal (config, { configType }) {
-    // transform markdown files to CSF so they can be loaded by storybook
-    config.plugins?.unshift(rollupMdToCsfPlugin());
+  async viteFinal (config, { configType }) {
+    // This dynamic import is the recommended Storybook way to
+    // import `vite`. With a static import you get a warning about CJS.
+    // see: https://storybook.js.org/docs/builders/vite#configuration
+    const { mergeConfig } = await import('vite');
+    /** @type {import('vite').InlineConfig} **/
+    let customConfig = {};
+
+    const commonPlugins = [rollupMdToCsfPlugin()];
+
+    const devModePlugins = [
+      // generate CEM on demand and serve it
+      generateCem(),
+      // add apiConfig to the smart container roots within markdown smart stories
+      injectAuthForSmartComponentsPlugin,
+    ];
 
     if (configType === 'DEVELOPMENT') {
-      // serve and process all files instead of storybook related files only
-      config.appType = 'mpa';
-
-      // generate CEM on demand and serve it
-      config.plugins?.push(generateCem());
-
-      // add apiConfig to the smart container roots within markdown smart stories
-      config.plugins?.push(injectAuthForSmartComponentsPlugin);
+      customConfig = {
+        // serve and process all files instead of storybook related files only
+        appType: 'mpa',
+        plugins: [...commonPlugins, ...devModePlugins],
+      }
     }
 
-    return config;
+    if (configType === 'PRODUCTION') {
+      customConfig = {
+        plugins: commonPlugins,
+      }
+    }
+
+    return mergeConfig(config, customConfig);
   }
 };
 

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -65,6 +65,17 @@ const config = {
       customConfig = {
         // serve and process all files instead of storybook related files only
         appType: 'mpa',
+        resolve: {
+          alias: [
+            { 
+              // Without this, vite resolves our imports to the actual `custom-elements.json` file 
+              // inside the `dist` folder.
+              // We need to rely on a virtual file in dev mode, see the `generateCem` plugin for more info.
+              find: /.*\/dist\/custom-elements\.json$/, 
+              replacement: 'virtual:custom-elements.json'
+            },
+          ],
+        },
         plugins: [...commonPlugins, ...devModePlugins],
       }
     }

--- a/cem/generate-cem-vite-plugin.js
+++ b/cem/generate-cem-vite-plugin.js
@@ -1,23 +1,31 @@
 import { cli } from '@custom-elements-manifest/analyzer/cli.js';
 
+/**
+ * This Plugin should only be used in dev mode
+ * This plugin handles resolving, loading and hot replacing the CEM (virtual) module.
+ * In dev mode, we need to rely on a virtual file for the CEM so that we don't have
+ * to constantly write a new CEM on the disk.
+ * We have defined an alias that changes all `/dist/custom-elements.json` imports to
+ * `virtual:custom-elements.json` (see dev config in `/.storybook/main.js`, `viteFinal`).
+ *
+ * To sum it up: in dev mode we import a virtual module/file, in prod we import an actual file.
+ */
 export default function generateCem () {
-  const virtualModuleId = '/dist/custom-elements.json';
-  // the `\0` convention is recommended by rollup when dealing with virtual files / modules
-  // see https://vitejs.dev/guide/api-plugin#virtual-modules-convention for more info
-  // Based on this convention we should have used `virtual:custom-elements.json` but it would
-  // complicate things because once storybook is built, we actually import the manifest from this path
-  // To sum it up: in dev mode we import a virtual module, in prod we import an actual file.
-  // We use the actual path of the manifest as module id to avoid having to set a different path in dev / build
+  // The naming `virtual` and `\0` are important,
+  // see: https://vitejs.dev/guide/api-plugin#virtual-modules-convention for more info
+  const virtualModuleId = 'virtual:custom-elements.json';
   const resolvedVirtualModuleId = '\0' + virtualModuleId;
 
   return {
     // the name is required, it will show up in warnings and errors
     name: 'generate-cem',
+    /** @type {import('vite').Rollup.ResolveIdHook} */
     resolveId (id) {
       if (id.includes(virtualModuleId)) {
         return resolvedVirtualModuleId;
       }
     },
+    /** @type {import('vite').Rollup.LoadHook} */
     async load (id) {
       if (id === resolvedVirtualModuleId) {
         const cemJson = await cli({
@@ -26,6 +34,14 @@ export default function generateCem () {
         });
 
         return JSON.stringify(cemJson);
+      }
+    },
+    /** @param {import('vite').HmrContext} context */
+    handleHotUpdate ({ server, file }) {
+      const isComponentFileRegex = /cc-[^/]+\.js$/;
+      if (file.match(isComponentFileRegex)) {
+        const cemModule = server.moduleGraph.getModuleById(resolvedVirtualModuleId);
+        server.moduleGraph.invalidateModule(cemModule);
       }
     },
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,7 +98,8 @@
         "text-table": "^0.2.0",
         "ts-lit-plugin": "^2.0.0-pre.1",
         "typescript": "~4.3.2",
-        "unified": "^9.2.1"
+        "unified": "^9.2.1",
+        "vite": "^5.2.0"
       }
     },
     "node_modules/@75lb/deep-merge": {
@@ -4783,8 +4784,6 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
       "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25"
@@ -4795,8 +4794,6 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
       "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -5186,8 +5183,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
       "version": "4.13.0",
@@ -5200,8 +5196,7 @@
       "optional": true,
       "os": [
         "android"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
       "version": "4.13.0",
@@ -5214,8 +5209,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
       "version": "4.13.0",
@@ -5228,8 +5222,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.13.0",
@@ -5242,8 +5235,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
       "version": "4.13.0",
@@ -5256,8 +5248,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
       "version": "4.13.0",
@@ -5270,8 +5261,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.13.0",
@@ -5284,8 +5274,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
       "version": "4.13.0",
@@ -5298,8 +5287,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.13.0",
@@ -5312,8 +5300,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
       "version": "4.13.0",
@@ -5326,8 +5313,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
       "version": "4.13.0",
@@ -5340,8 +5326,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
       "version": "4.13.0",
@@ -5354,8 +5339,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@shoelace-style/animations": {
       "version": "1.1.0",
@@ -7214,57 +7198,11 @@
         }
       }
     },
-    "node_modules/@storybook/web-components-vite/node_modules/@types/estree": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-      "dev": true,
-      "peer": true
-    },
     "node_modules/@storybook/web-components-vite/node_modules/es-module-lexer": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
       "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
       "dev": true
-    },
-    "node_modules/@storybook/web-components-vite/node_modules/esbuild": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
-      "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
-      "dev": true,
-      "hasInstallScript": true,
-      "peer": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.20.2",
-        "@esbuild/android-arm": "0.20.2",
-        "@esbuild/android-arm64": "0.20.2",
-        "@esbuild/android-x64": "0.20.2",
-        "@esbuild/darwin-arm64": "0.20.2",
-        "@esbuild/darwin-x64": "0.20.2",
-        "@esbuild/freebsd-arm64": "0.20.2",
-        "@esbuild/freebsd-x64": "0.20.2",
-        "@esbuild/linux-arm": "0.20.2",
-        "@esbuild/linux-arm64": "0.20.2",
-        "@esbuild/linux-ia32": "0.20.2",
-        "@esbuild/linux-loong64": "0.20.2",
-        "@esbuild/linux-mips64el": "0.20.2",
-        "@esbuild/linux-ppc64": "0.20.2",
-        "@esbuild/linux-riscv64": "0.20.2",
-        "@esbuild/linux-s390x": "0.20.2",
-        "@esbuild/linux-x64": "0.20.2",
-        "@esbuild/netbsd-x64": "0.20.2",
-        "@esbuild/openbsd-x64": "0.20.2",
-        "@esbuild/sunos-x64": "0.20.2",
-        "@esbuild/win32-arm64": "0.20.2",
-        "@esbuild/win32-ia32": "0.20.2",
-        "@esbuild/win32-x64": "0.20.2"
-      }
     },
     "node_modules/@storybook/web-components-vite/node_modules/fs-extra": {
       "version": "11.2.0",
@@ -7292,59 +7230,6 @@
         "graceful-fs": "^4.1.6"
       }
     },
-    "node_modules/@storybook/web-components-vite/node_modules/rollup": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.13.0.tgz",
-      "integrity": "sha512-3YegKemjoQnYKmsBlOHfMLVPPA5xLkQ8MHLLSw/fBrFaVkEayL51DilPpNNLq1exr98F2B1TzrV0FUlN3gWRPg==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@types/estree": "1.0.5"
-      },
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.13.0",
-        "@rollup/rollup-android-arm64": "4.13.0",
-        "@rollup/rollup-darwin-arm64": "4.13.0",
-        "@rollup/rollup-darwin-x64": "4.13.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.13.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.13.0",
-        "@rollup/rollup-linux-arm64-musl": "4.13.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.13.0",
-        "@rollup/rollup-linux-x64-gnu": "4.13.0",
-        "@rollup/rollup-linux-x64-musl": "4.13.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.13.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.13.0",
-        "@rollup/rollup-win32-x64-msvc": "4.13.0",
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/@storybook/web-components-vite/node_modules/terser": {
-      "version": "5.29.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.29.2.tgz",
-      "integrity": "sha512-ZiGkhUBIM+7LwkNjXYJq8svgkd+QK3UUr0wJqY4MieaezBSAIPgbSPZyIx0idM6XWK5CMzSWa8MJIzmRcB8Caw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.8.2",
-        "commander": "^2.20.0",
-        "source-map-support": "~0.5.20"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@storybook/web-components-vite/node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -7352,62 +7237,6 @@
       "dev": true,
       "engines": {
         "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@storybook/web-components-vite/node_modules/vite": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.2.tgz",
-      "integrity": "sha512-FWZbz0oSdLq5snUI0b6sULbz58iXFXdvkZfZWR/F0ZJuKTSPO7v72QPXt6KqYeMFb0yytNp6kZosxJ96Nr/wDQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "esbuild": "^0.20.1",
-        "postcss": "^8.4.36",
-        "rollup": "^4.13.0"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/vitejs/vite?sponsor=1"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      },
-      "peerDependencies": {
-        "@types/node": "^18.0.0 || >=20.0.0",
-        "less": "*",
-        "lightningcss": "^1.21.0",
-        "sass": "*",
-        "stylus": "*",
-        "sugarss": "*",
-        "terser": "^5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "lightningcss": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        }
       }
     },
     "node_modules/@stylelint/postcss-css-in-js": {
@@ -14073,6 +13902,29 @@
         "node": ">= 6"
       }
     },
+    "node_modules/html-minifier-terser/node_modules/terser": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
+      "integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^2.20.0",
+        "source-map": "~0.6.1",
+        "source-map-support": "~0.5.12"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/html-minifier-terser/node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
     "node_modules/html-tags": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.2.0.tgz",
@@ -19552,15 +19404,6 @@
         "randombytes": "^2.1.0"
       }
     },
-    "node_modules/rollup-plugin-terser/node_modules/source-map": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/rollup-plugin-terser/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -19571,23 +19414,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/rollup-plugin-terser/node_modules/terser": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.5.0.tgz",
-      "integrity": "sha512-eopt1Gf7/AQyPhpygdKePTzaet31TvQxXvrf7xYUvD/d8qkCJm4SKPDzu+GHK5ZaYTn8rvttfqaZc3swK21e5g==",
-      "dev": true,
-      "dependencies": {
-        "commander": "^2.20.0",
-        "source-map": "~0.7.2",
-        "source-map-support": "~0.5.19"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/rollup-plugin-visualizer": {
@@ -21256,20 +21082,21 @@
       }
     },
     "node_modules/terser": {
-      "version": "4.6.6",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.6.tgz",
-      "integrity": "sha512-4lYPyeNmstjIIESr/ysHg2vUPRGf2tzF9z2yYwnowXVuVzLEamPN1Gfrz7f8I9uEPuHcbFlW4PLIAsJoxXyJ1g==",
+      "version": "5.29.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.29.2.tgz",
+      "integrity": "sha512-ZiGkhUBIM+7LwkNjXYJq8svgkd+QK3UUr0wJqY4MieaezBSAIPgbSPZyIx0idM6XWK5CMzSWa8MJIzmRcB8Caw==",
       "dev": true,
       "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.8.2",
         "commander": "^2.20.0",
-        "source-map": "~0.6.1",
-        "source-map-support": "~0.5.12"
+        "source-map-support": "~0.5.20"
       },
       "bin": {
         "terser": "bin/terser"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=10"
       }
     },
     "node_modules/text-extensions": {
@@ -22130,6 +21957,137 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.2.tgz",
+      "integrity": "sha512-FWZbz0oSdLq5snUI0b6sULbz58iXFXdvkZfZWR/F0ZJuKTSPO7v72QPXt6KqYeMFb0yytNp6kZosxJ96Nr/wDQ==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.20.1",
+        "postcss": "^8.4.36",
+        "rollup": "^4.13.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/@types/estree": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "dev": true
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
+      "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.20.2",
+        "@esbuild/android-arm": "0.20.2",
+        "@esbuild/android-arm64": "0.20.2",
+        "@esbuild/android-x64": "0.20.2",
+        "@esbuild/darwin-arm64": "0.20.2",
+        "@esbuild/darwin-x64": "0.20.2",
+        "@esbuild/freebsd-arm64": "0.20.2",
+        "@esbuild/freebsd-x64": "0.20.2",
+        "@esbuild/linux-arm": "0.20.2",
+        "@esbuild/linux-arm64": "0.20.2",
+        "@esbuild/linux-ia32": "0.20.2",
+        "@esbuild/linux-loong64": "0.20.2",
+        "@esbuild/linux-mips64el": "0.20.2",
+        "@esbuild/linux-ppc64": "0.20.2",
+        "@esbuild/linux-riscv64": "0.20.2",
+        "@esbuild/linux-s390x": "0.20.2",
+        "@esbuild/linux-x64": "0.20.2",
+        "@esbuild/netbsd-x64": "0.20.2",
+        "@esbuild/openbsd-x64": "0.20.2",
+        "@esbuild/sunos-x64": "0.20.2",
+        "@esbuild/win32-arm64": "0.20.2",
+        "@esbuild/win32-ia32": "0.20.2",
+        "@esbuild/win32-x64": "0.20.2"
+      }
+    },
+    "node_modules/vite/node_modules/rollup": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.13.0.tgz",
+      "integrity": "sha512-3YegKemjoQnYKmsBlOHfMLVPPA5xLkQ8MHLLSw/fBrFaVkEayL51DilPpNNLq1exr98F2B1TzrV0FUlN3gWRPg==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.5"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.13.0",
+        "@rollup/rollup-android-arm64": "4.13.0",
+        "@rollup/rollup-darwin-arm64": "4.13.0",
+        "@rollup/rollup-darwin-x64": "4.13.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.13.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.13.0",
+        "@rollup/rollup-linux-arm64-musl": "4.13.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.13.0",
+        "@rollup/rollup-linux-x64-gnu": "4.13.0",
+        "@rollup/rollup-linux-x64-musl": "4.13.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.13.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.13.0",
+        "@rollup/rollup-win32-x64-msvc": "4.13.0",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/vscode-css-languageservice": {
@@ -26263,8 +26221,6 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
       "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "requires": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25"
@@ -26275,8 +26231,6 @@
           "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
           "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
           "dev": true,
-          "optional": true,
-          "peer": true,
           "requires": {
             "@jridgewell/set-array": "^1.2.1",
             "@jridgewell/sourcemap-codec": "^1.4.10",
@@ -26614,104 +26568,91 @@
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.13.0.tgz",
       "integrity": "sha512-5ZYPOuaAqEH/W3gYsRkxQATBW3Ii1MfaT4EQstTnLKViLi2gLSQmlmtTpGucNP3sXEpOiI5tdGhjdE111ekyEg==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "@rollup/rollup-android-arm64": {
       "version": "4.13.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.13.0.tgz",
       "integrity": "sha512-BSbaCmn8ZadK3UAQdlauSvtaJjhlDEjS5hEVVIN3A4bbl3X+otyf/kOJV08bYiRxfejP3DXFzO2jz3G20107+Q==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "@rollup/rollup-darwin-arm64": {
       "version": "4.13.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.13.0.tgz",
       "integrity": "sha512-Ovf2evVaP6sW5Ut0GHyUSOqA6tVKfrTHddtmxGQc1CTQa1Cw3/KMCDEEICZBbyppcwnhMwcDce9ZRxdWRpVd6g==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "@rollup/rollup-darwin-x64": {
       "version": "4.13.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.13.0.tgz",
       "integrity": "sha512-U+Jcxm89UTK592vZ2J9st9ajRv/hrwHdnvyuJpa5A2ngGSVHypigidkQJP+YiGL6JODiUeMzkqQzbCG3At81Gg==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "@rollup/rollup-linux-arm-gnueabihf": {
       "version": "4.13.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.13.0.tgz",
       "integrity": "sha512-8wZidaUJUTIR5T4vRS22VkSMOVooG0F4N+JSwQXWSRiC6yfEsFMLTYRFHvby5mFFuExHa/yAp9juSphQQJAijQ==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "@rollup/rollup-linux-arm64-gnu": {
       "version": "4.13.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.13.0.tgz",
       "integrity": "sha512-Iu0Kno1vrD7zHQDxOmvweqLkAzjxEVqNhUIXBsZ8hu8Oak7/5VTPrxOEZXYC1nmrBVJp0ZcL2E7lSuuOVaE3+w==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "@rollup/rollup-linux-arm64-musl": {
       "version": "4.13.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.13.0.tgz",
       "integrity": "sha512-C31QrW47llgVyrRjIwiOwsHFcaIwmkKi3PCroQY5aVq4H0A5v/vVVAtFsI1nfBngtoRpeREvZOkIhmRwUKkAdw==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.13.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.13.0.tgz",
       "integrity": "sha512-Oq90dtMHvthFOPMl7pt7KmxzX7E71AfyIhh+cPhLY9oko97Zf2C9tt/XJD4RgxhaGeAraAXDtqxvKE1y/j35lA==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "@rollup/rollup-linux-x64-gnu": {
       "version": "4.13.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.13.0.tgz",
       "integrity": "sha512-yUD/8wMffnTKuiIsl6xU+4IA8UNhQ/f1sAnQebmE/lyQ8abjsVyDkyRkWop0kdMhKMprpNIhPmYlCxgHrPoXoA==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "@rollup/rollup-linux-x64-musl": {
       "version": "4.13.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.13.0.tgz",
       "integrity": "sha512-9RyNqoFNdF0vu/qqX63fKotBh43fJQeYC98hCaf89DYQpv+xu0D8QFSOS0biA7cGuqJFOc1bJ+m2rhhsKcw1hw==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "@rollup/rollup-win32-arm64-msvc": {
       "version": "4.13.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.13.0.tgz",
       "integrity": "sha512-46ue8ymtm/5PUU6pCvjlic0z82qWkxv54GTJZgHrQUuZnVH+tvvSP0LsozIDsCBFO4VjJ13N68wqrKSeScUKdA==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "@rollup/rollup-win32-ia32-msvc": {
       "version": "4.13.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.13.0.tgz",
       "integrity": "sha512-P5/MqLdLSlqxbeuJ3YDeX37srC8mCflSyTrUsgbU1c/U9j6l2g2GiIdYaGD9QjdMQPMSgYm7hgg0551wHyIluw==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "@rollup/rollup-win32-x64-msvc": {
       "version": "4.13.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.13.0.tgz",
       "integrity": "sha512-UKXUQNbO3DOhzLRwHSpa0HnhhCgNODvfoPWv2FCXme8N/ANFfhIPMGuOT+QuKd16+B5yxZ0HdpNlqPvTMS1qfw==",
       "dev": true,
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "@shoelace-style/animations": {
       "version": "1.1.0",
@@ -28067,50 +28008,11 @@
             "ts-dedent": "^2.0.0"
           }
         },
-        "@types/estree": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-          "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-          "dev": true,
-          "peer": true
-        },
         "es-module-lexer": {
           "version": "0.9.3",
           "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
           "integrity": "sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==",
           "dev": true
-        },
-        "esbuild": {
-          "version": "0.20.2",
-          "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
-          "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "@esbuild/aix-ppc64": "0.20.2",
-            "@esbuild/android-arm": "0.20.2",
-            "@esbuild/android-arm64": "0.20.2",
-            "@esbuild/android-x64": "0.20.2",
-            "@esbuild/darwin-arm64": "0.20.2",
-            "@esbuild/darwin-x64": "0.20.2",
-            "@esbuild/freebsd-arm64": "0.20.2",
-            "@esbuild/freebsd-x64": "0.20.2",
-            "@esbuild/linux-arm": "0.20.2",
-            "@esbuild/linux-arm64": "0.20.2",
-            "@esbuild/linux-ia32": "0.20.2",
-            "@esbuild/linux-loong64": "0.20.2",
-            "@esbuild/linux-mips64el": "0.20.2",
-            "@esbuild/linux-ppc64": "0.20.2",
-            "@esbuild/linux-riscv64": "0.20.2",
-            "@esbuild/linux-s390x": "0.20.2",
-            "@esbuild/linux-x64": "0.20.2",
-            "@esbuild/netbsd-x64": "0.20.2",
-            "@esbuild/openbsd-x64": "0.20.2",
-            "@esbuild/sunos-x64": "0.20.2",
-            "@esbuild/win32-arm64": "0.20.2",
-            "@esbuild/win32-ia32": "0.20.2",
-            "@esbuild/win32-x64": "0.20.2"
-          }
         },
         "fs-extra": {
           "version": "11.2.0",
@@ -28133,62 +28035,11 @@
             "universalify": "^2.0.0"
           }
         },
-        "rollup": {
-          "version": "4.13.0",
-          "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.13.0.tgz",
-          "integrity": "sha512-3YegKemjoQnYKmsBlOHfMLVPPA5xLkQ8MHLLSw/fBrFaVkEayL51DilPpNNLq1exr98F2B1TzrV0FUlN3gWRPg==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "@rollup/rollup-android-arm-eabi": "4.13.0",
-            "@rollup/rollup-android-arm64": "4.13.0",
-            "@rollup/rollup-darwin-arm64": "4.13.0",
-            "@rollup/rollup-darwin-x64": "4.13.0",
-            "@rollup/rollup-linux-arm-gnueabihf": "4.13.0",
-            "@rollup/rollup-linux-arm64-gnu": "4.13.0",
-            "@rollup/rollup-linux-arm64-musl": "4.13.0",
-            "@rollup/rollup-linux-riscv64-gnu": "4.13.0",
-            "@rollup/rollup-linux-x64-gnu": "4.13.0",
-            "@rollup/rollup-linux-x64-musl": "4.13.0",
-            "@rollup/rollup-win32-arm64-msvc": "4.13.0",
-            "@rollup/rollup-win32-ia32-msvc": "4.13.0",
-            "@rollup/rollup-win32-x64-msvc": "4.13.0",
-            "@types/estree": "1.0.5",
-            "fsevents": "~2.3.2"
-          }
-        },
-        "terser": {
-          "version": "5.29.2",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-5.29.2.tgz",
-          "integrity": "sha512-ZiGkhUBIM+7LwkNjXYJq8svgkd+QK3UUr0wJqY4MieaezBSAIPgbSPZyIx0idM6XWK5CMzSWa8MJIzmRcB8Caw==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@jridgewell/source-map": "^0.3.3",
-            "acorn": "^8.8.2",
-            "commander": "^2.20.0",
-            "source-map-support": "~0.5.20"
-          }
-        },
         "universalify": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
           "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
           "dev": true
-        },
-        "vite": {
-          "version": "5.2.2",
-          "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.2.tgz",
-          "integrity": "sha512-FWZbz0oSdLq5snUI0b6sULbz58iXFXdvkZfZWR/F0ZJuKTSPO7v72QPXt6KqYeMFb0yytNp6kZosxJ96Nr/wDQ==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "esbuild": "^0.20.1",
-            "fsevents": "~2.3.3",
-            "postcss": "^8.4.36",
-            "rollup": "^4.13.0"
-          }
         }
       }
     },
@@ -33531,6 +33382,25 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
           "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
           "dev": true
+        },
+        "terser": {
+          "version": "4.8.1",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
+          "integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
+          "dev": true,
+          "requires": {
+            "commander": "^2.20.0",
+            "source-map": "~0.6.1",
+            "source-map-support": "~0.5.12"
+          },
+          "dependencies": {
+            "commander": {
+              "version": "2.20.3",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+              "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+              "dev": true
+            }
+          }
         }
       }
     },
@@ -37822,12 +37692,6 @@
             "randombytes": "^2.1.0"
           }
         },
-        "source-map": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-          "dev": true
-        },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -37835,17 +37699,6 @@
           "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
-          }
-        },
-        "terser": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/terser/-/terser-5.5.0.tgz",
-          "integrity": "sha512-eopt1Gf7/AQyPhpygdKePTzaet31TvQxXvrf7xYUvD/d8qkCJm4SKPDzu+GHK5ZaYTn8rvttfqaZc3swK21e5g==",
-          "dev": true,
-          "requires": {
-            "commander": "^2.20.0",
-            "source-map": "~0.7.2",
-            "source-map-support": "~0.5.19"
           }
         }
       }
@@ -39189,14 +39042,15 @@
       }
     },
     "terser": {
-      "version": "4.6.6",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.6.6.tgz",
-      "integrity": "sha512-4lYPyeNmstjIIESr/ysHg2vUPRGf2tzF9z2yYwnowXVuVzLEamPN1Gfrz7f8I9uEPuHcbFlW4PLIAsJoxXyJ1g==",
+      "version": "5.29.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.29.2.tgz",
+      "integrity": "sha512-ZiGkhUBIM+7LwkNjXYJq8svgkd+QK3UUr0wJqY4MieaezBSAIPgbSPZyIx0idM6XWK5CMzSWa8MJIzmRcB8Caw==",
       "dev": true,
       "requires": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.8.2",
         "commander": "^2.20.0",
-        "source-map": "~0.6.1",
-        "source-map-support": "~0.5.12"
+        "source-map-support": "~0.5.20"
       }
     },
     "text-extensions": {
@@ -39907,6 +39761,80 @@
       "requires": {
         "@types/unist": "^2.0.0",
         "unist-util-stringify-position": "^2.0.0"
+      }
+    },
+    "vite": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.2.tgz",
+      "integrity": "sha512-FWZbz0oSdLq5snUI0b6sULbz58iXFXdvkZfZWR/F0ZJuKTSPO7v72QPXt6KqYeMFb0yytNp6kZosxJ96Nr/wDQ==",
+      "dev": true,
+      "requires": {
+        "esbuild": "^0.20.1",
+        "fsevents": "~2.3.3",
+        "postcss": "^8.4.36",
+        "rollup": "^4.13.0"
+      },
+      "dependencies": {
+        "@types/estree": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
+          "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+          "dev": true
+        },
+        "esbuild": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
+          "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
+          "dev": true,
+          "requires": {
+            "@esbuild/aix-ppc64": "0.20.2",
+            "@esbuild/android-arm": "0.20.2",
+            "@esbuild/android-arm64": "0.20.2",
+            "@esbuild/android-x64": "0.20.2",
+            "@esbuild/darwin-arm64": "0.20.2",
+            "@esbuild/darwin-x64": "0.20.2",
+            "@esbuild/freebsd-arm64": "0.20.2",
+            "@esbuild/freebsd-x64": "0.20.2",
+            "@esbuild/linux-arm": "0.20.2",
+            "@esbuild/linux-arm64": "0.20.2",
+            "@esbuild/linux-ia32": "0.20.2",
+            "@esbuild/linux-loong64": "0.20.2",
+            "@esbuild/linux-mips64el": "0.20.2",
+            "@esbuild/linux-ppc64": "0.20.2",
+            "@esbuild/linux-riscv64": "0.20.2",
+            "@esbuild/linux-s390x": "0.20.2",
+            "@esbuild/linux-x64": "0.20.2",
+            "@esbuild/netbsd-x64": "0.20.2",
+            "@esbuild/openbsd-x64": "0.20.2",
+            "@esbuild/sunos-x64": "0.20.2",
+            "@esbuild/win32-arm64": "0.20.2",
+            "@esbuild/win32-ia32": "0.20.2",
+            "@esbuild/win32-x64": "0.20.2"
+          }
+        },
+        "rollup": {
+          "version": "4.13.0",
+          "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.13.0.tgz",
+          "integrity": "sha512-3YegKemjoQnYKmsBlOHfMLVPPA5xLkQ8MHLLSw/fBrFaVkEayL51DilPpNNLq1exr98F2B1TzrV0FUlN3gWRPg==",
+          "dev": true,
+          "requires": {
+            "@rollup/rollup-android-arm-eabi": "4.13.0",
+            "@rollup/rollup-android-arm64": "4.13.0",
+            "@rollup/rollup-darwin-arm64": "4.13.0",
+            "@rollup/rollup-darwin-x64": "4.13.0",
+            "@rollup/rollup-linux-arm-gnueabihf": "4.13.0",
+            "@rollup/rollup-linux-arm64-gnu": "4.13.0",
+            "@rollup/rollup-linux-arm64-musl": "4.13.0",
+            "@rollup/rollup-linux-riscv64-gnu": "4.13.0",
+            "@rollup/rollup-linux-x64-gnu": "4.13.0",
+            "@rollup/rollup-linux-x64-musl": "4.13.0",
+            "@rollup/rollup-win32-arm64-msvc": "4.13.0",
+            "@rollup/rollup-win32-ia32-msvc": "4.13.0",
+            "@rollup/rollup-win32-x64-msvc": "4.13.0",
+            "@types/estree": "1.0.5",
+            "fsevents": "~2.3.2"
+          }
+        }
       }
     },
     "vscode-css-languageservice": {

--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "text-table": "^0.2.0",
     "ts-lit-plugin": "^2.0.0-pre.1",
     "typescript": "~4.3.2",
+    "vite": "^5.2.0",
     "unified": "^9.2.1"
   },
   "customElements": "dist/custom-elements.json",


### PR DESCRIPTION
Fixes #989 

## What does this PR do?

- Improve the `viteFinal` config handling. We rely on the `mergeConfig` helper from vite to avoid erasing parts of the builder config by mistake. This is on par with the Storybook docs (see [viteFinal - Storybook](https://storybook.js.org/docs/api/main-config-vite-final#options)).
- Add vite to our dev dependencies. We need to for the `mergeConfig` helper (although we could rely on the `storybook` node modules one) + the types. Note that since v8.0.0, storybook automatically adds vite to the dev dependencies so this feels like the right move anyway?
- Regenerate CEM everytime a component is updated (in dev mode only). (see #989 for more info + the comments within the code to review).

## How to review?

- Check both commits (the first commit's diff is not easy to read, you might as well just check the code itself for the config at least),
- Run storybook locally, go to a component's doc page and update the doc of the component you are viewing. The doc story should reload and you should see the modified doc.
- The "built" version (preview/prod) should not be affected by these changes so nothing to check expect that the preview has been built and is working.