### PR TITLE
fix(cem-types-plugin): ignore non relative path imports

### DIFF
--- a/cem/support-typedef-jsdoc-utils.js
+++ b/cem/support-typedef-jsdoc-utils.js
@@ -332,6 +332,11 @@ export function findPathAndTypesFromImports(ts, filePath, ancestors = null) {
   importsDeclaration.forEach((importNode) => {
     const types = [];
     const importFile = importNode.moduleSpecifier.text;
+    const isImportRelative = importFile.startsWith('./') || importFile.startsWith('../');
+    if (!isImportRelative) {
+      return;
+    }
+
     const parsedImportPath = path.parse(importFile);
 
     const formattedImportPath = path.join(parsedPath.dir, parsedImportPath.dir, convertToTSExt(parsedImportPath.base));

--- a/cem/support-typedef-jsdoc.js
+++ b/cem/support-typedef-jsdoc.js
@@ -135,9 +135,10 @@ export default function supportTypedefJsdoc() {
         // Extract the path from the @typedef import
         const typePath = findTypePath(tag, ROOT_DIR, moduleDir);
 
-        // If an import is not correct and warn the plugin user.
+        // If an import is not correct, warn the plugin user.
         if (typePath == null) {
           console.warn(`There's a problem with one of your @typedef - ${tag.getText()}`);
+          process.exitCode = 1;
           return;
         }
 

--- a/cem/test/fixtures/cc-test-component.types.d.ts
+++ b/cem/test/fixtures/cc-test-component.types.d.ts
@@ -1,4 +1,5 @@
-import {ToImport, ImpExtendInterface} from "./test-imports.types";
+import { ToImport, ImpExtendInterface } from "./test-imports.types";
+import { TemplateResult } from "lit";
 
 interface Foo {
   one: string;
@@ -10,17 +11,18 @@ type Bar = "One" | "Two" | false | null;
 interface TheInterface {
   one: number;
   two: string;
+  three: string | TemplateResult;
   sub: SubInterface;
   subSpecialArray: Array<OtherInterface>;
   subArray: OtherInterfaceTwo[];
   subType: SubType;
   subUnion: UnionFoo | UnionBar;
-  onlyType : TheOnlyType;
+  onlyType: TheOnlyType;
 }
 
 interface TupleInterface {
   subTuple: [TupleFoo];
-  multipleTuple: [TupleFooBar, TupleBar, TupleBaz ];
+  multipleTuple: [TupleFooBar, TupleBar, TupleBaz];
 }
 
 interface UnionInterface {
@@ -29,7 +31,7 @@ interface UnionInterface {
 
 type TheOnlyType = SubOnlyType;
 
-interface SubOnlyType {}
+interface SubOnlyType { }
 
 type TheType = "One" | "Two" | SubInterface | Array<OtherInterface> | OtherInterfaceTwo[];
 
@@ -106,7 +108,7 @@ interface PrivateInterface {
 
 }
 
-interface ToBeExtended  extends ExtendedInterface {
+interface ToBeExtended extends ExtendedInterface {
 
 }
 

--- a/cem/test/support-typedef-jsdoc-utils.test.js
+++ b/cem/test/support-typedef-jsdoc-utils.test.js
@@ -250,6 +250,7 @@ describe('findSubtypes()', function () {
 
   it('should find the subtypes for a given type/interface', function () {
     expect(findSubtypes(ts, sourceAst, ['TheInterface', 'TheType'])).to.have.members([
+      'TemplateResult',
       'SubInterface',
       'OtherInterface',
       'OtherInterfaceTwo',
@@ -318,12 +319,13 @@ describe('convertInterface()', function () {
         'interface TheInterface {\n' +
         '  one: number;\n' +
         '  two: string;\n' +
+        '  three: string | TemplateResult;\n' +
         '  sub: SubInterface;\n' +
         '  subSpecialArray: Array<OtherInterface>;\n' +
         '  subArray: OtherInterfaceTwo[];\n' +
         '  subType: SubType;\n' +
         '  subUnion: UnionFoo | UnionBar;\n' +
-        '  onlyType : TheOnlyType;\n' +
+        '  onlyType: TheOnlyType;\n' +
         '}\n' +
         '\n' +
         '```',

--- a/src/components/cc-addon-backups/cc-addon-backups.js
+++ b/src/components/cc-addon-backups/cc-addon-backups.js
@@ -28,7 +28,7 @@ const SKELETON_BACKUPS = {
  * @typedef {import('./cc-addon-backups.types.js').AddonBackupsStateLoading} AddonBackupsStateLoading
  * @typedef {import('./cc-addon-backups.types.js').ProviderId} ProviderId
  * @typedef {import('../cc-button/cc-button.js').CcButton} CcButton
- * @typedef {Event & { target: CcButton }} CcButtonClickEvent
+ * @typedef {import('../../lib/events.types.js').EventWithTarget<CcButton>} CcButtonClickEvent
  * @typedef {import('lit').TemplateResult<1>} TemplateResult
  */
 

--- a/src/components/cc-logs-application-view/cc-logs-application-view.js
+++ b/src/components/cc-logs-application-view/cc-logs-application-view.js
@@ -79,7 +79,7 @@ const MENU_ENTRIES = ['live', 'lastHour', 'last4Hours', 'today', 'yesterday', 'l
  * @typedef {import('lit/directives/ref.js').Ref<CcPopover>} RefCcPopover
  * @typedef {import('lit').PropertyValues<CcLogsApplicationView>} CcLogsApplicationViewPropertyValues
  * @typedef {import('lit').TemplateResult<1>} TemplateResult
- * @typedef {'none'|'init'|'started'|'waiting'|'running'|'paused'|'completed'} ProgressState
+ * @typedef {import('./cc-logs-application-view.types.js').ProgressState} ProgressState
  */
 
 /**

--- a/src/components/cc-logs-application-view/cc-logs-application-view.types.d.ts
+++ b/src/components/cc-logs-application-view/cc-logs-application-view.types.d.ts
@@ -67,3 +67,5 @@ export interface LogsApplicationViewOptions {
   timezone: Timezone;
   'wrap-lines': boolean;
 }
+
+export type ProgressState = 'none' | 'init' | 'started' | 'waiting' | 'running' | 'paused' | 'completed';


### PR DESCRIPTION
## What does this PR do?

* When using bare imports in the types, the plugin tried to look up in the corresponding file the subtypes. However, we don't want that and only want to use the type from the bare import.
* This PR also makes the plugin exit to `1` if an error has been detected.