### PR TITLE
fix: prettier adr wasn't in the correct directory

### DIFF
--- a/docs/adr/adr-0026-introducing-prettier.md
+++ b/docs/adr/adr-0026-introducing-prettier.md
@@ -1,3 +1,4 @@
+---
 kind: '📌 Architecture Decision Records'
 ---
 


### PR DESCRIPTION
The Prettier ADR wasn't in the correct category and appeared in the index.

## How to review?

* Check the [production Storybook](https://www.clever-cloud.com/doc/clever-components/?path=%2Fdocs%2Fadr-0026-introducing-prettier-as-a-formatter--docs), you should see that the ADR is in the index.
* Checkout the branch and run your storybook locally, you should now see it in the correct directory  

It's a quick fix, one reviewer should be enough. :slightly_smiling_face: 