### PR TITLE
feat(cc-invoice): add `currency` as part of the `state`

### DIFF
--- a/src/components/cc-invoice-list/cc-invoice-list.stories.js
+++ b/src/components/cc-invoice-list/cc-invoice-list.stories.js
@@ -105,6 +105,26 @@ export const dataLoadedWithNoProcessed = makeStory(conf, {
   ],
 });
 
+export const dataLoadedWithDollars = makeStory(conf, {
+  items: [
+    {
+      /** @type {InvoiceListStateLoaded} */
+      state: {
+        type: 'loaded',
+        invoices: [
+          ...pendingInvoices('2020').map((invoice) => ({
+            ...invoice,
+            total: {
+              ...invoice.total,
+              currency: 'USD',
+            },
+          })),
+        ],
+      },
+    },
+  ],
+});
+
 export const simulations = makeStory(conf, {
   items: [{}, {}],
   simulations: [

--- a/src/components/cc-invoice-table/cc-invoice-table.js
+++ b/src/components/cc-invoice-table/cc-invoice-table.js
@@ -137,7 +137,10 @@ export class CcInvoiceTable extends LitElement {
               </td>
               <td class="number">
                 <code class="${classMap({ skeleton, 'credit-note': invoice.type === 'CREDITNOTE' })}">
-                  ${i18n('cc-invoice-table.total.value', { amount: invoice.total.amount })}
+                  ${i18n('cc-invoice-table.total.value', {
+                    amount: invoice.total.amount,
+                    currency: invoice.total.currency,
+                  })}
                 </code>
               </td>
               <td>${this._renderLinks(skeleton, invoice)}</td>
@@ -166,6 +169,7 @@ export class CcInvoiceTable extends LitElement {
                   number: invoice.number,
                   date: invoice.emissionDate,
                   amount: invoice.total.amount,
+                  currency: invoice.total.currency,
                 })}
                 <br />
                 ${this._renderLinks(skeleton, invoice)}

--- a/src/components/cc-invoice-table/cc-invoice-table.stories.js
+++ b/src/components/cc-invoice-table/cc-invoice-table.stories.js
@@ -71,3 +71,20 @@ export const dataLoadedWithCreditNotes = makeStory(conf, {
     },
   ],
 });
+
+export const dataLoadedWithDollars = makeStory(conf, {
+  /** @type {{ state: InvoiceTableStateLoaded }[] } */
+  items: [
+    {
+      state: {
+        type: 'loaded',
+        invoices: [
+          ...processedInvoices('2019').map((invoice) => ({
+            ...invoice,
+            total: { ...invoice.total, currency: 'USD' },
+          })),
+        ],
+      },
+    },
+  ],
+});

--- a/src/components/cc-invoice/cc-invoice.js
+++ b/src/components/cc-invoice/cc-invoice.js
@@ -63,7 +63,11 @@ export class CcInvoice extends LitElement {
               <div slot="button">${ccLink(invoice.downloadUrl, i18n('cc-invoice.download-pdf'), skeleton)}</div>
               <div class="info">
                 <em class=${classMap({ skeleton })}>
-                  ${i18n('cc-invoice.info', { date: invoice.emissionDate, amount: invoice.amount })}
+                  ${i18n('cc-invoice.info', {
+                    date: invoice.emissionDate,
+                    amount: invoice.amount,
+                    currency: invoice.currency,
+                  })}
                 </em>
               </div>
               <cc-html-frame class="frame" ?loading="${skeleton}" iframe-title="${title}">

--- a/src/components/cc-invoice/cc-invoice.smart.js
+++ b/src/components/cc-invoice/cc-invoice.smart.js
@@ -38,6 +38,7 @@ defineSmartComponent({
           downloadUrl: invoice.downloadUrl,
           emissionDate: invoice.emissionDate,
           amount: invoice.total.amount,
+          currency: invoice.total.currency,
           invoiceHtml: invoice.invoiceHtml,
         });
       })

--- a/src/components/cc-invoice/cc-invoice.stories.js
+++ b/src/components/cc-invoice/cc-invoice.stories.js
@@ -25,6 +25,7 @@ const defaultNumber = '20210501-1234';
 const defaultInvoiceState = {
   type: 'loaded',
   number: defaultNumber,
+  currency: 'EUR',
   downloadUrl: '/download/20210501-1234',
   emissionDate: '2021-05-01',
   amount: 327.48,
@@ -46,6 +47,7 @@ const defaultInvoiceState = {
 };
 
 export const defaultStory = makeStory(conf, {
+  /** @type {Array<Partial<CcInvoice>>} */
   items: [{ state: defaultInvoiceState }],
 });
 
@@ -77,7 +79,13 @@ export const error = makeStory(conf, {
 });
 
 export const dataLoaded = makeStory(conf, {
+  /** @type {Array<Partial<CcInvoice>>} */
   items: [{ state: defaultInvoiceState }],
+});
+
+export const dataLoadedWithDollar = makeStory(conf, {
+  /** @type {Array<Partial<CcInvoice>>} */
+  items: [{ state: { ...defaultInvoiceState, currency: 'USD' } }],
 });
 
 export const simulations = makeStory(conf, {

--- a/src/components/cc-invoice/cc-invoice.types.d.ts
+++ b/src/components/cc-invoice/cc-invoice.types.d.ts
@@ -16,5 +16,6 @@ interface InvoiceStateLoaded {
   downloadUrl: string;
   emissionDate: string;
   amount: number;
+  currency: string; // ISO 4217 currency code
   invoiceHtml: string;
 }

--- a/src/components/common.types.d.ts
+++ b/src/components/common.types.d.ts
@@ -75,7 +75,7 @@ export interface IconModel {
 
 interface InvoiceAmount {
   amount: number;
-  currency: 'EUR' | 'USD';
+  currency: string; // ISO 4217 currency code
 }
 
 export interface Invoice {

--- a/src/lib/i18n/i18n-number.js
+++ b/src/lib/i18n/i18n-number.js
@@ -29,26 +29,23 @@ export function formatNumber(lang, value, options = {}) {
  * @param {number} value - The number to format
  * @param {Object} [options]
  * @param {string} [options.currency] - Currency code (defaults to EUR)
+ * @param {'code'|'symbol'|'narrowSymbol'|'name'} [options.currencyDisplay] - currency formatting display (defaults to "narrowSymbol")
  * @param {number} [options.minimumFractionDigits] - minimum fraction digits (defaults to 2)
  * @param {number} [options.maximumFractionDigits] - maximum fraction digits (defaults to 2)
  * @returns {string}
  */
 export function formatCurrency(lang, value, options = {}) {
   const { currency = 'EUR' } = options;
-  const { minimumFractionDigits = 2, maximumFractionDigits = 2 } = options;
+  const { currencyDisplay = 'narrowSymbol', minimumFractionDigits = 2, maximumFractionDigits = 2 } = options;
   const nf = new Intl.NumberFormat(lang, {
     style: 'currency',
     currency,
+    currencyDisplay,
     minimumFractionDigits,
     maximumFractionDigits,
   });
 
-  return (
-    nf
-      .format(value)
-      // Safari does not support currencySymbol: 'narrow' in Intl.NumberFormat so we need to do this #sorry
-      .replace('$US', '$')
-  );
+  return nf.format(value);
 }
 
 /**

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -122,16 +122,13 @@ export function asyncMap(array, asyncCallback) {
  * Returns the currency symbol corresponding to the given currency.
  *
  * @param {string} currency - the currency to get the symbol for
+ * @param {string} [currencyDisplay] - the currency formatting dysplay (defaults to "narrowSymbol")
  */
-export function getCurrencySymbol(currency) {
+export function getCurrencySymbol(currency, currencyDisplay = 'narrowSymbol') {
   // The lang does not really matter
-  const nf = new Intl.NumberFormat('en', { style: 'currency', currency });
+  const nf = new Intl.NumberFormat('en', { style: 'currency', currency, currencyDisplay });
 
-  // Safari does not support currencySymbol: 'narrow' in Intl.NumberFormat so we need to do this `.replace()` #sorry
-  return nf
-    .formatToParts(0)
-    .find((p) => p.type === 'currency')
-    .value.replace('$US', '$');
+  return nf.formatToParts(0).find((p) => p.type === 'currency');
 }
 
 /**

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -613,8 +613,12 @@ export const translations = {
   //#region cc-invoice
   'cc-invoice.download-pdf': `Download PDF`,
   'cc-invoice.error': `Something went wrong while loading the invoice.`,
-  'cc-invoice.info': /** @param {{date: string, amount: number}} _ */ ({ date, amount }) => {
-    return sanitize`This invoice was issued on <strong>${formatDateOnly(date)}</strong> for a total amount of <strong>${formatCurrency(lang, amount)}</strong>.`;
+  'cc-invoice.info': /** @param {{date: string, amount: number, currency: string}} _ */ ({
+    date,
+    amount,
+    currency,
+  }) => {
+    return sanitize`This invoice was issued on <strong>${formatDateOnly(date)}</strong> for a total amount of <strong>${formatCurrency(lang, amount, { currency })}</strong>.`;
   },
   'cc-invoice.title': `Invoice`,
   //#endregion

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -638,15 +638,17 @@ export const translations = {
   'cc-invoice-table.number': `Number`,
   'cc-invoice-table.open-pdf': `Download PDF`,
   'cc-invoice-table.pay': `Pay`,
-  'cc-invoice-table.text': /** @param {{number: string, date: string|number, amount: number}} _ */ ({
+  'cc-invoice-table.text': /** @param {{number: string, date: string|number, amount: number, currency: string}} _ */ ({
     number,
     date,
     amount,
+    currency,
   }) => {
-    return sanitize`Invoice <strong>${number}</strong> issued on <strong>${formatDateOnly(date)}</strong> for a total amount of <code>${formatCurrency(lang, amount)}</code>`;
+    return sanitize`Invoice <strong>${number}</strong> issued on <strong>${formatDateOnly(date)}</strong> for a total amount of <code>${formatCurrency(lang, amount, { currency })}</code>`;
   },
   'cc-invoice-table.total.label': `Total`,
-  'cc-invoice-table.total.value': /** @param {{amount: number}} _ */ ({ amount }) => `${formatCurrency(lang, amount)}`,
+  'cc-invoice-table.total.value': /** @param {{amount: number, currency: string}} _ */ ({ amount, currency }) =>
+    `${formatCurrency(lang, amount, { currency })}`,
   //#endregion
   //#region cc-jenkins-info
   'cc-jenkins-info.documentation.link': `Read the documentation`,

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -650,14 +650,16 @@ export const translations = {
   'cc-invoice-table.number': `Numéro`,
   'cc-invoice-table.open-pdf': `Télécharger le PDF`,
   'cc-invoice-table.pay': `Régler`,
-  'cc-invoice-table.text': /** @param {{number: number, date: string|number, amount: number}} _ */ ({
+  'cc-invoice-table.text': /** @param {{number: number, date: string|number, amount: number, currency: string}} _ */ ({
     number,
     date,
     amount,
+    currency,
   }) =>
-    sanitize`Facture <strong>${number}</strong> émise le <strong>${formatDateOnly(date)}</strong> pour un total de <code>${formatCurrency(lang, amount)}</code>`,
+    sanitize`Facture <strong>${number}</strong> émise le <strong>${formatDateOnly(date)}</strong> pour un total de <code>${formatCurrency(lang, amount, { currency })}</code>`,
   'cc-invoice-table.total.label': `Total`,
-  'cc-invoice-table.total.value': /** @param {{amount: number}} _ */ ({ amount }) => `${formatCurrency(lang, amount)}`,
+  'cc-invoice-table.total.value': /** @param {{amount: number, currency: string}} _ */ ({ amount, currency }) =>
+    `${formatCurrency(lang, amount, { currency })}`,
   //#endregion
   //#region cc-jenkins-info
   'cc-jenkins-info.documentation.link': `Consulter la documentation`,

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -625,8 +625,12 @@ export const translations = {
   //#region cc-invoice
   'cc-invoice.download-pdf': `Télécharger le PDF`,
   'cc-invoice.error': `Une erreur est survenue pendant le chargement de la facture.`,
-  'cc-invoice.info': /** @param {{date: string|number, amount: number}} _ */ ({ date, amount }) => {
-    return sanitize`Cette facture a été émise le <strong>${formatDateOnly(date)}</strong> pour un total de <strong>${formatCurrency(lang, amount)}</strong>.`;
+  'cc-invoice.info': /** @param {{date: string|number, amount: number, currency: string }} _ */ ({
+    date,
+    amount,
+    currency,
+  }) => {
+    return sanitize`Cette facture a été émise le <strong>${formatDateOnly(date)}</strong> pour un total de <strong>${formatCurrency(lang, amount, { currency })}</strong>.`;
   },
   'cc-invoice.title': `Facture`,
   //#endregion


### PR DESCRIPTION
Fixes #1169

## What does this PR do?

- Adds a `currency` property to the loaded state of `cc-invoice`,
- Within the `cc-invoice` smart component, pass down `currency` from the API response to the UI component,
- Within the `cc-invoice-table` component, pass the `currency` property to translation functions,
- Adds stories to showcase that these components handle multiple currencies.

## How to review?

- Check the new stories (dollar currency for `cc-invoice-list`, `cc-invoice-table`, `cc-invoice`),
- Check the `demo-smart` > `cc-invoice`. You can mock an API call return USD instead of 'EUR' if you want (not mandatory since I've done it already),
- Check the code,
- 2 reviewers should be enough for this one but I need our Pricing expert (aka @Galimede) review :sunglasses: 