### PR TITLE
fix(cc-tile-metrics): use the correct value for average memory usage within last 24h

### DIFF
--- a/src/components/cc-tile-metrics/cc-tile-metrics.js
+++ b/src/components/cc-tile-metrics/cc-tile-metrics.js
@@ -285,7 +285,7 @@ export class CcTileMetrics extends LitElement {
     const skeleton = (this.metricsState.type === 'loading');
 
     const lastCpuValue = (this.metricsState.type === 'loaded') ? this.metricsState.metricsData.cpuMetrics.slice(-1)[0]?.value : 0;
-    const lastMemValue = (this.metricsState.type === 'loaded') ? this.metricsState.metricsData.cpuMetrics.slice(-1)[0]?.value : 0;
+    const lastMemValue = (this.metricsState.type === 'loaded') ? this.metricsState.metricsData.memMetrics.slice(-1)[0]?.value : 0;
 
     const cpuColorType = (this.metricsState.type === 'loaded') ? this._getColorLegend(lastCpuValue) : SKELETON_COLOR;
     const memColorType = (this.metricsState.type === 'loaded') ? this._getColorLegend(lastMemValue) : SKELETON_COLOR;


### PR DESCRIPTION
Fixes #1092

## What does this PR do?

- The component displayed the average CPU usage within last 24h instead of memory usage (see screenshot below). This PR fixes this issue.
![cc-tile-metrics showing the same value for last 24H memory and cpu usage even though charts highlight different values](https://github.com/CleverCloud/clever-components/assets/100240294/3b4f0afb-0201-4125-a731-1dc9dc07dd4c)

## How to review?

- Check the code,
- Check locally with `demo-smart`,
- 1 reviewer should be enough.