### PR TITLE
fix(cc-addon-admin): remove improper spacing within the danger zone

### DIFF
--- a/src/components/cc-addon-admin/cc-addon-admin.js
+++ b/src/components/cc-addon-admin/cc-addon-admin.js
@@ -187,11 +187,6 @@ export class CcAddonAdmin extends LitElement {
           margin-top: var(--cc-margin-top-btn-horizontal-form);
         }
 
-        .danger-desc {
-          display: grid;
-          gap: 0.5em;
-        }
-
         .danger-desc p {
           margin: 0;
         }


### PR DESCRIPTION
Fixes #1042

## What does this PR do?

- Removes improper spacing between the danger zone paragraphs.

## How to review?

- Check the commit,
- Check the preview (narrow + large viewport),
- 1 reviewer should be enough for this one.