### PR TITLE
fix(cc-addon-credentials)!: change `addonType` value for Materia KV

### DIFF
--- a/src/components/cc-addon-credentials/cc-addon-credentials.js
+++ b/src/components/cc-addon-credentials/cc-addon-credentials.js
@@ -66,8 +66,8 @@ export class CcAddonCredentials extends LitElement {
         return i18n('cc-addon-credentials.description.kibana');
       case 'pulsar':
         return i18n('cc-addon-credentials.description.pulsar');
-      case 'materiadb-kv':
-        return i18n('cc-addon-credentials.description.materiadb-kv');
+      case 'materia-kv':
+        return i18n('cc-addon-credentials.description.materia-kv');
       default:
         return '';
     }

--- a/src/components/cc-addon-credentials/cc-addon-credentials.stories.js
+++ b/src/components/cc-addon-credentials/cc-addon-credentials.stories.js
@@ -89,7 +89,7 @@ export const dataLoadedWithPulsar = makeStory(conf, {
 
 export const dataLoadedWithMateriaKv = makeStory(conf, {
   items: [{
-    type: 'materiadb-kv',
+    type: 'materia-kv',
     name: 'Materia KV',
     toggleState: 'off',
     image: 'https://assets.clever-cloud.com/logos/materia-db-kv.png',

--- a/src/components/cc-addon-credentials/cc-addon-credentials.types.d.ts
+++ b/src/components/cc-addon-credentials/cc-addon-credentials.types.d.ts
@@ -1,7 +1,7 @@
-interface Credential {
+export interface Credential {
   type: "auth-token" | "host" | "password" | "url" | "user" | "port";
   value: string;
   secret: boolean;
 }
 
-type AddonType = "apm" | "elasticsearch" | "kibana" | "pulsar" | "materiadb-kv";
+export type AddonType = "apm" | "elasticsearch" | "kibana" | "pulsar" | "materia-kv";

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -108,7 +108,7 @@ export const translations = {
   'cc-addon-credentials.description.apm': `Use those credentials to connect an APM Server instance to your Elasticsearch cluster.`,
   'cc-addon-credentials.description.elasticsearch': `Use those credentials to connect to your Elasticsearch cluster.`,
   'cc-addon-credentials.description.kibana': `Use those credentials to connect a Kibana instance to your Elasticsearch cluster.`,
-  'cc-addon-credentials.description.materiadb-kv': `Use this information to connect your Materia KV add-on.`,
+  'cc-addon-credentials.description.materia-kv': `Use this information to connect your Materia KV add-on.`,
   'cc-addon-credentials.description.pulsar': `Use this information to connect your Pulsar add-on.`,
   'cc-addon-credentials.field.auth-token': `Token`,
   'cc-addon-credentials.field.host': `Host`,

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -121,7 +121,7 @@ export const translations = {
   'cc-addon-credentials.description.apm': `Utilisez ces identifiants pour connecter une instance d'APM Server à votre cluster Elasticsearch.`,
   'cc-addon-credentials.description.elasticsearch': `Utilisez ces identifiants pour vous connecter à votre cluster Elasticsearch.`,
   'cc-addon-credentials.description.kibana': `Utilisez ces identifiants pour connecter une instance de Kibana à votre cluster Elasticsearch.`,
-  'cc-addon-credentials.description.materiadb-kv': `Utilisez ces informations pour vous connecter à votre add-on Materia KV.`,
+  'cc-addon-credentials.description.materia-kv': `Utilisez ces informations pour vous connecter à votre add-on Materia KV.`,
   'cc-addon-credentials.description.pulsar': `Utilisez ces informations pour vous connecter à votre add-on Pulsar.`,
   'cc-addon-credentials.field.auth-token': `Token`,
   'cc-addon-credentials.field.host': `Hôte`,


### PR DESCRIPTION
Fixes #1068

## What does this PR do?

- Changes the `addonType` value for Materia KV from `materiadb-kv` to `materia-kv`

## How to review?

- Check the commit,
- Check the Materia KV story in preview,
- 1 reviewer should be enough for this one.