### PR TITLE
refactor(cc-header-orga)!: rework properties to avoid impossible states

### DIFF
--- a/src/components/cc-header-orga/cc-header-orga.js
+++ b/src/components/cc-header-orga/cc-header-orga.js
@@ -14,6 +14,7 @@ import { linkStyles } from '../../templates/cc-link/cc-link.js';
 
 /**
  * @typedef {import('./cc-header-orga.types.js').HeaderOrgaState} HeaderOrgaState
+ * @typedef {import('lit').TemplateResult<1>} TemplateResult
  */
 
 /**
@@ -27,7 +28,7 @@ export class CcHeaderOrga extends LitElement {
 
   static get properties () {
     return {
-      orga: { type: Object },
+      state: { type: Object },
     };
   }
 
@@ -35,11 +36,16 @@ export class CcHeaderOrga extends LitElement {
     super();
 
     /** @type {HeaderOrgaState} Sets the component state. */
-    this.orga = {
-      state: 'loading',
+    this.state = {
+      type: 'loading',
     };
   }
 
+  /**
+   * @param {string} name
+   * @returns {string}
+   * @private
+   */
   _getInitials (name) {
     return name
       .trim()
@@ -51,30 +57,42 @@ export class CcHeaderOrga extends LitElement {
 
   render () {
 
-    if (this.orga.state === 'error') {
+    if (this.state.type === 'error') {
       return html`
         <cc-notice intent="warning" message="${i18n('cc-header-orga.error')}"></cc-notice>
       `;
     }
 
-    if (this.orga.state === 'loading') {
+    if (this.state.type === 'loading') {
       return this._renderHeader({
         name: '??????????????????????????',
         skeleton: true,
       });
     }
 
-    if (this.orga.state === 'loaded') {
+    if (this.state.type === 'loaded') {
       return this._renderHeader({
-        name: this.orga.name,
-        avatar: this.orga.avatar,
-        cleverEnterprise: this.orga.cleverEnterprise,
-        emergencyNumber: this.orga.emergencyNumber,
+        name: this.state.name,
+        avatar: this.state.avatar,
+        cleverEnterprise: this.state.cleverEnterprise,
+        emergencyNumber: this.state.emergencyNumber,
         skeleton: false,
       });
     }
+
+    return '';
   }
 
+  /**
+   * @param {Object} param
+   * @param {string} param.name
+   * @param {string} [param.avatar]
+   * @param {boolean} [param.cleverEnterprise]
+   * @param {string} [param.emergencyNumber]
+   * @param {boolean} [param.skeleton]
+   * @returns {TemplateResult}
+   * @private
+   */
   _renderHeader ({ name, avatar = null, cleverEnterprise = false, emergencyNumber = null, skeleton = false }) {
 
     return html`
@@ -107,6 +125,13 @@ export class CcHeaderOrga extends LitElement {
     `;
   }
 
+  /**
+   * @param {boolean} skeleton
+   * @param {string} avatar
+   * @param {string} name
+   * @returns {TemplateResult}
+   * @private
+   */
   _renderAvatar (skeleton, avatar, name) {
     if (skeleton) {
       return html`

--- a/src/components/cc-header-orga/cc-header-orga.stories.js
+++ b/src/components/cc-header-orga/cc-header-orga.stories.js
@@ -17,8 +17,16 @@ const conf = {
   `,
 };
 
-const DEFAULT_ORGA = {
-  state: 'loaded',
+/**
+ * @typedef {import('./cc-header-orga.js').CcHeaderOrga} CcHeaderOrga
+ * @typedef {import('./cc-header-orga.types.js').HeaderOrgaStateLoaded} HeaderOrgaStateLoaded
+ * @typedef {import('./cc-header-orga.types.js').HeaderOrgaStateLoading} HeaderOrgaStateLoading
+ * @typedef {import('./cc-header-orga.types.js').HeaderOrgaStateError} HeaderOrgaStateError
+ */
+
+/** @type {HeaderOrgaStateLoaded} */
+const DEFAULT_ORGA_STATE = {
+  type: 'loaded',
   name: 'ACME corporation world',
   avatar: 'http://placekitten.com/350/350',
   cleverEnterprise: true,
@@ -31,30 +39,30 @@ const DEFAULT_SLOTTED_CONTENT = `<div slot="footer">
 
 export const defaultStory = makeStory(conf, {
   items: [{
-    orga: DEFAULT_ORGA,
+    /** @type {HeaderOrgaStateLoaded} */
+    state: DEFAULT_ORGA_STATE,
   }],
 });
 
-export const skeleton = makeStory(conf, {
+export const loading = makeStory(conf, {
   items: [{
-    orga: {
-      state: 'loading',
-    },
+    /** @type {HeaderOrgaStateLoading} */
+    state: { type: 'loading' },
   }],
 });
 
 export const error = makeStory(conf, {
   items: [{
-    orga: {
-      state: 'error',
-    },
+    /** @type {HeaderOrgaStateError} */
+    state: { type: 'error' },
   }],
 });
 
 export const dataLoadedWithClassicClient = makeStory(conf, {
   items: [{
-    orga: {
-      ...DEFAULT_ORGA,
+    /** @type {HeaderOrgaStateLoaded} */
+    state: {
+      ...DEFAULT_ORGA_STATE,
       name: 'ACME Startup',
       cleverEnterprise: false,
       emergencyNumber: null,
@@ -64,8 +72,9 @@ export const dataLoadedWithClassicClient = makeStory(conf, {
 
 export const dataLoadedWithClassicClientAndSlottedContent = makeStory(conf, {
   items: [{
-    orga: {
-      ...DEFAULT_ORGA,
+    /** @type {HeaderOrgaStateLoaded} */
+    state: {
+      ...DEFAULT_ORGA_STATE,
       name: 'ACME Startup',
       cleverEnterprise: false,
       emergencyNumber: null,
@@ -76,8 +85,9 @@ export const dataLoadedWithClassicClientAndSlottedContent = makeStory(conf, {
 
 export const dataLoadedWithClassicClientNoAvatar = makeStory(conf, {
   items: [{
-    orga: {
-      ...DEFAULT_ORGA,
+    /** @type {HeaderOrgaStateLoaded} */
+    state: {
+      ...DEFAULT_ORGA_STATE,
       name: 'ACME Startup',
       avatar: null,
       cleverEnterprise: false,
@@ -88,8 +98,9 @@ export const dataLoadedWithClassicClientNoAvatar = makeStory(conf, {
 
 export const dataLoadedWithEnterpriseClient = makeStory(conf, {
   items: [{
-    orga: {
-      ...DEFAULT_ORGA,
+    /** @type {HeaderOrgaStateLoaded} */
+    state: {
+      ...DEFAULT_ORGA_STATE,
       emergencyNumber: null,
     },
   }],
@@ -97,8 +108,9 @@ export const dataLoadedWithEnterpriseClient = makeStory(conf, {
 
 export const dataLoadedWithEnterpriseClientAndSlottedContent = makeStory(conf, {
   items: [{
-    orga: {
-      ...DEFAULT_ORGA,
+    /** @type {HeaderOrgaStateLoaded} */
+    state: {
+      ...DEFAULT_ORGA_STATE,
       emergencyNumber: null,
     },
     innerHTML: DEFAULT_SLOTTED_CONTENT,
@@ -107,13 +119,15 @@ export const dataLoadedWithEnterpriseClientAndSlottedContent = makeStory(conf, {
 
 export const dataLoadedWithEnterpriseClientEmergencyNumber = makeStory(conf, {
   items: [{
-    orga: DEFAULT_ORGA,
+    /** @type {HeaderOrgaStateLoaded} */
+    state: DEFAULT_ORGA_STATE,
   }],
 });
 
 export const dataLoadedWithEnterpriseClientEmergencyNumberAndSlottedContent = makeStory(conf, {
   items: [{
-    orga: DEFAULT_ORGA,
+    /** @type {HeaderOrgaStateLoaded} */
+    state: DEFAULT_ORGA_STATE,
     innerHTML: DEFAULT_SLOTTED_CONTENT,
   }],
 });
@@ -129,7 +143,8 @@ export const dataLoadedWithSlottedContentCustomStyling = makeStory(conf, {
     }
   `,
   items: [{
-    orga: DEFAULT_ORGA,
+    /** @type {HeaderOrgaStateLoaded} */
+    state: DEFAULT_ORGA_STATE,
     innerHTML: `
       <div slot="footer">
         <p>The slotted content container has a default styling: <code>background-color</code>, <code>padding</code> and <code>border-top</code>.</p>
@@ -143,17 +158,19 @@ export const dataLoadedWithSlottedContentCustomStyling = makeStory(conf, {
 export const simulations = makeStory(conf, {
   items: [{}, {}, { innerHTML: DEFAULT_SLOTTED_CONTENT }, {}],
   simulations: [
-    storyWait(3000, ([component, componentNoAvatar, componentWithSlottedContent, componentError]) => {
-      component.orga = DEFAULT_ORGA;
-      componentWithSlottedContent.orga = {
-        ...DEFAULT_ORGA,
-        emergencyNumber: null,
-      };
-      componentNoAvatar.orga = {
-        ...DEFAULT_ORGA,
-        avatar: null,
-      };
-      componentError.orga = { state: 'error' };
-    }),
+    storyWait(3000,
+      /** @param {CcHeaderOrga[]} components */
+      ([component, componentNoAvatar, componentWithSlottedContent, componentError]) => {
+        component.state = DEFAULT_ORGA_STATE;
+        componentWithSlottedContent.state = {
+          ...DEFAULT_ORGA_STATE,
+          emergencyNumber: null,
+        };
+        componentNoAvatar.state = {
+          ...DEFAULT_ORGA_STATE,
+          avatar: null,
+        };
+        componentError.state = { type: 'error' };
+      }),
   ],
 });

--- a/src/components/cc-header-orga/cc-header-orga.types.d.ts
+++ b/src/components/cc-header-orga/cc-header-orga.types.d.ts
@@ -1,17 +1,17 @@
 export type HeaderOrgaState = HeaderOrgaStateLoaded | HeaderOrgaStateLoading | HeaderOrgaStateError;
 
-interface HeaderOrgaStateLoaded {
-  state: 'loaded';
+export interface HeaderOrgaStateLoaded {
+  type: 'loaded';
   name: string;
   avatar?: string;
   cleverEnterprise?: boolean;
-  emergencyNumber?: number; 
+  emergencyNumber?: string;
 }
 
-interface HeaderOrgaStateLoading {
-  state: 'loading';
+export interface HeaderOrgaStateLoading {
+  type: 'loading';
 }
 
-interface HeaderOrgaStateError {
-  state: 'error';
+export interface HeaderOrgaStateError {
+  type: 'error';
 }


### PR DESCRIPTION
## What does this PR do?

- Refactors the `cc-header-orga` component to implement our new state structure,
- Implements TypeChecking within the `cc-header-orga` component and its stories.

## How to review?

- Check the commit (the diff may not be easy to read so you can review the final result locally if you prefer),
- If you check it locally, you should not get any Typescript error within the component file or the story file,
- Compare the [prod stories](https://www.clever-cloud.com/doc/clever-components/?path=/story/%F0%9F%9B%A0-overview-cc-header-orga--default-story) to the [preview stories](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-header-orga/state-migration/index.html?path=/story/%F0%9F%9B%A0-overview-cc-header-orga--default-story).