### PR TITLE
fix(cc-input-*): fix Enter keystroke when not into a form element

### DIFF
--- a/src/components/cc-input-date/cc-input-date.js
+++ b/src/components/cc-input-date/cc-input-date.js
@@ -421,12 +421,12 @@ export class CcInputDate extends CcFormControlElement {
     // Here we prevent keydown on enter key from modifying the value
     if (e.type === 'keydown' && e.key === 'Enter') {
       e.preventDefault();
-      this._internals.form.requestSubmit();
+      this._internals.form?.requestSubmit();
       dispatchCustomEvent(this, 'requestimplicitsubmit');
     }
     // Request implicit submit with keypress on enter key
     if (!this.readonly && e.type === 'keypress' && e.key === 'Enter') {
-      this._internals.form.requestSubmit();
+      this._internals.form?.requestSubmit();
       dispatchCustomEvent(this, 'requestimplicitsubmit');
     }
 

--- a/src/components/cc-input-number/cc-input-number.js
+++ b/src/components/cc-input-number/cc-input-number.js
@@ -218,12 +218,12 @@ export class CcInputNumber extends CcFormControlElement {
     // Here we prevent keydown on enter key from modifying the value
     if (e.type === 'keydown' && e.keyCode === 13) {
       e.preventDefault();
-      this._internals.form.requestSubmit();
+      this._internals.form?.requestSubmit();
       dispatchCustomEvent(this, 'requestimplicitsubmit');
     }
     // Request implicit submit with keypress on enter key
     if (!this.readonly && e.type === 'keypress' && e.keyCode === 13) {
-      this._internals.form.requestSubmit();
+      this._internals.form?.requestSubmit();
       dispatchCustomEvent(this, 'requestimplicitsubmit');
     }
   }

--- a/src/components/cc-input-text/cc-input-text.js
+++ b/src/components/cc-input-text/cc-input-text.js
@@ -310,13 +310,13 @@ export class CcInputText extends CcFormControlElement {
     // Here we prevent keydown on enter key from modifying the value
     if (this._tagsEnabled && e.type === 'keydown' && e.keyCode === 13) {
       e.preventDefault();
-      this._internals.form.requestSubmit();
+      this._internals.form?.requestSubmit();
       dispatchCustomEvent(this, 'requestimplicitsubmit');
     }
     // Request implicit submit with keypress on enter key
     if (!this.readonly && e.type === 'keypress' && e.keyCode === 13) {
       if ((!this.multi) || (this.multi && e.ctrlKey)) {
-        this._internals.form.requestSubmit();
+        this._internals.form?.requestSubmit();
         dispatchCustomEvent(this, 'requestimplicitsubmit');
       }
     }


### PR DESCRIPTION
When the `Enter` key is typed, we ask for the underlying form to be submitted. It fails when the input is not into a `<form>` element.

This PR fixes that by requesting a form submit only if a `<form>` is attached to the input ElementInternals.

## How to review

Use Storybook and type `Enter` in either a `cc-input-text`, `cc-input-date`, or `cc-input-number`. Check for errors in the browser console.

Only 1 reviewer is enough.