### PR TITLE
refactor(cc-invoice-components): !: rework properties to avoid impossible states

### DIFF
--- a/src/components/cc-invoice-list/cc-invoice-list.smart.js
+++ b/src/components/cc-invoice-list/cc-invoice-list.smart.js
@@ -3,6 +3,10 @@ import '../cc-smart-container/cc-smart-container.js';
 import { fetchAllInvoices } from '../../lib/api-helpers.js';
 import { defineSmartComponent } from '../../lib/define-smart-component.js';
 
+/**
+  * @typedef {import('../common.types.js').Invoice} Invoice
+  */
+
 defineSmartComponent({
   selector: 'cc-invoice-list',
   params: {
@@ -16,9 +20,11 @@ defineSmartComponent({
     const { apiConfig, ownerId } = context;
 
     fetchAllInvoices({ apiConfig, ownerId, signal })
-      .then((invoices) => {
-        updateComponent('state', { type: 'loaded', invoices });
-      })
+      .then(
+        /** @param {Invoice[]} invoices */
+        (invoices) => {
+          updateComponent('state', { type: 'loaded', invoices });
+        })
       .catch((error) => {
         console.error(error);
         updateComponent('state', { type: 'error' });

--- a/src/components/cc-invoice-list/cc-invoice-list.stories.js
+++ b/src/components/cc-invoice-list/cc-invoice-list.stories.js
@@ -1,19 +1,7 @@
 import './cc-invoice-list.js';
+import { fullInvoicesExample, pendingInvoices, processedInvoices } from '../../stories/fixtures/invoices.js';
 import { makeStory, storyWait } from '../../stories/lib/make-story.js';
-
 import { PROCESSING_STATUS } from '../cc-invoice-table/cc-invoice-table.js';
-import { pendingInvoices, processedInvoices, processingInvoices } from '../cc-invoice-table/cc-invoice-table.stories.js';
-
-const fullInvoicesExample = [
-  ...pendingInvoices('2020').slice(0, 4),
-  ...processingInvoices('2020'),
-  ...processedInvoices('2019'),
-  ...processedInvoices('2020').slice(2, 10),
-  ...processedInvoices('2018').slice(2, 10),
-  ...processedInvoices('2017').slice(3, 10),
-  ...processedInvoices('2016').slice(1, 9),
-  ...processedInvoices('2015').slice(1, 9),
-];
 
 export default {
   tags: ['autodocs'],
@@ -25,67 +13,92 @@ const conf = {
   component: 'cc-invoice-list',
 };
 
+/**
+ * @typedef {import('./cc-invoice-list.js').CcInvoiceList} CcInvoiceList
+ * @typedef {import('./cc-invoice-list.types.js').InvoiceListStateLoaded} InvoiceListStateLoaded
+ * @typedef {import('./cc-invoice-list.types.js').InvoiceListStateLoading} InvoiceListStateLoading
+ * @typedef {import('./cc-invoice-list.types.js').InvoiceListStateError} InvoiceListStateError
+ */
+
 export const defaultStory = makeStory(conf, {
-  items: [{ state: { type: 'loaded', invoices: fullInvoicesExample } }],
+  items: [{
+    /** @type {InvoiceListStateLoaded} */
+    state: { type: 'loaded', invoices: fullInvoicesExample },
+  }],
 });
 
 export const loading = makeStory(conf, {
-  items: [{}],
+  items: [{
+    /** @type {InvoiceListStateLoading} */
+    state: { type: 'loading' },
+  }],
 });
 
 export const empty = makeStory(conf, {
-  items: [{ state: { type: 'loaded', invoices: [] } }],
+  items: [{
+    /** @type {InvoiceListStateLoaded} */
+    state: { type: 'loaded', invoices: [] },
+  }],
 });
 
 export const error = makeStory(conf, {
-  items: [{ state: { type: 'error' } }],
+  items: [{
+    /** @type {InvoiceListStateError} */
+    state: { type: 'error' },
+  }],
 });
 
 export const dataLoaded = makeStory(conf, {
-  items: [{ state: { type: 'loaded', invoices: fullInvoicesExample } }],
+  items: [{
+    /** @type {InvoiceListStateLoaded} */
+    state: { type: 'loaded', invoices: fullInvoicesExample },
+  }],
 });
 
 export const dataLoadedWithNoProcessing = makeStory(conf, {
-  items: [{ state: { type: 'loaded', invoices: fullInvoicesExample.filter((i) => i.status !== PROCESSING_STATUS) } }],
+  items: [{
+    /** @type {InvoiceListStateLoaded} */
+    state: { type: 'loaded', invoices: fullInvoicesExample.filter((i) => i.status !== PROCESSING_STATUS) },
+  }],
 });
 
 export const dataLoadedWithNoPending = makeStory(conf, {
-  items: [
-    {
-      state:
-        {
-          type: 'loaded',
-          invoices: [
-            ...processedInvoices('2020'),
-            ...processedInvoices('2020').slice(2, 10),
-            ...processedInvoices('2018').slice(2, 10),
-            ...processedInvoices('2017').slice(3, 11),
-            ...processedInvoices('2016').slice(1, 9),
-            ...processedInvoices('2015').slice(1, 9),
-          ],
-        },
-    }],
+  items: [{
+    /** @type {InvoiceListStateLoaded} */
+    state: {
+      type: 'loaded',
+      invoices: [
+        ...processedInvoices('2020'),
+        ...processedInvoices('2020').slice(2, 10),
+        ...processedInvoices('2018').slice(2, 10),
+        ...processedInvoices('2017').slice(3, 11),
+        ...processedInvoices('2016').slice(1, 9),
+        ...processedInvoices('2015').slice(1, 9),
+      ],
+    },
+  }],
 });
 
 export const dataLoadedWithNoProcessed = makeStory(conf, {
-  items: [
-    {
-      state:
-        {
-          type: 'loaded',
-          invoices: [
-            ...pendingInvoices(2020).slice(0, 4),
-          ],
-        },
-    }],
+  items: [{
+    /** @type {InvoiceListStateLoaded} */
+    state: {
+      type: 'loaded',
+      invoices: [
+        ...pendingInvoices('2020').slice(0, 4),
+      ],
+    },
+  }],
 });
 
 export const simulations = makeStory(conf, {
   items: [{}, {}],
   simulations: [
-    storyWait(2000, ([component, componentError]) => {
-      component.state = { type: 'loaded', invoices: fullInvoicesExample };
-      componentError.state = { type: 'error' };
-    }),
+    storyWait(2000,
+      /** @param {CcInvoiceList[]} components */
+      ([component, componentError]) => {
+        component.state = { type: 'loaded', invoices: fullInvoicesExample };
+        componentError.state = { type: 'error' };
+      }),
   ],
 });

--- a/src/components/cc-invoice-list/cc-invoice-list.types.d.ts
+++ b/src/components/cc-invoice-list/cc-invoice-list.types.d.ts
@@ -1,16 +1,16 @@
-import { Invoice } from "../common.types";
+import { Invoice } from '../common.types.js';
 
 export type InvoiceListState = InvoiceListStateLoading | InvoiceListStateError | InvoiceListStateLoaded;
 
-interface InvoiceListStateLoading {
+export interface InvoiceListStateLoading {
   type: 'loading';
 }
 
-interface InvoiceListStateError {
+export interface InvoiceListStateError {
   type: 'error';
 }
 
-interface InvoiceListStateLoaded {
+export interface InvoiceListStateLoaded {
   type: 'loaded';
   invoices: Array<Invoice>;
 }

--- a/src/components/cc-invoice-table/cc-invoice-table.stories.js
+++ b/src/components/cc-invoice-table/cc-invoice-table.stories.js
@@ -1,48 +1,6 @@
 import './cc-invoice-table.js';
+import { createInvoice, pendingInvoices, processedInvoices, processingInvoices } from '../../stories/fixtures/invoices.js';
 import { makeStory } from '../../stories/lib/make-story.js';
-
-function createInvoice (year, month, amount, status, type = 'INVOICE') {
-  const emissionDate = `${year}-${month}-01`;
-  const number = `${year + month}01-${String((Math.ceil(amount * 100)) % 1000).padStart(4, '0')}`;
-  const downloadUrl = '/download/' + number;
-  const paymentUrl = '/pay/' + number;
-  return { emissionDate, number, type, status, total: { currency: 'EUR', amount }, downloadUrl, paymentUrl };
-}
-
-export const pendingInvoices = (year) => [
-  createInvoice(year, '01', 17.79, 'WONTPAY'),
-  createInvoice(year, '02', 29.24, 'PENDING'),
-  createInvoice(year, '03', 73.34, 'PENDING'),
-  createInvoice(year, '04', 71.96, 'PENDING'),
-  createInvoice(year, '05', 662.95, 'PENDING'),
-  createInvoice(year, '06', 100.42, 'PENDING'),
-  createInvoice(year, '07', 1894.88, 'PENDING'),
-  createInvoice(year, '08', 111971.46, 'PENDING'),
-  createInvoice(year, '09', 99.14, 'PENDING'),
-  createInvoice(year, '10', 2261.81, 'PAYMENTHELD'),
-  createInvoice(year, '11', 6218.31, 'PENDING'),
-  createInvoice(year, '12', 11487.02, 'PENDING'),
-];
-
-export const processingInvoices = (year) => [
-  createInvoice(year, '11', 172.79, 'PROCESSING'),
-  createInvoice(year, '12', 2287.02, 'PROCESSING'),
-];
-
-export const processedInvoices = (year) => [
-  createInvoice(year, '01', 1782.79, 'PAID'),
-  createInvoice(year, '02', 1129.24, 'PAID'),
-  createInvoice(year, '03', 4273.34, 'PAID'),
-  createInvoice(year, '04', 2171.96, 'CANCELED'),
-  createInvoice(year, '05', 3662.95, 'PAID'),
-  createInvoice(year, '06', 100.42, 'PAID'),
-  createInvoice(year, '07', 1894.88, 'PAID'),
-  createInvoice(year, '08', 1971.46, 'REFUNDED'),
-  createInvoice(year, '09', 1699.14, 'PAID'),
-  createInvoice(year, '10', 2261.81, 'CANCELED'),
-  createInvoice(year, '11', 618.31, 'PAID'),
-  createInvoice(year, '12', 1487.02, 'PAID'),
-];
 
 export default {
   tags: ['autodocs'],
@@ -55,36 +13,52 @@ const conf = {
   component: 'cc-invoice-table',
 };
 
+/**
+ * @typedef {import('./cc-invoice-table.types.js').InvoiceTableStateLoaded} InvoiceTableStateLoaded
+ * @typedef {import('./cc-invoice-table.types.js').InvoiceTableStateLoading} InvoiceTableStateLoading
+ */
+
 export const defaultStory = makeStory(conf, {
+  /** @type {{ state: InvoiceTableStateLoaded }[] } */
   items: [
-    { invoices: pendingInvoices(2020).slice(0, 4) },
-    { invoices: processingInvoices(2020).slice(0, 4) },
-    { invoices: processedInvoices(2019).slice(0, 4) },
+    { state: { type: 'loaded', invoices: pendingInvoices('2020').slice(0, 4) } },
+    { state: { type: 'loaded', invoices: processingInvoices('2020').slice(0, 4) } },
+    { state: { type: 'loaded', invoices: processedInvoices('2019').slice(0, 4) } },
   ],
 });
 
-export const skeleton = makeStory(conf, {
-  items: [{}],
+export const loading = makeStory(conf, {
+  items: [{
+    /** @type {InvoiceTableStateLoading} */
+    state: { type: 'loading' },
+  }],
 });
 
 export const dataLoadedWithPending = makeStory(conf, {
-  items: [{ invoices: pendingInvoices(2020) }],
+  /** @type {{ state: InvoiceTableStateLoaded }[] } */
+  items: [{ state: { type: 'loaded', invoices: pendingInvoices('2020') } }],
 });
 
 export const dataLoadedWithProcessing = makeStory(conf, {
-  items: [{ invoices: processingInvoices(2020) }],
+  /** @type {{ state: InvoiceTableStateLoaded }[] } */
+  items: [{ state: { type: 'loaded', invoices: processingInvoices('2020') } }],
 });
 
 export const dataLoadedWithProcessed = makeStory(conf, {
-  items: [{ invoices: processedInvoices(2019) }],
+  /** @type {{ state: InvoiceTableStateLoaded }[] } */
+  items: [{ state: { type: 'loaded', invoices: processedInvoices('2019') } }],
 });
 
 export const dataLoadedWithCreditNotes = makeStory(conf, {
+  /** @type {{ state: InvoiceTableStateLoaded }[] } */
   items: [{
-    invoices: [
-      ...processedInvoices(2019),
-      createInvoice('2019', '09', 88.27, 'PAID', 'CREDITNOTE'),
-      createInvoice('2019', '04', 121.22, 'PAID', 'CREDITNOTE'),
-    ],
+    state: {
+      type: 'loaded',
+      invoices: [
+        ...processedInvoices('2019'),
+        createInvoice('2019', '09', 88.27, 'PAID', 'CREDITNOTE'),
+        createInvoice('2019', '04', 121.22, 'PAID', 'CREDITNOTE'),
+      ],
+    },
   }],
 });

--- a/src/components/cc-invoice-table/cc-invoice-table.types.d.ts
+++ b/src/components/cc-invoice-table/cc-invoice-table.types.d.ts
@@ -1,0 +1,12 @@
+import { Invoice } from '../common.types.js';
+
+export type InvoiceTableState = InvoiceTableStateLoaded | InvoiceTableStateLoading;
+
+export interface InvoiceTableStateLoaded {
+  type: 'loaded';
+  invoices: Invoice[];
+}
+
+export interface InvoiceTableStateLoading {
+  type: 'loading';
+}

--- a/src/components/cc-invoice/cc-invoice.stories.js
+++ b/src/components/cc-invoice/cc-invoice.stories.js
@@ -1,9 +1,29 @@
 import './cc-invoice.js';
 import { makeStory, storyWait } from '../../stories/lib/make-story.js';
 
+export default {
+  tags: ['autodocs'],
+  title: '🛠 Invoices/<cc-invoice>',
+  component: 'cc-invoice',
+};
+
+const conf = {
+  component: 'cc-invoice',
+};
+
+/**
+ * @typedef {import('./cc-invoice.types.js').InvoiceStateLoaded} InvoiceStateLoaded
+ * @typedef {import('./cc-invoice.types.js').InvoiceStateLoading} InvoiceStateLoading
+ * @typedef {import('./cc-invoice.types.js').InvoiceStateError} InvoiceStateError
+ * @typedef {import('./cc-invoice.js').CcInvoice} CcInvoice
+ *
+ */
+
 const defaultNumber = '20210501-1234';
 
-const defaultInvoice = {
+/** @type {InvoiceStateLoaded} */
+const defaultInvoiceState = {
+  type: 'loaded',
   number: defaultNumber,
   downloadUrl: '/download/20210501-1234',
   emissionDate: '2021-05-01',
@@ -25,56 +45,49 @@ const defaultInvoice = {
   `,
 };
 
-export default {
-  tags: ['autodocs'],
-  title: '🛠 Invoices/<cc-invoice>',
-  component: 'cc-invoice',
-};
-
-const conf = {
-  component: 'cc-invoice',
-};
-
 export const defaultStory = makeStory(conf, {
-  items: [{
-    state: {
-      type: 'loaded',
-      ...defaultInvoice,
-    },
-  }],
+  items: [{ state: defaultInvoiceState }],
 });
 
 export const loading = makeStory(conf, {
-  items: [{ state: { type: 'loading', number: defaultNumber } }],
-});
-
-export const loadingWithoutInvoiceNumber = makeStory(conf, {
-  items: [{ state: { type: 'loading' } }],
-});
-
-export const error = makeStory(conf, {
-  items: [{ state: { type: 'error', number: defaultNumber } }],
-});
-
-export const dataLoaded = makeStory(conf, {
   items: [{
-    state: {
-      type: 'loaded',
-      ...defaultInvoice,
-    },
+    /** @type {InvoiceStateLoading} */
+    state: { type: 'loading', number: defaultNumber },
   }],
 });
 
+export const loadingWithoutInvoiceNumber = makeStory(conf, {
+  items: [{
+    /** @type {InvoiceStateLoading} */
+    state: { type: 'loading' },
+  }],
+});
+
+export const error = makeStory(conf, {
+  items: [{
+    /** @type {InvoiceStateError} */
+    state: { type: 'error', number: defaultNumber },
+  }],
+});
+
+export const dataLoaded = makeStory(conf, {
+  items: [{ state: defaultInvoiceState }],
+});
+
 export const simulations = makeStory(conf, {
-  items: [{ }, { }],
+  items: [{}, {}],
   simulations: [
-    storyWait(2000, ([component, componentError]) => {
-      component.state = { type: 'loading', number: defaultNumber };
-      componentError.state = { type: 'loading', number: '20210501-????' };
-    }),
-    storyWait(2000, ([component, componentError]) => {
-      component.state = { type: 'loaded', ...defaultInvoice };
-      componentError.state = { type: 'error', number: '20210501-????' };
-    }),
+    storyWait(2000,
+      /** @param {CcInvoice[]} components */
+      ([component, componentError]) => {
+        component.state = { type: 'loading', number: defaultNumber };
+        componentError.state = { type: 'loading', number: '20210501-????' };
+      }),
+    storyWait(2000,
+      /** @param {CcInvoice[]} components */
+      ([component, componentError]) => {
+        component.state = defaultInvoiceState;
+        componentError.state = { type: 'error', number: '20210501-????' };
+      }),
   ],
 });

--- a/src/components/common.types.d.ts
+++ b/src/components/common.types.d.ts
@@ -56,11 +56,11 @@ export interface IconModel {
 }
 
 interface InvoiceAmount {
-  amount: Number;
-  currency: string;
+  amount: number;
+  currency: 'EUR'|'USD';
 }
 
-interface Invoice {
+export interface Invoice {
   downloadUrl: string;
   emissionDate: string;
   invoiceHtml: string;
@@ -71,9 +71,9 @@ interface Invoice {
   type: InvoiceType;
 }
 
-type InvoiceStatusType = "PENDING" | "PROCESSING" | "PAID" | "PAYMENTHELD" | "CANCELED" | "REFUNDED" | "WONTPAY";
+export type InvoiceStatusType = "PENDING" | "PROCESSING" | "PAID" | "PAYMENTHELD" | "CANCELED" | "REFUNDED" | "WONTPAY";
 
-type InvoiceType = "INVOICE" | "CREDITNOTE";
+export type InvoiceType = "INVOICE" | "CREDITNOTE";
 
 interface HeatmapPoint {
   lat: number;   // Latitude

--- a/src/stories/fixtures/invoices.js
+++ b/src/stories/fixtures/invoices.js
@@ -67,3 +67,15 @@ export const processedInvoices = (year) => [
   createInvoice(year, '11', 618.31, 'PAID'),
   createInvoice(year, '12', 1487.02, 'PAID'),
 ];
+
+/** @type {Invoice[]} */
+export const fullInvoicesExample = [
+  ...pendingInvoices('2020').slice(0, 4),
+  ...processingInvoices('2020'),
+  ...processedInvoices('2019'),
+  ...processedInvoices('2020').slice(2, 10),
+  ...processedInvoices('2018').slice(2, 10),
+  ...processedInvoices('2017').slice(3, 10),
+  ...processedInvoices('2016').slice(1, 9),
+  ...processedInvoices('2015').slice(1, 9),
+];

--- a/src/stories/fixtures/invoices.js
+++ b/src/stories/fixtures/invoices.js
@@ -1,0 +1,69 @@
+/**
+ * @typedef {import('../../components/common.types.js').Invoice} Invoice
+ * @typedef {import('../../components/common.types.js').InvoiceStatusType} InvoiceStatusType
+ * @typedef {import('../../components/common.types.js').InvoiceType} InvoiceType
+ * @typedef {'01' | '02' | '03' | '04' | '05' | '06' | '07' | '08' | '09' | '10' | '11' | '12'} MonthNumberAsString
+ */
+
+/**
+ * @param {string} year
+ * @param {MonthNumberAsString} month
+ * @param {number} amount
+ * @param {InvoiceStatusType} status
+ * @param {InvoiceType} [type]
+ * @return {Invoice}
+ */
+export function createInvoice (year, month, amount, status, type = 'INVOICE') {
+  const emissionDate = `${year}-${month}-01`;
+  const number = `${year + month}01-${String((Math.ceil(amount * 100)) % 1000).padStart(4, '0')}`;
+  const downloadUrl = '/download/' + number;
+  const paymentUrl = '/pay/' + number;
+  return { emissionDate, number, type, status, total: { currency: 'EUR', amount }, downloadUrl, paymentUrl, invoiceHtml: '' };
+}
+
+/**
+ * @param {string} year
+ * @return {Invoice[]}
+ */
+export const pendingInvoices = (year) => [
+  createInvoice(year, '01', 17.79, 'WONTPAY'),
+  createInvoice(year, '02', 29.24, 'PENDING'),
+  createInvoice(year, '03', 73.34, 'PENDING'),
+  createInvoice(year, '04', 71.96, 'PENDING'),
+  createInvoice(year, '05', 662.95, 'PENDING'),
+  createInvoice(year, '06', 100.42, 'PENDING'),
+  createInvoice(year, '07', 1894.88, 'PENDING'),
+  createInvoice(year, '08', 111971.46, 'PENDING'),
+  createInvoice(year, '09', 99.14, 'PENDING'),
+  createInvoice(year, '10', 2261.81, 'PAYMENTHELD'),
+  createInvoice(year, '11', 6218.31, 'PENDING'),
+  createInvoice(year, '12', 11487.02, 'PENDING'),
+];
+
+/**
+ * @param {string} year
+ * @return {Invoice[]}
+ */
+export const processingInvoices = (year) => [
+  createInvoice(year, '11', 172.79, 'PROCESSING'),
+  createInvoice(year, '12', 2287.02, 'PROCESSING'),
+];
+
+/**
+ * @param {string} year
+ * @return {Invoice[]}
+ */
+export const processedInvoices = (year) => [
+  createInvoice(year, '01', 1782.79, 'PAID'),
+  createInvoice(year, '02', 1129.24, 'PAID'),
+  createInvoice(year, '03', 4273.34, 'PAID'),
+  createInvoice(year, '04', 2171.96, 'CANCELED'),
+  createInvoice(year, '05', 3662.95, 'PAID'),
+  createInvoice(year, '06', 100.42, 'PAID'),
+  createInvoice(year, '07', 1894.88, 'PAID'),
+  createInvoice(year, '08', 1971.46, 'REFUNDED'),
+  createInvoice(year, '09', 1699.14, 'PAID'),
+  createInvoice(year, '10', 2261.81, 'CANCELED'),
+  createInvoice(year, '11', 618.31, 'PAID'),
+  createInvoice(year, '12', 1487.02, 'PAID'),
+];


### PR DESCRIPTION
## What does this PR do?

- Refactors the `cc-invoice-table` component to implement our new state structure,
- Refactors the `cc-invoice-list` component to adapt to the `cc-invoice-table` changes,
- Implements TypeChecking within the `cc-invoice-table` & `cc-invoice-list` components and their stories.

## How to review?

- Check the commit (the diff may not be easy to read so you can review the final result locally if you prefer),
- If you check it locally, you should not get any Typescript error within the component file or the story file,
- Compare the [cc-invoice-table prod stories](https://www.clever-cloud.com/doc/clever-components/?path=/story/%F0%9F%9B%A0-invoices-cc-invoice-table--default-story) to the [cc-invoice-table preview stories](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-invoice-list/state-migration/index.html?path=/story/%F0%9F%9B%A0-invoices-cc-invoice-table--default-story),
- Compare the [cc-invoice-list prod stories](https://www.clever-cloud.com/doc/clever-components/?path=/story/%F0%9F%9B%A0-invoices-cc-invoice-list--default-story) to the [cc-invoice-list preview stories](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-invoice-list/state-migration/index.html?path=/story/%F0%9F%9B%A0-invoices-cc-invoice-list--default-story),
- Check the `cc-invoice-list` component from demo-smart, everything should be working as before (this component only loads a list so as long as you get a list of invoices, it's fine),
- Also review the smart component using the demo-smart page.

**Note**: since `cc-invoice-table` has separate sub renders for narrow viewport & big viewport, it might be good to check stories with reduced and normal viewports just in case.