### PR TITLE
cc-logs: easy-quick-wins

### DIFF
--- a/src/components/cc-logs/cc-logs.js
+++ b/src/components/cc-logs/cc-logs.js
@@ -419,6 +419,42 @@ export class CcLogs extends LitElement {
   }
 
   /**
+   * This function is wired through `this._inputCtrl`.
+   *
+   * It is called when `Home` key is pressed
+   * It asks the logs controller to move the focus on the first log.
+   * If `withCtrlShift` is enabled, it asks the logs controller to expand the selection to the first log.
+   *
+   * @param {boolean} withCtrlShift
+   */
+  _onHome (withCtrlShift) {
+    if (withCtrlShift) {
+      this._logsCtrl.extendSelection(0, 'replace');
+    }
+    else {
+      this._logsCtrl.focus(0);
+    }
+  }
+
+  /**
+   * This function is wired through `this._inputCtrl`.
+   *
+   * It is called when `End` key is pressed
+   * It asks the logs controller to move the focus on the last log.
+   * If `withCtrlShift` is enabled, it asks the logs controller to expand the selection to the last log.
+   *
+   * @param {boolean} withCtrlShift
+   */
+  _onEnd (withCtrlShift) {
+    if (withCtrlShift) {
+      this._logsCtrl.extendSelection(this._logsCtrl.listLength - 1, 'replace');
+    }
+    else {
+      this._logsCtrl.focus(this._logsCtrl.listLength - 1);
+    }
+  }
+
+  /**
    * This event handler is called whenever the virtualizer adds child elements to the DOM, or removes child elements from the DOM.
    *
    * It helps in detecting when the focused button is removed from the DOM, which is when user scrolls far from the focused button.

--- a/src/components/cc-logs/cc-logs.js
+++ b/src/components/cc-logs/cc-logs.js
@@ -596,6 +596,10 @@ export class CcLogs extends LitElement {
     this._setFollow(false);
   }
 
+  _onSelectAll () {
+    this._logsCtrl.selectAll();
+  }
+
   // endregion
 
   // region Copy logic

--- a/src/components/cc-logs/cc-logs.js
+++ b/src/components/cc-logs/cc-logs.js
@@ -567,9 +567,23 @@ export class CcLogs extends LitElement {
    * This function is wired through `this._inputCtrl`.
    *
    * It clears the selection when users click on the logs container but not in the gutter area.
+   * It also handles triple click: selects the whole log line (including timestamp and metadata)
+   *
+   * @param {MouseEvent & {target : HTMLElement}} e
    */
-  _onClick () {
-    this._logsCtrl.clearSelection();
+  _onClick (e) {
+    if (e.detail === 3) {
+      const logElement = e.target.closest(`.log`);
+      if (logElement != null) {
+        window.getSelection().empty();
+        const range = document.createRange();
+        range.selectNode(logElement);
+        window.getSelection().addRange(range);
+      }
+    }
+    else {
+      this._logsCtrl.clearSelection();
+    }
   }
 
   /**

--- a/src/components/cc-logs/cc-logs.js
+++ b/src/components/cc-logs/cc-logs.js
@@ -812,7 +812,8 @@ export class CcLogs extends LitElement {
               class="copy_button"
               .icon=${iconCopy}
               @cc-button:click=${this._onCopySelectionToClipboard}
-              hide-text>${i18n('cc-logs.copy')}
+            >
+              ${i18n('cc-logs.copy')}
             </cc-button>`
           : null
         }

--- a/src/components/cc-logs/cc-logs.js
+++ b/src/components/cc-logs/cc-logs.js
@@ -47,6 +47,10 @@ const DEFAULT_PALETTE_STYLE = ansiPaletteStyle(
  * A function that can be disabled during an amount of time.
  */
 class TemporaryFunctionDisabler {
+  /**
+   * @param {() => any} callback
+   * @param {number} timeout
+   */
   constructor (callback, timeout) {
     this._callback = callback;
     this._timeout = timeout;
@@ -68,11 +72,19 @@ class TemporaryFunctionDisabler {
 
 /**
  * @typedef {import('./cc-logs.types.js').Log} Log
+ * @typedef {import('./cc-logs.types.js').Metadata} Metadata
  * @typedef {import('./cc-logs.types.js').MetadataFilter} MetadataFilter
  * @typedef {import('./cc-logs.types.js').MetadataRenderer} MetadataRenderer
+ * @typedef {import('./cc-logs.types.js').MetadataRendering} MetadataRendering
  * @typedef {import('./cc-logs.types.js').LogMessageFilterMode} LogMessageFilterMode
  * @typedef {import('./date-display.types.js').DateDisplay} DateDisplay
  * @typedef {import('../../lib/date/date.types.js').Timezone} Timezone
+ * @typedef {import('@lit-labs/virtualizer/events.js').RangeChangedEvent} RangeChangedEvent
+ * @typedef {import('@lit-labs/virtualizer/events.js').VisibilityChangedEvent} VisibilityChangedEvent
+ * @typedef {import('@lit-labs/virtualizer/LitVirtualizer.js').LitVirtualizer} Virtualizer
+ * @typedef {import('lit').PropertyValues<CcLogs>} CcLogsPropertyValues
+ * @typedef {import('lit').TemplateResult<1>} TemplateResult
+ * @typedef {import('lit/directives/ref.js').Ref<Virtualizer>} VirtualizerRef
  */
 
 /**
@@ -285,7 +297,7 @@ export class CcLogs extends LitElement {
     /** @type {LogsController} */
     this._logsCtrl = new LogsController(this);
 
-    /** @type {Ref<Virtualizer>} A reference to the logs' container. */
+    /** @type {VirtualizerRef} A reference to the logs' container. */
     this._logsRef = createRef();
 
     /** @type {DateDisplayer} */
@@ -355,7 +367,7 @@ export class CcLogs extends LitElement {
    * In cases handled programmatically (when moving focus with arrow keys), the focus is already set.
    * But, this is needed when users click on the select button.
    *
-   * @param e
+   * @param {FocusEvent & {target: HTMLButtonElement}} e
    */
   _onFocusLog (e) {
     const button = e.target;
@@ -412,6 +424,7 @@ export class CcLogs extends LitElement {
    * It helps in detecting when the focused button is removed from the DOM, which is when user scrolls far from the focused button.
    * When the focused button is removed from the DOM, the focus is lost which is something we want to avoid.
    * Instead, we move to focus on the logs container, and we store the index of the lost button (so that we know where we were when user plays with arrow keys).
+   * @param {RangeChangedEvent} e
    */
   _onRangeChanged (e) {
     this._focusedIndexIsInDom = this._logsCtrl.isFocusedIndexInRange({ first: e.first, last: e.last });
@@ -429,7 +442,7 @@ export class CcLogs extends LitElement {
    *
    * It initiates the drag movement.
    *
-   * @param e
+   * @param {MouseEvent} e
    */
   _onMouseDownGutter (e) {
 
@@ -514,6 +527,10 @@ export class CcLogs extends LitElement {
    * This function is wired through `this._inputCtrl`.
    *
    * Handles the logic selection with support of Ctrl and Shift modifiers key
+   * @param {number} logIndex
+   * @param {Object} modifiers
+   * @param {boolean} modifiers.ctrl
+   * @param {boolean} modifiers.shift
    */
   _onClickLog (logIndex, { ctrl, shift }) {
     if (ctrl && !shift) {
@@ -573,6 +590,8 @@ export class CcLogs extends LitElement {
    * This event handler captures the Ctrl+C native shortcut for copy to clipboard.
    * It takes the browser text selection as input.
    * Both plain text and html version of this text selection are put in the clipboard.
+   *
+   * @param {ClipboardEvent} e
    */
   _onCopy (e) {
     const lines = document.getSelection().toString().split(/[\r\n]+/gm);
@@ -619,6 +638,8 @@ export class CcLogs extends LitElement {
   /**
    * When logs are appended very fast, the visibilityChanged event is fired very often.
    * We need to listen to the wheel event to force unfollowing.
+   *
+   * @param {WheelEvent} e
    */
   _onWheel (e) {
     if (e.deltaY < 0) {
@@ -634,6 +655,8 @@ export class CcLogs extends LitElement {
    *
    * It synchronizes the `follow` property according to the scroll position.
    * It also keeps track of the first and last visible elements needed for keyboard navigation.
+   *
+   * @param {VisibilityChangedEvent} e
    */
   _onVisibilityChanged (e) {
     this._visibleRange = { first: e.first, last: e.last };
@@ -651,6 +674,9 @@ export class CcLogs extends LitElement {
     this._setFollow(this._visibleRange.last === Math.max(0, this._logsCtrl.listLength - 1));
   }
 
+  /**
+   * @param {boolean} follow
+   */
   _setFollow (follow) {
     const oldFollow = this.follow;
     this.follow = follow;
@@ -696,6 +722,9 @@ export class CcLogs extends LitElement {
 
   // endregion
 
+  /**
+   * @param {CcLogsPropertyValues} changedProperties
+   */
   willUpdate (changedProperties) {
 
     if (changedProperties.has('dateDisplay') || changedProperties.has('timezone')) {
@@ -711,7 +740,9 @@ export class CcLogs extends LitElement {
       this._logsCtrl.limit = this.limit;
     }
 
-    if (changedProperties.has('messageFilter') || changedProperties.has('messageFilterMode') || changedProperties.has('metadataFilter')) {
+    if (changedProperties.has('messageFilter')
+      || changedProperties.has('messageFilterMode')
+      || changedProperties.has('metadataFilter')) {
       this._logsCtrl.filter = {
         message: isStringEmpty(this.messageFilter) ? null : { value: this.messageFilter, type: this.messageFilterMode },
         metadata: this.metadataFilter,
@@ -719,7 +750,10 @@ export class CcLogs extends LitElement {
     }
   }
 
-  updated (changedProperties) {
+  /**
+   * @param {CcLogsPropertyValues} _changedProperties
+   */
+  updated (_changedProperties) {
     this._horizontalScrollbarHeight = this.wrapLines
       ? 0
       : this._logsRef.value.offsetHeight - this._logsRef.value.clientHeight;
@@ -735,6 +769,23 @@ export class CcLogs extends LitElement {
         }
       : null;
 
+    /**
+     * @param {Log} it
+     * @return {string}
+     */
+    function keyFunction (it) {
+      return it.id;
+    }
+
+    /**
+     * @param {Log} item
+     * @param {number} index
+     * @return {TemplateResult}
+     */
+    const renderItem = (item, index) => {
+      return this._renderLog(item, index);
+    };
+
     return html`
       <div class="wrapper" style="--last-log-margin: ${this._horizontalScrollbarHeight}px">
         <lit-virtualizer
@@ -743,8 +794,8 @@ export class CcLogs extends LitElement {
           tabindex="0"
           .items=${this._logsCtrl.getList().slice()}
           ?scroller=${true}
-          .keyFunction=${(it) => it.id}
-          .renderItem=${(item, index) => this._renderLog(item, index)}
+          .keyFunction=${keyFunction}
+          .renderItem=${renderItem}
           .layout=${layout}
           @click=${this._inputCtrl.onClick}
           @keydown=${this._inputCtrl.onKeyDown}

--- a/src/components/cc-logs/logs-controller.js
+++ b/src/components/cc-logs/logs-controller.js
@@ -224,6 +224,9 @@ export class LogsController {
    * @param {boolean} [notifyHost = true] Whether to notify the host when the focused index has changed
    */
   focus (filteredIndex, notifyHost = true) {
+    if (filteredIndex != null && (filteredIndex < 0 || filteredIndex > this._logsFiltered.length - 1)) {
+      return;
+    }
     if (this._focusedIndex !== filteredIndex) {
       this._focusedIndex = filteredIndex;
       if (notifyHost) {

--- a/src/components/cc-logs/logs-controller.js
+++ b/src/components/cc-logs/logs-controller.js
@@ -173,6 +173,15 @@ export class LogsController {
     this._host._onSelectionChanged();
   }
 
+  selectAll () {
+    if (this._logsFiltered.length > 0) {
+      this._selection = new Set(this._logsFiltered);
+      this._selectionLast = this._logsFiltered[this._logsFiltered.length - 1];
+      this._host.requestUpdate();
+      this._host._onSelectionChanged();
+    }
+  }
+
   /**
    * @return {number} The length of the selection
    */

--- a/src/components/cc-logs/logs-input-controller.js
+++ b/src/components/cc-logs/logs-input-controller.js
@@ -103,6 +103,11 @@ export class LogsInputController {
       const logIndex = Number(e.target.closest(`.log`).dataset.index);
       this._host._onClickLog(logIndex, this._keyModifiers);
     }
+    else if (e.key === 'a' && this._keyModifiers.ctrl) {
+      // we prevent default because we don't want the native keyboard "ctrl + a" to be fired
+      e.preventDefault();
+      this._host._onSelectAll();
+    }
   }
 
   onKeyUp (e) {

--- a/src/components/cc-logs/logs-input-controller.js
+++ b/src/components/cc-logs/logs-input-controller.js
@@ -108,6 +108,12 @@ export class LogsInputController {
       e.preventDefault();
       this._host._onSelectAll();
     }
+    else if (e.key === 'Home') {
+      this._host._onHome(this._keyModifiers.ctrl && this._keyModifiers.shift);
+    }
+    else if (e.key === 'End') {
+      this._host._onEnd(this._keyModifiers.ctrl && this._keyModifiers.shift);
+    }
   }
 
   onKeyUp (e) {

--- a/src/components/cc-logs/logs-input-controller.js
+++ b/src/components/cc-logs/logs-input-controller.js
@@ -122,7 +122,7 @@ export class LogsInputController {
     // Firefox doesn't! And we think that a drag movement ending should not be a click.
     // Therefore, if a drag stop just happened (_dragState = stopping) we should not trigger the onClick on the host.
     if (this._dragState !== 'stopping') {
-      this._host._onClick();
+      this._host._onClick(e);
     }
   }
 


### PR DESCRIPTION
This PR contains som easy quick wins:

- add `Home` and `End` keystrokes (Fixes #1009)
- feat(cc-logs): add ctrl+A keystroke for selecting all log lines (Fixes #1008)
- feat(cc-logs): select whole log line with triple click (Fixes #1006)
- feat(cc-logs): make copy button more visible (Fixes #1012)
