### PR TITLE
feat(cc-domain-management): display all A Records within a single input

### DIFF
--- a/src/components/cc-domain-management/cc-domain-management.js
+++ b/src/components/cc-domain-management/cc-domain-management.js
@@ -592,17 +592,14 @@ export class CcDomainManagement extends LitElement {
         <div slot="title">${i18n('cc-domain-management.dns.a.heading')}</div>
         <div slot="info">${i18n('cc-domain-management.dns.a.desc')}</div>
         <div class="a-records">
-          ${aRecords.map(
-            (aRecord, index) => html`
-              <cc-input-text
-                hidden-label
-                label="${i18n('cc-domain-management.dns.a.label', { index: index + 1 })}"
-                readonly
-                clipboard
-                value=${aRecord}
-              ></cc-input-text>
-            `,
-          )}
+          <cc-input-text
+            hidden-label
+            label="${i18n('cc-domain-management.dns.a.label')}"
+            clipboard
+            readonly
+            multi
+            .value=${aRecords.join('\n')}
+          ></cc-input-text>
         </div>
       </cc-block-section>
     `;

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -248,7 +248,7 @@ export const translations = {
     () => sanitize`<p>If you choose to use <code>A</code> records, you'll need to update them yourself.</p>
   <p>Follow our <a href="https://developers.clever-cloud.com/changelog/">changelog</a> or check our <a href="https://developers.clever-cloud.com/api/v4/#load-balancers">v4 API documentation</a> for this.</p>`,
   'cc-domain-management.dns.a.heading': `A records`,
-  'cc-domain-management.dns.a.label': ({ index }) => `A Record value number ${index}`,
+  'cc-domain-management.dns.a.label': `A Record values`,
   'cc-domain-management.dns.cname.desc': () =>
     sanitize`<p>Using a <code>CNAME</code> record is recommended. This automatically keeps your configuration up to date.</p>`,
   'cc-domain-management.dns.cname.heading': `CNAME record`,

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -259,7 +259,7 @@ export const translations = {
     () => sanitize`<p>Si vous choisissez d'utiliser des enregistrements de type <code>A</code>, vous devrez vous-même assurer leur mise à jour.</p>
   <p>Pensez à suivre notre <a href="https://developers.clever-cloud.com/changelog/" lang="en">changelog</a> ou à utiliser notre <a href="https://developers.clever-cloud.com/api/v4/#load-balancers" lang="en">API v4</a> pour cela.</p>`,
   'cc-domain-management.dns.a.heading': `Enregistrements A`,
-  'cc-domain-management.dns.a.label': ({ index }) => `Valeur d'enregistrement A numéro ${index}`,
+  'cc-domain-management.dns.a.label': `Valeurs d'enregistrement A`,
   'cc-domain-management.dns.cname.desc': () =>
     sanitize`<p>Utiliser un enregistrement <code>CNAME</code> est fortement recommandé. Ainsi, votre configuration est automatiquement maintenue à jour.`,
   'cc-domain-management.dns.cname.heading': `Enregistrement CNAME`,


### PR DESCRIPTION
Fixes #1134

## What does this PR do?

- Changes the display of A Record values within the `DNS configuration` section to show all of them within a single `<cc-input-text>` element in `multi` (`textarea` mode).
- This makes it possible for users to copy all values at once.

## How to review?

- Review the commit,
- Check the [preview (bottom of the screen, within the DNS config section)](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-domain-management/textarea-for-a-records/index.html?path=/story/%F0%9F%9B%A0-domains-cc-domain-management--data-loaded-with-http-only-domain)
- Give your opinion on whether you want to see this merged or not :
  - :+1: Yes merge this, it's better this way.
  - :-1: No, don't merge this. We should stick with separate `<cc-input-text>`  for each A record value + add a global copy button.
- Everybody should review since I want as many opinions as possible :wink: 