### PR TITLE
fix(cc-tile-status-codes.smart): pass `warpConfig` instead of `apiConfig`

### DIFF
--- a/src/components/cc-tile-status-codes/cc-tile-status-codes.smart.js
+++ b/src/components/cc-tile-status-codes/cc-tile-status-codes.smart.js
@@ -34,5 +34,5 @@ async function fetchStatusCodes ({ apiConfig, signal, ownerId, appId }) {
   const warpToken = await getWarp10AccessLogsToken({ orgaId: ownerId })
     .then(sendToApi({ apiConfig, signal, cacheDelay: ONE_DAY }));
   return getStatusCodesFromWarp10({ warpToken, ownerId, appId })
-    .then(sendToWarp({ apiConfig, signal, timeout: THIRTY_SECONDS }));
+    .then(sendToWarp({ warpConfig: apiConfig, signal, timeout: THIRTY_SECONDS }));
 }


### PR DESCRIPTION
Fixes #1085

## What does this PR do?

- Fixes the `cc-tile-status-codes` smart component,

## How to review?

- Run this branch / PR locally 
  - check the `demo-smart` page,
  - select the component & `app-node` or `app-play`,
  - There should be no error + the component should be showing a chart (you can compare on master, doing the same thing throws an error).
- 1 reviewer should be enough