### PR TITLE
fix(cc-logs-instances): make sure deploying instances grid layout is never broken

### DIFF
--- a/src/components/cc-logs-instances/cc-logs-instances.js
+++ b/src/components/cc-logs-instances/cc-logs-instances.js
@@ -491,6 +491,7 @@ export class CcLogsInstances extends LitElement {
         class: 'instance-state--deleted',
       };
     }
+    return null;
   }
 
   /**
@@ -500,7 +501,7 @@ export class CcLogsInstances extends LitElement {
   _renderInstanceState (instance) {
     const icon = this._getInstanceStateIcon(instance);
     if (icon == null) {
-      return null;
+      return html`<span></span>`;
     }
 
     return html`


### PR DESCRIPTION
Fixes #1070

Since I could not reproduce the bug in real life, I just protected the grid layout from being broken when the state is not supported.