### PR TITLE
chore(storybook): remove embedded stories from autodocs

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -2,6 +2,7 @@ import '../src/stories/lib/i18n-control.js';
 import { setCustomElementsManifest } from '@storybook/web-components';
 import customElementsManifest from '../dist/custom-elements.json';
 import { getAvailableLanguages } from '../src/lib/i18n.js';
+import { AutodocsTemplate } from '../src/stories/lib/autodocs-template.jsx';
 
 setCustomElementsManifest(customElementsManifest);
 
@@ -27,6 +28,9 @@ const availableLanguages = Object
 /** @type { import('@storybook/web-components').Preview } */
 const preview = {
   parameters: {
+    docs: {
+      page: AutodocsTemplate
+    },
     options: {
       storySort: {
         method: 'alphabetical',

--- a/src/stories/lib/autodocs-template.jsx
+++ b/src/stories/lib/autodocs-template.jsx
@@ -1,0 +1,16 @@
+// we disable this rule because this file is only meant to be processed by Storybook. It is not part of our npm / CDN bundle.
+// eslint-disable-next-line import/no-extraneous-dependencies, no-unused-vars
+import { Title, Subtitle, Description, Controls } from '@storybook/blocks';
+// eslint-disable-next-line import/no-extraneous-dependencies, no-unused-vars
+import React from 'react';
+
+export function AutodocsTemplate () {
+  return (
+    <>
+      <Title />
+      <Subtitle />
+      <Description />
+      <Controls />
+    </>
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -51,6 +51,7 @@
     "noPropertyAccessFromIndexSignature": false, /* Enforces using indexed accessors for keys declared using an indexed type. */
     "allowUnusedLabels": false, /* Disable error reporting for unused labels. */
     "allowUnreachableCode": false, /* Disable error reporting for unreachable code. */
+    "jsx": "react", /* useful when dealing with storybook specific components */
     "plugins": [
       {
         "name": "ts-lit-plugin",


### PR DESCRIPTION
Fixes #997 

## What does this PR do?

- Removes embedded stories from auto generated docs

## How to review?

- 2 reviewers should be enough,
- Review the commit,
- Check both the [preview](https://clever-components-preview.cellar-c2.services.clever-cloud.com/storybook/remove-embedded-stories-from-docs/index.html) and locally that docs do not contain stories