### PR TITLE
fix(cc-domain-management): allow newly added domain to be marked as primary

### DIFF
--- a/src/components/cc-domain-management/cc-domain-management.smart.js
+++ b/src/components/cc-domain-management/cc-domain-management.smart.js
@@ -107,9 +107,8 @@ defineSmartComponent({
               'domainListState',
               /** @param {DomainManagementListStateLoaded} domainListState */
               (domainListState) => {
-                const hasPathPrefix = pathPrefix != null && pathPrefix !== '/';
                 // TODO: once the API returns actual ids, this should be adapted (either refetch or use the API response)
-                const id = hasPathPrefix ? hostname + pathPrefix : hostname;
+                const id = hostname + pathPrefix;
 
                 /** @type {DomainStateIdle} */
                 const newDomain = {


### PR DESCRIPTION
Fixes #1213

## What does this PR do?

- Fixes an issue when trying to set a domain that you have just associated to an app as primary.

## How to review?

- Check the commit,
- Go to `localhost:6006/demo-smart/`, `cc-domain-management`, `app-node`:

1. add a new domain (with no path prefix),
2. mark it as primary,
3. you should get no error,
4. try to mark others as primary, delete some domains, nothing should throw any error.