### PR TITLE
refactor(cc-addon-admin)!: rework properties to avoid impossible states

### DIFF
--- a/src/components/cc-addon-admin/cc-addon-admin.js
+++ b/src/components/cc-addon-admin/cc-addon-admin.js
@@ -8,16 +8,16 @@ import { dispatchCustomEvent } from '../../lib/events.js';
 import { i18n } from '../../lib/i18n.js';
 
 /**
- * @typedef {import('../common.types.js').Addon} Addon
+ * @typedef {import('./cc-addon-admin.types.js').AddonAdminState} AddonAdminState
+ * @typedef {import('./cc-addon-admin.types.js').AddonAdminStateLoaded} AddonAdminStateLoaded
+ * @typedef {import('./cc-addon-admin.types.js').AddonAdminStateLoading} AddonAdminStateLoading
+ * @typedef {import('./cc-addon-admin.types.js').AddonAdminStateSaving} AddonAdminStateSaving
+ * @typedef {import('lit').PropertyValues<CcAddonAdmin>} CcAddonAdminPropertyValues
+ * @typedef {import('lit').TemplateResult<1>} TemplateResult
  */
 
 /**
  * A component displaying the admin interface of an add-on to edit its name or delete the add-on.
- *
- * ## Details
- *
- * * When addon is nullish, a skeleton screen UI pattern is displayed (loading hint).
- *
  *
  * @cssdisplay block
  *
@@ -29,13 +29,10 @@ export class CcAddonAdmin extends LitElement {
 
   static get properties () {
     return {
-      addon: { type: Object },
-      error: { type: Boolean },
       noDangerZoneBackupText: { type: Boolean, attribute: 'no-danger-zone-backup-text' },
       noDangerZoneVmText: { type: Boolean, attribute: 'no-danger-zone-vm-text' },
-      saving: { type: Boolean },
+      state: { type: Object },
       _name: { type: String, state: true },
-      _skeleton: { type: Boolean, state: true },
       _tags: { type: Array, state: true },
     };
   }
@@ -43,127 +40,157 @@ export class CcAddonAdmin extends LitElement {
   constructor () {
     super();
 
-    /** @type {Addon|null} Sets the add-on details (name and tags). */
-    this.addon = null;
-
-    /** @type {boolean} Sets the error state on the component. */
-    this.error = false;
-
     /** @type {boolean} Hides the text about backups within the danger zone when set to `true` */
     this.noDangerZoneBackupText = false;
 
     /** @type {boolean} Hides the text about VM delay within the danger zone when set to `true` */
     this.noDangerZoneVmText = false;
 
-    /** @type {boolean} Enables the saving state */
-    this.saving = false;
+    /** @type {AddonAdminState} Sets the state of the component */
+    this.state = { type: 'loading' };
 
-    /** @type {string} */
-    this._name = '';
+    /** @type {string|null} Sets the value of the `name` input field */
+    this._name = null;
 
-    /** @type {boolean} */
-    this._skeleton = false;
-
-    /** @type {string[]} */
-    this._tags = [];
+    /** @type {string[]|null} Sets the value of the `tags` input field */
+    this._tags = null;
   }
 
-  _onNameInput ({ detail: name }) {
-    this._name = name;
-  }
-
-  _onNameSubmit () {
-    dispatchCustomEvent(this, 'update-name', { name: this._name });
-  }
-
-  _onTagsInput ({ detail: tags }) {
-    this._tags = tags;
-  }
-
-  _onTagsSubmit () {
-    dispatchCustomEvent(this, 'update-tags', { tags: this._tags });
-  }
-
+  /** @private */
   _onDeleteSubmit () {
     dispatchCustomEvent(this, 'delete-addon');
   }
 
-  _onDismissError () {
-    this.error = false;
+  /**
+   * @param {{ detail: string }} event
+   * @private
+   */
+  _onNameInput ({ detail: name }) {
+    this._name = name;
   }
 
-  willUpdate (changedProperties) {
+  /** @private */
+  _onNameSubmit () {
+    dispatchCustomEvent(this, 'update-name', { name: this._name });
+  }
 
-    if (changedProperties.has('addon')) {
-      this._skeleton = (this.addon == null);
-      this._name = this._skeleton ? '' : this.addon.name;
-      this._tags = this._skeleton ? [] : this.addon.tags;
+  /**
+   * @param {{ detail: string[] }} event
+   * @private
+   */
+  _onTagsInput ({ detail: tags }) {
+    this._tags = tags;
+  }
+
+  /** @private */
+  _onTagsSubmit () {
+    dispatchCustomEvent(this, 'update-tags', { tags: this._tags });
+  }
+
+  /**
+   * @param {CcAddonAdminPropertyValues} changedProperties
+   */
+  willUpdate (changedProperties) {
+    if (changedProperties.has('state') && 'name' in this.state) {
+      this._name = this.state.name;
+    }
+
+    if (changedProperties.has('state') && 'tags' in this.state) {
+      this._tags = this.state.tags;
     }
   }
 
   render () {
 
-    const isFormDisabled = this.error || this.saving;
-    const loadingError = (this.error && !this.saving) || (this.error && this.addon == null);
-    const shouldShowBackupsText = !this.noDangerZoneBackupText;
-    const shouldShowVmText = !this.noDangerZoneVmText;
-
     return html`
       <cc-block>
         <div slot="title">${i18n('cc-addon-admin.admin')}</div>
 
-        ${!loadingError ? html`
-          <cc-block-section>
-            <div slot="title">${i18n('cc-addon-admin.heading.name')}</div>
-            <div slot="info"></div>
-            <div class="one-line-form">
-              <cc-input-text
-                label="${i18n('cc-addon-admin.input.name')}"
-                ?skeleton=${this._skeleton}
-                ?disabled=${isFormDisabled}
-                .value=${this._name}
-                @cc-input-text:input=${this._onNameInput}
-                @cc-input-text:requestimplicitsubmit=${this._onNameSubmit}
-              ></cc-input-text>
-              <cc-button primary ?skeleton=${this._skeleton} ?disabled=${isFormDisabled} @cc-button:click=${this._onNameSubmit}>${i18n('cc-addon-admin.update')}</cc-button>
-            </div>
-          </cc-block-section>
-
-          <cc-block-section>
-            <div slot="title">${i18n('cc-addon-admin.heading.tags')}</div>
-            <div slot="info">${i18n('cc-addon-admin.tags-description')}</div>
-            <div class="one-line-form">
-              <cc-input-text
-                label="${i18n('cc-addon-admin.input.tags')}"
-                ?skeleton=${this._skeleton}
-                ?disabled=${isFormDisabled}
-                .tags=${this._tags}
-                placeholder="${i18n('cc-addon-admin.tags-empty')}"
-                @cc-input-text:tags=${this._onTagsInput}
-                @cc-input-text:requestimplicitsubmit=${this._onTagsSubmit}
-              ></cc-input-text>
-              <cc-button primary ?skeleton=${this._skeleton} ?disabled=${isFormDisabled} @cc-button:click=${this._onTagsSubmit}>${i18n('cc-addon-admin.tags-update')}</cc-button>
-            </div>
-          </cc-block-section>
-
-          <cc-block-section>
-            <div slot="title" class="danger">${i18n('cc-addon-admin.danger-zone')}</div>
-            <div slot="info" class="danger-desc">
-              <p>${i18n('cc-addon-admin.delete-disclaimer')}</p>
-              ${shouldShowVmText ? html`<p>${i18n('cc-addon-admin.delete-vm')}</p>` : ''}
-              ${shouldShowBackupsText ? html`<p>${i18n('cc-addon-admin.delete-backups')}</p>` : ''}
-            </div>
-            <div>
-              <cc-button danger ?skeleton=${this._skeleton} ?disabled=${isFormDisabled} @cc-button:click=${this._onDeleteSubmit}>${i18n('cc-addon-admin.delete')}</cc-button>
-            </div>
-          </cc-block-section>
-        ` : ''}
-
-        ${loadingError ? html`
+        ${this.state.type === 'error' ? html`
           <cc-notice intent="warning" message="${i18n('cc-addon-admin.error-loading')}"></cc-notice>
         ` : ''}
+
+        ${this.state.type !== 'error' ? this._renderContent(this.state) : ''}
       </cc-block>
     `;
+  }
+
+  /**
+   * @param {AddonAdminStateLoaded|AddonAdminStateLoading|AddonAdminStateSaving} state
+   * @returns {TemplateResult}
+   * @private
+   */
+  _renderContent (state) {
+    const isSkeleton = state.type === 'loading';
+    const isSaving = state.type === 'updatingTags' || state.type === 'updatingName' || state.type === 'deleting';
+    const isFormDisabled = state.type === 'loading' || isSaving;
+    const shouldShowBackupsText = !this.noDangerZoneBackupText;
+    const shouldShowVmText = !this.noDangerZoneVmText;
+
+    return html`
+      <cc-block-section>
+        <div slot="title">${i18n('cc-addon-admin.heading.name')}</div>
+        <div slot="info"></div>
+        <div class="one-line-form">
+          <cc-input-text
+            label="${i18n('cc-addon-admin.input.name')}"
+            ?skeleton=${isSkeleton}
+            ?disabled=${isFormDisabled}
+            .value=${this._name}
+            @cc-input-text:input=${this._onNameInput}
+            @cc-input-text:requestimplicitsubmit=${this._onNameSubmit}
+          ></cc-input-text>
+          <cc-button 
+            primary 
+            ?skeleton=${isSkeleton} 
+            ?disabled=${isFormDisabled} 
+            ?waiting=${state.type === 'updatingName'}
+            @cc-button:click=${this._onNameSubmit}
+          >${i18n('cc-addon-admin.update')}</cc-button>
+        </div>
+      </cc-block-section>
+
+      <cc-block-section>
+        <div slot="title">${i18n('cc-addon-admin.heading.tags')}</div>
+        <div slot="info">${i18n('cc-addon-admin.tags-description')}</div>
+        <div class="one-line-form">
+          <cc-input-text
+            label="${i18n('cc-addon-admin.input.tags')}"
+            ?skeleton=${isSkeleton}
+            ?disabled=${isFormDisabled}
+            .tags=${this._tags}
+            placeholder="${i18n('cc-addon-admin.tags-empty')}"
+            @cc-input-text:tags=${this._onTagsInput}
+            @cc-input-text:requestimplicitsubmit=${this._onTagsSubmit}
+          ></cc-input-text>
+          <cc-button 
+            primary
+            ?skeleton=${isSkeleton}
+            ?disabled=${isFormDisabled}
+            ?waiting=${state.type === 'updatingTags'}
+            @cc-button:click=${this._onTagsSubmit}
+          >${i18n('cc-addon-admin.tags-update')}</cc-button>
+        </div>
+      </cc-block-section>
+
+      <cc-block-section>
+        <div slot="title" class="danger">${i18n('cc-addon-admin.danger-zone')}</div>
+        <div slot="info" class="danger-desc">
+          <p>${i18n('cc-addon-admin.delete-disclaimer')}</p>
+          ${shouldShowVmText ? html`<p>${i18n('cc-addon-admin.delete-vm')}</p>` : ''}
+          ${shouldShowBackupsText ? html`<p>${i18n('cc-addon-admin.delete-backups')}</p>` : ''}
+        </div>
+        <div>
+          <cc-button
+            danger 
+            ?skeleton=${isSkeleton} 
+            ?disabled=${isFormDisabled} 
+            ?waiting=${state.type === 'deleting'}
+            @cc-button:click=${this._onDeleteSubmit}
+          >${i18n('cc-addon-admin.delete')}</cc-button>
+        </div>
+      </cc-block-section>
+      `;
   }
 
   static get styles () {
@@ -182,7 +209,7 @@ export class CcAddonAdmin extends LitElement {
           flex: 1 1 10em;
           margin-right: 0.5em;
         }
-        
+
         .one-line-form cc-button {
           margin-top: var(--cc-margin-top-btn-horizontal-form);
         }

--- a/src/components/cc-addon-admin/cc-addon-admin.stories.js
+++ b/src/components/cc-addon-admin/cc-addon-admin.stories.js
@@ -11,49 +11,199 @@ const conf = {
   component: 'cc-addon-admin',
 };
 
+/**
+ * @typedef {import('./cc-addon-admin.js').CcAddonAdmin} CcAddonAdmin
+ * @typedef {import('./cc-addon-admin.types.js').AddonAdminStateLoaded} AddonAdminStateLoaded
+ * @typedef {import('./cc-addon-admin.types.js').AddonAdminStateLoading} AddonAdminStateLoading
+ * @typedef {import('./cc-addon-admin.types.js').AddonAdminStateError} AddonAdminStateError
+ * @typedef {import('./cc-addon-admin.types.js').AddonAdminStateUpdatingName} AddonAdminStateUpdatingName
+ * @typedef {import('./cc-addon-admin.types.js').AddonAdminStateUpdatingTags} AddonAdminStateUpdatingTags
+ * @typedef {import('./cc-addon-admin.types.js').AddonAdminStateDeleting} AddonAdminStateDeleting
+ * @typedef {import('../common.types.js').Addon} Addon
+ */
+
 const addon = {
   name: 'Awesome addon (PROD)',
   tags: ['foo:bar', 'simple-tag'],
 };
 
 export const defaultStory = makeStory(conf, {
-  items: [{ addon }],
+  items: [{
+    /** @type {AddonAdminStateLoaded} */
+    state: {
+      type: 'loaded',
+      ...addon,
+    },
+  }],
 });
 
-export const skeleton = makeStory(conf, {
-  items: [{}],
+export const loading = makeStory(conf, {
+  items: [{
+    /** @type {AddonAdminStateLoading} */
+    state: {
+      type: 'loading',
+    },
+  }],
 });
 
-export const saving = makeStory(conf, {
-  items: [{ addon, saving: true }],
+export const waitingWithUpdatingName = makeStory(conf, {
+  items: [{
+    /** @type {AddonAdminStateUpdatingName}*/
+    state: {
+      type: 'updatingName',
+      ...addon,
+    },
+  }],
+});
+
+export const waitingWithUpdatingTags = makeStory(conf, {
+  items: [{
+    /** @type {AddonAdminStateUpdatingTags}*/
+    state: {
+      type: 'updatingTags',
+      ...addon,
+    },
+  }],
+});
+
+export const waitingWithDeleting = makeStory(conf, {
+  items: [{
+    /** @type {AddonAdminStateDeleting}*/
+    state: {
+      type: 'deleting',
+      ...addon,
+    },
+  }],
 });
 
 export const dataLoadedWithDangerZoneVmAndBackups = makeStory(conf, {
-  items: [{ addon }],
+  items: [{
+    /** @type {AddonAdminStateLoaded} */
+    state: {
+      type: 'loaded',
+      ...addon,
+    },
+  }],
 });
 
 export const dataLoadedWithDangerZoneVmButNoBackups = makeStory(conf, {
-  items: [{ addon, noDangerZoneBackupText: true }],
+  items: [{
+    /** @type {AddonAdminStateLoaded} */
+    state: {
+      type: 'loaded',
+      ...addon,
+    },
+    noDangerZoneBackupText: true,
+  }],
 });
 
 export const dataLoadedWithDangerZoneNoVmButBackups = makeStory(conf, {
-  items: [{ addon, noDangerZoneVmText: true }],
+  items: [{
+    /** @type {AddonAdminStateLoaded} */
+    state: {
+      type: 'loaded',
+      ...addon,
+    },
+    noDangerZoneVmText: true,
+  }],
 });
 
 export const dataLoadedWithDangerZoneNoVmNoBackups = makeStory(conf, {
-  items: [{ addon, noDangerZoneBackupText: true, noDangerZoneVmText: true }],
+  items: [{
+    /** @type {AddonAdminStateLoaded} */
+    state: {
+      type: 'loaded',
+      ...addon,
+    },
+    noDangerZoneBackupText: true,
+    noDangerZoneVmText: true,
+  }],
 });
 
 export const errorWithLoading = makeStory(conf, {
-  items: [{ error: true }],
+  items: [{
+    /** @type {AddonAdminStateError} */
+    state: {
+      type: 'error',
+    },
+  }],
 });
 
 export const simulations = makeStory(conf, {
   items: [{}, {}],
   simulations: [
-    storyWait(2000, ([component, componentError]) => {
-      component.addon = addon;
-      componentError.error = true;
-    }),
+    storyWait(2000,
+      /** @param {CcAddonAdmin[]} components */
+      ([component, componentError]) => {
+        component.state = {
+          type: 'loaded',
+          name: addon.name,
+          tags: addon.tags,
+        };
+        componentError.state = { type: 'error' };
+      }),
+    storyWait(1000,
+      /** @param {CcAddonAdmin[]} components */
+      ([component]) => {
+        component.state = {
+          type: 'loaded',
+          name: 'My new Addon Name',
+          tags: addon.tags,
+        };
+      }),
+    storyWait(1000,
+      /** @param {CcAddonAdmin[]} components */
+      ([component]) => {
+        component.state = {
+          type: 'updatingName',
+          name: 'My new Addon Name',
+          tags: addon.tags,
+        };
+      }),
+    storyWait(1000,
+      /** @param {CcAddonAdmin[]} components */
+      ([component]) => {
+        component.state = {
+          type: 'loaded',
+          name: 'My new Addon Name',
+          tags: addon.tags,
+        };
+      }),
+    storyWait(1000,
+      /** @param {CcAddonAdmin[]} components */
+      ([component]) => {
+        component.state = {
+          type: 'loaded',
+          name: 'My new Addon Name',
+          tags: [...addon.tags, 'new-tag'],
+        };
+      }),
+    storyWait(1000,
+      /** @param {CcAddonAdmin[]} components */
+      ([component]) => {
+        component.state = {
+          type: 'updatingTags',
+          name: 'My new Addon Name',
+          tags: [...addon.tags, 'new-tag'],
+        };
+      }),
+    storyWait(1000,
+      /** @param {CcAddonAdmin[]} components */
+      ([component]) => {
+        component.state = {
+          type: 'loaded',
+          name: 'My new Addon Name',
+          tags: [...addon.tags, 'new-tag'],
+        };
+      }),
+    storyWait(1000,
+      /** @param {CcAddonAdmin[]} components */
+      ([component]) => {
+        component.state = {
+          type: 'deleting',
+          name: 'My new Addon Name',
+          tags: [...addon.tags, 'new-tag'],
+        };
+      }),
   ],
 });

--- a/src/components/cc-addon-admin/cc-addon-admin.types.d.ts
+++ b/src/components/cc-addon-admin/cc-addon-admin.types.d.ts
@@ -1,0 +1,36 @@
+export type AddonAdminState = AddonAdminStateLoaded | AddonAdminStateLoading | AddonAdminStateError | AddonAdminStateSaving;
+
+export interface AddonAdminStateLoaded {
+  type: 'loaded';
+  name: string;
+  tags: string[];
+}
+
+export interface AddonAdminStateLoading {
+  type: 'loading';
+}
+
+export interface AddonAdminStateError {
+  type: 'error';
+}
+
+export type AddonAdminStateSaving = AddonAdminStateDeleting | AddonAdminStateUpdatingName | AddonAdminStateUpdatingTags;
+
+export interface AddonAdminStateDeleting {
+  type: 'deleting';
+  name: string;
+  tags: string[];
+}
+
+export interface AddonAdminStateUpdatingName {
+  type: 'updatingName';
+  name: string;
+  tags: string[];
+}
+
+export interface AddonAdminStateUpdatingTags {
+  type: 'updatingTags';
+  name: string;
+  tags: string[];
+}
+

--- a/src/components/common.types.d.ts
+++ b/src/components/common.types.d.ts
@@ -6,7 +6,7 @@ export interface App {
   lastDeploymentLogsUrl?: string; // URL to the logs for the last deployment if app is not brand new
 }
 
-interface Addon {
+export interface Addon {
   id: string;
   realId: string;
   name: string;


### PR DESCRIPTION
## What does this PR do?

- Refactors the `cc-addon-admin` component to implement our new state structure,
- Implements TypeChecking within the `cc-addon-admin` component and its stories,
- Adds 2 new stories because we handle name / tag updates a little bit differently: we now set the related submit button in waiting mode ("update name" button for name update for instance) and disable other buttons while waiting,
- Updates the simulation story to reflect the new stories (simulates a name update, then a tag update, then an add-on deletion).

## How to review?

- Check the commit (the diff may not be easy to read so you can review the final result locally if you prefer),
- If you check it locally, you should not get any Typescript error within the component file or the story file,
- Compare the [prod stories](https://www.clever-cloud.com/doc/clever-components/?path=/story/%F0%9F%9B%A0-addon-cc-addon-admin--default-story) to the [preview stories](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-addon-admin/state-migration/index.html?path=/story/%F0%9F%9B%A0-addon-cc-addon-admin--default-story).