### PR TITLE
chore(storybook): prevent error with HMR and `sandbox` / `demo-smart`

### DIFF
--- a/cem/generate-cem-vite-plugin.js
+++ b/cem/generate-cem-vite-plugin.js
@@ -39,8 +39,16 @@ export default function generateCem () {
     /** @param {import('vite').HmrContext} context */
     handleHotUpdate ({ server, file }) {
       const isComponentFileRegex = /cc-[^/]+\.js$/;
+
       if (file.match(isComponentFileRegex)) {
         const cemModule = server.moduleGraph.getModuleById(resolvedVirtualModuleId);
+
+        // When serving a component file outside of Storybook (`demo-smart` / `sandbox`),
+        // the cemModule is `undefined` because CEM is not imported by any file (no docs to display, no Storybook UI, etc.)
+        if (cemModule == null) {
+          return;
+        }
+
         server.moduleGraph.invalidateModule(cemModule);
       }
     },


### PR DESCRIPTION
Fixes #1026

## What does this PR do?

- Fixes an error that happens when modifying a component file while browsing `sandbox` or `demo-smart`.

## How to review?

- On the master branch:
  - go to localhost:6006/demo-smart/,
  - modify a component (any component, it does not have to be the one you are viewing, it does not have to be related to a smart demo),
  - you should get the following error `Cannot read properties of undefined (reading 'invalidationState')`.
  - :warning: Don't forget to have your smart component env vars sourced otherwise the error will not be triggered!
- Do the same on this branch, you should get no error.
- 2 reviewers should be enough for this one.