### PR TITLE
Web Test Runner: tests timeout randomly

### DIFF
--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -8,6 +8,8 @@ export default {
   files: ['test/**/*.test.*', 'src/components/**/*.test.*'],
   browsers: [
     chromeLauncher({
+      // Fixes random timeouts with Chrome > 127, see https://github.com/CleverCloud/clever-components/issues/1146 for more info
+      concurrency: 1,
       launchOptions: {
         env: { LANGUAGE: 'en_US' },
       },


### PR DESCRIPTION
## Context

With Chromium / Chrome > 127, it seems that our tests timeout randomly.

The tests that timeout are never the same, it's always within the second half of the testing phase + the last 3 tests.

The [issue #2403 on the @web repo](https://github.com/modernweb-dev/web/issues/2403) states that setting concurrency > 1 makes tests timeout. We never had the issue before but it's clear that setting `concurrency: 1` fixes the issue now so we'll go with that for the time being.

This may slow down tests so it should only be a temporary solution.

## How to review?

- Check that CI tests pass,
- Run tests locally and check that they pass as well,
- Check the commit code,
- 1 reviewer should be enough for this one.
