### PR TITLE
fix(cc-input-text): match text and input

### DIFF
--- a/src/components/cc-input-text/cc-input-text.js
+++ b/src/components/cc-input-text/cc-input-text.js
@@ -358,9 +358,8 @@ export class CcInputText extends CcFormControlElement {
                 We use this to display colored background rectangles behind space separated values. 
                 This needs to be on the same line and the 2 level parent is important to keep scroll behaviour.
               -->
-                      <div class="input input-underlayer" style="--rows: ${rows}">
-                        <div class="all-tags">${tags}</div>
-                      </div>
+                      <!-- prettier-ignore -->
+                      <div class="input input-underlayer" style="--rows: ${rows}"><div class="all-tags">${tags}</div></div>
                     `
                   : ''}
                 <textarea


### PR DESCRIPTION
Fixes #1130

### How to review ?
- Check the code.
- Check the `cc-input-text` stories in the preview.
- Check some components using `cc-input-text` (for instance `cc-addon-admin`).

2 reviewers should be enough.