### PR TITLE
fix(cc-toast): decrease paragraph margins

### DIFF
--- a/src/components/cc-toast/cc-toast.js
+++ b/src/components/cc-toast/cc-toast.js
@@ -265,6 +265,10 @@ export class CcToast extends LitElement {
           padding: var(--padding);
         }
 
+        .content p {
+          margin-block: 0.5em;
+        }
+
         .heading {
           font-weight: bold;
         }

--- a/src/components/cc-toast/cc-toast.stories.js
+++ b/src/components/cc-toast/cc-toast.stories.js
@@ -70,7 +70,9 @@ export const withLongHeadingAndMessageAndWithCloseable = makeStory(conf, {
 export const withSanitizedHtmlMessage = makeStory(conf, {
   items: getItems({
     heading: 'Notification message can be topped by a heading',
-    message: (intent) =>
-      sanitize`This is an <strong>HTML</strong> notification message with intent <code>${intent}</code>.`,
+    message: (intent) => sanitize`
+      <p>This is an <strong>HTML</strong> notification message with intent <code>${intent}</code>.</p>
+      <p>It contains several paragraphs.</p>
+    `,
   }),
 });


### PR DESCRIPTION
Fixes #1127

## What does this PR do?

- Adds default margins for paragraphs within the `cc-toast` component so that paragraphs created from translations don't get the default native paragraph margin (which is too big).

## How to review?

- You may review the `cc-toast--with-sanitized-html-message` story and you can also go to the `demo-smart` => domain-management => add a new domain and check the info toast content.
- 1 reviewer should be enough for this one.