### PR TITLE
refactor(cc-doc-components)!: rework properties to avoid impossible states

### DIFF
--- a/src/components/cc-doc-card/cc-doc-card.js
+++ b/src/components/cc-doc-card/cc-doc-card.js
@@ -6,10 +6,18 @@ import { i18n } from '../../lib/i18n.js';
 import { skeletonStyles } from '../../styles/skeleton.js';
 import { linkStyles } from '../../templates/cc-link/cc-link.js';
 
+/** @type {DocCard} */
 const SKELETON_INFO = {
   heading: fakeString(6),
   description: fakeString(110),
+  link: null,
+  icons: [],
 };
+
+/**
+ * @typedef {import('./cc-doc-card.types.js').DocCardState} DocCardState
+ * @typedef {import('./cc-doc-card.types.js').DocCard} DocCard
+ */
 
 /**
  * A component displaying basic information of a product with a link to redirect to its documentation in a card.
@@ -20,57 +28,43 @@ export class CcDocCard extends LitElement {
 
   static get properties () {
     return {
-      description: { type: String },
-      heading: { type: String },
-      icons: { type: Array },
-      link: { type: String },
+      state: { type: Object },
     };
   }
 
   constructor () {
     super();
 
-    /** @type {string|null} Sets the description of the documentation card. */
-    this.description = null;
-
-    /** @type {string[]} Sets the icon of the documentation card. */
-    this.icons = null;
-
-    /** @type {string|null} Sets the link of the documentation card. */
-    this.link = null;
-
-    /** @type {string|null} Sets the title heading of the documentation card.  */
-    this.heading = null;
+    /** @type {DocCardState} Sets the state of the component */
+    this.state = { type: 'loading' };
   }
 
   render () {
-
-    const skeleton = (this.icons == null || this.heading == null || this.description == null || this.link == null);
-    const heading = this.heading ?? SKELETON_INFO.heading;
-    const description = this.description ?? SKELETON_INFO.description;
+    const skeleton = (this.state.type === 'loading');
+    const { heading, description, link } = this.state.type === 'loaded' ? this.state : SKELETON_INFO;
 
     return html`
-        <div class="images">
-          ${skeleton ? html`
-            <cc-img></cc-img>
-          ` : ''}
-          ${!skeleton ? html`
-            ${this.icons.map((icon) => html`
-              <cc-img src=${icon}></cc-img>
-            `)}
-          ` : ''}
-        </div>
-        <div class="title">
-          <span class="${classMap({ skeleton })}">${heading}</span>
-        </div>
-        <div class="desc">
-          <span class="${classMap({ skeleton })}">${description}</span>
-        </div>
-        <div class="link ${classMap({ skeleton })}">
-          ${!skeleton
-            ? i18n('cc-doc-card.link', { link: this.link, product: this.heading })
-            : i18n('cc-doc-card.skeleton-link-title')}
-        </div>
+      <div class="images">
+        ${skeleton ? html`
+          <cc-img skeleton></cc-img>
+        ` : ''}
+        ${this.state.type === 'loaded' ? html`
+          ${this.state.icons.map((iconUrl) => html`
+            <cc-img src=${iconUrl}></cc-img>
+          `)}
+        ` : ''}
+      </div>
+      <div class="title">
+        <span class="${classMap({ skeleton })}">${heading}</span>
+      </div>
+      <div class="desc">
+        <span class="${classMap({ skeleton })}">${description}</span>
+      </div>
+      <div class="link ${classMap({ skeleton })}">
+        ${this.state.type === 'loaded'
+          ? i18n('cc-doc-card.link', { link, product: heading })
+          : i18n('cc-doc-card.skeleton-link-title')}
+      </div>
     `;
   }
 

--- a/src/components/cc-doc-card/cc-doc-card.stories.js
+++ b/src/components/cc-doc-card/cc-doc-card.stories.js
@@ -1,20 +1,6 @@
 import './cc-doc-card.js';
 import { makeStory, storyWait } from '../../stories/lib/make-story.js';
 
-const DEFAULT_CARD = {
-  heading: 'ruby',
-  icons: ['https://assets.clever-cloud.com/logos/ruby.svg'],
-  description: 'Run your Ruby and Ruby on Rails applications. Compatible with Rake, Sidekiq and Active Storage for Cellar.',
-  link: '#',
-};
-
-const MULTIPLE_ICONS_CARD = {
-  icons: ['https://assets.clever-cloud.com/logos/java-jar.svg', 'https://assets.clever-cloud.com/logos/maven.svg', 'https://assets.clever-cloud.com/logos/play2.svg'],
-  heading: 'Java',
-  description: 'Deploy Java runtimes with your specific process (Jar or War) or build tools (Maven, SBT…).',
-  link: '#',
-};
-
 export default {
   tags: ['autodocs'],
   title: '🛠 homepage/<cc-doc-card>',
@@ -30,12 +16,43 @@ const conf = {
   }`,
 };
 
+/**
+ * @typedef {import('./cc-doc-card.js').CcDocCard} CcDocCard
+ * @typedef {import('./cc-doc-card.types.js').DocCardStateLoaded} DocCardStateLoaded
+ * @typedef {import('./cc-doc-card.types.js').DocCardStateLoading} DocCardStateLoading
+ */
+
+const DEFAULT_CARD = {
+  /** @type {DocCardStateLoaded} */
+  state: {
+    type: 'loaded',
+    heading: 'ruby',
+    icons: ['https://assets.clever-cloud.com/logos/ruby.svg'],
+    description: 'Run your Ruby and Ruby on Rails applications. Compatible with Rake, Sidekiq and Active Storage for Cellar.',
+    link: '#',
+  },
+};
+
+const MULTIPLE_ICONS_CARD = {
+  /** @type {DocCardStateLoaded} */
+  state: {
+    type: 'loaded',
+    icons: ['https://assets.clever-cloud.com/logos/java-jar.svg', 'https://assets.clever-cloud.com/logos/maven.svg', 'https://assets.clever-cloud.com/logos/play2.svg'],
+    heading: 'Java',
+    description: 'Deploy Java runtimes with your specific process (Jar or War) or build tools (Maven, SBT…).',
+    link: '#',
+  },
+};
+
 export const defaultStory = makeStory(conf, {
   items: [DEFAULT_CARD, MULTIPLE_ICONS_CARD],
 });
 
-export const skeleton = makeStory(conf, {
-  items: [{}],
+export const loading = makeStory(conf, {
+  items: [{
+    /** @type {DocCardStateLoading} */
+    state: { type: 'loading' },
+  }],
 });
 
 // No need to invest time on empty story right now.
@@ -49,11 +66,10 @@ export const dataLoaded = makeStory(conf, {
 export const simulations = makeStory(conf, {
   items: [{}],
   simulations: [
-    storyWait(2000, ([component]) => {
-      component.heading = DEFAULT_CARD.heading;
-      component.icons = DEFAULT_CARD.icons;
-      component.description = DEFAULT_CARD.description;
-      component.link = DEFAULT_CARD.link;
-    }),
+    storyWait(2000,
+      /** @param {[CcDocCard]} components */
+      ([component]) => {
+        component.state = DEFAULT_CARD.state;
+      }),
   ],
 });

--- a/src/components/cc-doc-card/cc-doc-card.types.d.ts
+++ b/src/components/cc-doc-card/cc-doc-card.types.d.ts
@@ -1,1 +1,16 @@
-// No need here
+export type DocCardState = DocCardStateLoaded | DocCardStateLoading;
+
+export interface DocCardStateLoaded extends DocCard {
+    type: 'loaded';
+}
+
+export interface DocCardStateLoading {
+    type: 'loading';
+}
+
+export interface DocCard {
+    description: string;
+    heading: string;
+    icons: string[];
+    link: string;
+}

--- a/src/components/cc-doc-list/cc-doc-list.js
+++ b/src/components/cc-doc-list/cc-doc-list.js
@@ -6,7 +6,7 @@ import { i18n } from '../../lib/i18n.js';
 const DOC_SKELETON_NUMBER = 9;
 
 /**
- * @typedef {import('./cc-doc-list.types.js').Documentation} Documentation
+ * @typedef {import('./cc-doc-list.types.js').DocListState} DocListState
  */
 
 /**
@@ -18,43 +18,36 @@ export class CcDocList extends LitElement {
 
   static get properties () {
     return {
-      docs: { type: Array },
-      error: { type: Boolean },
+      state: { type: Object },
     };
   }
 
   constructor () {
     super();
 
-    /** @type {Documentation[]} Sets the content that will be put into the cards. */
-    this.docs = null;
-
-    /** @type {boolean} Displays an error message. */
-    this.error = false;
+    /** @type {DocListState} Sets the state of the component */
+    this.state = { type: 'loading' };
   }
 
   render () {
 
-    const skeleton = (this.docs == null);
+    if (this.state.type === 'error') {
+      return html`
+        <cc-notice intent="warning" message="${i18n('cc-doc-list.error')}"></cc-notice>
+      `;
+    }
 
     return html`
       <div class="doc-wrapper">
-        ${this.error ? html`
-            <cc-notice intent="warning" message="${i18n('cc-doc-list.error')}"></cc-notice>
-        ` : ''}
-        ${skeleton && !this.error ? html`
+        ${this.state.type === 'loading' ? html`
           ${new Array(DOC_SKELETON_NUMBER).fill(html`
             <cc-doc-card></cc-doc-card>
           `)}
         ` : ''}
-        ${!skeleton && !this.error ? html`
-          ${this.docs.map((article) => html`
-            <cc-doc-card
-              description=${article.description ?? ''}
-              heading=${article.heading ?? ''}
-              .icons=${article.icons ?? []}
-              link=${article.link ?? ''}
-            ></cc-doc-card>
+
+        ${this.state.type === 'loaded' ? html`
+          ${this.state.docs.map((docCard) => html`
+            <cc-doc-card .state=${{ type: 'loaded', ...docCard }}></cc-doc-card>
           `)}
         ` : ''}
       </div>

--- a/src/components/cc-doc-list/cc-doc-list.stories.js
+++ b/src/components/cc-doc-list/cc-doc-list.stories.js
@@ -1,6 +1,32 @@
 import './cc-doc-list.js';
 import { makeStory, storyWait } from '../../stories/lib/make-story.js';
 
+export default {
+  tags: ['autodocs'],
+  title: '🛠 homepage/<cc-doc-list>',
+  component: 'cc-doc-list',
+};
+
+const conf = {
+  component: 'cc-doc-list',
+  // language=CSS
+  css: `
+    :host {
+      max-width: 92em !important;
+    }
+  `,
+};
+
+/**
+ * @typedef {import('./cc-doc-list.js').CcDocList} CcDocList
+ * @typedef {import('./cc-doc-list.types.js').DocListStateLoaded} DocListStateLoaded
+ * @typedef {import('./cc-doc-list.types.js').DocListStateLoading} DocListStateLoading
+ * @typedef {import('./cc-doc-list.types.js').DocListStateError} DocListStateError
+ * @typedef {import('../cc-doc-card/cc-doc-card.types.js').DocCardStateLoaded} DocCardStateLoaded
+ * @typedef {import('../cc-doc-card/cc-doc-card.types.js').DocCard} DocCard
+ */
+
+/** @type {DocCard[]} */
 const DOCS_ITEMS = [
   {
     heading: 'ruby',
@@ -40,54 +66,63 @@ const DOCS_ITEMS = [
   },
 ];
 
-export default {
-  tags: ['autodocs'],
-  title: '🛠 homepage/<cc-doc-list>',
-  component: 'cc-doc-list',
-};
-
-const conf = {
-  component: 'cc-doc-list',
-  // language=CSS
-  css: `
-    :host {
-      max-width: 92em !important;
-    }
-  `,
-};
-
 export const defaultStory = makeStory(conf, {
-  items: [{ docs: DOCS_ITEMS }],
+  items: [{
+    /** @type {DocListStateLoaded} */
+    state: {
+      type: 'loaded',
+      docs: DOCS_ITEMS,
+    },
+  }],
 });
 
-export const skeleton = makeStory(conf, {
-  items: [{}],
+export const loading = makeStory(conf, {
+  items: [{
+    /** @type {DocListStateLoading} */
+    state: { type: 'loading' },
+  }],
 });
 
 // No need to invest time on empty story right now.
 
 export const error = makeStory(conf, {
-  items: [{ error: true }],
+  items: [{
+    /** @type {DocListStateError} */
+    state: { type: 'error' },
+  }],
 });
 
 export const dataLoaded = makeStory(conf, {
-  items: [{ docs: DOCS_ITEMS }],
+  items: [{
+    /** @type {DocListStateLoaded} */
+    state: {
+      type: 'loaded',
+      docs: DOCS_ITEMS,
+    },
+  }],
 });
 
 export const simulationsWithSuccess = makeStory(conf, {
   items: [{}],
   simulations: [
-    storyWait(2000, ([component]) => {
-      component.docs = DOCS_ITEMS;
-    }),
+    storyWait(2000,
+      /** @param {[CcDocList]} components */
+      ([component]) => {
+        component.state = {
+          type: 'loaded',
+          docs: DOCS_ITEMS,
+        };
+      }),
   ],
 });
 
 export const simulationsWithFailure = makeStory(conf, {
   items: [{}],
   simulations: [
-    storyWait(2000, ([component]) => {
-      component.error = true;
-    }),
+    storyWait(2000,
+      /** @param {[CcDocList]} components */
+      ([component]) => {
+        component.state = { type: 'error' };
+      }),
   ],
 });

--- a/src/components/cc-doc-list/cc-doc-list.types.d.ts
+++ b/src/components/cc-doc-list/cc-doc-list.types.d.ts
@@ -1,6 +1,16 @@
-interface Documentation {
-  desc: string;
-  icons: string[];
-  link: string;
-  title: string;
+import{ DocCard } from '../cc-doc-card/cc-doc-card.types.js';
+
+export type DocListState = DocListStateLoaded | DocListStateLoading | DocListStateError;
+
+export interface DocListStateLoaded {
+  type: 'loaded';
+  docs: DocCard[];
+}
+
+export interface DocListStateLoading {
+  type: 'loading';
+}
+
+export interface DocListStateError {
+  type: 'error';
 }


### PR DESCRIPTION
## What does this PR do?

- Refactors the `cc-doc-card` and `cc-doc-list` components to implement our new state structure,
- Implements TypeChecking within the `cc-doc-card`  and `cc-doc-list` components and their stories.

## How to review?

- Check the commits (the diff may not be easy to read so you can review the final result locally if you prefer),
- If you check it locally, you should not get any Typescript error within the components files or the story files,
- Compare the `cc-doc-card` [prod stories](https://www.clever-cloud.com/doc/clever-components/?path=/story/%F0%9F%9B%A0-homepage-cc-doc-card--default-story) to the [preview stories](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-doc-list/state-migration/index.html?path=/story/%F0%9F%9B%A0-homepage-cc-doc-card--default-story) and the `cc-doc-list` [prod stories](https://www.clever-cloud.com/doc/clever-components/?path=/story/%F0%9F%9B%A0-homepage-cc-doc-list--default-story) to the [preview stories](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-doc-list/state-migration/index.html?path=/story/%F0%9F%9B%A0-homepage-cc-doc-list--default-story)