### PR TITLE
chore(demo-smart): update app ids

### DIFF
--- a/demo-smart/index.html
+++ b/demo-smart/index.html
@@ -120,8 +120,8 @@
   <button data-context='{"apiConfig":{}}'>bad API config</button>
   <button data-context='{"lang":"en", "limit": 5}'>article-list</button>
   <button data-context='{"ownerId":"orga_3547a882-d464-4c34-8168-add4b3e0c135","grafanaBaseLink":"https://example.com"}'>grafana-info</button>
-  <button data-context='{"ownerId":"orga_3547a882-d464-4c34-8168-add4b3e0c135","appId":"app_b849c8d2-82e4-4c8f-af19-14423b8557f5"}'>app-node</button>
-  <button data-context='{"ownerId":"orga_3547a882-d464-4c34-8168-add4b3e0c135","appId":"app_e048c5ba-dc84-4f01-a750-d053706805fd"}'>app-play</button>
+  <button data-context='{"ownerId":"orga_540caeb6-521c-4a19-a955-efe6da35d142","appId":"app_f2f99229-4aba-42ef-bcb1-d69e8a443cd1","consoleGrafanaLink":"https://console.clever-cloud.com","grafanaBaseLink":"https://grafana.services.clever-cloud.com/"}'>app-node</button>
+  <button data-context='{"ownerId":"orga_540caeb6-521c-4a19-a955-efe6da35d142","appId":"app_ff66bc31-45e5-45bb-90d0-245b7552a7e2","consoleGrafanaLink":"https://console.clever-cloud.com","grafanaBaseLink":"https://grafana.services.clever-cloud.com/"}'>app-play</button>
   <button data-context='{"ownerId":"orga_3547a882-d464-4c34-8168-add4b3e0c135","currentUserId":"user_d3d02829-8847-40ea-ab76-ada4e2f026c0"}'>ACME BAR</button>
   <button data-context='{"ownerId":"orga_540caeb6-521c-4a19-a955-efe6da35d142","currentUserId":"user_d3d02829-8847-40ea-ab76-ada4e2f026c0"}'>ACME FOO</button>
   <button data-context='{"ownerId":"orga_3547a882-d464-4c34-8168-add4b3e0c135","addonId":"addon_53167b5a-3290-430d-912a-a084b6e905e7"}'>addon-elastic</button>


### PR DESCRIPTION
## What does this PR do?

- changes the `app-node` & `app-play` app ids within the demo-smart file because previous demo apps have been deleted,
- adds `grafanaBaseLink` & `consoleBaseLink` to the context so they can be used to review the `cc-tile-metrics` component.

## How to review?

- Check the commit,
- Run the storybook locally and check the demo-smart > `tile-metrics`  page. With `app-node`, metrics should show up after a minute or so. With `app-play`, the component should show a message saying the app is stopped,
- One review should be enough for this one.

**Note:** this PR does not modify the `cpu-load-bench` app because I don't know if we still want to use it or not (it may be overkill now that the component is stable and we may not want to keep this app running constantly for nothing, I'll discuss it with Mathieu later on).