### PR TITLE
feat(cc-zone-picker): add disabled and readonly modes

### DIFF
--- a/src/components/cc-zone-picker/cc-zone-picker.stories.js
+++ b/src/components/cc-zone-picker/cc-zone-picker.stories.js
@@ -201,6 +201,63 @@ export const defaultStory = makeStory(conf, {
   ],
 });
 
+export const partiallyDisabled = makeStory(conf, {
+  /** @type {Array<Partial<CcZonePicker>>} */
+  items: [
+    {
+      zonesSections: [
+        {
+          zones: PUBLIC_ZONES.map((z, i) => ({ ...z, disabled: i % 2 === 1 })),
+        },
+      ],
+      value: 'par',
+    },
+  ],
+});
+
+export const disabled = makeStory(conf, {
+  /** @type {Array<Partial<CcZonePicker>>} */
+  items: [
+    {
+      disabled: true,
+      zonesSections: [
+        {
+          zones: PUBLIC_ZONES,
+        },
+      ],
+      value: 'par',
+    },
+  ],
+});
+
+export const readonly = makeStory(conf, {
+  /** @type {Array<Partial<CcZonePicker>>} */
+  items: [
+    {
+      readonly: true,
+      zonesSections: [
+        {
+          zones: PUBLIC_ZONES,
+        },
+      ],
+      value: 'par',
+    },
+  ],
+});
+
+export const defaultValue = makeStory(conf, {
+  /** @type {Array<Partial<CcZonePicker>>} */
+  items: [
+    {
+      zonesSections: [
+        {
+          zones: PUBLIC_ZONES,
+        },
+      ],
+    },
+  ],
+});
+
 export const publicAndPrivateZones = makeStory(conf, {
   /** @type {Array<Partial<CcZonePicker>>} */
   items: [


### PR DESCRIPTION
## What does this PR do?

* This PR introduces a `disabled` prop to disable the whole form
* This PR introduces a `readonly` prop to disable the whole form except the selected value
* This PR makes the component always select the first value if no value has been set 

## How to review?

* Check the commit
* Check the stories (disabled, partDisabled, readonly, noPreselectedValue)