### PR TITLE
fix(cc-header-orga): center enterprise icons vertically

### DIFF
--- a/src/components/cc-header-orga/cc-header-orga.js
+++ b/src/components/cc-header-orga/cc-header-orga.js
@@ -224,6 +224,7 @@ export class CcHeaderOrga extends LitElement {
 
         .enterprise-row {
           display: flex;
+          align-items: center;
           gap: 0.5em;
         }
 


### PR DESCRIPTION
Fixes #1084

## What does this PR do?

- Fixes the icon alignment issue (see screenshot of the issue below)

![image](https://github.com/CleverCloud/clever-components/assets/100240294/f4166ab6-0b01-46a9-9bc8-f9e5fbfbd9d5)

## How to review?

- Check the preview story,
- 1 reviewer should be enough for this one.