### PR TITLE
fix(cc-block): fix css and description text

### DIFF
--- a/src/components/cc-block/cc-block.js
+++ b/src/components/cc-block/cc-block.js
@@ -164,7 +164,6 @@ export class CcBlock extends LitElement {
           border-radius: var(--cc-border-radius-default, 0.25em);
           box-sizing: border-box;
           display: block;
-          margin-bottom: 1em;
           overflow: hidden;
           position: relative;
         }

--- a/src/components/cc-domain-management/cc-domain-management.js
+++ b/src/components/cc-domain-management/cc-domain-management.js
@@ -644,7 +644,7 @@ export class CcDomainManagement extends LitElement {
         .wrapper {
           display: flex;
           flex-direction: column;
-          gap: 0.5em;
+          gap: 1.5em;
         }
 
         code {

--- a/src/components/cc-invoice/cc-invoice.js
+++ b/src/components/cc-invoice/cc-invoice.js
@@ -118,7 +118,6 @@ export class CcInvoice extends LitElement {
           height: 31cm;
           margin-inline: auto;
           max-width: 22cm;
-          padding-inline: 1em;
           width: 100%;
         }
       `,

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -439,7 +439,7 @@ export const translations = {
   'cc-env-var-form.description.config-provider': /** @param {{addonName: string}} _ */ ({ addonName }) =>
     sanitize`Configuration exposed to dependent applications. <a href="https://www.clever-cloud.com/doc/deploy/addon/config-provider/">Learn more</a><br>These variables will be injected as environment variables in applications that have the add-on <strong>${addonName}</strong> in their service dependencies.<br>Every time you update your changes, all the dependent applications will be automatically restarted.`,
   'cc-env-var-form.description.env-var': /** @param {{appName: string}} _ */ ({ appName }) =>
-    sanitize`These variables will be injected as environment variables in the application <strong>${appName}</strong>. <a href="https://developers.clever-cloud.com/doc/reference/reference-environment-variables/">Learn more</a>`,
+    sanitize`These variables will be injected as environment variables in the application <strong>${appName}</strong>.`,
   'cc-env-var-form.description.exposed-config': /** @param {{appName: string}} _ */ ({ appName }) =>
     sanitize`Configuration exposed to dependent applications. <a href="https://www.clever-cloud.com/doc/admin-console/service-dependencies/">Learn more</a><br>These variables won't be injected in the application <strong>${appName}</strong>, they will be injected as environment variables in applications that have <strong>${appName}</strong> in their service dependencies.`,
   'cc-env-var-form.documentation.text': `Environment variables - Reference`,

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -448,10 +448,10 @@ export const translations = {
   'cc-env-var-form.description.config-provider': /** @param {{addonName: string}} _ */ ({ addonName }) =>
     sanitize`Configuration publiée pour les applications dépendantes. <a href="https://www.clever-cloud.com/doc/deploy/addon/config-provider/">En savoir plus</a><br>Ces seront injectées en tant que variables d'environnement dans les applications qui ont l'add-on <strong>${addonName}</strong> dans leurs services liés.<br>À chaque fois que vous mettez à jour les changements, toutes les applications dépendantes seront redémarrées automatiquement.`,
   'cc-env-var-form.description.env-var': /** @param {{appName: string}} _ */ ({ appName }) =>
-    sanitize`Ces variables seront injectées en tant que variables d'environnement dans l'application <strong>${appName}</strong>. <a href="https://developers.clever-cloud.com/doc/reference/reference-environment-variables/">En savoir plus</a>`,
+    sanitize`Ces variables seront injectées en tant que variables d'environnement dans l'application <strong>${appName}</strong>.`,
   'cc-env-var-form.description.exposed-config': /** @param {{appName: string}} _ */ ({ appName }) =>
     sanitize`Configuration publiée pour les applications dépendantes. <a href="https://www.clever-cloud.com/doc/admin-console/service-dependencies/">En savoir plus</a><br>Ces variables ne seront pas injectées dans l'application <strong>${appName}</strong>, elles seront injectées en tant que variables d'environnement dans les applications qui ont <strong>${appName}</strong> dans leurs services liés.`,
-  'cc-env-var-form.documentation.text': `Variable d’environnement - Référence`,
+  'cc-env-var-form.documentation.text': `Variables d’environnement - Référence`,
   'cc-env-var-form.error.loading': `Une erreur est survenue pendant le chargement des variables.`,
   'cc-env-var-form.heading.config-provider': `Variables`,
   'cc-env-var-form.heading.env-var': `Variables d'environnement`,


### PR DESCRIPTION
## What does this PR do?

- `cc-env-var-form` : adds plural to "variable" in description text and removes unnecessary "En savoir plus / Learn more" in description text,
- `cc-block` : removes margin bottom,
- `cc-domain-management` : reverts to initial gap,
- `cc-invoice`: remove unnecessary padding.

## How to review?

- Check the commit,
- Check the components in [preview](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-block/fix-component/index.html)