### PR TITLE
refactor(cc-header-app): revert `align-items` removal

### DIFF
--- a/src/components/cc-header-addon/cc-header-addon.js
+++ b/src/components/cc-header-addon/cc-header-addon.js
@@ -190,6 +190,9 @@ export class CcHeaderAddon extends LitElement {
         }
 
         cc-zone {
+          /* FIXME: remove align-items once #1225 is merged */
+
+          align-items: center;
           font-style: normal;
           white-space: nowrap;
         }

--- a/src/components/cc-header-app/cc-header-app.js
+++ b/src/components/cc-header-app/cc-header-app.js
@@ -549,6 +549,9 @@ export class CcHeaderApp extends LitElement {
         }
 
         cc-zone {
+          /* FIXME: remove align-items once #1225 is merged */
+
+          align-items: center;
           font-style: normal;
           white-space: nowrap;
         }

--- a/src/components/cc-header-app/cc-header-app.js
+++ b/src/components/cc-header-app/cc-header-app.js
@@ -502,6 +502,7 @@ export class CcHeaderApp extends LitElement {
         }
 
         .messages {
+          align-items: center;
           display: flex;
           flex-wrap: wrap;
           font-size: 0.9em;

--- a/src/components/cc-zone/cc-zone.js
+++ b/src/components/cc-zone/cc-zone.js
@@ -188,6 +188,7 @@ export class CcZone extends LitElement {
         }
 
         .wrapper-details {
+          align-items: center;
           display: flex;
         }
 


### PR DESCRIPTION
## What does this PR do?

The #1219 PR removed `align-items: center` from `.messages` in `cc-header-app` because my feedback was not clear.

This PR reverts it and improves the `cc-zone` alignment in `cc-header-app` & `cc-header-addon`. 

The alignment issue of the `cc-zone` is very subtle and it should be handled from the `cc-zone` component directly but this would require to add a wrapper instead of flexing the host directly, and it would probably lead to a breaking change so I'll create a quick win issue that we can squeeze in the next breaking change release (pricing probably).
This is why this PR handles it from outside the `cc-zone` in the meantime.

## How to review?

- Compare prod and preview default stories for `cc-header-app` & `cc-header-addon` (footer) and check the alignment is better in preview (may need to zoom a bit).