### PR TITLE
fix(cc-header-addon): revert `messages` class

### DIFF
--- a/src/components/cc-block/cc-block.js
+++ b/src/components/cc-block/cc-block.js
@@ -346,6 +346,7 @@ export class CcBlock extends LitElement {
         /* region footer */
 
         .footer {
+          align-items: center;
           background-color: var(--cc-color-bg-neutral);
           box-shadow: inset 0 6px 6px -6px rgb(0 0 0 / 40%);
           display: none;

--- a/src/components/cc-header-addon/cc-header-addon.js
+++ b/src/components/cc-header-addon/cc-header-addon.js
@@ -119,7 +119,9 @@ export class CcHeaderAddon extends LitElement {
           </div>
         </div>
 
-        <cc-zone slot="footer-right" .state=${zoneState} mode="small-infra"></cc-zone>
+        <div slot="footer-right" class="messages">
+          <cc-zone .state=${zoneState} mode="small-infra"></cc-zone>
+        </div>
       </cc-block>
     `;
   }
@@ -180,6 +182,11 @@ export class CcHeaderAddon extends LitElement {
 
         .description-label {
           font-weight: bold;
+        }
+
+        .messages {
+          font-size: 0.9em;
+          padding-block: 0.2em;
         }
 
         cc-zone {

--- a/src/components/cc-header-app/cc-header-app.js
+++ b/src/components/cc-header-app/cc-header-app.js
@@ -502,7 +502,6 @@ export class CcHeaderApp extends LitElement {
         }
 
         .messages {
-          align-items: center;
           display: flex;
           flex-wrap: wrap;
           font-size: 0.9em;


### PR DESCRIPTION
As noticed by @Galimede, the logos in the `cc-header-addon` footer were bigger than before since the component were adapted with the new `cc-block`. During the refactoring, I have removed the `messages` class the was applying a font-size, this PR revert it with the necessery properties to match the old footer design.