### PR TITLE
cc-button/cc-link: prevent activation in skeleton mode

### DIFF
--- a/src/components/cc-button/cc-button.js
+++ b/src/components/cc-button/cc-button.js
@@ -179,7 +179,7 @@ export class CcButton extends LitElement {
     e.stopPropagation();
 
     // we need to check that because we use aria-disabled which doesn't prevent the onclick event to be fired.
-    if (this.disabled) {
+    if (this.disabled || this.skeleton || this.waiting) {
       return;
     }
 
@@ -631,6 +631,10 @@ export class CcButton extends LitElement {
 
         .cc-link .text-normal {
           font-size: 1em;
+        }
+
+        .cc-link.skeleton:hover {
+          color: transparent;
         }
       `,
     ];

--- a/src/templates/cc-link/cc-link.js
+++ b/src/templates/cc-link/cc-link.js
@@ -15,7 +15,7 @@ function isDifferentOrigin (rawUrl) {
 
 // NOTE: we could just create raw DOM but here we benefit from lit-html safe/escaping system on "content"
 export const ccLink = (url, content, skeleton = false, title) => {
-  const href = (url != null) ? url : undefined;
+  const href = (url != null && !skeleton) ? url : undefined;
   const target = isDifferentOrigin(href) ? '_blank' : undefined;
   const rel = isDifferentOrigin(href) ? 'noopener noreferrer' : undefined;
   return html`<a class="cc-link ${classMap({ skeleton })}" href=${ifDefined(href)} target=${ifDefined(target)} rel=${ifDefined(rel)} title="${ifDefined(title)}">${content}</a>`;
@@ -29,7 +29,7 @@ export const linkStyles = css`
   .cc-link,
   .cc-link:visited,
   .cc-link:active {
-      color: var(--cc-color-text-primary-highlight, blue);
+    color: var(--cc-color-text-primary-highlight, blue);
   }
 
   .sanitized-link:enabled:hover,
@@ -41,7 +41,7 @@ export const linkStyles = css`
   .cc-link:focus {
     background-color: var(--cc-color-bg-default, #fff);
     border-radius: 0.1em;
-    outline: var(--cc-focus-outline, #000000 solid 2px);
+    outline: var(--cc-focus-outline, #000 solid 2px);
     outline-offset: var(--cc-focus-outline-offset, 2px);
   }
 
@@ -54,7 +54,7 @@ export const linkStyles = css`
   .sanitized-link.skeleton,
   .cc-link .skeleton,
   .sanitized-link .skeleton {
-    background-color: var(--cc-color-text-primary-weak, hsl(209, 98%, 73%));
+    background-color: var(--cc-color-text-primary-weak, hsl(209deg 98% 73%));
     color: transparent;
   }
 `;


### PR DESCRIPTION
Fixes #994 

## What does this PR do?

- cc-button: Prevent click events from going through in skeleton / waiting mode.
- cc-button: Make sure the text is not visible in link + skeleton mode.
- cc-link: Unset the `href` attribute in skeleton mode.

## How to review?

- 2 reviewers should be enough,
- review both commits,
- compare the [cc-addon-backups - skeleton story - Production](https://www.clever-cloud.com/doc/clever-components/?path=/story/%F0%9F%9B%A0-addon-cc-addon-backups--skeleton) and [cc-addon-backups - skeleton story - Preview](https://clever-components-preview.cellar-c2.services.clever-cloud.com/links/fix-skeleton/index.html?path=/story/%F0%9F%9B%A0-addon-cc-addon-backups--skeleton).
  - In prod, when clicking the first blue skeleton within a backup row, the page is refreshed. It shouldn't be the case in preview.
  - In prod, when hovering the second blue skeleton within a backup row, the text is visible. It shouldn't be the case in preview.