### PR TITLE
refactor(cc-tile-metrics)!: rework properties to avoid impossible states

### DIFF
--- a/src/components/cc-tile-metrics/cc-tile-metrics.types.d.ts
+++ b/src/components/cc-tile-metrics/cc-tile-metrics.types.d.ts
@@ -1,30 +1,49 @@
-interface Metric {
+export type TileMetricsMetricsState = TileMetricsMetricsStateLoading | TileMetricsMetricsStateError | TileMetricsMetricsStateLoaded | TileMetricsMetricsStateEmpty;
+
+export interface TileMetricsMetricsStateLoaded {
+  type: 'loaded';
+  metricsData: MetricsData;
+}
+
+export interface TileMetricsMetricsStateLoading {
+  type: 'loading';
+}
+
+export interface TileMetricsMetricsStateError {
+  type: 'error';
+}
+
+export interface TileMetricsMetricsStateEmpty {
+  type: 'empty';
+}
+
+export interface Metric {
   // Timestamp in ms
-  timestamp: number,
+  timestamp: number;
   // Value is a percentage (e.g: 14.02)
-  value: number,
+  value: number;
 }
 
-interface MetricsData {
-  cpuData: Metric[];
-  memData: Metric[];
+export interface MetricsData {
+  cpuMetrics: Metric[];
+  memMetrics: Metric[];
 }
 
-interface MetricsStateLoading {
-  state: 'loading';
+export type TileMetricsGrafanaLinkState = TileMetricsGrafanaLinkStateLoaded | TileMetricsGrafanaLinkStateLoading;
+
+export interface TileMetricsGrafanaLinkStateLoaded {
+  type: 'loaded';
+  link: string;
 }
 
-interface MetricsStateError {
-  state: 'error';
+export interface TileMetricsGrafanaLinkStateLoading {
+  type: 'loading';
 }
 
-interface MetricsStateEmpty {
-  state: 'empty';
+// this is what we retrieve directly from the API
+export interface RawMetric {
+  data: { timestamp: number, value: string }[],
+  name: 'mem' | 'cpu', 
+  resource: string, 
+  unit: string,
 }
-
-interface MetricsStateLoaded {
-  state: 'loaded';
-  value: MetricsData;
-}
-
-export type MetricsState = MetricsStateLoading | MetricsStateError | MetricsStateLoaded | MetricsStateEmpty;


### PR DESCRIPTION
## What does this PR do?

- Refactors the `cc-tile-metrics` component to implement our new state structure,
- Implements TypeChecking within the `cc-tile-metrics` component and its stories.

## How to review?

- Check the commit (the diff may not be easy to read so you can review the final result locally if you prefer),
- If you check it locally, you should not get any Typescript error within the component file or the story file,
- Compare the [prod stories](https://www.clever-cloud.com/doc/clever-components/?path=/story/%F0%9F%9B%A0-overview-cc-tile-metrics--default-story) to the [preview stories](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-tile-metrics/state-migration/index.html?path=/story/%F0%9F%9B%A0-overview-cc-tile-metrics--default-story),
- Don't forget to check the smart using the `demo-smart` page.

**Note:** There are a few changes that you should review / pay more attention to. The grafana link now has a state of its own because its data comes from a separate source. It cannot be set to error because there is a fallback link within the smart. This may not be the best idea, I'm not really sure so don't hesitate to weigh in with other ideas / suggestions.
On the contrary, the `metricsLink` is a simple property since it is not set by the smart and it does not depend on any API. This means that the metricsLink cannot be loading / in skeleton mode contrary to what we currently have in prod :thinking:.

