### PR TITLE
cc-domain-management: init component

### DIFF
--- a/demo-smart/index.html
+++ b/demo-smart/index.html
@@ -80,6 +80,9 @@
   <li>
     <a class="definition-link" href="?definition=cc-jenkins-info.smart">cc-jenkins-info.smart</a>
   </li>
+  <li>
+    <a class="definition-link" href="?definition=cc-domain-management.smart">cc-domain-management.smart</a>
+  </li>
   <!--  <li>-->
   <!--    <a class="definition-link" href="?definition=cc-pricing-page.smart">cc-pricing-page.smart</a>-->
   <!--  </li>-->

--- a/src/components/cc-domain-management/cc-domain-management.js
+++ b/src/components/cc-domain-management/cc-domain-management.js
@@ -1,0 +1,841 @@
+import { LitElement, css, html } from 'lit';
+import { classMap } from 'lit/directives/class-map.js';
+import { createRef, ref } from 'lit/directives/ref.js';
+import { repeat } from 'lit/directives/repeat.js';
+import {
+  iconRemixDeleteBinLine as iconDelete,
+  iconRemixLockUnlockFill as iconHttpOnly,
+  iconRemixExternalLinkLine as iconLink,
+  iconRemixStarLine as iconPrimary,
+  iconRemixFlaskLine as iconTest,
+} from '../../assets/cc-remix.icons.js';
+import { LostFocusController } from '../../controllers/lost-focus-controller.js';
+import {
+  DomainParseError,
+  getDomainUrl,
+  getHostWithWildcard,
+  isTestDomain,
+  isTestDomainWithSubdomain,
+  parseDomain,
+  sortDomains,
+} from '../../lib/domain.js';
+import { dispatchCustomEvent } from '../../lib/events.js';
+import { focusBySelector } from '../../lib/focus-helper.js';
+import { i18n } from '../../lib/i18n.js';
+import { accessibilityStyles } from '../../styles/accessibility.js';
+import { linkStyles } from '../../templates/cc-link/cc-link.js';
+import '../cc-badge/cc-badge.js';
+import '../cc-block-section/cc-block-section.js';
+import '../cc-block/cc-block.js';
+import '../cc-button/cc-button.js';
+import '../cc-input-text/cc-input-text.js';
+import '../cc-loader/cc-loader.js';
+import '../cc-notice/cc-notice.js';
+
+/**
+ * @typedef {import('./cc-domain-management.types.js').DomainManagementDnsInfoState} DomainManagementDnsInfoState
+ * @typedef {import('./cc-domain-management.types.js').DomainManagementListState} DomainManagementListState
+ * @typedef {import('./cc-domain-management.types.js').DomainManagementFormState} DomainManagementFormState
+ * @typedef {import('./cc-domain-management.types.js').DomainManagementFormStateIdle} DomainManagementFormStateIdle
+ * @typedef {import('./cc-domain-management.types.js').FormattedDomainInfo} FormattedDomainInfo
+ * @typedef {import('./cc-domain-management.types.js').DomainInfo} DomainInfo
+ * @typedef {import('./cc-domain-management.types.js').FormError} FormError
+ * @typedef {import('../cc-input-text/cc-input-text.js').CcInputText} CcInputText
+ * @typedef {import('lit').TemplateResult<1>} TemplateResult
+ * @typedef {import('lit/directives/ref.js').Ref<CcInputText>} RefCcInputText
+ * @typedef {import('lit/directives/ref.js').Ref<HTMLParagraphElement>} RefHTMLParagraphElement
+ * @typedef {import('lit').PropertyValues<CcDomainManagement>} CcDomainManagementPropertyValues
+ */
+
+/**
+ * A component to manage domains associated to an application.
+ *
+ * @cssdisplay block
+ *
+ * @fires {CustomEvent<{ hostname: string, pathPrefix: string }>} cc-domain-management:add - Fires when clicking the "Add a domain" button.
+ * @fires {CustomEvent<DomainInfo>} cc-domain-management:mark-as-primary - Fires when clicking a "mark as primary" button.
+ * @fires {CustomEvent<DomainInfo>} cc-domain-management:delete - Fires when clicking a "delete" button.
+ */
+export class CcDomainManagement extends LitElement {
+  static get properties() {
+    return {
+      dnsInfoState: { type: Object, attribute: 'dns-info-state' },
+      domainFormState: { type: Object, attribute: 'domain-form-state' },
+      domainListState: { type: Object, attribute: 'domain-list-state' },
+      _sortedDomains: { type: Array, state: true },
+    };
+  }
+
+  /**
+   * @returns {DomainManagementFormStateIdle}
+   */
+  static get INIT_DOMAIN_FORM_STATE() {
+    return {
+      type: 'idle',
+      hostname: {
+        value: '',
+      },
+      pathPrefix: {
+        value: '',
+      },
+    };
+  }
+
+  constructor() {
+    super();
+
+    /** @type {DomainManagementDnsInfoState} Sets the state of the DNS info section */
+    this.dnsInfoState = { type: 'loading' };
+
+    /** @type {DomainManagementFormState} Sets the state of the form section */
+    this.domainFormState = CcDomainManagement.INIT_DOMAIN_FORM_STATE;
+
+    /** @type {DomainManagementListState} Sets the state of the domain list section. */
+    this.domainListState = { type: 'loading' };
+
+    /** @type {RefCcInputText} */
+    this._domainInputRef = createRef();
+
+    /** @type {RefHTMLParagraphElement} */
+    this._emptyMessageRef = createRef();
+
+    /** @type {FormattedDomainInfo[]|null} */
+    this._sortedDomains = null;
+
+    new LostFocusController(this, '.delete-domain', ({ suggestedElement }) => {
+      if (suggestedElement != null) {
+        suggestedElement.focus();
+      } else {
+        this._emptyMessageRef.value?.focus();
+      }
+    });
+
+    new LostFocusController(this, '.mark-primary', () => {
+      focusBySelector(this.shadowRoot, '.primary');
+    });
+  }
+
+  /**
+   * @param {string} hostnameValue
+   * @returns {FormError|null} The error code or `null` if no error
+   */
+  _getFormError(hostnameValue) {
+    try {
+      const { pathname } = parseDomain(hostnameValue?.trim());
+
+      if (!hostnameValue.match(/.+\..+/)) {
+        return { code: 'invalid-format' };
+      }
+      if (pathname !== '/') {
+        /** We store the path so we can tell users to move this part to the "Path" input field instead. */
+        return { code: 'hostname-contains-path', pathWithinHostname: pathname };
+      }
+
+      return null;
+    } catch (error) {
+      if (error instanceof DomainParseError) {
+        return { code: error.code };
+      }
+
+      return { code: 'invalid-format' };
+    }
+  }
+
+  /**
+   * @param {FormError|null} error
+   * @returns {string}
+   */
+  _getErrorMessage(error) {
+    switch (error?.code) {
+      case 'empty':
+        return i18n('cc-domain-management.form.domain.error.empty');
+      case 'invalid-format':
+        return i18n('cc-domain-management.form.domain.error.format');
+      case 'invalid-wildcard':
+        return i18n('cc-domain-management.form.domain.error.wildcard');
+      case 'hostname-contains-path':
+        return i18n('cc-domain-management.form.domain.error.contains-path', { path: error.pathWithinHostname });
+    }
+  }
+
+  /** @param {ClipboardEvent} event */
+  _onDomainPaste(event) {
+    if (this.domainFormState.type !== 'idle' || this.domainFormState.hostname.value.trim() !== '') {
+      return;
+    }
+
+    event.preventDefault();
+
+    const clipboardValue = event.clipboardData.getData('text');
+
+    try {
+      const { hostname, pathname, isWildcard } = parseDomain(clipboardValue);
+
+      this.domainFormState = {
+        ...this.domainFormState,
+        hostname: {
+          ...this.domainFormState.hostname,
+          value: getHostWithWildcard(hostname, isWildcard),
+        },
+        pathPrefix: {
+          ...this.domainFormState.pathPrefix,
+          value: pathname.replace(/\/$/, ''),
+        },
+      };
+    } catch {
+      this.domainFormState = {
+        ...this.domainFormState,
+        hostname: {
+          ...this.domainFormState.hostname,
+          value: clipboardValue,
+        },
+      };
+    }
+  }
+
+  /** @param {SubmitEvent} e */
+  _onDomainSubmit(e) {
+    e.preventDefault();
+
+    if (this.domainFormState.type !== 'idle') {
+      return;
+    }
+
+    // we trim and we'll send this value to the API but we don't change what is displayed within the input
+    const hostnameValue = this.domainFormState.hostname.value.trim();
+    const pathPrefixValue = this.domainFormState.pathPrefix.value.trim();
+    const error = this._getFormError(hostnameValue);
+
+    if (error != null) {
+      this.domainFormState = {
+        ...this.domainFormState,
+        hostname: {
+          ...this.domainFormState.hostname,
+          error,
+        },
+      };
+
+      this._domainInputRef.value.focus();
+      return;
+    }
+
+    this.domainFormState = {
+      ...this.domainFormState,
+      hostname: {
+        value: this.domainFormState.hostname.value,
+      },
+    };
+
+    // we do this to strip off unwanted parts like query parameters for instance
+    const { hostname, pathname, isWildcard } = parseDomain(hostnameValue + pathPrefixValue);
+
+    dispatchCustomEvent(this, 'add', {
+      hostname,
+      pathPrefix: pathname,
+      isWildcard,
+    });
+  }
+
+  /** @param {FormattedDomainInfo} domainInfo */
+  _onMarkPrimary(domainInfo) {
+    const { id, hostname, pathPrefix, isWildcard, isPrimary } = domainInfo;
+    return () => dispatchCustomEvent(this, 'mark-as-primary', { id, hostname, pathPrefix, isWildcard, isPrimary });
+  }
+
+  /** @param {FormattedDomainInfo} domainInfo */
+  _onDelete(domainInfo) {
+    const { id, hostname, pathPrefix, isWildcard, isPrimary } = domainInfo;
+    return () => dispatchCustomEvent(this, 'delete', { id, hostname, pathPrefix, isWildcard, isPrimary });
+  }
+
+  /** @param {Event & { detail: string }} event */
+  _onDomainInput({ detail: value }) {
+    if (this.domainFormState.type !== 'idle') {
+      return;
+    }
+
+    this.domainFormState = {
+      ...this.domainFormState,
+      hostname: {
+        ...this.domainFormState.hostname,
+        value,
+      },
+    };
+  }
+
+  /** @param {Event & { detail: string }} event */
+  _onPathPrefixInput({ detail: value }) {
+    // add "/" at the beginning in case the user forgot to type it
+    if (value.length > 0 && !value.startsWith('/')) {
+      value = '/' + value;
+    }
+    this.domainFormState = {
+      ...this.domainFormState,
+      pathPrefix: {
+        ...this.domainFormState.pathPrefix,
+        value,
+      },
+    };
+  }
+
+  /** @param {CcDomainManagementPropertyValues} changedProperties */
+  willUpdate(changedProperties) {
+    if (
+      changedProperties.has('domainFormState') &&
+      changedProperties.get('domainFormState')?.hostname.error == null &&
+      this.domainFormState.hostname.error != null
+    ) {
+      this.updateComplete.then(() => this._domainInputRef.value?.focus());
+    }
+
+    if (changedProperties.has('domainListState') && this.domainListState.type === 'loaded') {
+      // Make sure we use a copy before using .sort() which modifies the array in place
+      this._sortedDomains = [...this.domainListState.domains].sort(sortDomains).map((domainState) => {
+        const { hostname } = domainState;
+
+        /** @type {FormattedDomainInfo} */
+        const formattedDomain = {
+          ...domainState,
+          isHttpOnly: isTestDomainWithSubdomain(hostname),
+          isTestingOnly: isTestDomain(hostname),
+        };
+
+        return formattedDomain;
+      });
+    }
+  }
+
+  render() {
+    return html`
+      <div class="wrapper">
+        <cc-block>
+          <div slot="title">${i18n('cc-domain-management.main-heading')}</div>
+
+          <cc-block-section>
+            <div class="form-info">
+              <p>${i18n('cc-domain-management.form.info.docs')}</p>
+              <p>${i18n('cc-domain-management.form.info.cleverapps')}</p>
+            </div>
+            <div>${this._renderForm(this.domainFormState)}</div>
+          </cc-block-section>
+
+          <cc-block-section>
+            <div slot="title">
+              ${i18n('cc-domain-management.list.heading')}
+              ${this.domainListState.type === 'loaded'
+                ? html` <cc-badge class="domain-count" circle>${this._sortedDomains.length}</cc-badge> `
+                : ''}
+            </div>
+
+            ${this.domainListState.type === 'error'
+              ? html`
+                  <cc-notice intent="warning" message="${i18n('cc-domain-management.list.loading-error')}"></cc-notice>
+                `
+              : ''}
+            ${this.domainListState.type === 'loading' ? html` <cc-loader></cc-loader> ` : ''}
+            ${this.domainListState.type === 'loaded' ? this._renderDomains(this._sortedDomains) : ''}
+          </cc-block-section>
+        </cc-block>
+
+        <cc-block>
+          <div slot="title">${i18n('cc-domain-management.certif.heading')}</div>
+          <div class="certif-info">
+            <p>${i18n('cc-domain-management.certif.automated')}</p>
+            <p>${i18n('cc-domain-management.certif.custom')}</p>
+          </div>
+        </cc-block>
+
+        <cc-block class="dns-info">
+          <div slot="title">${i18n('cc-domain-management.dns.heading')}</div>
+          <div>
+            <div class="dns-info__desc">${i18n('cc-domain-management.dns.desc')}</div>
+            <cc-notice intent="info" heading="${i18n('cc-domain-management.dns.info.heading')}">
+              <div slot="message">
+                <p>${i18n('cc-domain-management.dns.info.load-balancer')}</p>
+                <p>${i18n('cc-domain-management.dns.info.apex')}</p>
+              </div>
+            </cc-notice>
+          </div>
+
+          ${this.dnsInfoState.type === 'loading' ? html` <cc-loader></cc-loader> ` : ''}
+          ${this.dnsInfoState.type === 'error'
+            ? html`
+                <cc-notice intent="warning" message="${i18n('cc-domain-management.dns.loading-error')}"></cc-notice>
+              `
+            : ''}
+          ${this.dnsInfoState.type === 'loaded'
+            ? this._renderDnsInfo(this.dnsInfoState.cnameRecord, this.dnsInfoState.aRecords)
+            : ''}
+        </cc-block>
+      </div>
+    `;
+  }
+
+  /**
+   * @param {DomainManagementFormState} formState
+   * @returns {TemplateResult}
+   */
+  _renderForm({ type, hostname: domain, pathPrefix }) {
+    const isDisabled = type === 'adding';
+
+    return html`
+      <form novalidate @submit=${this._onDomainSubmit}>
+        <div class="fieldgroup">
+          <cc-input-text
+            class="fieldgroup__domain"
+            label="${i18n('cc-domain-management.form.domain.label')}"
+            required
+            .value="${domain.value}"
+            ?disabled="${isDisabled}"
+            .errorMessage=${this._getErrorMessage(domain.error)}
+            ${ref(this._domainInputRef)}
+            @cc-input-text:input=${this._onDomainInput}
+            @paste=${this._onDomainPaste}
+          >
+            <p slot="help">${i18n('cc-domain-management.form.domain.help')}</p>
+          </cc-input-text>
+          <cc-input-text
+            class="fieldgroup__path"
+            label="${i18n('cc-domain-management.form.path.label')}"
+            .value="${pathPrefix.value}"
+            ?disabled="${isDisabled}"
+            @cc-input-text:input=${this._onPathPrefixInput}
+          >
+            <p slot="help">${i18n('cc-domain-management.form.path.help')}</p>
+          </cc-input-text>
+        </div>
+        <cc-button primary ?waiting="${type === 'adding'}" type="submit"
+          >${i18n('cc-domain-management.form.submit')}</cc-button
+        >
+      </form>
+    `;
+  }
+
+  /**
+   * @param {FormattedDomainInfo[]} domains
+   * @returns {TemplateResult}
+   */
+  _renderDomains(domains) {
+    const hasDomains = domains.length > 0;
+    const isOneRowMarkingPrimary = domains.filter((domain) => domain.type === 'marking-primary').length > 0;
+    const hasHttpOnlyDomains = domains.filter((domain) => domain.isHttpOnly).length > 0;
+
+    if (!hasDomains) {
+      return html`
+        <p class="empty" tabindex="-1" ${ref(this._emptyMessageRef)}>${i18n('cc-domain-management.list.empty')}</p>
+      `;
+    }
+
+    return html`
+      ${hasHttpOnlyDomains
+        ? html`
+            <cc-notice no-icon intent="warning">
+              <div slot="message" class="http-only-info">
+                <cc-badge intent="warning" weight="outlined">
+                  <div class="badge-content">
+                    <cc-icon
+                      .icon=${iconHttpOnly}
+                      a11y-name=${i18n('cc-domain-management.list.badge.http-only.alt')}
+                    ></cc-icon>
+                    ${i18n('cc-domain-management.list.badge.http-only.text')}
+                  </div>
+                </cc-badge>
+                ${i18n('cc-domain-management.list.http-only.notice')}
+              </div>
+            </cc-notice>
+          `
+        : ''}
+
+      <div class="domains">
+        ${repeat(
+          domains,
+          ({ id }) => id,
+          (domain) => this._renderDomain(domain, isOneRowMarkingPrimary),
+        )}
+      </div>
+    `;
+  }
+
+  /**
+   * @param {FormattedDomainInfo} domainInfo
+   * @param {boolean} isOneRowMarkingPrimary
+   * @returns {TemplateResult}
+   **/
+  _renderDomain(domainInfo, isOneRowMarkingPrimary) {
+    const {
+      type: domainItemStateType,
+      hostname,
+      pathPrefix,
+      isWildcard,
+      isPrimary,
+      isHttpOnly,
+      isTestingOnly,
+    } = domainInfo;
+    const waiting = domainItemStateType === 'deleting' || domainItemStateType === 'marking-primary';
+    const isMarkingPrimaryDisabled = isOneRowMarkingPrimary || domainItemStateType === 'deleting';
+    const hostWithWildcard = getHostWithWildcard(hostname, isWildcard);
+    const domainUrl = getDomainUrl(hostname, pathPrefix, isWildcard, isHttpOnly);
+
+    return html`
+      <!--
+        Caution: the primary class is used to focus the primary domain when it changes, do not remove or change this class
+        (see LostFocusController within the constructor for more info) 
+      -->
+      <div class="domain ${classMap({ primary: isPrimary, waiting })}" tabindex="-1">
+        <span class="domain-name-with-path">
+          <!-- These tags need to remain on the same line so there is no white-space when pasting domain+path -->
+          <span>${hostWithWildcard}</span><span class="path-prefix">${pathPrefix}</span>
+          <a
+            class="domain-link"
+            href="${domainUrl}"
+            title="${i18n('cc-domain-management.list.link.title', { domainUrl })}"
+            target="_blank"
+          >
+            <span class="visually-hidden">${domainUrl}</span>
+            <cc-icon .icon=${iconLink} a11y-name="${i18n('cc-domain-management.new-window')}"></cc-icon>
+          </a>
+        </span>
+
+        <div class="badges">
+          ${isPrimary
+            ? html`
+                <cc-badge>
+                  <div class="badge-content">
+                    <cc-icon .icon=${iconPrimary}></cc-icon>
+                    ${i18n('cc-domain-management.list.badge.primary')}
+                  </div>
+                </cc-badge>
+              `
+            : ''}
+          ${isTestingOnly
+            ? html`
+                <cc-badge intent="info" weight="outlined">
+                  <div class="badge-content">
+                    <cc-icon .icon=${iconTest}></cc-icon>
+                    ${i18n('cc-domain-management.list.badge.testing-only')}
+                  </div>
+                </cc-badge>
+              `
+            : ''}
+          ${isHttpOnly
+            ? html`
+                <cc-badge intent="warning" weight="outlined">
+                  <div class="badge-content">
+                    <cc-icon
+                      .icon=${iconHttpOnly}
+                      a11y-name=${i18n('cc-domain-management.list.badge.http-only.alt')}
+                    ></cc-icon>
+                    ${i18n('cc-domain-management.list.badge.http-only.text')}
+                  </div>
+                </cc-badge>
+              `
+            : ''}
+        </div>
+
+        <div class="actions">
+          ${!isPrimary
+            ? html`
+                <cc-button
+                  class="mark-primary"
+                  primary
+                  outlined
+                  ?disabled=${isMarkingPrimaryDisabled}
+                  ?waiting="${domainItemStateType === 'marking-primary'}"
+                  a11y-name="${i18n('cc-domain-management.list.btn.primary.a11y-name', { domain: hostWithWildcard })}"
+                  .icon=${iconPrimary}
+                  hide-text
+                  circle
+                  @cc-button:click=${this._onMarkPrimary(domainInfo)}
+                >
+                  ${i18n('cc-domain-management.list.btn.primary.text')}
+                </cc-button>
+              `
+            : ''}
+          <cc-button
+            class="delete-domain"
+            danger
+            outlined
+            ?disabled="${domainItemStateType === 'marking-primary'}"
+            ?waiting="${domainItemStateType === 'deleting'}"
+            a11y-name="${i18n('cc-domain-management.list.btn.delete.a11y-name', { domain: hostWithWildcard })}"
+            .icon=${iconDelete}
+            hide-text
+            circle
+            @cc-button:click=${this._onDelete(domainInfo)}
+          >
+            ${i18n('cc-domain-management.list.btn.delete.text')}
+          </cc-button>
+        </div>
+      </div>
+    `;
+  }
+
+  /**
+   * @param {string} cnameRecord
+   * @param {string[]} aRecords
+   * @returns {TemplateResult}
+   */
+  _renderDnsInfo(cnameRecord, aRecords) {
+    return html`
+      <cc-block-section>
+        <div slot="title">${i18n('cc-domain-management.dns.cname.heading')}</div>
+        <div slot="info">${i18n('cc-domain-management.dns.cname.desc')}</div>
+        <cc-input-text
+          hidden-label
+          label="${i18n('cc-domain-management.dns.cname.label')}"
+          readonly
+          clipboard
+          value=${cnameRecord}
+        ></cc-input-text>
+      </cc-block-section>
+      <cc-block-section>
+        <div slot="title">${i18n('cc-domain-management.dns.a.heading')}</div>
+        <div slot="info">${i18n('cc-domain-management.dns.a.desc')}</div>
+        <div class="a-records">
+          ${aRecords.map(
+            (aRecord, index) => html`
+              <cc-input-text
+                hidden-label
+                label="${i18n('cc-domain-management.dns.a.label', { index: index + 1 })}"
+                readonly
+                clipboard
+                value=${aRecord}
+              ></cc-input-text>
+            `,
+          )}
+        </div>
+      </cc-block-section>
+    `;
+  }
+
+  static get styles() {
+    return [
+      accessibilityStyles,
+      linkStyles,
+      css`
+        :host {
+          display: block;
+        }
+
+        .wrapper {
+          display: flex;
+          flex-direction: column;
+          gap: 1.5em;
+        }
+
+        code {
+          background-color: var(--cc-color-bg-neutral);
+          border-radius: var(--cc-border-radius-default, 0.25em);
+          font-family: var(--cc-ff-monospace);
+          padding: 0.15em 0.3em;
+          word-break: break-all;
+        }
+
+        /** #region form */
+
+        .fieldgroup {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 1em;
+        }
+
+        .fieldgroup__domain {
+          flex-grow: 5;
+        }
+
+        .fieldgroup__path {
+          flex-basis: 16em;
+          flex-grow: 2;
+        }
+
+        form {
+          display: flex;
+          flex-direction: column;
+          gap: 1.5em;
+          justify-content: flex-end;
+        }
+
+        form cc-button {
+          margin-left: auto;
+        }
+
+        .form-info {
+          color: var(--cc-color-text-weak);
+          line-height: 1.5;
+          margin-bottom: 1em;
+        }
+
+        .form-info p {
+          margin: 0;
+        }
+
+        .form-info__cleverapps {
+          align-items: center;
+          display: flex;
+          gap: 0.5em;
+        }
+
+        .form-info cc-icon {
+          color: var(--cc-color-text-primary);
+        }
+
+        /** we need this because the help message contains a <code> tag that has some extra padding */
+
+        [slot='help'] {
+          padding-top: 0.3em;
+        }
+
+        /** #endregion */
+
+        /** #region domain-list */
+
+        .domain-count {
+          font-size: 0.9em;
+          margin-left: 0.2em;
+        }
+
+        .domains {
+          display: grid;
+          gap: 1em;
+          grid-auto-rows: 1fr;
+          grid-template-columns: repeat(auto-fit, minmax(min(25em, 100%), 1fr));
+        }
+
+        .domain {
+          align-content: center;
+          align-items: center;
+          border: solid 1px var(--cc-color-border-neutral-weak);
+          border-radius: var(--cc-border-radius-default);
+          display: grid;
+          gap: 0.5em 1em;
+          grid-template-areas:
+            'domain-info domain-info'
+            'badges actions';
+          padding: 1em;
+        }
+
+        .domain:hover {
+          background-color: var(--cc-color-bg-neutral);
+        }
+
+        .domain:focus-visible {
+          outline: var(--cc-focus-outline, #000 solid 2px);
+          outline-offset: var(--cc-focus-outline-offset, 2px);
+        }
+
+        .domain-name-with-path {
+          grid-area: domain-info;
+          word-break: break-all;
+        }
+
+        .path-prefix {
+          color: var(--cc-color-text-primary-strongest);
+          font-family: var(--cc-ff-monospace);
+          font-weight: bold;
+          padding-left: 0.5em;
+        }
+
+        .domain-link {
+          /** fixes icon alignment that differs depending on the font-family */
+
+          font-family: var(--cc-ff-monospace, monospace);
+          padding: 0.3em;
+          vertical-align: middle;
+        }
+
+        .domain-link cc-icon {
+          vertical-align: baseline;
+        }
+
+        .waiting .domain-name-with-path {
+          opacity: var(--cc-opacity-when-disabled, 0.5);
+        }
+
+        .badges {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 0.5em;
+          grid-area: badges;
+        }
+
+        .badge-content {
+          align-items: center;
+          display: flex;
+          gap: 0.5em;
+        }
+
+        .badge-content cc-icon {
+          flex: 0 0 auto;
+        }
+
+        .actions {
+          align-items: center;
+          display: flex;
+          gap: 0.5em;
+          grid-area: actions;
+          justify-content: flex-end;
+        }
+
+        .empty {
+          font-style: italic;
+        }
+
+        .empty:focus {
+          outline: none;
+        }
+
+        .http-only-info cc-badge {
+          line-height: normal;
+          margin-right: 0.5em;
+        }
+
+        .http-only-info {
+          line-height: 1.5;
+        }
+
+        /** #endregion */
+
+        /** #region certifAndDNS */
+
+        .certif-info {
+          display: grid;
+          gap: 0.5em;
+          line-height: 1.5;
+        }
+
+        .certif-info p,
+        .dns-info p {
+          margin: 0;
+        }
+
+        .dns-info__desc {
+          display: grid;
+          gap: 0.5em;
+          margin-bottom: 1em;
+        }
+
+        .dns-info div[slot='info'] {
+          align-content: flex-start;
+          display: grid;
+          gap: 0;
+        }
+
+        .a-records {
+          align-content: baseline;
+          display: grid;
+          gap: 1em;
+          grid-template-columns: repeat(auto-fit, minmax(8em, 1fr));
+        }
+
+        .dns-info cc-notice[intent='info'] {
+          margin-bottom: 1em;
+          margin-top: 1.5em;
+        }
+
+        /** #endregion */
+      `,
+    ];
+  }
+}
+
+window.customElements.define('cc-domain-management', CcDomainManagement);

--- a/src/components/cc-domain-management/cc-domain-management.smart.js
+++ b/src/components/cc-domain-management/cc-domain-management.smart.js
@@ -1,0 +1,413 @@
+import {
+  addDomain,
+  getAllDomains,
+  getFavouriteDomain as getPrimaryDomain,
+  markFavouriteDomain as markPrimaryDomain,
+  removeDomain,
+  unmarkFavouriteDomain as unmarkPrimaryDomain,
+} from '@clevercloud/client/esm/api/v2/application.js';
+import { defineSmartComponent } from '../../lib/define-smart-component.js';
+import { getHostWithWildcard, isTestDomain, parseDomain } from '../../lib/domain.js';
+import { i18n } from '../../lib/i18n.js';
+import { notify, notifyError, notifySuccess } from '../../lib/notifications.js';
+import { sendToApi } from '../../lib/send-to-api.js';
+import '../cc-smart-container/cc-smart-container.js';
+import { CcDomainManagement } from './cc-domain-management.js';
+
+/**
+ * @typedef {import('./cc-domain-management.types.js').DomainManagementFormState} DomainManagementFormState
+ * @typedef {import('./cc-domain-management.types.js').DomainManagementListStateLoaded} DomainManagementListStateLoaded
+ * @typedef {import('./cc-domain-management.types.js').DomainStateIdle} DomainStateIdle
+ * @typedef {import('./cc-domain-management.types.js').DomainState} DomainState
+ * @typedef {import('./cc-domain-management.types.js').DomainInfo} DomainInfo
+ * @typedef {import('../../lib/send-to-api.js').ApiConfig} ApiConfig
+ * @typedef {{ fqdn: string }} RawDomainFromApi
+ * @typedef {Omit<DomainInfo, 'isPrimary'>} DomainInfoWithoutIsPrimary
+ */
+
+defineSmartComponent({
+  selector: 'cc-domain-management',
+  params: {
+    apiConfig: { type: Object },
+    appId: { type: String },
+    ownerId: { type: String },
+  },
+  onContextUpdate({ context, onEvent, updateComponent, signal }) {
+    const { apiConfig, appId, ownerId } = context;
+
+    /**
+     * @param {string} id
+     * @param {(domainState: DomainState) => void} callback
+     **/
+    function updateDomain(id, callback) {
+      updateComponent(
+        'domainListState',
+        /** @param {DomainManagementListStateLoaded} domainListState */
+        (domainListState) => {
+          const domainState = domainListState.domains.find((domain) => domain.id === id);
+          if (domainState != null) {
+            callback(domainState);
+          }
+        },
+      );
+    }
+
+    getDomains({ apiConfig, ownerId, appId, signal })
+      .then((domains) => {
+        updateComponent('domainListState', { type: 'loaded', domains });
+      })
+      .catch((error) => {
+        console.error(error);
+        updateComponent('domainListState', { type: 'error' });
+      });
+
+    fetchDnsInfo({ apiConfig, ownerId, appId, signal })
+      .then(({ cnameRecord, aRecords }) => {
+        updateComponent('dnsInfoState', { type: 'loaded', cnameRecord, aRecords });
+      })
+      .catch((error) => {
+        console.error(error);
+        updateComponent('dnsInfoState', { type: 'error' });
+      });
+
+    onEvent(
+      'cc-domain-management:add',
+      /** @param {{ hostname: string, pathPrefix: string, isWildcard: boolean }} domain */
+      ({ hostname, pathPrefix, isWildcard }) => {
+        const domainWithPathAndWildcard = getHostWithWildcard(hostname + pathPrefix, isWildcard);
+        updateComponent(
+          'domainFormState',
+          /** @param {DomainManagementFormState} domainFormState */
+          (domainFormState) => {
+            domainFormState.type = 'adding';
+          },
+        );
+
+        createNewDomain({ apiConfig, ownerId, appId, hostname, pathPrefix, isWildcard })
+          .then(() => {
+            if (isTestDomain(hostname)) {
+              notifySuccess(i18n('cc-domain-management.form.submit.success', { domain: domainWithPathAndWildcard }));
+            } else {
+              notify({
+                intent: 'info',
+                message: i18n('cc-domain-management.form.submit.success-config', { domain: domainWithPathAndWildcard }),
+                options: {
+                  timeout: 0,
+                  closeable: true,
+                },
+              });
+            }
+            updateComponent('domainFormState', CcDomainManagement.INIT_DOMAIN_FORM_STATE);
+            updateComponent(
+              'domainListState',
+              /** @param {DomainManagementListStateLoaded} domainListState */
+              (domainListState) => {
+                const hasPathPrefix = pathPrefix != null && pathPrefix !== '/';
+                // TODO: once the API returns actual ids, this should be adapted (either refetch or use the API response)
+                const id = hasPathPrefix ? hostname + pathPrefix : hostname;
+
+                /** @type {DomainStateIdle} */
+                const newDomain = {
+                  id,
+                  hostname: hostname,
+                  type: 'idle',
+                  pathPrefix,
+                  isWildcard,
+                  isPrimary: false,
+                };
+
+                domainListState.domains.push(newDomain);
+              },
+            );
+          })
+          .catch(
+            /** @param {Error} error */
+            (error) => {
+              console.error(error);
+              const errorCode = convertApiError(error);
+
+              updateComponent(
+                'domainFormState',
+                /** @param {DomainManagementFormState} domainFormState */
+                (domainFormState) => {
+                  domainFormState.type = 'idle';
+                },
+              );
+
+              if (errorCode === 'invalid-format') {
+                updateComponent(
+                  'domainFormState',
+                  /** @param {DomainManagementFormState} domainFormState */
+                  (domainFormState) => {
+                    domainFormState.hostname.error = { code: errorCode };
+                  },
+                );
+                return;
+              }
+
+              if (errorCode === 'already-used') {
+                notifyError(
+                  i18n('cc-domain-management.form.submit.error-duplicate.text', { domain: domainWithPathAndWildcard }),
+                  i18n('cc-domain-management.form.submit.error-duplicate.heading'),
+                );
+                return;
+              }
+
+              notifyError(i18n('cc-domain-management.form.submit.error', { domain: domainWithPathAndWildcard }));
+            },
+          );
+      },
+    );
+
+    onEvent(
+      'cc-domain-management:delete',
+      /** @param {DomainInfo} domain */
+      ({ id, hostname, pathPrefix, isWildcard }) => {
+        const domainWithPathAndWildcard = getHostWithWildcard(hostname + pathPrefix, isWildcard);
+        updateDomain(id, (domainState) => {
+          domainState.type = 'deleting';
+        });
+
+        deleteDomain({ apiConfig, ownerId, appId, id })
+          .then(() => {
+            updateComponent(
+              'domainListState',
+              /** @param {DomainManagementListStateLoaded} domainListState */
+              (domainListState) => {
+                domainListState.domains = domainListState.domains.filter((domain) => domain.id !== id);
+              },
+            );
+            notifySuccess(i18n('cc-domain-management.list.delete.success', { domain: domainWithPathAndWildcard }));
+          })
+          .catch((error) => {
+            console.error(error);
+
+            notifyError(i18n('cc-domain-management.list.delete.error', { domain: domainWithPathAndWildcard }));
+
+            updateDomain(id, (domainState) => {
+              domainState.type = 'idle';
+            });
+          });
+      },
+    );
+
+    onEvent(
+      'cc-domain-management:mark-as-primary',
+      /** @param {DomainInfo}  domain */
+      ({ id, hostname, pathPrefix, isWildcard }) => {
+        const domainWithPathAndWildcard = getHostWithWildcard(hostname + pathPrefix, isWildcard);
+        updateDomain(id, (domainState) => {
+          domainState.type = 'marking-primary';
+        });
+
+        markAsPrimaryDomain({ apiConfig, ownerId, appId, id })
+          .then(() => {
+            updateComponent(
+              'domainListState',
+              /** @param {DomainManagementListStateLoaded} domainListState */
+              (domainListState) => {
+                domainListState.domains = domainListState.domains.map((domainState) => ({
+                  ...domainState,
+                  type: 'idle',
+                  isPrimary: domainState.id === id,
+                }));
+              },
+            );
+
+            // Dispatch event to make the console refresh its UI
+            const primaryChangeEvent = new CustomEvent('domain-management-primary-change', {
+              detail: id,
+            });
+            window.dispatchEvent(primaryChangeEvent);
+
+            notifySuccess(i18n('cc-domain-management.list.primary.success', { domain: domainWithPathAndWildcard }));
+          })
+          .catch((error) => {
+            console.error(error);
+            updateDomain(id, (domainState) => {
+              domainState.type = 'idle';
+            });
+
+            if (error.id === 3004) {
+              notifyError(
+                i18n('cc-domain-management.list.error-not-found.text', { domain: domainWithPathAndWildcard }),
+                i18n('cc-domain-management.list.error-not-found.heading'),
+              );
+              return;
+            }
+
+            notifyError(i18n('cc-domain-management.list.primary.error', { domain: domainWithPathAndWildcard }));
+          });
+      },
+    );
+  },
+});
+
+/**
+ * @param {Object} params
+ * @param {ApiConfig} params.apiConfig
+ * @param {string} params.ownerId
+ * @param {string} params.appId
+ * @param {AbortSignal} params.signal
+ * @returns {Promise<DomainStateIdle[]>}
+ */
+function getDomains({ apiConfig, ownerId, appId, signal }) {
+  return Promise.all([
+    fetchPrimaryDomain(ownerId, appId, apiConfig, signal),
+    fetchDomains(ownerId, appId, apiConfig),
+  ]).then(([primaryDomain, domains]) => {
+    /** @type {DomainStateIdle[]} */
+    const formattedDomains = domains.map((domainState) => ({
+      ...domainState,
+      type: 'idle',
+      isPrimary: primaryDomain?.fqdn === domainState.id,
+    }));
+
+    return formattedDomains;
+  });
+}
+
+/**
+ * @param {Object} params
+ * @param {ApiConfig} params.apiConfig
+ * @param {string} params.ownerId
+ * @param {string} params.appId
+ * @param {string} params.hostname
+ * @param {string} params.pathPrefix
+ * @param {boolean} params.isWildcard
+ * @returns {Promise<DomainStateIdle[]>}
+ */
+function createNewDomain({ apiConfig, ownerId, appId, hostname, pathPrefix, isWildcard }) {
+  const domainWithEncodedPathAndWildcard = getHostWithWildcard(hostname, isWildcard) + encodeURIComponent(pathPrefix);
+  return addDomain({ id: ownerId, appId, domain: domainWithEncodedPathAndWildcard }).then(sendToApi({ apiConfig }));
+}
+
+/**
+ * @param {Object} params
+ * @param {ApiConfig} params.apiConfig
+ * @param {string} params.ownerId
+ * @param {string} params.appId
+ * @param {string} params.id
+ * @returns {Promise<DomainStateIdle[]>}
+ */
+function deleteDomain({ apiConfig, ownerId, appId, id }) {
+  return removeDomain({ id: ownerId, appId, domain: encodeURIComponent(id) }).then(sendToApi({ apiConfig }));
+}
+
+/**
+ * @param {Object} params
+ * @param {ApiConfig} params.apiConfig
+ * @param {string} params.ownerId
+ * @param {string} params.appId
+ * @param {string} params.id
+ * @returns {Promise<DomainStateIdle[]>}
+ */
+function markAsPrimaryDomain({ apiConfig, ownerId, appId, id }) {
+  return unmarkPrimaryDomain({ id: ownerId, appId })
+    .then(sendToApi({ apiConfig }))
+    .then(() => markPrimaryDomain({ id: ownerId, appId }, { fqdn: id }).then(sendToApi({ apiConfig })));
+}
+
+/**
+ * @param {Object} params
+ * @param {ApiConfig} params.apiConfig
+ * @param {string} params.ownerId
+ * @param {string} params.appId
+ * @param {AbortSignal} params.signal
+ * @returns {Promise<{ cnameRecord: string, aRecords: string[] }>}
+ */
+function fetchDnsInfo({ apiConfig, ownerId, appId, signal }) {
+  return getDefaultLoadBalancersDnsInfo({ appId, ownerId })
+    .then(sendToApi({ apiConfig, signal }))
+    .then((defaultLoadBalancers) => {
+      const defaultLoadBalancerData = defaultLoadBalancers[0];
+      return {
+        cnameRecord: defaultLoadBalancerData?.dns?.cname,
+        aRecords: defaultLoadBalancerData?.dns?.a,
+      };
+    });
+}
+
+/**
+ * TODO: move this to Clever Client
+ *
+ * @param {Object} params
+ * @param {string} params.ownerId
+ * @param {string} params.appId
+ * @returns {Promise<any>}
+ */
+function getDefaultLoadBalancersDnsInfo({ appId, ownerId }) {
+  return Promise.resolve({
+    method: 'get',
+    url: `/v4/load-balancers/organisations/${ownerId}/applications/${appId}/load-balancers/default`,
+    headers: { Accept: 'application/json' },
+  });
+}
+
+/**
+ * @param {string} id
+ * @param {string} appId
+ * @param {ApiConfig} apiConfig
+ * @param {AbortSignal} signal
+ * @returns {Promise<RawDomainFromApi>}
+ */
+function fetchPrimaryDomain(id, appId, apiConfig, signal) {
+  return getPrimaryDomain({ id, appId })
+    .then(sendToApi({ apiConfig, signal }))
+    .catch(
+      /**
+       * @param {Error & { response: { status: number }}} error
+       * @returns {null|void}
+       */
+      (error) => {
+        if (error.response.status === 404) {
+          return null;
+        }
+      },
+    );
+}
+
+/**
+ * @param {string} id
+ * @param {string} appId
+ * @param {ApiConfig} apiConfig
+ * @returns {Promise<DomainInfoWithoutIsPrimary[]>}
+ */
+function fetchDomains(id, appId, apiConfig) {
+  return getAllDomains({ id, appId })
+    .then(sendToApi({ apiConfig }))
+    .then(
+      /** @param {RawDomainFromApi[]} domains */
+      (domains) => {
+        return domains.map(({ fqdn }) => {
+          const { hostname, pathname, isWildcard } = parseDomain(fqdn);
+
+          /** @type {DomainInfoWithoutIsPrimary} */
+          const formattedDomain = {
+            id: fqdn,
+            hostname,
+            pathPrefix: pathname,
+            isWildcard,
+          };
+
+          return formattedDomain;
+        });
+      },
+    );
+}
+
+/**
+ * @param {Error} apiError
+ * @returns {'invalid-format'|'already-used'|null}
+ */
+function convertApiError(apiError) {
+  // FIXME: ask the API for a proper id to map a message to an error
+  if (apiError.message === 'Invalid domain' || apiError.message.includes('is invalid')) {
+    return 'invalid-format';
+  }
+  // FIXME: ask the API for a proper id to map a message to an error
+  if (apiError.message.includes('is already taken') || apiError.message.includes('You are not allowed to use')) {
+    return 'already-used';
+  }
+  return null;
+}

--- a/src/components/cc-domain-management/cc-domain-management.smart.md
+++ b/src/components/cc-domain-management/cc-domain-management.smart.md
@@ -1,0 +1,68 @@
+---
+kind: '🛠 Domains/<cc-domain-management>'
+title: '💡 Smart'
+---
+
+# 💡 Smart `<cc-domain-management>`
+
+## ℹ️ Details
+
+<table>
+  <tr><td><strong>Component    </strong> <td><a href="https://www.clever-cloud.com/doc/clever-components/?path=/docs/🛠-domains-cc-domain-management--default-story"><code>&lt;cc-domain-management&gt;</code></a>
+  <tr><td><strong>Selector     </strong> <td><code>cc-domain-management</code>
+  <tr><td><strong>Requires auth</strong> <td>Yes
+</table>
+
+## 👋️ Events fired
+
+| Name                                | Payload | Details                                                                                                                           |
+|-------------------------------------|---------|-----------------------------------------------------------------------------------------------------------------------------------|
+| `domain-management-primary-change` |         | Fired when the primary domain has been changed successfully.<br/>Should be used to refresh the app link within the console header |
+
+
+## ⚙️ Params
+
+| Name        | Type        | Details                                                 | Default |
+|-------------|-------------|---------------------------------------------------------|---------|
+| `apiConfig` | `ApiConfig` | Object with API configuration (target host, tokens...)  |         |
+| `ownerId`   | `string`    | UUID prefixed with orga_                                |         |
+| `appId`     | `string`    | UUID prefixed with app_                                 |         |
+
+```ts
+interface ApiConfig {
+  API_HOST: string,
+  API_OAUTH_TOKEN: string,
+  API_OAUTH_TOKEN_SECRET: string,
+  OAUTH_CONSUMER_KEY: string,
+  OAUTH_CONSUMER_SECRET: string,
+}
+```
+
+## 🌐 API endpoints
+
+| Method   | Type                                                                                       | Cache?  |
+|----------|:-------------------------------------------------------------------------------------------|---------|
+| `GET`    | `/v2/self/id`                                                                              | Default |
+| `GET`    | `/v4/load-balancers/organisations/${ownerId}/applications/${appId}/load-balancers/default` | Default |
+| `GET`    | `/v2/organisations/{ownerId}/applications/{appId}/vhosts`                                  | Default |
+| `PUT`    | `/v2/organisations/{ownerId}/applications/{appId}/vhosts/{domain}`                         | Default |
+| `DELETE` | `/v2/organisations/{ownerId}/applications/{appId}/vhosts/{domain}`                         | Default |
+| `GET`    | `/v2/organisations/{ownerId}/applications/{appId}/vhosts/favourite`                        | Default |
+| `PUT`    | `/v2/organisations/{ownerId}/applications/{appId}/vhosts/favourite`                        | Default |
+
+```html
+<cc-smart-container context='{
+    "apiConfig": {
+      API_HOST: "",
+      API_OAUTH_TOKEN: "",
+      API_OAUTH_TOKEN_SECRET: "",
+      OAUTH_CONSUMER_KEY: "",
+      OAUTH_CONSUMER_SECRET: "",
+    },
+    "ownerId": "",
+    "appId": "",
+}'>
+    <cc-domain-management></cc-domain-management>
+<cc-smart-container>
+```
+

--- a/src/components/cc-domain-management/cc-domain-management.stories.js
+++ b/src/components/cc-domain-management/cc-domain-management.stories.js
@@ -1,0 +1,413 @@
+import { baseDnsInfo, baseDomains, httpOnlyDomain, longBaseDomains } from '../../stories/fixtures/domains.js';
+import { makeStory, storyWait } from '../../stories/lib/make-story.js';
+import './cc-domain-management.js';
+
+export default {
+  tags: ['autodocs'],
+  title: '🛠 Domains/<cc-domain-management>',
+  component: 'cc-domain-management',
+};
+
+/**
+ * @typedef {import('./cc-domain-management.types.js').DomainStateDeleting} DomainStateDeleting
+ * @typedef {import('./cc-domain-management.types.js').DomainStateMarkingPrimary} DomainStateMarkingPrimary
+ * @typedef {import('./cc-domain-management.types.js').DomainManagementDnsInfoStateLoaded} DomainManagementDnsInfoStateLoaded
+ * @typedef {import('./cc-domain-management.types.js').DomainManagementDnsInfoStateLoading} DomainManagementDnsInfoStateLoading
+ * @typedef {import('./cc-domain-management.types.js').DomainManagementDnsInfoStateError} DomainManagementDnsInfoStateError
+ * @typedef {import('./cc-domain-management.types.js').DomainManagementListStateLoaded} DomainManagementListStateLoaded
+ * @typedef {import('./cc-domain-management.types.js').DomainManagementListStateLoading} DomainManagementListStateLoading
+ * @typedef {import('./cc-domain-management.types.js').DomainManagementListStateError} DomainManagementListStateError
+ * @typedef {import('./cc-domain-management.types.js').DomainManagementFormStateIdle} DomainManagementFormStateIdle
+ * @typedef {import('./cc-domain-management.types.js').DomainManagementFormStateAdding} DomainManagementFormStateAdding
+ * @typedef {import('./cc-domain-management.js').CcDomainManagement} CcDomainManagement
+ */
+
+const conf = {
+  component: 'cc-domain-management',
+};
+
+export const defaultStory = makeStory(conf, {
+  items: [
+    {
+      /** @type {DomainManagementListStateLoaded} */
+      domainListState: {
+        type: 'loaded',
+        domains: [...baseDomains.slice(0, 2), ...baseDomains.slice(-1)],
+      },
+      /** @type {DomainManagementDnsInfoStateLoaded} */
+      dnsInfoState: baseDnsInfo,
+    },
+  ],
+});
+
+export const dataLoadedWithMoreDomains = makeStory(conf, {
+  items: [
+    {
+      /** @type {DomainManagementListStateLoaded} */
+      domainListState: {
+        type: 'loaded',
+        domains: baseDomains,
+      },
+      /** @type {DomainManagementDnsInfoStateLoaded} */
+      dnsInfoState: baseDnsInfo,
+    },
+  ],
+});
+
+export const dataLoadedWithHttpOnlyDomain = makeStory(conf, {
+  items: [
+    {
+      /** @type {DomainManagementListStateLoaded} */
+      domainListState: {
+        type: 'loaded',
+        domains: [...baseDomains, httpOnlyDomain],
+      },
+      /** @type {DomainManagementDnsInfoStateLoaded} */
+      dnsInfoState: baseDnsInfo,
+    },
+  ],
+});
+
+export const dataLoadedWithLongDomains = makeStory(conf, {
+  items: [
+    {
+      /** @type {DomainManagementListStateLoaded} */
+      domainListState: {
+        type: 'loaded',
+        domains: [...baseDomains, httpOnlyDomain, ...longBaseDomains],
+      },
+      /** @type {DomainManagementDnsInfoStateLoaded} */
+      dnsInfoState: baseDnsInfo,
+    },
+  ],
+});
+
+export const empty = makeStory(conf, {
+  items: [
+    {
+      /** @type {DomainManagementListStateLoaded} */
+      domainListState: {
+        type: 'loaded',
+        domains: [],
+      },
+      /** @type {DomainManagementDnsInfoStateLoaded} */
+      dnsInfoState: baseDnsInfo,
+    },
+  ],
+});
+
+export const loading = makeStory(conf, {
+  items: [
+    {
+      /** @type {DomainManagementListStateLoading} */
+      domainListState: { type: 'loading' },
+      /** @type {DomainManagementDnsInfoStateLoading} */
+      dnsInfoState: { type: 'loading' },
+    },
+  ],
+});
+
+export const waitingWithAdding = makeStory(conf, {
+  items: [
+    {
+      /** @type {DomainManagementFormStateAdding} */
+      domainFormState: {
+        type: 'adding',
+        hostname: {
+          value: 'test.example.com',
+        },
+        pathPrefix: {
+          value: '/api',
+        },
+      },
+      /** @type {DomainManagementListStateLoaded} */
+      domainListState: {
+        type: 'loaded',
+        domains: baseDomains,
+      },
+      /** @type {DomainManagementDnsInfoStateLoaded} */
+      dnsInfoState: baseDnsInfo,
+    },
+  ],
+});
+
+export const waitingWithDeleting = makeStory(conf, {
+  items: [
+    {
+      /** @type {DomainManagementListStateLoaded} */
+      domainListState: {
+        type: 'loaded',
+        domains: baseDomains.map((domain, index) => {
+          if (index === 4) {
+            /** @type {DomainStateDeleting} */
+            const domainStateDeleting = {
+              ...domain,
+              type: 'deleting',
+            };
+            return domainStateDeleting;
+          }
+          return domain;
+        }),
+      },
+      /** @type {DomainManagementDnsInfoStateLoaded} */
+      dnsInfoState: baseDnsInfo,
+    },
+  ],
+});
+
+export const waitingWithMarkingAsPrimary = makeStory(conf, {
+  items: [
+    {
+      /** @type {DomainManagementListStateLoaded} */
+      domainListState: {
+        type: 'loaded',
+        domains: baseDomains.map((domain, index) => {
+          if (index === 4) {
+            /** @type {DomainStateMarkingPrimary} */
+            const domainStateMarkingPrimary = {
+              ...domain,
+              type: 'marking-primary',
+            };
+            return domainStateMarkingPrimary;
+          }
+          return domain;
+        }),
+      },
+      /** @type {DomainManagementDnsInfoStateLoaded} */
+      dnsInfoState: baseDnsInfo,
+    },
+  ],
+});
+
+export const error = makeStory(conf, {
+  items: [
+    {
+      /** @type {DomainManagementListStateError} */
+      domainListState: { type: 'error' },
+      /** @type {DomainManagementDnsInfoStateError} */
+      dnsInfoState: { type: 'error' },
+    },
+  ],
+});
+
+export const errorWithEmpty = makeStory(conf, {
+  items: [
+    {
+      /** @type {DomainManagementFormStateIdle} */
+      domainFormState: {
+        type: 'idle',
+        hostname: {
+          value: '',
+          error: { code: 'empty' },
+        },
+        pathPrefix: {
+          value: '',
+        },
+      },
+      /** @type {DomainManagementListStateLoaded} */
+      domainListState: {
+        type: 'loaded',
+        domains: baseDomains,
+      },
+      /** @type {DomainManagementDnsInfoStateLoaded} */
+      dnsInfoState: baseDnsInfo,
+    },
+  ],
+});
+
+export const errorWithPathWithinDomain = makeStory(conf, {
+  items: [
+    {
+      /** @type {DomainManagementFormStateIdle} */
+      domainFormState: {
+        type: 'idle',
+        hostname: {
+          value: 'example.com/example-path',
+        },
+        pathPrefix: {
+          value: '',
+        },
+      },
+      /** @type {DomainManagementListStateLoaded} */
+      domainListState: {
+        type: 'loaded',
+        domains: baseDomains,
+      },
+      /** @type {DomainManagementDnsInfoStateLoaded} */
+      dnsInfoState: baseDnsInfo,
+    },
+  ],
+  /** @type {(component: CcDomainManagement) => void} */
+  onUpdateComplete: (component) => {
+    // this is temporary, when we move to Element Internals, the component will expose its form anyway
+    component.shadowRoot.querySelector('form').requestSubmit();
+  },
+});
+
+export const errorWithInvalidDomain = makeStory(conf, {
+  items: [
+    {
+      /** @type {DomainManagementFormStateIdle} */
+      domainFormState: {
+        type: 'idle',
+        hostname: {
+          value: '[.example.com',
+          error: { code: 'invalid-format' },
+        },
+        pathPrefix: {
+          value: '',
+        },
+      },
+      /** @type {DomainManagementListStateLoaded} */
+      domainListState: {
+        type: 'loaded',
+        domains: baseDomains,
+      },
+      /** @type {DomainManagementDnsInfoStateLoaded} */
+      dnsInfoState: baseDnsInfo,
+    },
+  ],
+});
+
+export const errorWithInvalidWildcard = makeStory(conf, {
+  items: [
+    {
+      /** @type {DomainManagementFormStateIdle} */
+      domainFormState: {
+        type: 'idle',
+        hostname: {
+          value: 'toto*.example.com',
+          error: { code: 'invalid-wildcard' },
+        },
+        pathPrefix: {
+          value: '',
+        },
+      },
+      /** @type {DomainManagementListStateLoaded} */
+      domainListState: {
+        type: 'loaded',
+        domains: baseDomains,
+      },
+      /** @type {DomainManagementDnsInfoStateLoaded} */
+      dnsInfoState: baseDnsInfo,
+    },
+  ],
+});
+
+export const simulationsWithAddingSuccess = makeStory(conf, {
+  items: [{}],
+  simulations: [
+    storyWait(
+      2000,
+      /** @param {CcDomainManagement[]} components */
+      ([component]) => {
+        component.domainListState = {
+          type: 'loaded',
+          domains: baseDomains,
+        };
+        component.dnsInfoState = baseDnsInfo;
+      },
+    ),
+    storyWait(
+      1000,
+      /** @param {CcDomainManagement[]} components */
+      ([component]) => {
+        component.domainFormState = {
+          type: 'idle',
+          hostname: { value: 'example.com' },
+          pathPrefix: { value: '' },
+        };
+      },
+    ),
+    storyWait(
+      1000,
+      /** @param {CcDomainManagement[]} components */
+      ([component]) => {
+        component.domainFormState = {
+          type: 'idle',
+          hostname: { value: 'example.com' },
+          pathPrefix: { value: '/api' },
+        };
+      },
+    ),
+    storyWait(
+      1000,
+      /** @param {CcDomainManagement[]} components */
+      ([component]) => {
+        component.domainFormState = {
+          type: 'adding',
+          hostname: { value: 'example.com' },
+          pathPrefix: { value: '/api/v2' },
+        };
+      },
+    ),
+    storyWait(
+      1000,
+      /** @param {(CcDomainManagement & { domainListState: DomainManagementListStateLoaded })[]} components */
+      ([component]) => {
+        component.domainFormState = {
+          type: 'idle',
+          hostname: { value: '' },
+          pathPrefix: { value: '' },
+        };
+        component.domainListState = {
+          ...component.domainListState,
+          domains: [
+            ...component.domainListState.domains,
+            {
+              id: 'm53xpmuw4ra',
+              type: 'idle',
+              hostname: 'example.com/api/v2',
+              pathPrefix: '/',
+              isWildcard: false,
+              isPrimary: false,
+            },
+          ],
+        };
+      },
+    ),
+  ],
+});
+
+export const simulationsWithLoadingSuccess = makeStory(conf, {
+  items: [{}],
+  simulations: [
+    storyWait(
+      2000,
+      /** @param {CcDomainManagement[]} components */
+      ([component]) => {
+        component.domainListState = {
+          type: 'loaded',
+          domains: baseDomains,
+        };
+      },
+    ),
+    storyWait(
+      1000,
+      /** @param {CcDomainManagement[]} components */
+      ([component]) => {
+        component.dnsInfoState = baseDnsInfo;
+      },
+    ),
+  ],
+});
+
+export const simulationsWithLoadingError = makeStory(conf, {
+  items: [{}],
+  simulations: [
+    storyWait(
+      2000,
+      /** @param {CcDomainManagement[]} components */
+      ([component]) => {
+        component.domainListState = { type: 'error' };
+      },
+    ),
+    storyWait(
+      1000,
+      /** @param {CcDomainManagement[]} components */
+      ([component]) => {
+        component.dnsInfoState = { type: 'error' };
+      },
+    ),
+  ],
+});

--- a/src/components/cc-domain-management/cc-domain-management.test.js
+++ b/src/components/cc-domain-management/cc-domain-management.test.js
@@ -1,0 +1,11 @@
+/* eslint-env node, mocha */
+
+import { testAccessibility } from '../../../test/helpers/accessibility.js';
+import { getStories } from '../../../test/helpers/get-stories.js';
+import * as storiesModule from './cc-domain-management.stories.js';
+
+const storiesToTest = getStories(storiesModule);
+
+describe(`Component: ${storiesModule.default.component}`, function () {
+  testAccessibility(storiesToTest);
+});

--- a/src/components/cc-domain-management/cc-domain-management.types.d.ts
+++ b/src/components/cc-domain-management/cc-domain-management.types.d.ts
@@ -1,0 +1,95 @@
+export type DomainManagementFormState = DomainManagementFormStateIdle | DomainManagementFormStateAdding;
+
+interface DomainManagementFormStateIdle {
+  type: 'idle';
+  hostname: {
+    value: string;
+    error?: FormError | null;
+  };
+  pathPrefix: {
+    value: string;
+  };
+}
+
+interface DomainManagementFormStateAdding {
+  type: 'adding';
+  hostname: {
+    value: string;
+    error?: null;
+  };
+  pathPrefix: {
+    value: string;
+  };
+}
+
+export type FormError = { code: 'empty' | 'invalid-format' | 'invalid-wildcard' } | HostnameContainsPathError;
+
+interface HostnameContainsPathError {
+  code: 'hostname-contains-path';
+  pathWithinHostname: string;
+}
+
+export type DomainManagementListState =
+  | DomainManagementListStateLoaded
+  | DomainManagementListStateLoading
+  | DomainManagementListStateError;
+
+export interface DomainManagementListStateLoaded {
+  type: 'loaded';
+  domains: DomainState[];
+}
+
+export interface DomainManagementListStateLoading {
+  type: 'loading';
+}
+
+export interface DomainManagementListStateError {
+  type: 'error';
+}
+
+export type DomainState = DomainStateIdle | DomainStateDeleting | DomainStateMarkingPrimary;
+
+export interface DomainStateIdle extends DomainInfo {
+  type: 'idle';
+}
+
+interface DomainStateDeleting extends DomainInfo {
+  type: 'deleting';
+}
+
+interface DomainStateMarkingPrimary extends DomainInfo {
+  type: 'marking-primary';
+}
+
+interface DomainInfo {
+  id: string;
+  hostname: string;
+  pathPrefix: string;
+  isWildcard: boolean;
+  isPrimary: boolean;
+}
+
+interface FormattedDomainInfo extends DomainInfo {
+  type: DomainStateIdle['type'] | DomainStateMarkingPrimary['type'] | DomainStateDeleting['type'];
+  isHttpOnly: boolean;
+  isTestingOnly: boolean;
+}
+
+export type DomainManagementDnsInfoState =
+  | DomainManagementDnsInfoStateLoaded
+  | DomainManagementDnsInfoStateLoading
+  | DomainManagementDnsInfoStateError;
+
+interface DomainManagementDnsInfoStateLoaded {
+  type: 'loaded';
+  cnameRecord: string;
+  aRecords: string[];
+}
+
+interface DomainManagementDnsInfoStateLoading {
+  type: 'loading';
+}
+
+interface DomainManagementDnsInfoStateError {
+  type: 'error';
+}

--- a/src/lib/domain.js
+++ b/src/lib/domain.js
@@ -1,0 +1,118 @@
+/**
+ * @typedef {import('../components/cc-domain-management/cc-domain-management.types.js').DomainInfo} DomainInfo
+ */
+
+/**
+ * Extracts `hostname`, `pathname`, `isWildcard` from a given `domain`
+ *
+ * @param {string} domain
+ * @return {{ hostname: string, pathname: string, isWildcard: boolean }}
+ */
+export function parseDomain(domain) {
+  const domainWithHttp = domain.match(/^https?:\/\//) != null ? domain : 'https://' + domain;
+  // With firefox, 'https://*.toto.com' is considered invalid so we strip it off for the test
+  // because we know this part is valid and we want the rest to be sanitized by the URL parser
+  const isWildcard = domain.startsWith('*.');
+
+  if (!isWildcard && domain.includes('*')) {
+    throw new DomainParseError('invalid-wildcard', 'Invalid wildcard format. "*" may only be used as a subdomain');
+  }
+
+  try {
+    const { hostname, pathname } = new URL(domainWithHttp.replace('*.', ''));
+
+    return {
+      hostname,
+      pathname,
+      isWildcard,
+    };
+  } catch {
+    if (domain.length === 0) {
+      throw new DomainParseError('empty', 'Empty domain value');
+    }
+
+    throw new DomainParseError('invalid-format', 'Invalid domain format');
+  }
+}
+
+export class DomainParseError extends Error {
+  /**
+   * @param {'empty'|'invalid-wildcard'|'invalid-format'} code
+   * @param {string} message
+   */
+  constructor(code, message) {
+    super(message);
+
+    this.code = code;
+  }
+}
+
+/**
+ * If isWildcard is `true`, returns `*.${hostname}`
+ * else returns the `hostname` untouched
+ *
+ * @param {string} hostname
+ * @param {boolean} isWildcard
+ * @returns {string}
+ */
+export function getHostWithWildcard(hostname, isWildcard) {
+  return [isWildcard ? '*.' : '', hostname].join('');
+}
+
+/**
+ * @param {string} hostname
+ * @param {string} pathPrefix
+ * @param {boolean} isWildcard
+ * @param {boolean} isHttpOnly
+ * @returns {string}
+ */
+export function getDomainUrl(hostname, pathPrefix, isWildcard, isHttpOnly) {
+  return [isHttpOnly ? 'http://' : 'https://', isWildcard ? 'www.' : '', hostname, pathPrefix].join('');
+}
+
+/**
+ * @param {string} hostname
+ * @return {boolean}
+ */
+export function isTestDomain(hostname) {
+  return hostname.endsWith('cleverapps.io');
+}
+
+/**
+ * Checks if the domain is a `cleverapps.io` domain and if it contains a subdomain.
+ * For instance `subdomain.main.cleverapps.io` is HTTP only.
+ *
+ * @param {string} domain
+ * @return {boolean} whether the domain is a `cleverapps.io` is HTTP only or not
+ */
+export function isTestDomainWithSubdomain(domain) {
+  return isTestDomain(domain) && domain.split('.').length > 3;
+}
+
+/**
+ * @param {DomainInfo} domainA
+ * @param {DomainInfo} domainB
+ * @returns {number}
+ */
+export function sortDomains(domainA, domainB) {
+  if (domainA.isPrimary) {
+    return -1;
+  }
+
+  if (domainB.isPrimary) {
+    return 1;
+  }
+
+  const reversedDomainA = reverseDomain(domainA);
+  const reversedDomainB = reverseDomain(domainB);
+
+  return reversedDomainA.localeCompare(reversedDomainB);
+}
+
+/**
+ * @param {DomainInfo} domain
+ * @returns {string}
+ */
+function reverseDomain(domain) {
+  return domain.hostname.split('.').reverse().join('.') + (domain.isWildcard ? '.*' : '') + domain.pathPrefix;
+}

--- a/src/lib/i18n-sanitize.js
+++ b/src/lib/i18n-sanitize.js
@@ -1,8 +1,13 @@
 /* global globalThis */
-const AUTHORIZED_TAGS = ['STRONG', 'EM', 'CODE', 'A', 'BR', 'P'];
+const AUTHORIZED_TAGS = ['STRONG', 'EM', 'CODE', 'A', 'BR', 'P', 'SPAN'];
 
 function isAuthorizedAttribute(attributeName, tagName) {
-  return attributeName === 'title' || attributeName === 'aria-label' || (attributeName === 'href' && tagName === 'A');
+  return (
+    attributeName === 'title' ||
+    attributeName === 'aria-label' ||
+    (attributeName === 'href' && tagName === 'A') ||
+    attributeName === 'lang'
+  );
 }
 
 // Reuse one text node to escape HTML

--- a/src/stories/fixtures/domains.js
+++ b/src/stories/fixtures/domains.js
@@ -1,0 +1,69 @@
+import { randomString } from '../../lib/utils.js';
+
+/**
+ * @typedef {import('../../components/cc-domain-management/cc-domain-management.types.js').DomainStateIdle} DomainStateIdle
+ * @typedef {import('../../components/cc-domain-management/cc-domain-management.types.js').DomainManagementDnsInfoStateLoaded} DomainManagementDnsInfoStateLoaded
+ */
+
+export const randomDomainName = randomString(5).toLowerCase();
+
+/** @type {DomainStateIdle[]} */
+export const baseDomains = [
+  { type: 'idle', id: 'r51xpmaw1ra', hostname: 'www.example.com', pathPrefix: '/', isWildcard: false, isPrimary: true },
+  { type: 'idle', id: 'q6h54peg23f', hostname: 'example.com', pathPrefix: '/', isWildcard: false, isPrimary: false },
+  { type: 'idle', id: 'nzy6tm7z2ep', hostname: 'blog.example.com', pathPrefix: '/', isWildcard: false, isPrimary: false },
+  { type: 'idle', id: 'kunhycl66k8', hostname: 'example.com', pathPrefix: '/', isWildcard: true, isPrimary: false },
+  { type: 'idle', id: 'v4xhvg869mi', hostname: 'example.com', pathPrefix: '/api', isWildcard: false, isPrimary: false },
+  { type: 'idle', id: '2yzrgtjfego', hostname: 'example.org', pathPrefix: '/', isWildcard: false, isPrimary: false },
+  { type: 'idle', id: '5013jfpxoiw', hostname: 'www.example.org', pathPrefix: '/blog', isWildcard: false, isPrimary: false },
+  { type: 'idle', id: '1c0nn0rr6bc', hostname: 'blog.example.org', pathPrefix: '/', isWildcard: false, isPrimary: false },
+  { type: 'idle', id: 'ppoite5krzc', hostname: 'perso.example.org', pathPrefix: '/', isWildcard: false, isPrimary: false },
+  { type: 'idle', id: '6zf47vbo1pj', hostname: `app-${randomDomainName}.cleverapps.io`, pathPrefix: '/', isWildcard: false, isPrimary: false },
+];
+
+/** @type {DomainStateIdle[]} */
+export const longBaseDomains = [
+  {
+    type: 'idle',
+    id: '3lmu7pyitz5',
+    hostname: 'very-very-very-very-very-very-very-very-very-long.example.com',
+    pathPrefix: '/',
+    isWildcard: false,
+    isPrimary: false,
+  },
+  {
+    type: 'idle',
+    id: '4534rl5l9nn',
+    hostname: 'very-very-very-very-very-very-very-very-very-long.example.com',
+    pathPrefix: '/',
+    isWildcard: false,
+    isPrimary: false,
+  },
+  {
+    type: 'idle',
+    id: '5pqikcys2dk',
+    hostname: 'very-very-very-very-very-very-very-very-very-long.cleverapps.io',
+    pathPrefix: '/',
+    isWildcard: false,
+    isPrimary: false,
+  },
+];
+
+/** @type {DomainStateIdle} */
+export const httpOnlyDomain = {
+  type: 'idle',
+  id: 'dm0wy7xnpyo',
+  hostname: `subdomain.app-${randomDomainName}.cleverapps.io`,
+  pathPrefix: '/',
+  isWildcard: false,
+  isPrimary: false,
+};
+
+
+/** @type {DomainManagementDnsInfoStateLoaded} */
+export const baseDnsInfo = {
+  type: 'loaded',
+  cnameRecord: 'example.com.',
+  aRecords: ['93.184.216.34', '93.184.216.34', '93.184.216.34', '93.184.216.34', '93.184.216.34', '93.184.216.34'],
+};
+

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -238,6 +238,86 @@ export const translations = {
   //#region cc-doc-list
   'cc-doc-list.error': `An error occurred while loading documentation`,
   //#endregion
+  //#region cc-domain-management
+  'cc-domain-management.certif.automated': () =>
+    sanitize`Whether you use <code>cleverapps.io</code> or your own domain names with applications hosted by Clever Cloud, a Let's Encrypt certificate is automatically issued and renewed for HTTPS/TLS access. No action is required from you, this is all automated. For specific cases, refer to <a href="https://developers.clever-cloud.com/doc/administrate/ssl/">Installing TLS Certificates</a>.`,
+  'cc-domain-management.certif.custom': () =>
+    sanitize`You can provide your own certificate by using the <a href="https://api.clever-cloud.com/v2/certificates/new">Clever Cloud Certificate Manager</a>.`,
+  'cc-domain-management.certif.heading': `Secure your application`,
+  'cc-domain-management.dns.a.desc':
+    () => sanitize`<p>If you choose to use <code>A</code> records, you'll need to update them yourself.</p>
+  <p>Follow our <a href="https://developers.clever-cloud.com/changelog/">changelog</a> or check our <a href="https://developers.clever-cloud.com/api/v4/#load-balancers">v4 API documentation</a> for this.</p>`,
+  'cc-domain-management.dns.a.heading': `A records`,
+  'cc-domain-management.dns.a.label': ({ index }) => `A Record value number ${index}`,
+  'cc-domain-management.dns.cname.desc': () =>
+    sanitize`<p>Using a <code>CNAME</code> record is recommended. This automatically keeps your configuration up to date.</p>`,
+  'cc-domain-management.dns.cname.heading': `CNAME record`,
+  'cc-domain-management.dns.cname.label': `CNAME record value`,
+  'cc-domain-management.dns.desc':
+    () => sanitize`<p>To associate a domain managed by a third-party provider to your Clever Cloud application, you need to configure its DNS zone.</p>
+  <p>This may be achieved using a <code>CNAME</code> or <code>A</code> records. We recommend using a <code>CNAME</code> record, as you won't have to reconfigure it if we change our IPs.</p>`,
+  'cc-domain-management.dns.heading': `Configure your DNS`,
+  'cc-domain-management.dns.info.apex': () =>
+    sanitize`For APEX domains or subdomains with an existing DNS zone, refer to our <a href="https://developers.clever-cloud.com/doc/administrate/domain-names/">DNS & Domains documentation</a>.`,
+  'cc-domain-management.dns.info.heading': `Dedicated load balancers & specific cases`,
+  'cc-domain-management.dns.info.load-balancer': `If you are using a dedicated load balancer, refer to its configuration or contact support. Our team can also help you to order such a service.`,
+  'cc-domain-management.dns.loading-error': `Something went wrong while loading DNS information`,
+  'cc-domain-management.form.domain.error.contains-path': ({ path }) =>
+    `Enter the "${path}" part within the "Path" input field`,
+  'cc-domain-management.form.domain.error.empty': `Enter a domain`,
+  'cc-domain-management.form.domain.error.format': `Enter a valid domain, for instance "example.com"`,
+  'cc-domain-management.form.domain.error.wildcard': () =>
+    sanitize`Enter a valid domain.<br>Wildcards "*" may only be used as subdomains like: "*.example.com"`,
+  'cc-domain-management.form.domain.help': () =>
+    sanitize`For instance: <code>example.com</code>, <code>*.example.com</code> or <code>example.cleverapps.io</code>`,
+  'cc-domain-management.form.domain.label': `Domain name`,
+  'cc-domain-management.form.info.cleverapps': () =>
+    sanitize`By default, an application is automatically associated to <code>app_id.cleverapps.io</code> as default domain. You can remove it or change the sub-domain freely, but <code>xxx.cleverapps.io</code> should only be used for testing purposes (see our <a href="https://developers.clever-cloud.com/doc/administrate/domain-names/#using-a-cleverappsio-free-domain-with-built-in-ssl">documentation</a>).`,
+  'cc-domain-management.form.info.docs': `You can associate one or more domain names with your application. The primary domain is the one that will be used in Console links and in e-mails sent to you. Several applications can share the same domain, each with a specific sub-domain and/or route.`,
+  'cc-domain-management.form.path.help': () => sanitize`For example: <code>/api</code> or <code>/blog</code>`,
+  'cc-domain-management.form.path.label': `Path`,
+  'cc-domain-management.form.submit': `Add a domain`,
+  'cc-domain-management.form.submit.error': ({ domain }) => `An error occurred while trying to add "${domain}"`,
+  'cc-domain-management.form.submit.error-duplicate.heading': `Domain name not available`,
+  'cc-domain-management.form.submit.error-duplicate.text': ({
+    domain,
+  }) => sanitize`<p>"${domain}" is already associated to another application within Clever Cloud.</p>
+  <p>For more information, contact our support team.</p>`,
+  'cc-domain-management.form.submit.success': ({ domain }) =>
+    `"${domain}" has been successfully associated to your application`,
+  'cc-domain-management.form.submit.success-config': ({
+    domain,
+  }) => sanitize`<p>"${domain}" has been successfully associated to your application.</p>
+  <p>A manual configuration is required to make the domain point to Clever Cloud. Refer to the <strong>Configure your DNS</strong> section for more information</p>`,
+  'cc-domain-management.list.badge.http-only.alt': `Warning`,
+  'cc-domain-management.list.badge.http-only.text': `HTTP only`,
+  'cc-domain-management.list.badge.primary': `Primary`,
+  'cc-domain-management.list.badge.testing-only': `Testing purposes only`,
+  'cc-domain-management.list.btn.delete.a11y-name': ({ domain }) => `Delete domain - ${domain}`,
+  'cc-domain-management.list.btn.delete.text': `Delete`,
+  'cc-domain-management.list.btn.primary.a11y-name': ({ domain }) => `Mark as primary domain - ${domain}`,
+  'cc-domain-management.list.btn.primary.text': `Mark as primary`,
+  'cc-domain-management.list.delete.error': ({ domain }) =>
+    `Something went wrong while trying to delete the "${domain}" domain`,
+  'cc-domain-management.list.delete.success': ({ domain }) => `"${domain}" has been deleted successfully`,
+  'cc-domain-management.list.empty': `No domain associated to this application`,
+  'cc-domain-management.list.error-not-found.heading': `Domain not found`,
+  'cc-domain-management.list.error-not-found.text': ({
+    domain,
+  }) => sanitize`<p>"${domain}" may have been removed by someone else after loading the list of domains.<p>
+  <p>Please <strong>refresh your page</strong> to get the updated list of domains.</p>`,
+  'cc-domain-management.list.heading': `Domain names linked to this application`,
+  'cc-domain-management.list.http-only.notice': () =>
+    sanitize`Subdomains are not covered by the SSL certificate of <code>*.cleverapps.io</code>. They do not support HTTPS.`,
+  'cc-domain-management.list.link.title': ({ domainUrl }) => `Open - ${domainUrl} - new window`,
+  'cc-domain-management.list.loading-error': `Something went wrong while loading domains associated to this application`,
+  'cc-domain-management.list.primary.error': ({ domain }) =>
+    `Something went wrong while trying to mark "${domain}" as primary domain`,
+  'cc-domain-management.list.primary.success': ({ domain }) =>
+    `"${domain}" has been successfully marked as primary domain`,
+  'cc-domain-management.main-heading': `Manage your domain names`,
+  'cc-domain-management.new-window': `New Window`,
+  //#endregion
   //#region cc-elasticsearch-info
   'cc-elasticsearch-info.error': `Something went wrong while loading add-ons linked to this application.`,
   'cc-elasticsearch-info.info': `Info`,

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -249,6 +249,87 @@ export const translations = {
   //#region cc-doc-list
   'cc-doc-list.error': `Une erreur est survenue pendant le chargement de la documentation`,
   //#endregion
+  //#region cc-domain-management
+  'cc-domain-management.certif.automated': () =>
+    sanitize`Que vous utilisiez <code>cleverapps.io</code> ou vos propres noms de domaine avec les applications hébergées par Clever Cloud, un certificat Let's Encrypt est automatiquement généré et renouvelé pour l'accès HTTPS/TLS. Vous n'avez rien à faire. Pour les cas spécifiques, reportez-vous à notre <a href="https://developers.clever-cloud.com/doc/administrate/ssl/" lang="en">documentation</a>.`,
+  'cc-domain-management.certif.custom': () =>
+    sanitize`Vous pouvez fournir votre propre certificat grâce au <a href="https://api.clever-cloud.com/v2/certificates/new">gestionnaire de certificats Clever Cloud</a>.`,
+  'cc-domain-management.certif.heading': `Sécurisez votre application`,
+  'cc-domain-management.dns.a.desc':
+    () => sanitize`<p>Si vous choisissez d'utiliser des enregistrements de type <code>A</code>, vous devrez vous-même assurer leur mise à jour.</p>
+  <p>Pensez à suivre notre <a href="https://developers.clever-cloud.com/changelog/" lang="en">changelog</a> ou à utiliser notre <a href="https://developers.clever-cloud.com/api/v4/#load-balancers" lang="en">API v4</a> pour cela.</p>`,
+  'cc-domain-management.dns.a.heading': `Enregistrements A`,
+  'cc-domain-management.dns.a.label': ({ index }) => `Valeur d'enregistrement A numéro ${index}`,
+  'cc-domain-management.dns.cname.desc': () =>
+    sanitize`<p>Utiliser un enregistrement <code>CNAME</code> est fortement recommandé. Ainsi, votre configuration est automatiquement maintenue à jour.`,
+  'cc-domain-management.dns.cname.heading': `Enregistrement CNAME`,
+  'cc-domain-management.dns.cname.label': `Valeur d'enregistrement CNAME`,
+  'cc-domain-management.dns.desc': () =>
+    sanitize`<p>Afin de lier un domaine géré par un fournisseur tiers à votre application Clever Cloud, vous devez configurer votre zone DNS. Pour cela, vous pouvez utiliser un enregistrement <code>CNAME</code> ou <code>A</code>. L'enregistrement <code>CNAME</code> est à privilégier puisque vous n'aurez pas à le reconfigurer si nous modifions nos IP d'accès.</p>`,
+  'cc-domain-management.dns.heading': `Configurez vos DNS`,
+  'cc-domain-management.dns.info.apex': () =>
+    sanitize`Pour un domaine APEX ou un sous-domaine disposant déjà d'une zone DNS, référez-vous à notre <a href="https://developers.clever-cloud.com/doc/administrate/domain-names/">documentation</a>.`,
+  'cc-domain-management.dns.info.heading': `Load balancers dédiés et cas spécifiques`,
+  'cc-domain-management.dns.info.load-balancer': () =>
+    sanitize`Si vous bénéficiez d'un <span lang="en">load balancer</span> dédié, référez-vous à sa configuration ou contactez le support. Notre équipe pourra également vous aider pour commander un tel service.`,
+  'cc-domain-management.dns.loading-error': `Une erreur est survenue pendant le chargement des informations DNS`,
+  'cc-domain-management.form.domain.error.contains-path': ({ path }) =>
+    `Saisissez la partie "${path}" dans le champ "Route"`,
+  'cc-domain-management.form.domain.error.empty': `Saisissez un nom de domaine`,
+  'cc-domain-management.form.domain.error.format': `Saisissez un domaine valide, par exemple "example.com"`,
+  'cc-domain-management.form.domain.error.wildcard': () =>
+    sanitize`Saisissez un domaine valide.<br>Les <span lang="en">wildcard</span> "*" ne peuvent être utilisés qu'en sous-domaine, par exemple&nbsp;: "*.example.com"`,
+  'cc-domain-management.form.domain.help': () =>
+    sanitize`Par exemple: <code>example.com</code>, <code>*.example.com</code> ou <code>example.cleverapps.io</code>`,
+  'cc-domain-management.form.domain.label': `Nom de domaine`,
+  'cc-domain-management.form.info.cleverapps': () =>
+    sanitize`Par défaut, une application se voit attribuer un nom de domaine en <code>app_id.cleverapps.io</code>. Vous pouvez le supprimer ou changer le sous-domaine librement, mais <code>xxx.cleverapps.io</code> doit uniquement être utilisé à des fins de test (voir notre <a href="https://developers.clever-cloud.com/doc/administrate/domain-names/#using-a-cleverappsio-free-domain-with-built-in-ssl">documentation</a>).`,
+  'cc-domain-management.form.info.docs': `Vous pouvez associer un ou plusieurs noms de domaines à votre application. Le domaine principal est celui qui sera utilisé dans les liens de la Console et dans les e-mails qui vous serons envoyés. Plusieurs applications peuvent partager un même domaine, chacune avec un sous-domaine et/ou une route spécifique.`,
+  'cc-domain-management.form.path.help': () => sanitize`Par exemple: <code>/api</code> ou <code>/blog</code>`,
+  'cc-domain-management.form.path.label': `Route`,
+  'cc-domain-management.form.submit': `Ajouter le domaine`,
+  'cc-domain-management.form.submit.error': ({ domain }) =>
+    `Une erreur est survenue lors de l'ajout du nom de domaine "${domain}"`,
+  'cc-domain-management.form.submit.error-duplicate.heading': `Nom de domaine indisponible`,
+  'cc-domain-management.form.submit.error-duplicate.text': ({
+    domain,
+  }) => sanitize`<p>"${domain}" est déjà associé à une application au sein de Clever Cloud.</p>
+  <p>Contactez notre équipe support pour plus d'informations.</p>`,
+  'cc-domain-management.form.submit.success': ({ domain }) => `"${domain}" a bien été associé à votre application`,
+  'cc-domain-management.form.submit.success-config': ({
+    domain,
+  }) => sanitize`<p>"${domain}" a bien été associé à votre application.</p>
+  <p>Une configuration manuelle est nécessaire pour faire pointer votre domaine vers Clever Cloud. Consultez la section <strong>Configurez vos DNS</strong> pour plus d'informations.</p>`,
+  'cc-domain-management.list.badge.http-only.alt': `Avertissement`,
+  'cc-domain-management.list.badge.http-only.text': `HTTP uniquement`,
+  'cc-domain-management.list.badge.primary': `Principal`,
+  'cc-domain-management.list.badge.testing-only': `Tests uniquement`,
+  'cc-domain-management.list.btn.delete.a11y-name': ({ domain }) => `Supprimer le nom de domaine - ${domain}`,
+  'cc-domain-management.list.btn.delete.text': `Supprimer`,
+  'cc-domain-management.list.btn.primary.a11y-name': ({ domain }) =>
+    `Définir comme nom de domaine principal - ${domain}`,
+  'cc-domain-management.list.btn.primary.text': `Définir comme principal`,
+  'cc-domain-management.list.delete.error': ({ domain }) =>
+    `Une erreur est survenue lors de la suppression du nom de domaine "${domain}"`,
+  'cc-domain-management.list.delete.success': ({ domain }) => `"${domain}" a bien été supprimé`,
+  'cc-domain-management.list.empty': `Aucun domaine associé à cette application`,
+  'cc-domain-management.list.error-not-found.heading': `Nom de domaine introuvable`,
+  'cc-domain-management.list.error-not-found.text': ({
+    domain,
+  }) => sanitize`<p>"${domain}" a peut-être été supprimé après le chargement de la liste des domaines.</p>
+  <p><strong>Rechargez votre page</strong> pour récupérer la liste des domaines à jour.</p>`,
+  'cc-domain-management.list.heading': `Noms de domaines liés à cette application`,
+  'cc-domain-management.list.http-only.notice': () =>
+    sanitize`Les sous-domaines ne sont pas couverts par le certificat SSL de <code>*.cleverapps.io</code>. Ils ne bénéficient donc pas de HTTPS.`,
+  'cc-domain-management.list.link.title': ({ domainUrl }) => `Ouvrir - ${domainUrl} - nouvelle fenêtre`,
+  'cc-domain-management.list.loading-error': `Une erreur est survenue pendant le chargement des domaines associés à cette application`,
+  'cc-domain-management.list.primary.error': ({ domain }) =>
+    `Une erreur est survenue lors du passage du nom de domaine "${domain}" en domaine principal`,
+  'cc-domain-management.list.primary.success': ({ domain }) =>
+    `"${domain}" a bien été défini comme nom de domaine principal`,
+  'cc-domain-management.main-heading': `Gérez vos noms de domaine`,
+  'cc-domain-management.new-window': `Nouvelle fenêtre`,
+  //#endregion
   //#region cc-elasticsearch-info
   'cc-elasticsearch-info.error': `Une erreur est survenue pendant le chargement des liens des add-on liés à cette application.`,
   'cc-elasticsearch-info.info': `Info`,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -89,6 +89,7 @@
           // https://developer.mozilla.org/en-US/docs/Web/API/Element/mouseenter_event
           "wheel",
           "copy",
+          "paste",
           // HACK: Right now, we don't have a clean way to recognize events fired from something else than a component.
           // those events are fired by the `form-submit-directive` through `form-submit-handler`
           "form:valid",


### PR DESCRIPTION
Fixes #1095 

## How to review?

- Check the code (since these are mostly new files, it might be more convenient to review locally),
- Check the [preview](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-domain-management/init/index.html?path=/story/%F0%9F%9B%A0%EF%B8%8F-domains-cc-domain-management--default-story):
  - all stories,
  - both French & English,
  - different viewport sizes.
- Proceed with the [QA](https://docs.google.com/spreadsheets/d/1Gjb7LwqOx3ZDNDFt2C347wmF2pjk7IuFgFvaFEd2BAM/edit?gid=1267293083#gid=1267293083),
  - note that this QA should be done using the console (links to specific cases are available within the docs).
- At least 4 or 5 reviews are required for this PR.

## A few specific questions

- Component naming, should we got for `cc-domain-list` instead? It feels more consistent even though it doesn't only deal with the list of domains.
- The API sends us the domain & path concatenated into a single `fqdn` property:
  - to display the domain name and the path prefix separately and differently within the list, we need to have two separate properties (`domain` & `pathPrefix`). Internally, within the component, the `pathPrefix` can never be `null` or empty because it's always at least `/`.
  - for the API, the `pathPrefix` thing does not exist and we have to concatenate (+ encode :-1: ) everything. When no path prefix is set, there is no trailing slash within `fqdn`.
  - To sum it up, for `example.com`: 
    - API: `{ fqdn: 'example.com' }`
    - component data = `{ fqdn: 'example.com', domainName: 'example.com', pathPrefix: '/' }`
  - Question: do we keep `fqdn` naming or do we change it? At first I went with `domainWithPathPrefix` but it creates confusion because it's not an actual concatenation of `domainName + pathPrefix`. I opted to keep `fqdn` even though I don't like the naming because it highlights that this comes from the API. This is some kind of unique identifier we use to communicate with the API but we don't actually use it apart from within the smart.
- Do we go for a grid design or cards?
  - [Preview - Grid version](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-domain-management/init-grid-version/index.html?path=/story/%F0%9F%9B%A0%EF%B8%8F-domains-cc-domain-management--default-story)
  - [Preview - Cards version](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-domain-management/init/index.html?path=/story/%F0%9F%9B%A0%EF%B8%8F-domains-cc-domain-management--default-story)
  - Note that in the future, we'll propably add more badges (DNS config status, certificate status) and action buttons will be regrouped into 1 menu button.
  - I have tried several options for the grid version, none of which totally convinced me so far:

<details>
  <summary>No columns for badges</summary>

![No columns for badges](https://github.com/CleverCloud/clever-components/assets/100240294/cf7acf3b-a18e-4b83-a3c2-5fdd33cc9d60)


**Issues:** 

Some people are triggered by the "misaligned" aspect. Note that the more you think about it the more you find it annoying but as a user, there are similar cases that I had never noticed as annoying, for instance in GitHub PR view:
![GitHub PR view](https://github.com/CleverCloud/clever-components/assets/100240294/1780263e-07cf-491d-b985-d371f1b83f68)

</details>

<details>
 <summary>Column dedicated to primary badge</summary>

![Grid - column dedicated to primary badge](https://github.com/CleverCloud/clever-components/assets/100240294/1ee8e24a-18f4-433a-ac1b-eb067f39aa33)

**Issues:**

Considering "primary" can only applied to one row and that it is always the first row, it feels weird to dedicate a column to it.

</details>

<details>
  <summary>Align right for badge columns</summary>

![Align right](https://github.com/CleverCloud/clever-components/assets/100240294/309d6e4d-7212-465a-8fa3-be50eb8a1e0c)

**Issues:**

Badges are pretty far from what they are directly related to: the domain.

</details>

<details>
  <summary>My personal preference if you wanna know</summary>


1. cards
2. grid as within the preview (primary inlined with the domain name + column for badges, left aligned).
3. grid with no columns for the badges, all inlined next to the domain, GitHub's way

</details>

## Card design

@hsablonniere has suggested a few nice improvements for the card design, feel free to give your opinion about these as well

<details>
  <summary>Issue with domain names wrapping</summary>

When there's not enough space (small viewport or long domain name), the domain name wraps to a new line.
Sometimes the link icon ends up alone on a line, sometimes the path prefix ends up on a line.

We cannot really prevent that but we can improve the design so it happens less often by making the domain name span accross the whole width and position the buttons below it:
![domain cards with domain  name spanning across the width and buttons below](https://github.com/CleverCloud/clever-components/assets/100240294/eb8d7ed0-5609-4432-8cf3-9d9af1963301)

</details>

<details>
  <summary>Gap between cards or not</summary>

When there's only one column (small viewport), should we remove the gap between cards and make it look like a "table"?
![domain cards below each other without any gap between them, only borders](https://github.com/CleverCloud/clever-components/assets/100240294/17190cb4-71d6-424a-a023-7a552723e294)

</details>


## TODO Flo

- [x] update smart doc with proper links
- [x] rebase once forms have been merged
- [ ] run prettier once all reviews & feedback have been processed.