### PR TITLE
fix(cc-domain-management): fix typo & improve texts

### DIFF
--- a/src/components/cc-domain-management/cc-domain-management.js
+++ b/src/components/cc-domain-management/cc-domain-management.js
@@ -351,8 +351,7 @@ export class CcDomainManagement extends LitElement {
             <div class="dns-info__desc">${i18n('cc-domain-management.dns.desc')}</div>
             <cc-notice intent="info" heading="${i18n('cc-domain-management.dns.info.heading')}">
               <div slot="message">
-                <p>${i18n('cc-domain-management.dns.info.load-balancer')}</p>
-                <p>${i18n('cc-domain-management.dns.info.apex')}</p>
+                <p>${i18n('cc-domain-management.dns.info.desc')}</p>
               </div>
             </cc-notice>
           </div>

--- a/src/components/cc-domain-management/cc-domain-management.stories.js
+++ b/src/components/cc-domain-management/cc-domain-management.stories.js
@@ -222,7 +222,7 @@ export const errorWithPathWithinDomain = makeStory(conf, {
       domainFormState: {
         type: 'idle',
         hostname: {
-          value: 'example.com/example-path',
+          value: 'example.com/example-route',
         },
         pathPrefix: {
           value: '',

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -244,26 +244,24 @@ export const translations = {
   'cc-domain-management.certif.custom': () =>
     sanitize`You can provide your own certificate by using the <a href="https://api.clever-cloud.com/v2/certificates/new">Clever Cloud Certificate Manager</a>.`,
   'cc-domain-management.certif.heading': `Secure your application`,
-  'cc-domain-management.dns.a.desc':
-    () => sanitize`<p>If you choose to use <code>A</code> records, you'll need to update them yourself.</p>
-  <p>Follow our <a href="https://developers.clever-cloud.com/changelog/">changelog</a> or check our <a href="https://developers.clever-cloud.com/api/v4/#load-balancers">v4 API documentation</a> for this.</p>`,
+  'cc-domain-management.dns.a.desc': () =>
+    sanitize`<p>If you choose to use <code>A</code> records, you'll need to update them yourself. Follow our <a href="https://developers.clever-cloud.com/changelog/">changelog</a> or check our <a href="https://developers.clever-cloud.com/api/v4/#load-balancers">v4 API documentation</a> for this.</p>`,
   'cc-domain-management.dns.a.heading': `A records`,
   'cc-domain-management.dns.a.label': `A Record values`,
   'cc-domain-management.dns.cname.desc': () =>
-    sanitize`<p>Using a <code>CNAME</code> record is recommended. This automatically keeps your configuration up to date.</p>`,
+    sanitize`<p>Using a <code>CNAME</code> record is recommended. This keeps your configuration up to date.</p>`,
   'cc-domain-management.dns.cname.heading': `CNAME record`,
   'cc-domain-management.dns.cname.label': `CNAME record value`,
   'cc-domain-management.dns.desc':
     () => sanitize`<p>To associate a domain managed by a third-party provider to your Clever Cloud application, you need to configure its DNS zone.</p>
   <p>This may be achieved using a <code>CNAME</code> or <code>A</code> records. We recommend using a <code>CNAME</code> record, as you won't have to reconfigure it if we change our IPs.</p>`,
   'cc-domain-management.dns.heading': `Configure your DNS`,
-  'cc-domain-management.dns.info.apex': () =>
-    sanitize`For APEX domains or subdomains with an existing DNS zone, refer to our <a href="https://developers.clever-cloud.com/doc/administrate/domain-names/">DNS & Domains documentation</a>.`,
+  'cc-domain-management.dns.info.desc': () =>
+    sanitize`If you are using a dedicated load balancer, refer to its configuration or contact support. Our team can also help you to order such a service. For APEX domains or subdomains with an existing DNS zone, refer to our <a href="https://developers.clever-cloud.com/doc/administrate/domain-names/">DNS & Domains documentation</a>.`,
   'cc-domain-management.dns.info.heading': `Dedicated load balancers & specific cases`,
-  'cc-domain-management.dns.info.load-balancer': `If you are using a dedicated load balancer, refer to its configuration or contact support. Our team can also help you to order such a service.`,
   'cc-domain-management.dns.loading-error': `Something went wrong while loading DNS information`,
   'cc-domain-management.form.domain.error.contains-path': ({ path }) =>
-    `Enter the "${path}" part within the "Path" input field`,
+    `Enter the "${path}" part within the "Route" input field`,
   'cc-domain-management.form.domain.error.empty': `Enter a domain`,
   'cc-domain-management.form.domain.error.format': `Enter a valid domain, for instance "example.com"`,
   'cc-domain-management.form.domain.error.wildcard': () =>
@@ -272,10 +270,10 @@ export const translations = {
     sanitize`For instance: <code>example.com</code>, <code>*.example.com</code> or <code>example.cleverapps.io</code>`,
   'cc-domain-management.form.domain.label': `Domain name`,
   'cc-domain-management.form.info.cleverapps': () =>
-    sanitize`By default, an application is automatically associated to <code>app_id.cleverapps.io</code> as default domain. You can remove it or change the sub-domain freely, but <code>xxx.cleverapps.io</code> should only be used for testing purposes (see our <a href="https://developers.clever-cloud.com/doc/administrate/domain-names/#using-a-cleverappsio-free-domain-with-built-in-ssl">documentation</a>).`,
-  'cc-domain-management.form.info.docs': `You can associate one or more domain names with your application. The primary domain is the one that will be used in Console links and in e-mails sent to you. Several applications can share the same domain, each with a specific sub-domain and/or route.`,
+    sanitize`By default, an application is automatically associated to <code>app_id.cleverapps.io</code> as primary domain. You can remove it or change the subdomain freely, but <code>xxx.cleverapps.io</code> should only be used for testing purposes (see our <a href="https://developers.clever-cloud.com/doc/administrate/domain-names/#using-a-cleverappsio-free-domain-with-built-in-ssl">documentation</a>).`,
+  'cc-domain-management.form.info.docs': `You can associate one or more domain names with your application. The primary domain is the one that will be used in Console links and in e-mails sent to you. Several applications can share the same domain, each with a specific subdomain and/or route.`,
   'cc-domain-management.form.path.help': () => sanitize`For example: <code>/api</code> or <code>/blog</code>`,
-  'cc-domain-management.form.path.label': `Path`,
+  'cc-domain-management.form.path.label': `Route`,
   'cc-domain-management.form.submit': `Add a domain`,
   'cc-domain-management.form.submit.error': ({ domain }) => `An error occurred while trying to add "${domain}"`,
   'cc-domain-management.form.submit.error-duplicate.heading': `Domain name not available`,
@@ -308,7 +306,7 @@ export const translations = {
   <p>Please <strong>refresh your page</strong> to get the updated list of domains.</p>`,
   'cc-domain-management.list.heading': `Domain names linked to this application`,
   'cc-domain-management.list.http-only.notice': () =>
-    sanitize`Subdomains are not covered by the SSL certificate of <code>*.cleverapps.io</code>. They do not support HTTPS.`,
+    sanitize`Only direct domains of <code>cleverapps.io</code> are secured with SSL certificates, not <code>xx.yy.cleverapps.io</code> domains.`,
   'cc-domain-management.list.link.title': ({ domainUrl }) => `Open - ${domainUrl} - new window`,
   'cc-domain-management.list.loading-error': `Something went wrong while loading domains associated to this application`,
   'cc-domain-management.list.primary.error': ({ domain }) =>

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -255,9 +255,8 @@ export const translations = {
   'cc-domain-management.certif.custom': () =>
     sanitize`Vous pouvez fournir votre propre certificat grâce au <a href="https://api.clever-cloud.com/v2/certificates/new">gestionnaire de certificats Clever Cloud</a>.`,
   'cc-domain-management.certif.heading': `Sécurisez votre application`,
-  'cc-domain-management.dns.a.desc':
-    () => sanitize`<p>Si vous choisissez d'utiliser des enregistrements de type <code>A</code>, vous devrez vous-même assurer leur mise à jour.</p>
-  <p>Pensez à suivre notre <a href="https://developers.clever-cloud.com/changelog/" lang="en">changelog</a> ou à utiliser notre <a href="https://developers.clever-cloud.com/api/v4/#load-balancers" lang="en">API v4</a> pour cela.</p>`,
+  'cc-domain-management.dns.a.desc': () =>
+    sanitize`<p>Si vous choisissez d'utiliser des enregistrements de type <code>A</code>, vous devrez vous-même assurer leur mise à jour. Pensez à suivre notre <a href="https://developers.clever-cloud.com/changelog/" lang="en">changelog</a> ou à lire la documentation de notre <a href="https://developers.clever-cloud.com/api/v4/#load-balancers" lang="en">API v4</a> pour cela.</p>`,
   'cc-domain-management.dns.a.heading': `Enregistrements A`,
   'cc-domain-management.dns.a.label': `Valeurs d'enregistrement A`,
   'cc-domain-management.dns.cname.desc': () =>
@@ -267,11 +266,9 @@ export const translations = {
   'cc-domain-management.dns.desc': () =>
     sanitize`<p>Afin de lier un domaine géré par un fournisseur tiers à votre application Clever Cloud, vous devez configurer votre zone DNS. Pour cela, vous pouvez utiliser un enregistrement <code>CNAME</code> ou <code>A</code>. L'enregistrement <code>CNAME</code> est à privilégier puisque vous n'aurez pas à le reconfigurer si nous modifions nos IP d'accès.</p>`,
   'cc-domain-management.dns.heading': `Configurez vos DNS`,
-  'cc-domain-management.dns.info.apex': () =>
-    sanitize`Pour un domaine APEX ou un sous-domaine disposant déjà d'une zone DNS, référez-vous à notre <a href="https://developers.clever-cloud.com/doc/administrate/domain-names/">documentation</a>.`,
+  'cc-domain-management.dns.info.desc': () =>
+    sanitize`Si vous bénéficiez d'un <span lang="en">load balancer</span> dédié, référez-vous à sa configuration ou contactez le support. Notre équipe pourra également vous aider pour commander un tel service. Pour un domaine APEX ou un sous-domaine disposant déjà d'une zone DNS, référez-vous à notre <a href="https://developers.clever-cloud.com/doc/administrate/domain-names/">documentation</a>.`,
   'cc-domain-management.dns.info.heading': `Load balancers dédiés et cas spécifiques`,
-  'cc-domain-management.dns.info.load-balancer': () =>
-    sanitize`Si vous bénéficiez d'un <span lang="en">load balancer</span> dédié, référez-vous à sa configuration ou contactez le support. Notre équipe pourra également vous aider pour commander un tel service.`,
   'cc-domain-management.dns.loading-error': `Une erreur est survenue pendant le chargement des informations DNS`,
   'cc-domain-management.form.domain.error.contains-path': ({ path }) =>
     `Saisissez la partie "${path}" dans le champ "Route"`,
@@ -283,8 +280,8 @@ export const translations = {
     sanitize`Par exemple: <code>example.com</code>, <code>*.example.com</code> ou <code>example.cleverapps.io</code>`,
   'cc-domain-management.form.domain.label': `Nom de domaine`,
   'cc-domain-management.form.info.cleverapps': () =>
-    sanitize`Par défaut, une application se voit attribuer un nom de domaine en <code>app_id.cleverapps.io</code>. Vous pouvez le supprimer ou changer le sous-domaine librement, mais <code>xxx.cleverapps.io</code> doit uniquement être utilisé à des fins de test (voir notre <a href="https://developers.clever-cloud.com/doc/administrate/domain-names/#using-a-cleverappsio-free-domain-with-built-in-ssl">documentation</a>).`,
-  'cc-domain-management.form.info.docs': `Vous pouvez associer un ou plusieurs noms de domaines à votre application. Le domaine principal est celui qui sera utilisé dans les liens de la Console et dans les e-mails qui vous serons envoyés. Plusieurs applications peuvent partager un même domaine, chacune avec un sous-domaine et/ou une route spécifique.`,
+    sanitize`Par défaut, une application se voit attribuer un nom de domaine de type <code>app_id.cleverapps.io</code>. Vous pouvez le supprimer ou changer le sous-domaine librement, mais <code>xxx.cleverapps.io</code> doit uniquement être utilisé à des fins de test (voir notre <a href="https://developers.clever-cloud.com/doc/administrate/domain-names/#using-a-cleverappsio-free-domain-with-built-in-ssl">documentation</a>).`,
+  'cc-domain-management.form.info.docs': `Vous pouvez associer un ou plusieurs noms de domaines à votre application. Le domaine principal sera utilisé dans les liens de la Console et dans les e-mails qui vous seront envoyés. Plusieurs applications peuvent partager un même domaine, chacune avec un sous-domaine et/ou une route spécifique.`,
   'cc-domain-management.form.path.help': () => sanitize`Par exemple: <code>/api</code> ou <code>/blog</code>`,
   'cc-domain-management.form.path.label': `Route`,
   'cc-domain-management.form.submit': `Ajouter le domaine`,
@@ -320,7 +317,7 @@ export const translations = {
   <p><strong>Rechargez votre page</strong> pour récupérer la liste des domaines à jour.</p>`,
   'cc-domain-management.list.heading': `Noms de domaines liés à cette application`,
   'cc-domain-management.list.http-only.notice': () =>
-    sanitize`Les sous-domaines ne sont pas couverts par le certificat SSL de <code>*.cleverapps.io</code>. Ils ne bénéficient donc pas de HTTPS.`,
+    sanitize`Seuls les domaines directs de <code>cleverapps.io</code> bénéficient d’un certificat SSL, pas ceux de type <code>xx.yy.cleverapps.io</code>`,
   'cc-domain-management.list.link.title': ({ domainUrl }) => `Ouvrir - ${domainUrl} - nouvelle fenêtre`,
   'cc-domain-management.list.loading-error': `Une erreur est survenue pendant le chargement des domaines associés à cette application`,
   'cc-domain-management.list.primary.error': ({ domain }) =>


### PR DESCRIPTION
## What does this PR do?

- Updates `cc-domain-management`'s texts with modifications suggested by @davlgd.

## How to review?

- Check the commit,
- Check the component in [preview](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-domain-management/fix-translations/index.html?path=/story/%F0%9F%9B%A0-domains-cc-domain-management--data-loaded-with-http-only-domain), the sections to read carefully are:
  - the one above the form,
  - the warning notice for http-only domains,
  - the info notice within the `DNS config` section,
  - the desc on the left within `DNS config > CNAME` & `DNS config > A Records`.
- 1 reviewer is enough for this one.