### PR TITLE
fix(cc-toast): replace hard coded border radius with `--cc-border-radius-default`

### DIFF
--- a/src/components/cc-toast/cc-toast.js
+++ b/src/components/cc-toast/cc-toast.js
@@ -195,7 +195,7 @@ export class CcToast extends LitElement {
           align-items: stretch;
           background-color: var(--toast-color);
           border: 1px solid var(--toast-color);
-          border-radius: 0.3em;
+          border-radius: var(--cc-border-radius-default, 0.25em);
           box-shadow:
             0 2px 4px rgb(38 38 38 / 25%),
             0 5px 15px rgb(38 38 38 / 25%);


### PR DESCRIPTION
Fixes #1232

## What does this PR do?

- Replaces the hard coded `border-radius` value with the `--cc-border-radius-default`

## How to review?

- Check the preview,
- 1 reviewer is enough.