### PR TITLE
CEM & TypeScript: upgrade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@bundled-es-modules/chai": "^4.2.2",
         "@commitlint/cli": "^18.5.0",
         "@commitlint/config-conventional": "^18.5.0",
-        "@custom-elements-manifest/analyzer": "^0.6.4",
+        "@custom-elements-manifest/analyzer": "^0.9.4",
         "@esm-bundle/chai-as-promised": "^7.1.1",
         "@open-wc/dev-server-hmr": "^0.1.3",
         "@open-wc/testing": "^3.1.6",
@@ -97,7 +97,7 @@
         "svgo": "^1.3.2",
         "text-table": "^0.2.0",
         "ts-lit-plugin": "^2.0.0-pre.1",
-        "typescript": "~4.3.2",
+        "typescript": "~5.4.2",
         "unified": "^9.2.1",
         "vite": "^5.2.0"
       }
@@ -3797,20 +3797,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@commitlint/load/node_modules/typescript": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-      "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-      "dev": true,
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/@commitlint/message": {
       "version": "18.4.4",
       "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-18.4.4.tgz",
@@ -4081,12 +4067,13 @@
       }
     },
     "node_modules/@custom-elements-manifest/analyzer": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/@custom-elements-manifest/analyzer/-/analyzer-0.6.4.tgz",
-      "integrity": "sha512-yI/D+xl21kDszc8z3S5Oj2lSRBZtYKDf1h41XnSqqGO4Lny+JqQwq5SMHZc5ieS4hDIMR/WK9Jm348TKMZR4ig==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@custom-elements-manifest/analyzer/-/analyzer-0.9.4.tgz",
+      "integrity": "sha512-XPjEbfkq71oQl6tIfDy1ashdvOf42p3BtqebEaUohqTEPAyBuShGwQiB2B7xjsUwi3VfSQCnPlGwmigIDPjtWg==",
       "dev": true,
       "dependencies": {
         "@custom-elements-manifest/find-dependencies": "^0.0.5",
+        "@github/catalyst": "^1.6.0",
         "@web/config-loader": "0.1.3",
         "chokidar": "3.5.2",
         "command-line-args": "5.1.2",
@@ -4094,7 +4081,7 @@
         "custom-elements-manifest": "1.0.0",
         "debounce": "1.2.1",
         "globby": "11.0.4",
-        "typescript": "~4.3.2"
+        "typescript": "~5.4.2"
       },
       "bin": {
         "cem": "cem.js",
@@ -4636,6 +4623,12 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
       "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
+    },
+    "node_modules/@github/catalyst": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@github/catalyst/-/catalyst-1.6.0.tgz",
+      "integrity": "sha512-u8A+DameixqpeyHzvnJWTGj+wfiskQOYHzSiJscCWVfMkIT3rxnbHMtGh3lMthaRY21nbUOK71WcsCnCrXhBJQ==",
+      "dev": true
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.11",
@@ -21430,16 +21423,16 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/typical": {
@@ -25609,13 +25602,6 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
-        },
-        "typescript": {
-          "version": "5.3.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-          "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-          "dev": true,
-          "peer": true
         }
       }
     },
@@ -25808,12 +25794,13 @@
       "integrity": "sha512-tlJpwF40DEQcfR/QF+wNMVyGMaO9FQp6Z1Wahj4Gk3CJQYHwA2xVG7iKDFdW6zuxZY9XWOpGcfNCTsX4McOsOg=="
     },
     "@custom-elements-manifest/analyzer": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/@custom-elements-manifest/analyzer/-/analyzer-0.6.4.tgz",
-      "integrity": "sha512-yI/D+xl21kDszc8z3S5Oj2lSRBZtYKDf1h41XnSqqGO4Lny+JqQwq5SMHZc5ieS4hDIMR/WK9Jm348TKMZR4ig==",
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@custom-elements-manifest/analyzer/-/analyzer-0.9.4.tgz",
+      "integrity": "sha512-XPjEbfkq71oQl6tIfDy1ashdvOf42p3BtqebEaUohqTEPAyBuShGwQiB2B7xjsUwi3VfSQCnPlGwmigIDPjtWg==",
       "dev": true,
       "requires": {
         "@custom-elements-manifest/find-dependencies": "^0.0.5",
+        "@github/catalyst": "^1.6.0",
         "@web/config-loader": "0.1.3",
         "chokidar": "3.5.2",
         "command-line-args": "5.1.2",
@@ -25821,7 +25808,7 @@
         "custom-elements-manifest": "1.0.0",
         "debounce": "1.2.1",
         "globby": "11.0.4",
-        "typescript": "~4.3.2"
+        "typescript": "~5.4.2"
       }
     },
     "@custom-elements-manifest/find-dependencies": {
@@ -26117,6 +26104,12 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
       "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
+    },
+    "@github/catalyst": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@github/catalyst/-/catalyst-1.6.0.tgz",
+      "integrity": "sha512-u8A+DameixqpeyHzvnJWTGj+wfiskQOYHzSiJscCWVfMkIT3rxnbHMtGh3lMthaRY21nbUOK71WcsCnCrXhBJQ==",
+      "dev": true
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.11",
@@ -39319,9 +39312,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true
     },
     "typical": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -96,7 +96,7 @@
         "superagent": "^6.1.0",
         "svgo": "^1.3.2",
         "text-table": "^0.2.0",
-        "ts-lit-plugin": "^2.0.0-pre.1",
+        "ts-lit-plugin": "^2.0.2",
         "typescript": "~5.4.2",
         "unified": "^9.2.1",
         "vite": "^5.2.0"
@@ -3450,15 +3450,6 @@
         "y18n": "^5.0.5",
         "yargs-parser": "^21.1.1"
       },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@commitlint/cli/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -19118,12 +19109,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/require-main-filename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "dev": true
-    },
     "node_modules/requireindex": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
@@ -19758,12 +19743,6 @@
       "engines": {
         "node": ">= 0.8.0"
       }
-    },
-    "node_modules/set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-      "dev": true
     },
     "node_modules/set-function-length": {
       "version": "1.2.1",
@@ -21237,14 +21216,40 @@
       }
     },
     "node_modules/ts-lit-plugin": {
-      "version": "2.0.0-pre.1",
-      "resolved": "https://registry.npmjs.org/ts-lit-plugin/-/ts-lit-plugin-2.0.0-pre.1.tgz",
-      "integrity": "sha512-zXTdephVcjJ0VySiaQRbFCZegvhhePY1FHGsMYs7m/faUViPzPe8WwGryKeXmQtCaUJ7eA79areW2H/AeC7VBg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ts-lit-plugin/-/ts-lit-plugin-2.0.2.tgz",
+      "integrity": "sha512-DPXlVxhjWHxg8AyBLcfSYt2JXgpANV1ssxxwjY98o26gD8MzeiM68HFW9c2VeDd1CjoR3w7B/6/uKxwBQe+ioA==",
       "dev": true,
       "dependencies": {
-        "lit-analyzer": "^2.0.0-pre.3",
-        "web-component-analyzer": "^2.0.0-next.5"
+        "lit-analyzer": "^2.0.1",
+        "web-component-analyzer": "^2.0.0"
       }
+    },
+    "node_modules/ts-lit-plugin/node_modules/lit-analyzer": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/lit-analyzer/-/lit-analyzer-2.0.3.tgz",
+      "integrity": "sha512-XiAjnwVipNrKav7r3CSEZpWt+mwYxrhPRVC7h8knDmn/HWTzzWJvPe+mwBcL2brn4xhItAMzZhFC8tzzqHKmiQ==",
+      "dev": true,
+      "dependencies": {
+        "@vscode/web-custom-data": "^0.4.2",
+        "chalk": "^2.4.2",
+        "didyoumean2": "4.1.0",
+        "fast-glob": "^3.2.11",
+        "parse5": "5.1.0",
+        "ts-simple-type": "~2.0.0-next.0",
+        "vscode-css-languageservice": "4.3.0",
+        "vscode-html-languageservice": "3.1.0",
+        "web-component-analyzer": "^2.0.0"
+      },
+      "bin": {
+        "lit-analyzer": "cli.js"
+      }
+    },
+    "node_modules/ts-lit-plugin/node_modules/parse5": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
+      "integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
+      "dev": true
     },
     "node_modules/ts-simple-type": {
       "version": "2.0.0-next.0",
@@ -22154,15 +22159,15 @@
       }
     },
     "node_modules/web-component-analyzer": {
-      "version": "2.0.0-next.5",
-      "resolved": "https://registry.npmjs.org/web-component-analyzer/-/web-component-analyzer-2.0.0-next.5.tgz",
-      "integrity": "sha512-QaQwuwFaBuwc7RwX0KdR9bc57s9Jqj+PcekIt3c7WXRY4vGOr/rjyG8YWuT2R7KmGBh+KrCdY/KynMlWRCVR3w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/web-component-analyzer/-/web-component-analyzer-2.0.0.tgz",
+      "integrity": "sha512-UEvwfpD+XQw99sLKiH5B1T4QwpwNyWJxp59cnlRwFfhUW6JsQpw5jMeMwi7580sNou8YL3kYoS7BWLm+yJ/jVQ==",
       "dev": true,
       "dependencies": {
         "fast-glob": "^3.2.2",
         "ts-simple-type": "2.0.0-next.0",
-        "typescript": "~4.4.3",
-        "yargs": "^15.3.1"
+        "typescript": "~5.2.0",
+        "yargs": "^17.7.2"
       },
       "bin": {
         "wca": "cli.js",
@@ -22178,62 +22183,52 @@
         "node": ">=8"
       }
     },
+    "node_modules/web-component-analyzer/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/web-component-analyzer/node_modules/cliui": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
       "dependencies": {
         "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^6.2.0"
-      }
-    },
-    "node_modules/web-component-analyzer/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       }
     },
-    "node_modules/web-component-analyzer/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+    "node_modules/web-component-analyzer/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "dependencies": {
-        "p-locate": "^4.1.0"
+        "color-name": "~1.1.4"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=7.0.0"
       }
     },
-    "node_modules/web-component-analyzer/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/web-component-analyzer/node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
+    "node_modules/web-component-analyzer/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/web-component-analyzer/node_modules/strip-ansi": {
       "version": "6.0.1",
@@ -22248,44 +22243,60 @@
       }
     },
     "node_modules/web-component-analyzer/node_modules/typescript": {
-      "version": "4.4.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-      "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/web-component-analyzer/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/web-component-analyzer/node_modules/y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-      "dev": true
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/web-component-analyzer/node_modules/yargs": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "dev": true,
       "dependencies": {
-        "cliui": "^6.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^4.1.0",
-        "get-caller-file": "^2.0.1",
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^4.2.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^18.1.2"
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       }
     },
     "node_modules/webidl-conversions": {
@@ -22407,12 +22418,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/which-module": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
-      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
-      "dev": true
     },
     "node_modules/which-typed-array": {
       "version": "1.1.11",
@@ -22679,25 +22684,12 @@
       }
     },
     "node_modules/yargs-parser": {
-      "version": "18.1.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-      "dev": true,
-      "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/yargs-parser/node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
       "engines": {
-        "node": ">=6"
+        "node": ">=12"
       }
     },
     "node_modules/yargs-unparser": {
@@ -25352,12 +25344,6 @@
             "y18n": "^5.0.5",
             "yargs-parser": "^21.1.1"
           }
-        },
-        "yargs-parser": {
-          "version": "21.1.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-          "dev": true
         }
       }
     },
@@ -37460,12 +37446,6 @@
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true
     },
-    "require-main-filename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "dev": true
-    },
     "requireindex": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
@@ -37984,12 +37964,6 @@
         "parseurl": "~1.3.3",
         "send": "0.18.0"
       }
-    },
-    "set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-      "dev": true
     },
     "set-function-length": {
       "version": "1.2.1",
@@ -39163,13 +39137,38 @@
       "dev": true
     },
     "ts-lit-plugin": {
-      "version": "2.0.0-pre.1",
-      "resolved": "https://registry.npmjs.org/ts-lit-plugin/-/ts-lit-plugin-2.0.0-pre.1.tgz",
-      "integrity": "sha512-zXTdephVcjJ0VySiaQRbFCZegvhhePY1FHGsMYs7m/faUViPzPe8WwGryKeXmQtCaUJ7eA79areW2H/AeC7VBg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/ts-lit-plugin/-/ts-lit-plugin-2.0.2.tgz",
+      "integrity": "sha512-DPXlVxhjWHxg8AyBLcfSYt2JXgpANV1ssxxwjY98o26gD8MzeiM68HFW9c2VeDd1CjoR3w7B/6/uKxwBQe+ioA==",
       "dev": true,
       "requires": {
-        "lit-analyzer": "^2.0.0-pre.3",
-        "web-component-analyzer": "^2.0.0-next.5"
+        "lit-analyzer": "^2.0.1",
+        "web-component-analyzer": "^2.0.0"
+      },
+      "dependencies": {
+        "lit-analyzer": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/lit-analyzer/-/lit-analyzer-2.0.3.tgz",
+          "integrity": "sha512-XiAjnwVipNrKav7r3CSEZpWt+mwYxrhPRVC7h8knDmn/HWTzzWJvPe+mwBcL2brn4xhItAMzZhFC8tzzqHKmiQ==",
+          "dev": true,
+          "requires": {
+            "@vscode/web-custom-data": "^0.4.2",
+            "chalk": "^2.4.2",
+            "didyoumean2": "4.1.0",
+            "fast-glob": "^3.2.11",
+            "parse5": "5.1.0",
+            "ts-simple-type": "~2.0.0-next.0",
+            "vscode-css-languageservice": "4.3.0",
+            "vscode-html-languageservice": "3.1.0",
+            "web-component-analyzer": "^2.0.0"
+          }
+        },
+        "parse5": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
+          "integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
+          "dev": true
+        }
       }
     },
     "ts-simple-type": {
@@ -39898,15 +39897,15 @@
       }
     },
     "web-component-analyzer": {
-      "version": "2.0.0-next.5",
-      "resolved": "https://registry.npmjs.org/web-component-analyzer/-/web-component-analyzer-2.0.0-next.5.tgz",
-      "integrity": "sha512-QaQwuwFaBuwc7RwX0KdR9bc57s9Jqj+PcekIt3c7WXRY4vGOr/rjyG8YWuT2R7KmGBh+KrCdY/KynMlWRCVR3w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/web-component-analyzer/-/web-component-analyzer-2.0.0.tgz",
+      "integrity": "sha512-UEvwfpD+XQw99sLKiH5B1T4QwpwNyWJxp59cnlRwFfhUW6JsQpw5jMeMwi7580sNou8YL3kYoS7BWLm+yJ/jVQ==",
       "dev": true,
       "requires": {
         "fast-glob": "^3.2.2",
         "ts-simple-type": "2.0.0-next.0",
-        "typescript": "~4.4.3",
-        "yargs": "^15.3.1"
+        "typescript": "~5.2.0",
+        "yargs": "^17.7.2"
       },
       "dependencies": {
         "ansi-regex": {
@@ -39915,49 +39914,39 @@
           "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
         "cliui": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
           "dev": true,
           "requires": {
             "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^6.2.0"
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^7.0.0"
           }
         },
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
+            "color-name": "~1.1.4"
           }
         },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        },
-        "path-exists": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
         "strip-ansi": {
@@ -39970,34 +39959,41 @@
           }
         },
         "typescript": {
-          "version": "4.4.4",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
-          "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
+          "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
           "dev": true
         },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
         "y18n": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
           "dev": true
         },
         "yargs": {
-          "version": "15.4.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+          "version": "17.7.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+          "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
           "dev": true,
           "requires": {
-            "cliui": "^6.0.0",
-            "decamelize": "^1.2.0",
-            "find-up": "^4.1.0",
-            "get-caller-file": "^2.0.1",
+            "cliui": "^8.0.1",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
             "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^4.2.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^18.1.2"
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.1.1"
           }
         }
       }
@@ -40105,12 +40101,6 @@
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
       }
-    },
-    "which-module": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
-      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
-      "dev": true
     },
     "which-typed-array": {
       "version": "1.1.11",
@@ -40336,22 +40326,10 @@
       }
     },
     "yargs-parser": {
-      "version": "18.1.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-      "dev": true,
-      "requires": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      },
-      "dependencies": {
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-          "dev": true
-        }
-      }
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true
     },
     "yargs-unparser": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@bundled-es-modules/chai": "^4.2.2",
     "@commitlint/cli": "^18.5.0",
     "@commitlint/config-conventional": "^18.5.0",
-    "@custom-elements-manifest/analyzer": "^0.6.4",
+    "@custom-elements-manifest/analyzer": "^0.9.4",
     "@esm-bundle/chai-as-promised": "^7.1.1",
     "@open-wc/dev-server-hmr": "^0.1.3",
     "@open-wc/testing": "^3.1.6",
@@ -142,7 +142,7 @@
     "svgo": "^1.3.2",
     "text-table": "^0.2.0",
     "ts-lit-plugin": "^2.0.0-pre.1",
-    "typescript": "~4.3.2",
+    "typescript": "~5.4.2",
     "vite": "^5.2.0",
     "unified": "^9.2.1"
   },

--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "superagent": "^6.1.0",
     "svgo": "^1.3.2",
     "text-table": "^0.2.0",
-    "ts-lit-plugin": "^2.0.0-pre.1",
+    "ts-lit-plugin": "^2.0.2",
     "typescript": "~5.4.2",
     "vite": "^5.2.0",
     "unified": "^9.2.1"

--- a/src/components/cc-toast/cc-toast.js
+++ b/src/components/cc-toast/cc-toast.js
@@ -35,7 +35,7 @@ import '../cc-icon/cc-icon.js';
  *
  * ## Technical details
  *
- * The timer is implemented using [AnimateController from @lit-labs/motion](https://github.com/lit/lit/tree/main/packages/labs/motion).
+ * The timer is implemented using [AnimateController from \@lit-labs/motion](https://github.com/lit/lit/tree/main/packages/labs/motion).
  * This Lit reactive controller is not only used to animate the progress bar, but also to control the pause/resume of the timer.
  * This means that, even if the progress bar is not displayed (`showProgress = false`), the controller is still used to handle the timeout.
  * As a consequence, even when the progress bar should not be displayed, the DOM node to animate is still there, and we just make sure it is invisible to the user.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
   "exclude": [
     "node_modules",
     "storybook-static",
-    "dist",
+    "dist"
   ],
   "compilerOptions": {
     /* Visit https://www.typescriptlang.org/tsconfig to read more about this file */
@@ -14,11 +14,8 @@
       "DOM"
     ], /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     /* Modules */
-    // FIXME: when we upgrade typescript, change this to `NodeNext`
-    "module": "ESNext", /* Specify what module code is generated. */
-    "moduleResolution": "node", /* Specify how TypeScript looks up a file from a given module specifier. */
-    // FIXME: when we upgrade TypeScript, enable this setting. Our current TypeScript version does not support this setting.
-    // "moduleDetection": "force", /* Make TypeScript treat every file as a module even if it does not have any imports or export (see https://www.totaltypescript.com/cannot-redeclare-block-scoped-variable) */
+    "module": "nodenext", /* Specify what module code is generated. */
+    "moduleDetection": "force", /* Make TypeScript treat every file as a module even if it does not have any imports or export (see https://www.totaltypescript.com/cannot-redeclare-block-scoped-variable) */
     /* JavaScript Support */
     "allowJs": true, /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
     "checkJs": true, /* Enable error reporting in type-checked JavaScript files. */
@@ -33,14 +30,13 @@
     "strictFunctionTypes": true, /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
     "strictBindCallApply": true, /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
     "noImplicitThis": true, /* Enable error reporting when 'this' is given the type 'any'. */
-    // FIXME: enable when we upgrade TypeScript. Our current version does not support this.
-    // "useUnknownInCatchVariables": true, /* Default catch clause variables as 'unknown' instead of 'any'. */
+    "useUnknownInCatchVariables": true, /* Default catch clause variables as 'unknown' instead of 'any'. */
     "alwaysStrict": true, /* Ensure 'use strict' is always emitted. */
     // end of strict related properties
     "noUnusedLocals": true, /* Enable error reporting when local variables aren't read. */
     "noUnusedParameters": true, /* Raise an error when a function parameter isn't read. */
-    // FIXME: Enable when we upgrade typescript. This is not supported by our current version.
-    // "exactOptionalPropertyTypes": true, /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // This option can only be enabled if we also enable `strictNullChecks`
+    "exactOptionalPropertyTypes": false, /* Interpret optional property types as written, rather than adding 'undefined'. */
     "noImplicitReturns": true, /* Enable error reporting for codepaths that do not explicitly return in a function. */
     "noFallthroughCasesInSwitch": true, /* Enable error reporting for fallthrough cases in switch statements. */
     // this causes issues with our current i18n implementation
@@ -90,7 +86,7 @@
           // https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/animationend_event
           // https://developer.mozilla.org/en-US/docs/Web/API/Element/mouseenter_event
           "wheel",
-          "copy",
+          "copy"
         ]
       }
     ]


### PR DESCRIPTION
Fixes #950 

## What does this PR do?

- Upgrades `custom-elements-manifest/analyzer` to `0.9.4`,
- Upgrades `typescript` to `5.4.2`,
- Upgrades `ts-lit-plugin` to `2.0.2`,
- Updates the `tsconfig.json` file to enable options we could not use before,
- Fixes the only breaking change that impacted us following this upgrade.

## How to review?

- Check the commits,
- Check that `ts-lit-plugin` is still working fine, for instance: removing the `cc-icon` import within the `cc-badge` should trigger an error where `<cc-icon>` is used,
- Check some doc stories using the [preview](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cem-typescript/upgrade/index.html) (we have already checked the diff + stories that may have been impacted),
- 2 reviewers (other than @Galimede & me) should be enough for this one.