### PR TITLE
refactor(cc-tcp-components)!: rework properties to avoid impossible …

### DIFF
--- a/src/components/cc-tcp-redirection-form/cc-tcp-redirection-form.smart.js
+++ b/src/components/cc-tcp-redirection-form/cc-tcp-redirection-form.smart.js
@@ -7,6 +7,21 @@ import { i18n } from '../../lib/i18n.js';
 import { notifyError, notifySuccess } from '../../lib/notifications.js';
 import { sendToApi } from '../../lib/send-to-api.js';
 
+/**
+ * @typedef {import('./cc-tcp-redirection-form.js').CcTcpRedirectionForm} CcTcpRedirectionForm
+ * @typedef {import('../cc-tcp-redirection/cc-tcp-redirection.types.js').TcpRedirectionState} TcpRedirectionState
+ * @typedef {import('../cc-tcp-redirection/cc-tcp-redirection.types.js').TcpRedirectionStateLoaded} TcpRedirectionStateLoaded
+ * @typedef {import('../cc-tcp-redirection-form/cc-tcp-redirection-form.types.js').TcpRedirectionFormState} TcpRedirectionFormState
+ * @typedef {import('../cc-tcp-redirection-form/cc-tcp-redirection-form.types.js').TcpRedirectionFormStateLoaded} TcpRedirectionFormStateLoaded
+ * @typedef {import('../cc-tcp-redirection/cc-tcp-redirection.types.js').TcpRedirectionStateWaiting} TcpRedirectionStateWaiting
+ * @typedef {import('../../lib/send-to-api.js').ApiConfig} ApiConfig
+ * @typedef {[{namespace: string}]} NamespacesApiPayload
+ * @typedef {[{namespace: string, port: number}]} RedirectionsApiPayload
+ * @typedef {{namespace: string, sourcePort: number | null}} FormattedRedirectionData
+ */
+
+const PUBLIC_NAMESPACES = ['default', 'cleverapps'];
+
 defineSmartComponent({
   selector: 'cc-tcp-redirection-form',
   params: {
@@ -18,92 +33,132 @@ defineSmartComponent({
 
     const { apiConfig, ownerId, appId } = context;
 
+    /**
+     * @param {string} namespace
+     * @param {(redirectionState: TcpRedirectionState) => void} callback
+     */
     function updateRedirection (namespace, callback) {
-      updateComponent('redirections', (redirections) => {
-        const redirection = redirections.value.find((r) => r.namespace === namespace);
-        if (redirection != null) {
-          callback(redirection);
-        }
-      });
+      updateComponent('state',
+        /** @param {TcpRedirectionFormStateLoaded} redirectionFormState */
+        (redirectionFormState) => {
+          const redirectionState = redirectionFormState.redirections.find((redirectionState) => redirectionState.namespace === namespace);
+          if (redirectionState != null) {
+            callback(redirectionState);
+          }
+        });
     }
 
-    onEvent('cc-tcp-redirection:create', ({ namespace }) => {
-      updateRedirection(namespace, (redirection) => {
-        redirection.state = 'waiting';
-      });
-      createTcpRedirection({ apiConfig, ownerId, appId, namespace })
-        .then(({ port }) => {
-          notifySuccess(i18n('cc-tcp-redirection-form.create.success', { namespace }));
-          updateRedirection(namespace, (redirection) => {
-            redirection.state = 'loaded';
-            redirection.sourcePort = port;
-          });
-        })
-        .catch((error) => {
-          console.error(error);
-          notifyError(i18n('cc-tcp-redirection-form.create.error', { namespace }));
-          updateRedirection(namespace, (redirection) => {
-            redirection.state = 'loaded';
-          });
+    onEvent('cc-tcp-redirection:create',
+      /** @param {Event & { namespace: string }} event */
+      ({ namespace }) => {
+        updateRedirection(namespace, (redirectionState) => {
+          redirectionState.type = 'waiting';
         });
-    });
-
-    onEvent('cc-tcp-redirection:delete', ({ namespace, sourcePort }) => {
-      updateRedirection(namespace, (redirection) => {
-        redirection.state = 'waiting';
+        createTcpRedirection({ apiConfig, ownerId, appId, namespace })
+          .then(({ port }) => {
+            notifySuccess(i18n('cc-tcp-redirection-form.create.success', { namespace }));
+            updateRedirection(namespace, (redirectionState) => {
+              redirectionState.type = 'loaded';
+              // @ts-expect-error TypeScript is unable to infer that the state type is 'loaded' because we defined it just above
+              redirectionState.sourcePort = port;
+            });
+          })
+          .catch((error) => {
+            console.error(error);
+            notifyError(i18n('cc-tcp-redirection-form.create.error', { namespace }));
+            updateRedirection(namespace, (redirectionState) => {
+              redirectionState.type = 'loaded';
+            });
+          });
       });
-      deleteTcpRedirection({ apiConfig, ownerId, appId, sourcePort, namespace })
-        .then(() => {
-          notifySuccess(i18n('cc-tcp-redirection-form.delete.success', { namespace }));
-          updateRedirection(namespace, (redirection) => {
-            redirection.state = 'loaded';
-            redirection.sourcePort = null;
-          });
-        })
-        .catch((error) => {
-          console.error(error);
-          notifyError(i18n('cc-tcp-redirection-form.delete.error', { namespace }));
-          updateRedirection(namespace, (redirection) => {
-            redirection.state = 'loaded';
-          });
-        });
-    });
 
-    updateComponent('redirections', { state: 'loading' });
+    onEvent('cc-tcp-redirection:delete',
+      /** @param {Event & { namespace: string, sourcePort: number }} event */
+      ({ namespace, sourcePort }) => {
+        updateRedirection(namespace, (redirectionState) => {
+          redirectionState.type = 'waiting';
+        });
+        deleteTcpRedirection({ apiConfig, ownerId, appId, sourcePort, namespace })
+          .then(() => {
+            notifySuccess(i18n('cc-tcp-redirection-form.delete.success', { namespace }));
+            updateRedirection(namespace, (redirectionState) => {
+              redirectionState.type = 'loaded';
+              // @ts-expect-error TypeScript is unable to infer that the state type is 'loaded' because we defined it just above
+              redirectionState.sourcePort = null;
+            });
+          })
+          .catch((error) => {
+            console.error(error);
+            notifyError(i18n('cc-tcp-redirection-form.delete.error', { namespace }));
+            updateRedirection(namespace, (redirectionState) => {
+              redirectionState.type = 'loaded';
+            });
+          });
+      });
+
+    updateComponent('state', { type: 'loading' });
 
     fetchTcpRedirectionsAndNamespaces({ apiConfig, ownerId, appId, signal })
       .then((redirections) => {
-        updateComponent('redirections', {
-          state: 'loaded',
-          value: redirections.map((r) => ({ state: 'loaded', ...r })),
+        updateComponent('state', {
+          type: 'loaded',
+          redirections: redirections.map((redirection) => ({ type: 'loaded', ...redirection })),
         });
       })
       .catch((error) => {
         console.error(error);
-        updateComponent('redirections', { state: 'error' });
+        updateComponent('state', { type: 'error' });
       });
   },
 });
 
+/**
+ * @param {Object} settings
+ * @param {ApiConfig} settings.apiConfig
+ * @param {AbortSignal} settings.signal
+ * @param {string} settings.ownerId
+ * @param {string} settings.appId
+ * @returns {Promise<FormattedRedirectionData[]>}
+ */
 async function fetchTcpRedirectionsAndNamespaces ({ apiConfig, signal, ownerId, appId }) {
   return Promise
     .all([
       getNamespaces({ id: ownerId }).then(sendToApi({ apiConfig, signal })),
       getTcpRedirs({ id: ownerId, appId }).then(sendToApi({ apiConfig, signal })),
     ])
-    .then(([namespaces, redirections]) => {
-      return namespaces.map((n) => {
-        const sourcePort = redirections.find((r) => r.namespace === n.namespace)?.port;
-        return { namespace: n.namespace, sourcePort };
+    .then(
+      /** @param {[NamespacesApiPayload, RedirectionsApiPayload]} apiResponse */
+      ([namespaces, redirections]) => {
+        return namespaces.map(({ namespace }) => {
+          const sourcePort = redirections.find((redirection) => redirection.namespace === namespace)?.port;
+          const isPrivate = !PUBLIC_NAMESPACES.includes(namespace);
+          return { namespace, sourcePort, isPrivate };
+        });
       });
-    });
 }
 
+/**
+ * @param {Object} settings
+ * @param {ApiConfig} settings.apiConfig
+ * @param {string} settings.ownerId
+ * @param {string} settings.appId
+ * @param {string} settings.namespace
+ * @returns {Promise<{ port: number }>}
+ */
 async function createTcpRedirection ({ apiConfig, ownerId, appId, namespace }) {
   return addTcpRedir({ id: ownerId, appId, payment: 'accepted' }, { namespace })
     .then(sendToApi({ apiConfig }));
 }
 
+/**
+ * @param {Object} settings
+ * @param {ApiConfig} settings.apiConfig
+ * @param {string} settings.ownerId
+ * @param {string} settings.appId
+ * @param {Number|null} settings.sourcePort
+ * @param {string} settings.namespace
+ * @returns {Promise<void>}
+ */
 async function deleteTcpRedirection ({ apiConfig, ownerId, appId, sourcePort, namespace }) {
   return removeTcpRedir({ id: ownerId, appId, sourcePort, namespace })
     .then(sendToApi({ apiConfig }));

--- a/src/components/cc-tcp-redirection-form/cc-tcp-redirection-form.stories.js
+++ b/src/components/cc-tcp-redirection-form/cc-tcp-redirection-form.stories.js
@@ -12,13 +12,21 @@ const conf = {
   component: 'cc-tcp-redirection-form',
 };
 
+/**
+ * @typedef {import('./cc-tcp-redirection-form.js').CcTcpRedirectionForm} CcTcpRedirectionForm
+ * @typedef {import('./cc-tcp-redirection-form.types.js').TcpRedirectionFormStateLoaded} TcpRedirectionFormStateLoaded
+ * @typedef {import('./cc-tcp-redirection-form.types.js').TcpRedirectionFormStateLoading} TcpRedirectionFormStateLoading
+ * @typedef {import('./cc-tcp-redirection-form.types.js').TcpRedirectionFormStateError} TcpRedirectionFormStateError
+ * @typedef {import('./cc-tcp-redirection-form.types.js').TcpRedirectionFormContextType} TcpRedirectionFormContextType
+ */
 export const defaultStory = makeStory(conf, {
   items: [{
-    redirections: {
-      state: 'loaded',
-      value: [
-        { state: 'loaded', namespace: 'default', sourcePort: 5220 },
-        { state: 'loaded', namespace: 'cleverapps' },
+    /** @type {TcpRedirectionFormStateLoaded} */
+    state: {
+      type: 'loaded',
+      redirections: [
+        { type: 'loaded', namespace: 'default', isPrivate: false, sourcePort: 5220 },
+        { type: 'loaded', namespace: 'cleverapps', isPrivate: false },
       ],
     },
   }],
@@ -26,37 +34,41 @@ export const defaultStory = makeStory(conf, {
 
 export const empty = makeStory(conf, {
   items: [{
-    redirections: {
-      state: 'loaded',
-      value: [],
+    /** @type {TcpRedirectionFormStateLoaded} **/
+    state: {
+      type: 'loaded',
+      redirections: [],
     },
   }],
 });
 
 export const loading = makeStory(conf, {
   items: [{
-    redirections: {
-      state: 'loading',
+    /** @type {TcpRedirectionFormStateLoading} **/
+    state: {
+      type: 'loading',
     },
   }],
 });
 
 export const errorWithLoading = makeStory(conf, {
   items: [{
-    redirections: {
-      state: 'error',
+    /** @type {TcpRedirectionFormStateError} **/
+    state: {
+      type: 'error',
     },
   }],
 });
 
 export const dataLoaded = makeStory(conf, {
   items: [{
-    redirections: {
-      state: 'loaded',
-      value: [
-        { state: 'loaded', namespace: 'default', sourcePort: 5220 },
-        { state: 'loaded', namespace: 'cleverapps' },
-        { state: 'loaded', namespace: 'customer-name', sourcePort: 6440, private: true },
+    /** @type {TcpRedirectionFormStateLoaded} **/
+    state: {
+      type: 'loaded',
+      redirections: [
+        { type: 'loaded', namespace: 'default', isPrivate: false, sourcePort: 5220 },
+        { type: 'loaded', namespace: 'cleverapps', isPrivate: false },
+        { type: 'loaded', namespace: 'customer-name', sourcePort: 6440, isPrivate: true },
       ],
     },
   }],
@@ -65,12 +77,13 @@ export const dataLoaded = makeStory(conf, {
 export const dataLoadedWithContextAdmin = makeStory(conf, {
   docs: 'When `context="admin"` is used, the component description is hidden, the block is collapsed and a redirection counter bubble is be displayed.',
   items: [{
-    redirections: {
-      state: 'loaded',
-      value: [
-        { state: 'loaded', namespace: 'default', sourcePort: 5220 },
-        { state: 'loaded', namespace: 'cleverapps' },
-        { state: 'loaded', namespace: 'customer-name', sourcePort: 6440, private: true },
+    /** @type {TcpRedirectionFormStateLoaded} **/
+    state: {
+      type: 'loaded',
+      redirections: [
+        { type: 'loaded', namespace: 'default', isPrivate: false, sourcePort: 5220 },
+        { type: 'loaded', namespace: 'cleverapps', isPrivate: false },
+        { type: 'loaded', namespace: 'customer-name', sourcePort: 6440, isPrivate: true },
       ],
     },
     context: 'admin',
@@ -80,26 +93,29 @@ export const dataLoadedWithContextAdmin = makeStory(conf, {
 export const dataLoadedWithContextAdminAndNoRedirections = makeStory(conf, {
   docs: 'When `context="admin"` is used, the counter bubble is not displayed if there is no redirection.',
   items: [{
-    redirections: {
-      state: 'loaded',
-      value: [
-        { state: 'loaded', namespace: 'default' },
-        { state: 'loaded', namespace: 'cleverapps' },
-        { state: 'loaded', namespace: 'customer-name', private: true },
+    /** @type {TcpRedirectionFormStateLoaded} **/
+    state: {
+      type: 'loaded',
+      redirections: [
+        { type: 'loaded', namespace: 'default', isPrivate: false },
+        { type: 'loaded', namespace: 'cleverapps', isPrivate: false },
+        { type: 'loaded', namespace: 'customer-name', isPrivate: true },
       ],
     },
+    /** @type {TcpRedirectionFormContextType} **/
     context: 'admin',
   }],
 });
 
 export const dataLoadedWithCreatingRedirection = makeStory(conf, {
   items: [{
-    redirections: {
-      state: 'loaded',
-      value: [
-        { state: 'loaded', namespace: 'default', sourcePort: 5220 },
-        { state: 'waiting', namespace: 'cleverapps' },
-        { state: 'loaded', namespace: 'customer-name', sourcePort: 6440, private: true },
+    /** @type {TcpRedirectionFormStateLoaded} **/
+    state: {
+      type: 'loaded',
+      redirections: [
+        { type: 'loaded', namespace: 'default', isPrivate: false, sourcePort: 5220 },
+        { type: 'waiting', namespace: 'cleverapps', isPrivate: false },
+        { type: 'loaded', namespace: 'customer-name', sourcePort: 6440, isPrivate: true },
       ],
     },
   }],
@@ -107,12 +123,13 @@ export const dataLoadedWithCreatingRedirection = makeStory(conf, {
 
 export const dataLoadedWithDeletingRedirection = makeStory(conf, {
   items: [{
-    redirections: {
-      state: 'loaded',
-      value: [
-        { state: 'loaded', namespace: 'default', sourcePort: 5220 },
-        { state: 'loaded', namespace: 'cleverapps', sourcePort: 3821 },
-        { state: 'waiting', namespace: 'customer-name', sourcePort: 6440, private: true },
+    /** @type {TcpRedirectionFormStateLoaded} **/
+    state: {
+      type: 'loaded',
+      redirections: [
+        { type: 'loaded', namespace: 'default', isPrivate: false, sourcePort: 5220 },
+        { type: 'loaded', namespace: 'cleverapps', isPrivate: false, sourcePort: 3821 },
+        { type: 'waiting', namespace: 'customer-name', sourcePort: 6440, isPrivate: true },
       ],
     },
   }],
@@ -120,19 +137,20 @@ export const dataLoadedWithDeletingRedirection = makeStory(conf, {
 
 export const dataLoadedWithManyNamespaces = makeStory(conf, {
   items: [{
-    redirections: {
-      state: 'loaded',
-      value: [
-        { state: 'loaded', namespace: 'default', sourcePort: 874 },
-        { state: 'loaded', namespace: 'cleverapps', sourcePort: 12345 },
-        { state: 'loaded', namespace: 'secondary', sourcePort: 99 },
-        { state: 'loaded', namespace: 'customer-name-one', sourcePort: 1234 },
-        { state: 'loaded', namespace: 'customer-name-two', sourcePort: 4321 },
-        { state: 'loaded', namespace: 'customer-name-three' },
-        { state: 'loaded', namespace: 'customer-name-four', sourcePort: 7531 },
-        { state: 'loaded', namespace: 'customer-name-five' },
-        { state: 'loaded', namespace: 'customer-name-six' },
-        { state: 'loaded', namespace: 'customer-name-seven', sourcePort: 3456 },
+    /** @type {TcpRedirectionFormStateLoaded} **/
+    state: {
+      type: 'loaded',
+      redirections: [
+        { type: 'loaded', namespace: 'default', isPrivate: false, sourcePort: 874 },
+        { type: 'loaded', namespace: 'cleverapps', isPrivate: false, sourcePort: 12345 },
+        { type: 'loaded', namespace: 'secondary', isPrivate: false, sourcePort: 99 },
+        { type: 'loaded', namespace: 'customer-name-one', isPrivate: false, sourcePort: 1234 },
+        { type: 'loaded', namespace: 'customer-name-two', isPrivate: false, sourcePort: 4321 },
+        { type: 'loaded', namespace: 'customer-name-three', isPrivate: false },
+        { type: 'loaded', namespace: 'customer-name-four', isPrivate: false, sourcePort: 7531 },
+        { type: 'loaded', namespace: 'customer-name-five', isPrivate: false },
+        { type: 'loaded', namespace: 'customer-name-six', isPrivate: false },
+        { type: 'loaded', namespace: 'customer-name-seven', isPrivate: false, sourcePort: 3456 },
       ],
     },
   }],
@@ -140,55 +158,65 @@ export const dataLoadedWithManyNamespaces = makeStory(conf, {
 
 export const simulation = makeStory(conf, {
   items: [
-    { redirections: { state: 'loading' } },
-    { redirections: { state: 'loading' } },
+    { state: { type: 'loading' } },
+    { state: { type: 'loading' } },
   ],
   simulations: [
-    storyWait(2000, ([component, componentError]) => {
-      component.redirections = {
-        state: 'loaded',
-        value: [
-          { state: 'loaded', namespace: 'default', sourcePort: 5220 },
-          { state: 'loaded', namespace: 'cleverapps' },
-        ],
-      };
-      componentError.redirections = { state: 'error' };
-    }),
-    storyWait(1000, ([component, componentError]) => {
-      component.redirections = {
-        state: 'loaded',
-        value: [
-          { state: 'loaded', namespace: 'default', sourcePort: 5220 },
-          { state: 'waiting', namespace: 'cleverapps' },
-        ],
-      };
-    }),
-    storyWait(1500, ([component, componentError]) => {
-      component.redirections = {
-        state: 'loaded',
-        value: [
-          { state: 'waiting', namespace: 'default', sourcePort: 5220 },
-          { state: 'waiting', namespace: 'cleverapps' },
-        ],
-      };
-    }),
-    storyWait(1500, ([component, componentError]) => {
-      component.redirections = {
-        state: 'loaded',
-        value: [
-          { state: 'waiting', namespace: 'default', sourcePort: 5220 },
-          { state: 'loaded', namespace: 'cleverapps', sourcePort: 4242 },
-        ],
-      };
-    }),
-    storyWait(1500, ([component, componentError]) => {
-      component.redirections = {
-        state: 'loaded',
-        value: [
-          { state: 'loaded', namespace: 'default' },
-          { state: 'loaded', namespace: 'cleverapps', sourcePort: 4242 },
-        ],
-      };
-    }),
+    storyWait(2000,
+      /** @param {[CcTcpRedirectionForm, CcTcpRedirectionForm]} components */
+      ([component, componentError]) => {
+        component.state = {
+          type: 'loaded',
+          redirections: [
+            { type: 'loaded', namespace: 'default', isPrivate: false, sourcePort: 5220 },
+            { type: 'loaded', namespace: 'cleverapps', isPrivate: false },
+          ],
+        };
+        componentError.state = { type: 'error' };
+      }),
+    storyWait(1000,
+      /** @param {[CcTcpRedirectionForm]} components */
+      ([component]) => {
+        component.state = {
+          type: 'loaded',
+          redirections: [
+            { type: 'loaded', namespace: 'default', isPrivate: false, sourcePort: 5220 },
+            { type: 'waiting', namespace: 'cleverapps', isPrivate: false },
+          ],
+        };
+      }),
+    storyWait(1500,
+      /** @param {[CcTcpRedirectionForm]} components */
+      ([component]) => {
+        component.state = {
+          type: 'loaded',
+          redirections: [
+            { type: 'waiting', namespace: 'default', isPrivate: false, sourcePort: 5220 },
+            { type: 'waiting', namespace: 'cleverapps', isPrivate: false },
+          ],
+        };
+      }),
+    storyWait(1500,
+      /** @param {[CcTcpRedirectionForm]} components */
+      ([component]) => {
+        component.state = {
+          type: 'loaded',
+          redirections: [
+            { type: 'waiting', namespace: 'default', isPrivate: false, sourcePort: 5220 },
+            { type: 'loaded', namespace: 'cleverapps', isPrivate: false, sourcePort: 4242 },
+          ],
+        };
+      }),
+    storyWait(1500,
+      /** @param {[CcTcpRedirectionForm]} components */
+      ([component]) => {
+        component.state = {
+          type: 'loaded',
+          redirections: [
+            { type: 'loaded', namespace: 'default', isPrivate: false },
+            { type: 'loaded', namespace: 'cleverapps', isPrivate: false, sourcePort: 4242 },
+          ],
+        };
+      }),
   ],
 });

--- a/src/components/cc-tcp-redirection-form/cc-tcp-redirection-form.types.d.ts
+++ b/src/components/cc-tcp-redirection-form/cc-tcp-redirection-form.types.d.ts
@@ -1,4 +1,7 @@
-import { TcpRedirectionState } from "../cc-tcp-redirection/cc-tcp-redirection.types";
+import {
+  TcpRedirectionStateLoaded,
+  TcpRedirectionStateWaiting
+} from "../cc-tcp-redirection/cc-tcp-redirection.types.js";
 
 export type TcpRedirectionFormContextType = "user" | "admin";
 
@@ -7,16 +10,16 @@ export type TcpRedirectionFormState =
   | TcpRedirectionFormStateLoaded
   | TcpRedirectionFormStateError;
 
-interface TcpRedirectionFormStateLoading {
-  state: "loading";
+export interface TcpRedirectionFormStateLoading {
+  type: "loading";
 }
 
-interface TcpRedirectionFormStateLoaded {
-  state: "loaded";
-  value: TcpRedirectionState[]
+export interface TcpRedirectionFormStateLoaded {
+  type: "loaded";
+  redirections: Array<TcpRedirectionStateLoaded | TcpRedirectionStateWaiting>;
 }
 
-interface TcpRedirectionFormStateError {
-  state: "error";
+export interface TcpRedirectionFormStateError {
+  type: "error";
 }
 

--- a/src/components/cc-tcp-redirection/cc-tcp-redirection.stories.js
+++ b/src/components/cc-tcp-redirection/cc-tcp-redirection.stories.js
@@ -1,15 +1,17 @@
 import './cc-tcp-redirection.js';
 import { makeStory } from '../../stories/lib/make-story.js';
 
+/** @type {{state: TcpRedirectionStateLoaded}[]} */
 const baseItems = [
-  { redirection: { state: 'loaded', namespace: 'customer-name', isPrivate: true } },
-  { redirection: { state: 'loaded', namespace: 'default' } },
-  { redirection: { state: 'loaded', namespace: 'cleverapps' } },
-  { redirection: { state: 'loaded', namespace: 'alternative' } },
+  { state: { type: 'loaded', namespace: 'customer-name', isPrivate: true } },
+  { state: { type: 'loaded', namespace: 'default', isPrivate: false } },
+  { state: { type: 'loaded', namespace: 'cleverapps', isPrivate: false } },
+  { state: { type: 'loaded', namespace: 'alternative', isPrivate: false } },
 ];
 
+/** @type {{state: TcpRedirectionStateLoaded}[]} */
 const baseItemsWithRedirection = baseItems.map((item, i) => {
-  return { redirection: { ...item.redirection, sourcePort: 1000 + i } };
+  return { state: { ...item.state, sourcePort: 1000 + i } };
 });
 
 export default {
@@ -22,18 +24,25 @@ const conf = {
   component: 'cc-tcp-redirection',
 };
 
+/**
+ * @typedef {import('./cc-tcp-redirection.types.js').TcpRedirectionStateLoaded} TcpRedirectionStateLoaded
+ * @typedef {import('./cc-tcp-redirection.types.js').TcpRedirectionStateLoading} TcpRedirectionStateLoading
+ * @typedef {import('./cc-tcp-redirection.types.js').TcpRedirectionStateWaiting} TcpRedirectionStateWaiting
+ */
 export const defaultStory = makeStory(conf, {
+  /** @type {{state: TcpRedirectionStateLoaded}[]} */
   items: [
-    { redirection: { state: 'loaded', namespace: 'default', sourcePort: 5220 } },
-    { redirection: { state: 'loaded', namespace: 'cleverapps' } },
+    { state: { type: 'loaded', namespace: 'default', isPrivate: false, sourcePort: 5220 } },
+    { state: { type: 'loaded', namespace: 'cleverapps', isPrivate: false } },
   ],
 });
 
 export const loading = makeStory(conf, {
+  /** @type {{state: TcpRedirectionStateLoading}[]} */
   items: [
-    { redirection: { state: 'loading' } },
-    { redirection: { state: 'loading' } },
-    { redirection: { state: 'loading' } },
+    { state: { type: 'loading' } },
+    { state: { type: 'loading' } },
+    { state: { type: 'loading' } },
   ],
 });
 
@@ -46,13 +55,15 @@ export const dataLoadedWithNoRedirection = makeStory(conf, {
 });
 
 export const waitingWithRedirection = makeStory(conf, {
+  /** @type {{state: TcpRedirectionStateWaiting}[]} */
   items: baseItemsWithRedirection.map((item) => {
-    return { redirection: { ...item.redirection, state: 'waiting' } };
+    return { state: { ...item.state, type: 'waiting' } };
   }),
 });
 
 export const waitingWithNoRedirection = makeStory(conf, {
+  /** @type {{state: TcpRedirectionStateWaiting}[]} */
   items: baseItems.map((item) => {
-    return { redirection: { ...item.redirection, state: 'waiting' } };
+    return { state: { ...item.state, type: 'waiting' } };
   }),
 });

--- a/src/components/cc-tcp-redirection/cc-tcp-redirection.types.d.ts
+++ b/src/components/cc-tcp-redirection/cc-tcp-redirection.types.d.ts
@@ -1,21 +1,21 @@
-interface TcpRedirection {
+export interface TcpRedirection {
   namespace: string;
   isPrivate: boolean;
-  sourcePort?: number;
+  sourcePort?: number | null;
 }
 
 export type TcpRedirectionState = TcpRedirectionStateLoading | TcpRedirectionStateLoaded | TcpRedirectionStateWaiting;
 
-interface TcpRedirectionStateLoading {
-  state: "loading";
+export interface TcpRedirectionStateLoading {
+  type: "loading";
 }
 
-interface TcpRedirectionStateLoaded extends TcpRedirection {
-  state: "loaded";
+export interface TcpRedirectionStateLoaded extends TcpRedirection {
+  type: "loaded";
 }
 
-interface TcpRedirectionStateWaiting extends TcpRedirection {
-  state: "waiting";
+export interface TcpRedirectionStateWaiting extends TcpRedirection {
+  type: "waiting";
 }
 
 export interface CreateTcpRedirection {


### PR DESCRIPTION
## What does this PR do?

- Refactors the `cc-tcp-redirection` and `cc-tcp-redirection-form` components to implement our new state structure,
- Implements TypeChecking within the `cc-tcp-redirection`  and `cc-tcp-redirection-form` components and their stories,
- Fixes all data loaded stories (the last redirection item was supposed to be private but was not properly set).

## How to review?

- Check the commits (the diff may not be easy to read so you can review the final result locally if you prefer),
- If you check it locally, you should not get any Typescript error within the components files or the story files,
- Compare the `cc-tcp-redirection` [prod stories](https://www.clever-cloud.com/doc/clever-components/?path=/story/%F0%9F%9B%A0-tcp-redirections-cc-tcp-redirection--default-story&globals=locale:fr) to the [preview stories](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-tcp-redirection-form/state-migration/index.html?path=/story/%F0%9F%9B%A0-tcp-redirections-cc-tcp-redirection--default-story) and the `cc-tcp-redirection-form` [prod stories](https://www.clever-cloud.com/doc/clever-components/?path=/story/%F0%9F%9B%A0-tcp-redirections-cc-tcp-redirection-form--default-story&globals=locale:fr) to the [preview stories](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-tcp-redirection-form/state-migration/index.html?path=/story/%F0%9F%9B%A0-tcp-redirections-cc-tcp-redirection-form--default-story),
- Also review the smart component using the demo-smart page.