### PR TITLE
chore(test/helpers): pass story names and use them

### DIFF
--- a/test/helpers/accessibility.js
+++ b/test/helpers/accessibility.js
@@ -48,16 +48,16 @@ setupIgnoreIrrelevantErrors(before, after, (message) => {
 /**
  * Loop through stories to run accessibility tests on their content both on desktop and mobile
  *
- * @param {Array} stories the story functions to execute and run a11y test
- * @param {Array} ignoredRules names of the rules to ignore
+ * @param {Array<{ storyName: string, storyFunction: Function }>} stories the story names & functions to execute and run a11y test
+ * @param {Array<string>} ignoredRules names of the rules to ignore
  */
 export const testAccessibility = (stories, ignoredRules) => {
-  stories.forEach((story) => {
-    describe(`Story: ${story.storyName}`, function () {
+  stories.forEach(({ storyName, storyFunction }) => {
+    describe(`Story: ${storyName}`, function () {
       describe(`Accessibility`, function () {
         it(`Desktop: width = ${viewports.desktop.width} height = ${viewports.desktop.height}`, async function () {
           await setViewport(viewports.desktop);
-          const element = await fixture(story({}, storyConf));
+          const element = await fixture(storyFunction({}, storyConf));
 
           await elementUpdated(element);
 
@@ -66,7 +66,7 @@ export const testAccessibility = (stories, ignoredRules) => {
 
         it(`Mobile: width = ${viewports.mobile.width} height = ${viewports.mobile.height}`, async function () {
           await setViewport(viewports.mobile);
-          const element = await fixture(story({}, storyConf));
+          const element = await fixture(storyFunction({}, storyConf));
 
           await elementUpdated(element);
 

--- a/test/helpers/get-stories.js
+++ b/test/helpers/get-stories.js
@@ -21,7 +21,7 @@ export const getStories = (importedModule, excludedStories = []) => {
       const isFunction = typeof exportItem === 'function';
       return isNotExcludedStory && isNotSimulation && isFunction;
     })
-    .map(([name, value]) => value);
+    .map(([storyName, storyFunction]) => ({ storyName, storyFunction }));
 
   return filteredStories;
 };


### PR DESCRIPTION
Fixes #1069 

## What does this PR do?

- Adapt to a storybook breaking change by providing the story name to the automated test helpers another way.

## How to review?

- You may run the tests for a given component like this: `npm run test:watch src/components/cc-badge/cc-badge.test.js` and press `D` to debug within Chrome. There, you should see the story name within the browser logs (see screenshot below)
- 1 reviewer should be enough for this one :wink: 

![image](https://github.com/CleverCloud/clever-components/assets/100240294/0259f33d-b2df-491a-b998-53e15319fd98)

