### PR TITLE
fix(cc-domain-management): improve responsive aspect

### DIFF
--- a/src/components/cc-domain-management/cc-domain-management.js
+++ b/src/components/cc-domain-management/cc-domain-management.js
@@ -697,20 +697,16 @@ export class CcDomainManagement extends LitElement {
         .domains {
           display: grid;
           gap: 1em;
-          grid-auto-rows: 1fr;
           grid-template-columns: repeat(auto-fit, minmax(min(25em, 100%), 1fr));
         }
 
         .domain {
-          align-content: center;
           align-items: center;
           border: solid 1px var(--cc-color-border-neutral-weak);
           border-radius: var(--cc-border-radius-default);
-          display: grid;
+          display: flex;
+          flex-wrap: wrap;
           gap: 0.5em 1em;
-          grid-template-areas:
-            'domain-info domain-info'
-            'badges actions';
           padding: 1em;
         }
 
@@ -724,7 +720,7 @@ export class CcDomainManagement extends LitElement {
         }
 
         .domain-name-with-path {
-          grid-area: domain-info;
+          flex: 1 0 100%;
           word-break: break-all;
         }
 
@@ -755,7 +751,6 @@ export class CcDomainManagement extends LitElement {
           display: flex;
           flex-wrap: wrap;
           gap: 0.5em;
-          grid-area: badges;
         }
 
         .badge-content {
@@ -772,8 +767,7 @@ export class CcDomainManagement extends LitElement {
           align-items: center;
           display: flex;
           gap: 0.5em;
-          grid-area: actions;
-          justify-content: flex-end;
+          margin-inline-start: auto;
         }
 
         .empty {


### PR DESCRIPTION
Fixes #1126

## What does this PR do?

- Slightly improves the appearance of the `cc-domain-management` component when viewport is reduced.
  - Cards no longer have the same height between different rows,
  - Buttons wrap below badges when there not enough space,
  - Badges span through the whole width of their container unless there is not enough space (in which case they wrap below each other).

## How to review?

- Review the commit,
- Compare [prod - data loaded with http-only domain](https://www.clever-cloud.com/doc/clever-components/?path=/story/%F0%9F%9B%A0-domains-cc-domain-management--data-loaded-with-http-only-domain) & [preview -  data loaded with http-only domain](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-domain-management/improve-responsive/index.html?path=/story/%F0%9F%9B%A0-domains-cc-domain-management--data-loaded-with-http-only-domain) story by reducing the viewport gradually to see the differences,
- If there's a change you find strange or you don't like, don't hesitate to say it here, there are several options when it comes to how this component should look, I just went for what seemed simple looked good to me :shrug:,
- 1 reviewer should be enough for this one.