### PR TITLE
refactor: Typecheck smart components in CI

### DIFF
--- a/sandbox/forms/form-demo-with-smart-component.js
+++ b/sandbox/forms/form-demo-with-smart-component.js
@@ -139,6 +139,7 @@ defineSmartComponent({
    * @param {(prop: string, fn: (prop: any) => void) => void} settings.updateComponent
    * @param {(type: string, listener: (detail: any) => void) => void} settings.onEvent
    */
+  // @ts-expect-error FIXME: remove once `onContextUpdate` is typed with generics
   async onContextUpdate({ component, updateComponent, onEvent }) {
     console.log('update context');
     // setting form value from smart

--- a/src/components/cc-addon-linked-apps/cc-addon-linked-apps.smart.js
+++ b/src/components/cc-addon-linked-apps/cc-addon-linked-apps.smart.js
@@ -1,5 +1,8 @@
+// @ts-expect-error FIXME: remove when clever-client exports types
 import { getLinkedApplications } from '@clevercloud/client/esm/api/v2/addon.js';
+// @ts-expect-error FIXME: remove when clever-client exports types
 import { getAllZones } from '@clevercloud/client/esm/api/v4/product.js';
+// @ts-expect-error FIXME: remove when clever-client exports types
 import { ONE_DAY } from '@clevercloud/client/esm/with-cache.js';
 import { defineSmartComponent } from '../../lib/define-smart-component.js';
 import { sendToApi } from '../../lib/send-to-api.js';
@@ -12,6 +15,7 @@ import './cc-addon-linked-apps.js';
  * @typedef {import('./cc-addon-linked-apps.types.js').AddonLinkedAppsStateLoaded} AddonLinkedAppsStateLoaded
  * @typedef {{ variant: { logo: string, name: string }}} Instance
  * @typedef {{ name: string, instance: Instance, id: string, zone: string }} RawApp
+ * @typedef {import('./cc-addon-linked-apps.js').CcAddonLinkedApps} CcAddonLinkedApps
  * @typedef {import('../../lib/send-to-api.js').ApiConfig} ApiConfig
  */
 
@@ -22,6 +26,16 @@ defineSmartComponent({
     ownerId: { type: String },
     addonId: { type: String },
   },
+  /**
+   *
+   * @param {Object} settings
+   * @param {CcAddonLinkedApps} settings.component
+   * @param {{apiConfig: ApiConfig, ownerId: string, addonId: string }} settings.context
+   * @param {(type: string, listener: (detail: any) => void) => void} settings.onEvent
+   * @param {function} settings.updateComponent
+   * @param {AbortSignal} settings.signal
+   */
+  // @ts-expect-error FIXME: remove once `onContextUpdate` is typed with generics
   onContextUpdate({ context, updateComponent, signal }) {
     updateComponent('state', { type: 'loading' });
 

--- a/src/components/cc-article-list/cc-article-list.smart.js
+++ b/src/components/cc-article-list/cc-article-list.smart.js
@@ -1,4 +1,6 @@
+// @ts-expect-error FIXME: remove when clever-client exports types
 import { request } from '@clevercloud/client/esm/request.fetch.js';
+// @ts-expect-error FIXME: remove when clever-client exports types
 import { withCache } from '@clevercloud/client/esm/with-cache.js';
 import { defineSmartComponent } from '../../lib/define-smart-component.js';
 import { parseRssFeed } from '../../lib/xml-parser.js';
@@ -6,7 +8,9 @@ import '../cc-smart-container/cc-smart-container.js';
 import './cc-article-list.js';
 
 /**
+ * @typedef {import('./cc-article-list.js').CcArticleList} CcArticleList
  * @typedef {import('../cc-article-card/cc-article-card.types.js').ArticleCard} ArticleCard
+ * @typedef {import('../../lib/send-to-api.js').ApiConfig} ApiConfig
  */
 
 const FOUR_HOURS = 1000 * 60 * 60 * 4;
@@ -17,6 +21,15 @@ defineSmartComponent({
     lang: { type: String },
     limit: { type: Number },
   },
+  /**
+   * @param {Object} settings
+   * @param {CcArticleList} settings.component
+   * @param {{apiConfig: ApiConfig, lang: 'fr'|'en', limit: number}} settings.context
+   * @param {(type: string, listener: (detail: any) => void) => void} settings.onEvent
+   * @param {function} settings.updateComponent
+   * @param {AbortSignal} settings.signal
+   */
+  // @ts-expect-error FIXME: remove once `onContextUpdate` is typed with generics
   onContextUpdate({ context, updateComponent, signal }) {
     updateComponent('state', { type: 'loading' });
 

--- a/src/components/cc-domain-management/cc-domain-management.smart.js
+++ b/src/components/cc-domain-management/cc-domain-management.smart.js
@@ -1,11 +1,6 @@
-import {
-  addDomain,
-  getAllDomains,
-  getFavouriteDomain as getPrimaryDomain,
-  markFavouriteDomain as markPrimaryDomain,
-  removeDomain,
-  unmarkFavouriteDomain as unmarkPrimaryDomain,
-} from '@clevercloud/client/esm/api/v2/application.js';
+// prettier-ignore
+// @ts-expect-error FIXME: remove when clever-client exports types
+import { addDomain,getAllDomains,getFavouriteDomain as getPrimaryDomain,markFavouriteDomain as markPrimaryDomain,removeDomain,unmarkFavouriteDomain as unmarkPrimaryDomain,} from '@clevercloud/client/esm/api/v2/application.js';
 import { defineSmartComponent } from '../../lib/define-smart-component.js';
 import { getHostWithWildcard, isTestDomain, parseDomain } from '../../lib/domain.js';
 import { notify, notifyError, notifySuccess } from '../../lib/notifications.js';
@@ -32,6 +27,16 @@ defineSmartComponent({
     appId: { type: String },
     ownerId: { type: String },
   },
+  /**
+   *
+   * @param {Object} settings
+   * @param {CcDomainManagement} settings.component
+   * @param {{ apiConfig: ApiConfig, appId: string, ownerId: string }} settings.context
+   * @param {(type: string, listener: (detail: any) => void) => void} settings.onEvent
+   * @param {function} settings.updateComponent
+   * @param {AbortSignal} settings.signal
+   */
+  // @ts-expect-error FIXME: remove once `onContextUpdate` is type with generics
   onContextUpdate({ context, onEvent, updateComponent, signal }) {
     const { apiConfig, appId, ownerId } = context;
 

--- a/src/components/cc-email-list/cc-email-list.smart.js
+++ b/src/components/cc-email-list/cc-email-list.smart.js
@@ -1,9 +1,6 @@
-import {
-  todo_addEmailAddress as addEmailAddress,
-  todo_getEmailAddresses as getEmailAddresses,
-  todo_removeEmailAddress as removeEmailAddress,
-  todo_getConfirmationEmail as sendConfirmationEmail,
-} from '@clevercloud/client/esm/api/v2/user.js';
+// prettier-ignore
+// @ts-expect-error FIXME: remove when clever-client exports types
+import { todo_addEmailAddress as addEmailAddress,todo_getEmailAddresses as getEmailAddresses,todo_removeEmailAddress as removeEmailAddress,todo_getConfirmationEmail as sendConfirmationEmail,} from '@clevercloud/client/esm/api/v2/user.js';
 import { defineSmartComponent } from '../../lib/define-smart-component.js';
 import { notify, notifyError, notifySuccess } from '../../lib/notifications.js';
 import { sendToApi } from '../../lib/send-to-api.js';
@@ -26,7 +23,6 @@ defineSmartComponent({
     apiConfig: { type: Object },
   },
   /**
-   *
    * @param {Object} settings
    * @param {CcEmailList} settings.component
    * @param {{apiConfig: ApiConfig}} settings.context
@@ -34,6 +30,7 @@ defineSmartComponent({
    * @param {function} settings.updateComponent
    * @param {AbortSignal} settings.signal
    */
+  // @ts-expect-error FIXME: remove once `onContextUpdate` is type with generics
   onContextUpdate({ component, context, onEvent, updateComponent, signal }) {
     updateComponent('emails', { state: 'loading' });
     updateComponent('addEmailFormState', { state: 'idle' });
@@ -42,7 +39,6 @@ defineSmartComponent({
     const api = getApi(context.apiConfig, signal);
 
     /**
-     *
      * @param {string} address
      * @param {(state: SecondaryAddressState) => void}callback
      */
@@ -268,7 +264,6 @@ function convertApiError(apiErrorId) {
 
 // -- API calls
 /**
- *
  * @param {ApiConfig} apiConfig
  * @param {AbortSignal} signal
  */

--- a/src/components/cc-env-var-form/cc-env-var-form.smart-config-provider.js
+++ b/src/components/cc-env-var-form/cc-env-var-form.smart-config-provider.js
@@ -1,3 +1,4 @@
+// @ts-expect-error FIXME: remove when clever-client exports types
 import { get as getAddon } from '@clevercloud/client/esm/api/v2/addon.js';
 import { defineSmartComponent } from '../../lib/define-smart-component.js';
 import { notifyError, notifySuccess } from '../../lib/notifications.js';
@@ -6,6 +7,16 @@ import { i18n } from '../../translations/translation.js';
 import '../cc-smart-container/cc-smart-container.js';
 import './cc-env-var-form.js';
 
+/**
+ * @typedef {import('./cc-env-var-form.js').CcEnvVarForm} CcEnvVarForm
+ * @typedef {import('./cc-env-var-form.types.js').EnvVarFormState} EnvVarFormState
+ * @typedef {import('./cc-env-var-form.types.js').EnvVarFormStateLoaded} EnvVarFormStateLoaded
+ * @typedef {import('./cc-env-var-form.types.js').EnvVarFormStateSaving} EnvVarFormStateSaving
+ * @typedef {import('../common.types.js').EnvVar} EnvVar
+ * @typedef {import('../common.types.js').Addon} Addon
+ * @typedef {import('../../lib/send-to-api.js').ApiConfig} ApiConfig
+ */
+
 defineSmartComponent({
   selector: 'cc-env-var-form[context="config-provider"]',
   params: {
@@ -13,76 +24,142 @@ defineSmartComponent({
     ownerId: { type: String },
     addonId: { type: String },
   },
+  /**
+   * @param {Object} settings
+   * @param {CcEnvVarForm} settings.component
+   * @param {{ apiConfig: ApiConfig, ownerId: string, addonId: string }} settings.context
+   * @param {(type: string, listener: (detail: any) => void) => void} settings.onEvent
+   * @param {function} settings.updateComponent
+   * @param {AbortSignal} settings.signal
+   */
+  // @ts-expect-error FIXME: remove once `onContextUpdate` is typed with generics
   onContextUpdate({ context, onEvent, updateComponent, signal }) {
     updateComponent('state', { type: 'loading' });
 
     const { apiConfig, ownerId, addonId } = context;
 
+    /** @type {string} realAddonId */
     let realAddonId = null;
 
     fetchAddon({ apiConfig, ownerId, addonId, signal })
-      .then((addon) => {
-        updateComponent('addonName', addon.name);
-        realAddonId = addon.realId;
-        return fetchVariables({ apiConfig, realAddonId, signal });
-      })
-      .then((variables) => {
-        updateComponent('state', { type: 'loaded', validationMode: 'simple', variables });
-      })
-      .catch((error) => {
-        console.error(error);
-        updateComponent('state', { type: 'error' });
-      });
+      .then(
+        /** @param {Addon} addon */
+        (addon) => {
+          updateComponent('addonName', addon.name);
+          realAddonId = addon.realId;
+          return fetchVariables({ apiConfig, realAddonId, signal });
+        },
+      )
+      .then(
+        /** @param {Array<EnvVar>} variables */
+        (variables) => {
+          updateComponent('state', { type: 'loaded', validationMode: 'simple', variables });
+        },
+      )
+      .catch(
+        /** @param {Error} error */
+        (error) => {
+          console.error(error);
+          updateComponent('state', { type: 'error' });
+        },
+      );
 
     onEvent('cc-env-var-form:submit', (variables) => {
-      updateComponent('state', (state) => {
-        state.type = 'saving';
-      });
+      updateComponent(
+        'state',
+        /** @param {EnvVarFormState} state */
+        (state) => {
+          state.type = 'saving';
+        },
+      );
       updateVariables({ apiConfig, realAddonId, variables })
         .then(() => {
-          updateComponent('state', (state) => {
-            state.variables = variables;
-          });
+          updateComponent(
+            'state',
+            /** @param {EnvVarFormStateSaving} state */
+            (state) => {
+              state.variables = variables;
+            },
+          );
           notifySuccess(i18n('cc-env-var-form.update.success'));
         })
         .catch(() => notifyError(i18n('cc-env-var-form.update.error')))
         .finally(() => {
-          updateComponent('state', (state) => {
-            state.type = 'loaded';
-          });
+          updateComponent(
+            'state',
+            /** @param {EnvVarFormStateLoaded} state */
+            (state) => {
+              state.type = 'loaded';
+            },
+          );
         });
     });
   },
 });
 
+/**
+ * @param {object} params
+ * @param {ApiConfig} params.apiConfig
+ * @param {AbortSignal} params.signal
+ * @param {string} params.ownerId
+ * @param {string} params.addonId
+ * @returns {Promise<Addon>}
+ */
 function fetchAddon({ apiConfig, signal, ownerId, addonId }) {
   return getAddon({ id: ownerId, addonId }).then(sendToApi({ apiConfig, signal }));
 }
 
+/**
+ * @param {object} params
+ * @param {ApiConfig} params.apiConfig
+ * @param {AbortSignal} params.signal
+ * @param {string} params.realAddonId
+ * @returns {Promise<Array<EnvVar>>}
+ */
 async function fetchVariables({ apiConfig, signal, realAddonId }) {
   return getConfigProviderEnv({ realAddonId }).then(sendToApi({ apiConfig, signal }));
 }
 
-async function updateVariables({ apiConfig, signal, realAddonId, variables }) {
-  return updateConfigProviderEnv({ realAddonId }, variables).then(sendToApi({ apiConfig, signal }));
+/**
+ * @param {object} params
+ * @param {ApiConfig} params.apiConfig
+ * @param {string} params.realAddonId
+ * @param {Array<EnvVar>} params.variables
+ * @returns {Promise<Addon>}
+ */
+async function updateVariables({ apiConfig, realAddonId, variables }) {
+  return updateConfigProviderEnv({ realAddonId }, variables).then(sendToApi({ apiConfig }));
 }
 
-// TODO clever-client
-export function getConfigProviderEnv(params) {
+/**
+ * TODO: clever-client
+ *
+ * @param {object} params
+ * @param {string} params.realAddonId
+ * @returns {Promise<{ method: 'get', url: string, headers: { Accept: 'application/json' }}>}
+ */
+export function getConfigProviderEnv({ realAddonId }) {
   return Promise.resolve({
     method: 'get',
-    url: `/v4/addon-providers/config-provider/addons/${params.realAddonId}/env`,
+    url: `/v4/addon-providers/config-provider/addons/${realAddonId}/env`,
     headers: { Accept: 'application/json' },
     // no query params
     // no body
   });
 }
 
-// TODO clever-client
-export function updateConfigProviderEnv(params, body) {
+/**
+ * TODO: clever-client
+ *
+ * @param {object} params
+ * @param {string} params.realAddonId
+ * @param {Array<EnvVar>} body
+ * @returns {Promise<{ method: 'put', url: string, headers: { Accept: 'application/json' }, body: Array<EnvVar> }>}
+ */
+export function updateConfigProviderEnv({ realAddonId }, body) {
   return Promise.resolve({
     method: 'put',
-    url: `/v4/addon-providers/config-provider/addons/${params.realAddonId}/env`,
+    url: `/v4/addon-providers/config-provider/addons/${realAddonId}/env`,
     headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
     // no query params
     body,

--- a/src/components/cc-env-var-form/cc-env-var-form.smart-env-var-addon.js
+++ b/src/components/cc-env-var-form/cc-env-var-form.smart-env-var-addon.js
@@ -1,8 +1,15 @@
+// @ts-expect-error FIXME: remove when clever-client exports types
 import { getAllEnvVars } from '@clevercloud/client/esm/api/v2/addon.js';
 import { defineSmartComponent } from '../../lib/define-smart-component.js';
 import { sendToApi } from '../../lib/send-to-api.js';
 import '../cc-smart-container/cc-smart-container.js';
 import './cc-env-var-form.js';
+
+/**
+ * @typedef {import('./cc-env-var-form.js').CcEnvVarForm} CcEnvVarForm
+ * @typedef {import('../common.types.js').EnvVar} EnvVar
+ * @typedef {import('../../lib/send-to-api.js').ApiConfig} ApiConfig
+ */
 
 defineSmartComponent({
   selector: 'cc-env-var-form[context="env-var-addon"]',
@@ -11,22 +18,45 @@ defineSmartComponent({
     ownerId: { type: String },
     addonId: { type: String },
   },
+  /**
+   * @param {Object} settings
+   * @param {CcEnvVarForm} settings.component
+   * @param {{ apiConfig: ApiConfig, ownerId: string, addonId: string }} settings.context
+   * @param {(type: string, listener: (detail: any) => void) => void} settings.onEvent
+   * @param {function} settings.updateComponent
+   * @param {AbortSignal} settings.signal
+   */
+  // @ts-expect-error FIXME: remove once `onContextUpdate` is typed with generics
   onContextUpdate({ context, updateComponent, signal }) {
     updateComponent('state', { type: 'loading' });
 
     const { apiConfig, ownerId, addonId } = context;
 
     fetchEnvVars({ apiConfig, signal, ownerId, addonId })
-      .then((variables) => {
-        updateComponent('state', { type: 'loaded', validationMode: 'simple', variables });
-      })
-      .catch((error) => {
-        console.error(error);
-        updateComponent('state', { type: 'error' });
-      });
+      .then(
+        /** @param {Array<EnvVar>} variables */
+        (variables) => {
+          updateComponent('state', { type: 'loaded', validationMode: 'simple', variables });
+        },
+      )
+      .catch(
+        /** @param {Error} error */
+        (error) => {
+          console.error(error);
+          updateComponent('state', { type: 'error' });
+        },
+      );
   },
 });
 
+/**
+ * @param {object} params
+ * @param {ApiConfig} params.apiConfig
+ * @param {AbortSignal} params.signal
+ * @param {string} params.ownerId
+ * @param {string} params.addonId
+ * @returns {Promise<Array<EnvVar>>}
+ */
 function fetchEnvVars({ apiConfig, signal, ownerId, addonId }) {
   return getAllEnvVars({ id: ownerId, addonId }).then(sendToApi({ apiConfig, signal }));
 }

--- a/src/components/cc-env-var-form/cc-env-var-form.types.d.ts
+++ b/src/components/cc-env-var-form/cc-env-var-form.types.d.ts
@@ -6,23 +6,23 @@ export type EnvVarFormState =
   | EnvVarFormStateSaving
   | EnvVarFormStateError;
 
-interface EnvVarFormStateLoading {
+export interface EnvVarFormStateLoading {
   type: 'loading';
 }
 
-interface EnvVarFormStateLoaded {
+export interface EnvVarFormStateLoaded {
   type: 'loaded';
   variables: Array<EnvVar>;
   validationMode: EnvVarValidationMode;
 }
 
-interface EnvVarFormStateSaving {
+export interface EnvVarFormStateSaving {
   type: 'saving';
   variables: Array<EnvVar>;
   validationMode: EnvVarValidationMode;
 }
 
-interface EnvVarFormStateError {
+export interface EnvVarFormStateError {
   type: 'error';
 }
 

--- a/src/components/cc-grafana-info/cc-grafana-info.types.d.ts
+++ b/src/components/cc-grafana-info/cc-grafana-info.types.d.ts
@@ -1,31 +1,31 @@
 export type GrafanaInfoState = GrafanaInfoStateLoading | GrafanaInfoStateLoadingError | GrafanaInfoStateLoaded;
 
-interface GrafanaInfoStateLoading {
+export interface GrafanaInfoStateLoading {
   type: 'loading';
 }
 
-interface GrafanaInfoStateLoadingError {
+export interface GrafanaInfoStateLoadingError {
   type: 'error';
 }
 
-interface GrafanaInfoStateLoaded {
+export interface GrafanaInfoStateLoaded {
   type: 'loaded';
   info: GrafanaInfo;
 }
 
-type GrafanaInfo = GrafanaInfoEnabled | GrafanaInfoEnabledWithError | GrafanaInfoDisabled;
+export type GrafanaInfo = GrafanaInfoEnabled | GrafanaInfoEnabledWithError | GrafanaInfoDisabled;
 
-interface GrafanaInfoEnabled {
+export interface GrafanaInfoEnabled {
   status: 'enabled';
   link?: string;
-  action?: 'disabling' | 'resetting';
+  action?: 'disabling' | 'resetting' | null;
 }
 
-interface GrafanaInfoEnabledWithError {
+export interface GrafanaInfoEnabledWithError {
   status: 'enabled';
 }
 
-interface GrafanaInfoDisabled {
+export interface GrafanaInfoDisabled {
   status: 'disabled';
-  action?: 'enabling';
+  action?: 'enabling' | null;
 }

--- a/src/components/cc-invoice-list/cc-invoice-list.smart.js
+++ b/src/components/cc-invoice-list/cc-invoice-list.smart.js
@@ -4,7 +4,9 @@ import '../cc-smart-container/cc-smart-container.js';
 import './cc-invoice-list.js';
 
 /**
+ * @typedef {import('./cc-invoice-list.js').CcInvoiceList} CcInvoiceList
  * @typedef {import('../common.types.js').Invoice} Invoice
+ * @typedef {import('../../lib/send-to-api.types.js').ApiConfig} ApiConfig
  */
 
 defineSmartComponent({
@@ -13,6 +15,15 @@ defineSmartComponent({
     apiConfig: { type: Object },
     ownerId: { type: String },
   },
+  /**
+   * @param {Object} settings
+   * @param {CcInvoiceList} settings.component
+   * @param {{apiConfig: ApiConfig, ownerId: string }} settings.context
+   * @param {(type: string, listener: (detail: any) => void) => void} settings.onEvent
+   * @param {function} settings.updateComponent
+   * @param {AbortSignal} settings.signal
+   */
+  // @ts-expect-error FIXME: remove once `onContextUpdate` is type with generics
   onContextUpdate({ context, updateComponent, signal }) {
     updateComponent('state', { type: 'loading' });
 

--- a/src/components/cc-invoice/cc-invoice.smart.js
+++ b/src/components/cc-invoice/cc-invoice.smart.js
@@ -3,6 +3,12 @@ import { defineSmartComponent } from '../../lib/define-smart-component.js';
 import '../cc-smart-container/cc-smart-container.js';
 import './cc-invoice.js';
 
+/**
+ * @typedef {import('./cc-invoice.js').CcInvoice} CcInvoice
+ * @typedef {import('../common.types.js').Invoice} Invoice
+ * @typedef {import('../../lib/send-to-api.js').ApiConfig} ApiConfig
+ */
+
 defineSmartComponent({
   selector: 'cc-invoice',
   params: {
@@ -10,7 +16,16 @@ defineSmartComponent({
     ownerId: { type: String },
     invoiceNumber: { type: String },
   },
-  onContextUpdate({ component, context, onEvent, updateComponent, signal }) {
+  /**
+   * @param {Object} settings
+   * @param {CcInvoice} settings.component
+   * @param {{apiConfig: ApiConfig, ownerId: string, invoiceNumber: string}} settings.context
+   * @param {(type: string, listener: (detail: any) => void) => void} settings.onEvent
+   * @param {function} settings.updateComponent
+   * @param {AbortSignal} settings.signal
+   */
+  // @ts-expect-error FIXME: remove once `onContextUpdate` is typed with generics
+  onContextUpdate({ context, updateComponent, signal }) {
     const { apiConfig, ownerId, invoiceNumber } = context;
 
     updateComponent('state', { type: 'loading', number: invoiceNumber });
@@ -33,6 +48,14 @@ defineSmartComponent({
   },
 });
 
+/**
+ * @param {object} params
+ * @param {ApiConfig} params.apiConfig
+ * @param {AbortSignal} params.signal
+ * @param {string} params.ownerId
+ * @param {string} params.invoiceNumber
+ * @returns {Promise<Invoice>}
+ */
 function fetchFullInvoice({ apiConfig, signal, ownerId, invoiceNumber }) {
   return Promise.all([
     fetchInvoice({ apiConfig, signal, ownerId, invoiceNumber }),

--- a/src/components/cc-jenkins-info/cc-jenkins-info.smart.js
+++ b/src/components/cc-jenkins-info/cc-jenkins-info.smart.js
@@ -1,8 +1,15 @@
+// @ts-expect-error FIXME: remove when clever-client exports types
 import { getAddon, getJenkinsUpdates } from '@clevercloud/client/esm/api/v4/addon-providers.js';
 import { defineSmartComponent } from '../../lib/define-smart-component.js';
 import { sendToApi } from '../../lib/send-to-api.js';
 import '../cc-smart-container/cc-smart-container.js';
 import './cc-jenkins-info.js';
+
+/**
+ * @typedef {import('./cc-jenkins-info.js').CcJenkinsInfo} CcJenkinsInfo
+ * @typedef {import('./cc-jenkins-info.types.js').JenkinsInfoStateLoaded} JenkinsInfoStateLoaded
+ * @typedef {import('../../lib/send-to-api.js').ApiConfig} ApiConfig
+ */
 
 defineSmartComponent({
   selector: 'cc-jenkins-info',
@@ -10,6 +17,15 @@ defineSmartComponent({
     apiConfig: { type: Object },
     addonId: { type: String },
   },
+  /**
+   * @param {Object} settings
+   * @param {CcJenkinsInfo} settings.component
+   * @param {{ apiConfig: ApiConfig, ownerId: string, addonId: string }} settings.context
+   * @param {(type: string, listener: (detail: any) => void) => void} settings.onEvent
+   * @param {function} settings.updateComponent
+   * @param {AbortSignal} settings.signal
+   */
+  // @ts-expect-error FIXME: remove once `onContextUpdate` is typed with generics
   onContextUpdate({ component, context, updateComponent, signal }) {
     const { apiConfig, addonId } = context;
 
@@ -31,6 +47,13 @@ defineSmartComponent({
   },
 });
 
+/**
+ * @param {object} params
+ * @param {ApiConfig} params.apiConfig
+ * @param {AbortSignal} params.signal
+ * @param {string} params.addonId
+ * @returns {Promise<Omit<JenkinsInfoStateLoaded, 'type'>>}
+ */
 function fetchJenkinsAddon({ apiConfig, signal, addonId }) {
   return Promise.all([
     getAddon({ providerId: 'jenkins', addonId }).then(sendToApi({ apiConfig, signal })),

--- a/src/components/cc-orga-member-list/cc-orga-member-list.smart.js
+++ b/src/components/cc-orga-member-list/cc-orga-member-list.smart.js
@@ -1,9 +1,7 @@
-import {
-  addMember,
-  getAllMembers,
-  removeMemeber as removeMember,
-  updateMember,
-} from '@clevercloud/client/esm/api/v2/organisation.js';
+// prettier-ignore
+// @ts-expect-error FIXME: remove when clever-client exports types
+import { addMember,getAllMembers,removeMemeber as removeMember,updateMember,} from '@clevercloud/client/esm/api/v2/organisation.js';
+// @ts-expect-error FIXME: remove when clever-client exports types
 import { getId } from '@clevercloud/client/esm/api/v2/user.js';
 import { defineSmartComponent } from '../../lib/define-smart-component.js';
 import { notifyError, notifySuccess } from '../../lib/notifications.js';
@@ -32,7 +30,6 @@ defineSmartComponent({
     apiConfig: { type: Object },
     ownerId: { type: String },
   },
-
   /**
    * @param {Object} settings
    * @param {CcOrgaMemberList} settings.component
@@ -41,6 +38,7 @@ defineSmartComponent({
    * @param {function} settings.updateComponent
    * @param {AbortSignal} settings.signal
    */
+  // @ts-expect-error FIXME: remove once `onContextUpdate` is typed with generics
   onContextUpdate({ component, context, onEvent, updateComponent, signal }) {
     const { apiConfig, ownerId } = context;
 
@@ -325,7 +323,7 @@ function getMemberList({ apiConfig, ownerId, signal }) {
  * @param {string} args.ownerId
  * @param {string} args.email
  * @param {OrgaMemberRole} args.role
- * @return {Promise<any>}
+ * @return {Promise<void>}
  */
 function postNewMember({ apiConfig, ownerId, email, role }) {
   return addMember({ id: ownerId }, { email, role, job: null }).then(sendToApi({ apiConfig }));
@@ -336,7 +334,7 @@ function postNewMember({ apiConfig, ownerId, email, role }) {
  * @param {ApiConfig} args.apiConfig
  * @param {string} args.ownerId
  * @param {string} args.id
- * @return {Promise<any>}
+ * @return {Promise<void>}
  */
 function deleteMember({ apiConfig, ownerId, id }) {
   return removeMember({ id: ownerId, userId: id }).then(sendToApi({ apiConfig }));
@@ -348,7 +346,7 @@ function deleteMember({ apiConfig, ownerId, id }) {
  * @param {string} args.ownerId
  * @param {string} args.id
  * @param {OrgaMemberRole} args.newRole
- * @return {Promise<any>}
+ * @return {Promise<void>}
  */
 function editMember({ apiConfig, ownerId, id, newRole }) {
   return updateMember({ id: ownerId, userId: id }, { role: newRole }).then(sendToApi({ apiConfig }));

--- a/src/components/cc-pricing-header/cc-pricing-header.smart.js
+++ b/src/components/cc-pricing-header/cc-pricing-header.smart.js
@@ -1,4 +1,6 @@
+// @ts-expect-error FIXME: remove when clever-client exports types
 import { getAllZones } from '@clevercloud/client/esm/api/v4/product.js';
+// @ts-expect-error FIXME: remove when clever-client exports types
 import { ONE_DAY } from '@clevercloud/client/esm/with-cache.js';
 import { defineSmartComponent } from '../../lib/define-smart-component.js';
 import { sendToApi } from '../../lib/send-to-api.js';
@@ -6,7 +8,9 @@ import '../cc-smart-container/cc-smart-container.js';
 import './cc-pricing-header.js';
 
 /**
+ * @typedef {import('./cc-pricing-header.js').CcPricingHeader} CcPricingHeader
  * @typedef {import('./cc-pricing-header.types.js').PricingHeaderStateLoaded} PricingHeaderStateLoaded
+ * @typedef {import('../../lib/send-to-api.types.js').ApiConfig} ApiConfig
  * @typedef {import('../common.types.js').Zone} Zone
  */
 
@@ -15,6 +19,15 @@ defineSmartComponent({
   params: {
     zoneId: { type: String },
   },
+  /**
+   * @param {Object} settings
+   * @param {CcPricingHeader} settings.component
+   * @param {{apiConfig: ApiConfig, zoneId: string }} settings.context
+   * @param {(type: string, listener: (detail: any) => void) => void} settings.onEvent
+   * @param {function} settings.updateComponent
+   * @param {AbortSignal} settings.signal
+   */
+  // @ts-expect-error FIXME: remove once `onContextUpdate` is type with generics
   onContextUpdate({ container, component, context, onEvent, updateComponent, signal }) {
     const { zoneId } = context;
 
@@ -43,7 +56,7 @@ defineSmartComponent({
      * The only thing we want to do when zoneId changes is to make sure
      * we update `cc-pricing-header` accordingly.
      */
-    if (component.zones.state === 'loading') {
+    if (component.state.type === 'loading') {
       fetchAllZones({ signal })
         .then((zones) => {
           updateComponent('state', { type: 'loaded', zones });

--- a/src/components/cc-pricing-product-consumption/cc-pricing-product-consumption.smart.js
+++ b/src/components/cc-pricing-product-consumption/cc-pricing-product-consumption.smart.js
@@ -4,12 +4,26 @@ import { formatAddonCellar, formatAddonFsbucket, formatAddonHeptapod, formatAddo
 import '../cc-smart-container/cc-smart-container.js';
 import './cc-pricing-product-consumption.js';
 
+/**
+ * @typedef {import('./cc-pricing-product-consumption.js').CcPricingProductConsumption} CcPricingProductConsumption
+ * @typedef {import('../../lib/send-to-api.types.js').ApiConfig} ApiConfig
+ */
+
 defineSmartComponent({
   selector: 'cc-pricing-product-consumption',
   params: {
     productId: { type: String },
     zoneId: { type: String },
   },
+  /**
+   * @param {Object} settings
+   * @param {CcPricingProductConsumption} settings.component
+   * @param {{ apiConfig: ApiConfig, productId: string, zoneId: string }} settings.context
+   * @param {(type: string, listener: (detail: any) => void) => void} settings.onEvent
+   * @param {function} settings.updateComponent
+   * @param {AbortSignal} settings.signal
+   */
+  // @ts-expect-error FIXME: remove once `onContextUpdate` is typed with generics
   onContextUpdate({ updateComponent, context, signal }) {
     const { productId, zoneId } = context;
 
@@ -31,6 +45,12 @@ defineSmartComponent({
   },
 });
 
+/**
+ * @param {object} params
+ * @param {string} params.productId
+ * @param {string} params.zoneId
+ * @param {AbortSignal} params.signal
+ */
 function fetchProduct({ productId, zoneId, signal }) {
   return fetchPriceSystem({ zoneId, signal }).then((priceSystem) => {
     if (productId === 'cellar') {

--- a/src/components/cc-smart-container/cc-smart-container.js
+++ b/src/components/cc-smart-container/cc-smart-container.js
@@ -1,11 +1,26 @@
 import { css, html, LitElement } from 'lit';
 import { defineSmartComponentCore, observeContainer, updateContext } from '../../lib/smart-manager.js';
 
+/**
+ * @typedef {import('../../lib/smart-component.types.js').SmartContainer} SmartContainer
+ * @typedef {import('../../lib/smart-component.types.js').SmartContext} SmartContext
+ * @typedef {import('../../lib/smart-component.types.js').SmartComponent} SmartComponent
+ * @typedef {import('lit').PropertyValues<CcSmartContainer>} CcSmartContainerPropertyValues
+ */
+
 // Special case to propagate/merge contexts trough containers
 defineSmartComponentCore({
   selector: 'cc-smart-container',
-  onContextUpdate(container, component, context) {
-    component.parentContext = context;
+  /**
+   * @param {SmartContainer} _
+   * @param {CcSmartContainer} component
+   * @param {SmartContext} context
+   */
+  // @ts-expect-error FIXME: remove once `onContextUpdate` is typed with generics
+  onContextUpdate(_, component, context) {
+    if (component instanceof CcSmartContainer) {
+      component.parentContext = context;
+    }
   },
 });
 
@@ -35,7 +50,10 @@ export class CcSmartContainer extends LitElement {
     delete this._abortController;
   }
 
-  willUpdate(changedProperties) {
+  /**
+   * @param {CcSmartContainerPropertyValues} _changedProperties
+   */
+  willUpdate(_changedProperties) {
     updateContext(this, { ...this.parentContext, ...this.context });
   }
 

--- a/src/components/cc-ssh-key-list/cc-ssh-key-list.smart.js
+++ b/src/components/cc-ssh-key-list/cc-ssh-key-list.smart.js
@@ -1,10 +1,11 @@
+// @ts-expect-error FIXME: remove when clever-client exports types
 import { getKeys } from '@clevercloud/client/esm/api/v2/github.js';
+// @ts-expect-error FIXME: remove when clever-client exports types
 import { get as getUser } from '@clevercloud/client/esm/api/v2/organisation.js';
-import {
-  todo_addSshKey as addSshKey,
-  todo_getSshKeys as getSshKeys,
-  todo_removeSshKey as removeSshKey,
-} from '@clevercloud/client/esm/api/v2/user.js';
+// prettier-ignore
+// @ts-expect-error FIXME: remove when clever-client exports types
+import { todo_addSshKey as addSshKey,todo_getSshKeys as getSshKeys,todo_removeSshKey as removeSshKey } from '@clevercloud/client/esm/api/v2/user.js';
+// @ts-expect-error FIXME: remove when clever-client exports types
 import { ONE_DAY } from '@clevercloud/client/esm/with-cache.js';
 import { defineSmartComponent } from '../../lib/define-smart-component.js';
 import { notifyError, notifySuccess } from '../../lib/notifications.js';
@@ -27,7 +28,6 @@ defineSmartComponent({
   params: {
     apiConfig: { type: Object },
   },
-
   /**
    *
    * @param {Object} settings
@@ -37,6 +37,7 @@ defineSmartComponent({
    * @param {function} settings.updateComponent
    * @param {AbortSignal} settings.signal
    */
+  // @ts-expect-error FIXME: remove once `onContextUpdate` is type with generics
   onContextUpdate({ component, context, onEvent, updateComponent, signal }) {
     const { apiConfig } = context;
 

--- a/src/components/cc-tcp-redirection-form/cc-tcp-redirection-form.smart.js
+++ b/src/components/cc-tcp-redirection-form/cc-tcp-redirection-form.smart.js
@@ -1,4 +1,6 @@
+// @ts-expect-error FIXME: remove when clever-client exports types
 import { addTcpRedir, getTcpRedirs, removeTcpRedir } from '@clevercloud/client/esm/api/v2/application.js';
+// @ts-expect-error FIXME: remove when clever-client exports types
 import { getNamespaces } from '@clevercloud/client/esm/api/v2/organisation.js';
 import { defineSmartComponent } from '../../lib/define-smart-component.js';
 import { notifyError, notifySuccess } from '../../lib/notifications.js';
@@ -29,6 +31,15 @@ defineSmartComponent({
     ownerId: { type: String },
     appId: { type: String },
   },
+  /**
+   * @param {Object} settings
+   * @param {CcTcpRedirectionForm} settings.component
+   * @param {{ apiConfig: ApiConfig, ownerId: string, appId: string }} settings.context
+   * @param {(type: string, listener: (detail: any) => void) => void} settings.onEvent
+   * @param {function} settings.updateComponent
+   * @param {AbortSignal} settings.signal
+   */
+  // @ts-expect-error FIXME: remove once `onContextUpdate` is typed with generics
   onContextUpdate({ container, component, context, onEvent, updateComponent, signal }) {
     const { apiConfig, ownerId, appId } = context;
 

--- a/src/components/cc-tile-metrics/cc-tile-metrics.smart.js
+++ b/src/components/cc-tile-metrics/cc-tile-metrics.smart.js
@@ -5,9 +5,11 @@ import '../cc-smart-container/cc-smart-container.js';
 import './cc-tile-metrics.js';
 
 /**
+ * @typedef {import('./cc-tile-metrics.js').CcTileMetrics} CcTileMetrics
  * @typedef {import('./cc-tile-metrics.types.js').RawMetric} RawMetric
  * @typedef {import('./cc-tile-metrics.types.js').MetricsData} MetricsData
  * @typedef {import('./cc-tile-metrics.types.js').Metric} Metric
+ * @typedef {import('../../lib/send-to-api.types.js').ApiConfig} ApiConfig
  */
 
 const NUMBER_OF_POINTS = 24;
@@ -21,6 +23,16 @@ defineSmartComponent({
     consoleGrafanaLink: { type: String },
     grafanaBaseLink: { type: String },
   },
+  /**
+   *
+   * @param {Object} settings
+   * @param {CcTileMetrics} settings.component
+   * @param {{apiConfig: ApiConfig, ownerId: string, appId: string, grafanaBaseLink: string, consoleGrafanaLink: string }} settings.context
+   * @param {(type: string, listener: (detail: any) => void) => void} settings.onEvent
+   * @param {function} settings.updateComponent
+   * @param {AbortSignal} settings.signal
+   */
+  // @ts-expect-error FIXME: remove once `onContextUpdate` is typed with generics
   onContextUpdate({ component, context, onEvent, updateComponent, signal }) {
     const { apiConfig, ownerId, appId, grafanaBaseLink, consoleGrafanaLink } = context;
 
@@ -62,7 +74,7 @@ defineSmartComponent({
  * @returns {Promise<MetricsData>}
  */
 function fetchMetrics({ apiConfig, ownerId, appId, signal }) {
-  return getAppMetrics({ id: ownerId, appId, interval: 'P1D', span: 'PT1H' })
+  return getAppMetrics({ id: ownerId, appId })
     .then(sendToApi({ apiConfig, signal }))
     .then((metrics) => {
       const cpuMetrics = extractMetric(metrics, 'cpu');

--- a/src/components/cc-tile-status-codes/cc-tile-status-codes.smart.js
+++ b/src/components/cc-tile-status-codes/cc-tile-status-codes.smart.js
@@ -1,6 +1,10 @@
+// @ts-expect-error FIXME: remove when clever-client exports types
 import { getStatusCodesFromWarp10 } from '@clevercloud/client/esm/access-logs.js';
+// @ts-expect-error FIXME: remove when clever-client exports types
 import { getWarp10AccessLogsToken } from '@clevercloud/client/esm/api/v2/warp-10.js';
+// @ts-expect-error FIXME: remove when clever-client exports types
 import { THIRTY_SECONDS } from '@clevercloud/client/esm/request.fetch-with-timeout.js';
+// @ts-expect-error FIXME: remove when clever-client exports types
 import { ONE_DAY } from '@clevercloud/client/esm/with-cache.js';
 import { defineSmartComponent } from '../../lib/define-smart-component.js';
 import { sendToApi, sendToWarp } from '../../lib/send-to-api.js';
@@ -8,6 +12,7 @@ import '../cc-smart-container/cc-smart-container.js';
 import './cc-tile-status-codes.js';
 
 /**
+ * @typedef {import('./cc-tile-status-codes.js').CcTileStatusCodes} CcTileStatusCodes
  * @typedef {import('../../lib/send-to-api.types.js').ApiConfig} ApiConfig
  * @typedef {import('../../lib/send-to-api.types.js').Warp10ApiConfig} Warp10ApiConfig
  * @typedef {import('./cc-tile-status-codes.types.js').StatusCodesData} StatusCodesData
@@ -20,6 +25,15 @@ defineSmartComponent({
     ownerId: { type: String },
     appId: { type: String, optional: true },
   },
+  /**
+   * @param {Object} settings
+   * @param {CcTileStatusCodes} settings.component
+   * @param {{ apiConfig: ApiConfig & Warp10ApiConfig, ownerId: string, appId: string }} settings.context
+   * @param {(type: string, listener: (detail: any) => void) => void} settings.onEvent
+   * @param {function} settings.updateComponent
+   * @param {AbortSignal} settings.signal
+   */
+  // @ts-expect-error FIXME: remove once `onContextUpdate` is typed with generics
   onContextUpdate({ context, updateComponent, signal }) {
     const { apiConfig, ownerId, appId } = context;
 

--- a/tasks/typechecking-stats.js
+++ b/tasks/typechecking-stats.js
@@ -34,7 +34,8 @@ const categories = {
   'Components (smart)': ['src/components/**/*.smart.js'],
   'Components (test)': ['src/components/**/*.test.js'],
   'Components (stories)': ['src/components/**/cc-*.stories.js'],
-  Controllers: ['src/controllers/**/*.js'],
+  Controllers: ['src/controllers/**/*.js', '!src/controllers/**/*.stories.js'],
+  'Controllers (stories)': ['src/controllers/**/*.stories.js'],
   Libs: ['src/lib/**/*.js'],
   Tasks: ['tasks/**/*.js'],
 };

--- a/tsconfig.ci.json
+++ b/tsconfig.ci.json
@@ -17,12 +17,10 @@
     "src/controllers/*.stories.js",
     "src/components/**/*.test.js",
     "src/components/**/*.stories.js",
-    "src/components/**/*.smart*.js",
     "src/components/cc-grafana-info",
     "src/components/cc-logs/*",
     "src/components/cc-logs-*/*",
-    "src/components/cc-pricing-*",
-    "src/components/cc-smart-container/*"
+    "src/components/cc-pricing-*"
   ],
   "extends": "./tsconfig.json",
   "compilerOptions": {


### PR DESCRIPTION
## What does this PR do?

- Fixes typechecking issues within most of smart components,
- Adds all smart components that pass typechecking to the CI typechecking.

## How to review?

- Check every commit starting from `refactor(cc-smart-container): typecheck`,
- That's it, CI takes care of the rest :wink: 

## TODO

- [x] Merge #1136 and rebase this one after that