### PR TITLE
refactor(cc-addon-features)!: rework properties to avoid impossible s…

### DIFF
--- a/src/components/cc-addon-features/cc-addon-features.stories.js
+++ b/src/components/cc-addon-features/cc-addon-features.stories.js
@@ -1,14 +1,6 @@
 import './cc-addon-features.js';
 import { makeStory, storyWait } from '../../stories/lib/make-story.js';
 
-const defaultFeatures = [
-  { name: 'DISK', value: '40 GB' },
-  { name: 'MEMORY', value: '4 GB' },
-  { name: 'CPUs', value: '2' },
-  { name: 'Foo feature', value: 'No' },
-  { name: 'Bar feature', value: 'Yes' },
-];
-
 export default {
   tags: ['autodocs'],
   title: '🛠 Addon/<cc-addon-features>',
@@ -19,91 +11,145 @@ const conf = {
   component: 'cc-addon-features',
 };
 
+/**
+ * @typedef {import('./cc-addon-features.js').CcAddonFeatures} CcAddonFeatures
+ * @typedef {import('./cc-addon-features.types.js').AddonFeaturesStateLoaded} AddonFeaturesStateLoaded
+ * @typedef {import('./cc-addon-features.types.js').AddonFeaturesStateLoading} AddonFeaturesStateLoading
+ * @typedef {import('./cc-addon-features.types.js').AddonFeaturesStateError} AddonFeaturesStateError
+ * @typedef {import('./cc-addon-features.types.js').AddonFeature} AddonFeature
+ */
+
+/** @type {AddonFeature[]} */
+const defaultFeatures = [
+  { name: 'DISK', value: '40 GB' },
+  { name: 'MEMORY', value: '4 GB' },
+  { name: 'CPUs', value: '2' },
+  { name: 'Foo feature', value: 'No' },
+  { name: 'Bar feature', value: 'Yes' },
+];
+
 export const defaultStory = makeStory(conf, {
-  items: [{ features: defaultFeatures }],
+  items: [{
+    /** @type {AddonFeaturesStateLoaded} */
+    state: {
+      type: 'loaded',
+      features: defaultFeatures,
+    },
+  }],
 });
 
-export const skeleton = makeStory(conf, {
-  items: [{}],
+export const loading = makeStory(conf, {
+  items: [{
+    /** @type {AddonFeaturesStateLoading} */
+    state: { type: 'loading' },
+  }],
 });
 
 export const error = makeStory(conf, {
-  items: [{ error: true }],
+  items: [{
+    /** @type {AddonFeaturesStateError} */
+    state: { type: 'error' },
+  }],
 });
 
 export const dataLoadedWithElasticSearch = makeStory(conf, {
   items: [{
-    features: [
-      { name: 'DISK', value: '40 GB' },
-      { name: 'NODES', value: '1' },
-      { name: 'MEMORY', value: '4 GB' },
-      { name: 'CPUs', value: '2' },
-      { name: 'KIBANA', value: 'Yes' },
-      { name: 'API', value: 'No' },
-    ],
+    /** @type {AddonFeaturesStateLoaded} */
+    state: {
+      type: 'loaded',
+      features: [
+        { name: 'DISK', value: '40 GB' },
+        { name: 'NODES', value: '1' },
+        { name: 'MEMORY', value: '4 GB' },
+        { name: 'CPUs', value: '2' },
+        { name: 'KIBANA', value: 'Yes' },
+        { name: 'API', value: 'No' },
+      ],
+    },
   }],
 });
 
 export const dataLoadedWithRedis = makeStory(conf, {
   items: [{
-    features: [
-      { name: 'Connection limit', value: '250' },
-      { name: 'Type', value: 'Dedicated' },
-      { name: 'Isolation', value: 'Dedicated' },
-      { name: 'Databases', value: '100' },
-      { name: 'Size', value: '250mb' },
-    ],
+    /** @type {AddonFeaturesStateLoaded} */
+    state: {
+      type: 'loaded',
+      features: [
+        { name: 'Connection limit', value: '250' },
+        { name: 'Type', value: 'Dedicated' },
+        { name: 'Isolation', value: 'Dedicated' },
+        { name: 'Databases', value: '100' },
+        { name: 'Size', value: '250mb' },
+      ],
+    },
   }],
 });
 
 export const dataLoadedWithPostgresql = makeStory(conf, {
   items: [{
-    features: [
-      { name: 'PostGIS', value: 'Yes' },
-      { name: 'Logs', value: 'No' },
-      { name: 'Metrics', value: 'No' },
-      { name: 'Backups', value: 'Daily - 7 Retained' },
-      { name: 'Type', value: 'Shared' },
-      { name: 'Max connection limit', value: '5' },
-      { name: 'Migration Tool', value: 'Yes' },
-      { name: 'Max DB size', value: '256 MB' },
-      { name: 'vCPUS', value: 'Shared' },
-      { name: 'Memory', value: 'Shared' },
-    ],
+    /** @type {AddonFeaturesStateLoaded} */
+    state: {
+      type: 'loaded',
+      features: [
+        { name: 'PostGIS', value: 'Yes' },
+        { name: 'Logs', value: 'No' },
+        { name: 'Metrics', value: 'No' },
+        { name: 'Backups', value: 'Daily - 7 Retained' },
+        { name: 'Type', value: 'Shared' },
+        { name: 'Max connection limit', value: '5' },
+        { name: 'Migration Tool', value: 'Yes' },
+        { name: 'Max DB size', value: '256 MB' },
+        { name: 'vCPUS', value: 'Shared' },
+        { name: 'Memory', value: 'Shared' },
+      ],
+    },
   }],
 });
 
 export const dataLoadedWithCellar = makeStory(conf, {
   items: [{
-    features: [
-      { name: 'Outbound traffic < 10TB', value: '100MB free, 0.09€/GB/Mo' },
-      { name: 'Storage < 1TB', value: '100 MB free, 20.48€/TB/Mo' },
-      { name: 'Outbound traffic < 40TB', value: '0.07€/GB/Mo' },
-      { name: 'Storage < 25TB', value: '15.36€/TB/Mo' },
-      { name: 'Storage < 50TB', value: '10.24€/TB/Mo' },
-    ],
+    /** @type {AddonFeaturesStateLoaded} */
+    state: {
+      type: 'loaded',
+      features: [
+        { name: 'Outbound traffic < 10TB', value: '100MB free, 0.09€/GB/Mo' },
+        { name: 'Storage < 1TB', value: '100 MB free, 20.48€/TB/Mo' },
+        { name: 'Outbound traffic < 40TB', value: '0.07€/GB/Mo' },
+        { name: 'Storage < 25TB', value: '15.36€/TB/Mo' },
+        { name: 'Storage < 50TB', value: '10.24€/TB/Mo' },
+      ],
+    },
   }],
 });
 
 export const dataLoadedWithMysql = makeStory(conf, {
   items: [{
-    features: [
-      { name: 'Backups', value: 'Daily - 7 Retained' },
-      { name: 'vCPUS', value: '2' },
-      { name: 'Memory', value: '2 GB' },
-      { name: 'Max db size', value: '10 GB' },
-      { name: 'Max connection limit', value: '125' },
-      { name: 'TYPE', value: 'Dedicated' },
-    ],
+    /** @type {AddonFeaturesStateLoaded} */
+    state: {
+      type: 'loaded',
+      features: [
+        { name: 'Backups', value: 'Daily - 7 Retained' },
+        { name: 'vCPUS', value: '2' },
+        { name: 'Memory', value: '2 GB' },
+        { name: 'Max db size', value: '10 GB' },
+        { name: 'Max connection limit', value: '125' },
+        { name: 'TYPE', value: 'Dedicated' },
+      ],
+    },
   }],
 });
 
 export const simulations = makeStory(conf, {
   items: [{}, {}],
   simulations: [
-    storyWait(2000, ([component, componentError]) => {
-      component.features = defaultFeatures;
-      componentError.error = true;
-    }),
+    storyWait(2000,
+      /** @param {CcAddonFeatures[]} components */
+      ([component, componentError]) => {
+        component.state = {
+          type: 'loaded',
+          features: defaultFeatures,
+        };
+        componentError.state = { type: 'error' };
+      }),
   ],
 });

--- a/src/components/cc-addon-features/cc-addon-features.types.d.ts
+++ b/src/components/cc-addon-features/cc-addon-features.types.d.ts
@@ -1,4 +1,25 @@
-interface AddonFeature {
+import { IconModel } from '../common.types.js';
+
+export type AddonFeaturesState = AddonFeaturesStateLoaded | AddonFeaturesStateLoading | AddonFeaturesStateError;
+
+export interface AddonFeature {
   name: string;
   value: string;
+}
+
+export interface AddonFeaturesStateLoaded {
+  type: 'loaded';
+  features: AddonFeature[];
+}
+
+export interface AddonFeaturesStateLoading {
+  type: 'loading';
+}
+
+export interface AddonFeaturesStateError {
+  type: 'error';
+}
+
+export interface AddonFeatureWithIcon extends AddonFeature {
+  icon?: IconModel;
 }


### PR DESCRIPTION
## What does this PR do?

- Refactors the `cc-addon-features` component to implement our new state structure,
- Implements TypeChecking within the `cc-addon-features` component and its stories,
- Fix the skeleton and simulation stories.

## How to review?

- Check the commit (the diff may not be easy to read so you can review the final result locally if you prefer),
- If you check it locally, you should not get any Typescript error within the component file or the story file,
- Compare the [prod stories](https://www.clever-cloud.com/doc/clever-components/?path=/story/%F0%9F%9B%A0-addon-cc-addon-features--default-story) to the [preview stories](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-addon-features/state-migration/index.html?path=/story/%F0%9F%9B%A0-addon-cc-addon-features--default-story).