### PR TITLE
fix(cc-kv-terminal): handle huge command history

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@clevercloud/client": "^8.2.0",
         "@lit-labs/motion": "^1.0.3",
-        "@lit-labs/virtualizer": "^2.0.12",
+        "@lit-labs/virtualizer": "^2.0.14",
         "@shoelace-style/shoelace": "^2.5.0",
         "ansi-regex": "^6.0.1",
         "chart.js": "^3.5.0",
@@ -4769,51 +4769,51 @@
       "integrity": "sha512-9TC+/ZWb6BJlWCyUr14FKFlaGnyKpeEDorufXozQgke/VoVrslUQNaL7nBmrAWdNrmzx5jWgi8lFmWwrxMjnlA=="
     },
     "node_modules/@lit-labs/ssr-dom-shim": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.1.2.tgz",
-      "integrity": "sha512-jnOD+/+dSrfTWYfSXBXlo5l5f0q1UuJo3tkbMDCYA2lKUYq79jaxqtGEvnRoh049nt1vdo1+45RinipU6FGY2g=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.1.tgz",
+      "integrity": "sha512-wx4aBmgeGvFmOKucFKY+8VFJSYZxs9poN3SDNQFF6lT6NrQUnHiPB2PWz2sc4ieEcAaYYzN+1uWahEeTq2aRIQ=="
     },
     "node_modules/@lit-labs/virtualizer": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@lit-labs/virtualizer/-/virtualizer-2.0.12.tgz",
-      "integrity": "sha512-sL7AXhacSdzOJLEQFcPCrV7tu2rZQ10upeGMAxKmTT0Ae4kBFV8nwlFiUEQPBt1idUsAkiDG1yN91IgUWQXVNQ==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@lit-labs/virtualizer/-/virtualizer-2.0.14.tgz",
+      "integrity": "sha512-lXDKPKd4QmrBWDxyJyShUcnrKAggU3BhVZpg/XU/Oz7z/BZY2kp8aGDCa2+FHQYB8Rul0bEbBJx6XrzmxMoPXg==",
       "dependencies": {
-        "lit": "^3.1.0",
+        "lit": "^3.2.0",
         "tslib": "^2.0.3"
       }
     },
     "node_modules/@lit-labs/virtualizer/node_modules/@lit/reactive-element": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.2.tgz",
-      "integrity": "sha512-SVOwLAWUQg3Ji1egtOt1UiFe4zdDpnWHyc5qctSceJ5XIu0Uc76YmGpIjZgx9YJ0XtdW0Jm507sDvjOu+HnB8w==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.4.tgz",
+      "integrity": "sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==",
       "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.1.2"
+        "@lit-labs/ssr-dom-shim": "^1.2.0"
       }
     },
     "node_modules/@lit-labs/virtualizer/node_modules/lit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-3.1.0.tgz",
-      "integrity": "sha512-rzo/hmUqX8zmOdamDAeydfjsGXbbdtAFqMhmocnh2j9aDYqbu0fjXygjCa0T99Od9VQ/2itwaGrjZz/ZELVl7w==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.2.1.tgz",
+      "integrity": "sha512-1BBa1E/z0O9ye5fZprPtdqnc0BFzxIxTTOO/tQFmyC/hj1O3jL4TfmLBw0WEwjAokdLwpclkvGgDJwTIh0/22w==",
       "dependencies": {
-        "@lit/reactive-element": "^2.0.0",
-        "lit-element": "^4.0.0",
-        "lit-html": "^3.1.0"
+        "@lit/reactive-element": "^2.0.4",
+        "lit-element": "^4.1.0",
+        "lit-html": "^3.2.0"
       }
     },
     "node_modules/@lit-labs/virtualizer/node_modules/lit-element": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.0.2.tgz",
-      "integrity": "sha512-/W6WQZUa5VEXwC7H9tbtDMdSs9aWil3Ou8hU6z2cOKWbsm/tXPAcsoaHVEtrDo0zcOIE5GF6QgU55tlGL2Nihg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.1.1.tgz",
+      "integrity": "sha512-HO9Tkkh34QkTeUmEdNYhMT8hzLid7YlMlATSi1q4q17HE5d9mrrEHJ/o8O2D0cMi182zK1F3v7x0PWFjrhXFew==",
       "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.1.2",
-        "@lit/reactive-element": "^2.0.0",
-        "lit-html": "^3.1.0"
+        "@lit-labs/ssr-dom-shim": "^1.2.0",
+        "@lit/reactive-element": "^2.0.4",
+        "lit-html": "^3.2.0"
       }
     },
     "node_modules/@lit-labs/virtualizer/node_modules/lit-html": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.1.0.tgz",
-      "integrity": "sha512-FwAjq3iNsaO6SOZXEIpeROlJLUlrbyMkn4iuv4f4u1H40Jw8wkeR/OUXZUHUoiYabGk8Y4Y0F/rgq+R4MrOLmA==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.2.1.tgz",
+      "integrity": "sha512-qI/3lziaPMSKsrwlxH/xMgikhQ0EGOX2ICU73Bi/YHFvz2j/yMCIrw4+puF2IpQ4+upd3EWbvnHM9+PnJn48YA==",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
       }
@@ -25485,51 +25485,51 @@
       "integrity": "sha512-9TC+/ZWb6BJlWCyUr14FKFlaGnyKpeEDorufXozQgke/VoVrslUQNaL7nBmrAWdNrmzx5jWgi8lFmWwrxMjnlA=="
     },
     "@lit-labs/ssr-dom-shim": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.1.2.tgz",
-      "integrity": "sha512-jnOD+/+dSrfTWYfSXBXlo5l5f0q1UuJo3tkbMDCYA2lKUYq79jaxqtGEvnRoh049nt1vdo1+45RinipU6FGY2g=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.1.tgz",
+      "integrity": "sha512-wx4aBmgeGvFmOKucFKY+8VFJSYZxs9poN3SDNQFF6lT6NrQUnHiPB2PWz2sc4ieEcAaYYzN+1uWahEeTq2aRIQ=="
     },
     "@lit-labs/virtualizer": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@lit-labs/virtualizer/-/virtualizer-2.0.12.tgz",
-      "integrity": "sha512-sL7AXhacSdzOJLEQFcPCrV7tu2rZQ10upeGMAxKmTT0Ae4kBFV8nwlFiUEQPBt1idUsAkiDG1yN91IgUWQXVNQ==",
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@lit-labs/virtualizer/-/virtualizer-2.0.14.tgz",
+      "integrity": "sha512-lXDKPKd4QmrBWDxyJyShUcnrKAggU3BhVZpg/XU/Oz7z/BZY2kp8aGDCa2+FHQYB8Rul0bEbBJx6XrzmxMoPXg==",
       "requires": {
-        "lit": "^3.1.0",
+        "lit": "^3.2.0",
         "tslib": "^2.0.3"
       },
       "dependencies": {
         "@lit/reactive-element": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.2.tgz",
-          "integrity": "sha512-SVOwLAWUQg3Ji1egtOt1UiFe4zdDpnWHyc5qctSceJ5XIu0Uc76YmGpIjZgx9YJ0XtdW0Jm507sDvjOu+HnB8w==",
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.4.tgz",
+          "integrity": "sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==",
           "requires": {
-            "@lit-labs/ssr-dom-shim": "^1.1.2"
+            "@lit-labs/ssr-dom-shim": "^1.2.0"
           }
         },
         "lit": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/lit/-/lit-3.1.0.tgz",
-          "integrity": "sha512-rzo/hmUqX8zmOdamDAeydfjsGXbbdtAFqMhmocnh2j9aDYqbu0fjXygjCa0T99Od9VQ/2itwaGrjZz/ZELVl7w==",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/lit/-/lit-3.2.1.tgz",
+          "integrity": "sha512-1BBa1E/z0O9ye5fZprPtdqnc0BFzxIxTTOO/tQFmyC/hj1O3jL4TfmLBw0WEwjAokdLwpclkvGgDJwTIh0/22w==",
           "requires": {
-            "@lit/reactive-element": "^2.0.0",
-            "lit-element": "^4.0.0",
-            "lit-html": "^3.1.0"
+            "@lit/reactive-element": "^2.0.4",
+            "lit-element": "^4.1.0",
+            "lit-html": "^3.2.0"
           }
         },
         "lit-element": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.0.2.tgz",
-          "integrity": "sha512-/W6WQZUa5VEXwC7H9tbtDMdSs9aWil3Ou8hU6z2cOKWbsm/tXPAcsoaHVEtrDo0zcOIE5GF6QgU55tlGL2Nihg==",
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.1.1.tgz",
+          "integrity": "sha512-HO9Tkkh34QkTeUmEdNYhMT8hzLid7YlMlATSi1q4q17HE5d9mrrEHJ/o8O2D0cMi182zK1F3v7x0PWFjrhXFew==",
           "requires": {
-            "@lit-labs/ssr-dom-shim": "^1.1.2",
-            "@lit/reactive-element": "^2.0.0",
-            "lit-html": "^3.1.0"
+            "@lit-labs/ssr-dom-shim": "^1.2.0",
+            "@lit/reactive-element": "^2.0.4",
+            "lit-html": "^3.2.0"
           }
         },
         "lit-html": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.1.0.tgz",
-          "integrity": "sha512-FwAjq3iNsaO6SOZXEIpeROlJLUlrbyMkn4iuv4f4u1H40Jw8wkeR/OUXZUHUoiYabGk8Y4Y0F/rgq+R4MrOLmA==",
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.2.1.tgz",
+          "integrity": "sha512-qI/3lziaPMSKsrwlxH/xMgikhQ0EGOX2ICU73Bi/YHFvz2j/yMCIrw4+puF2IpQ4+upd3EWbvnHM9+PnJn48YA==",
           "requires": {
             "@types/trusted-types": "^2.0.2"
           }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@clevercloud/client": "^8.2.0",
     "@lit-labs/motion": "^1.0.3",
-    "@lit-labs/virtualizer": "^2.0.12",
+    "@lit-labs/virtualizer": "^2.0.14",
     "@shoelace-style/shoelace": "^2.5.0",
     "ansi-regex": "^6.0.1",
     "chart.js": "^3.5.0",

--- a/src/components/cc-kv-console/cc-kv-console.types.d.ts
+++ b/src/components/cc-kv-console/cc-kv-console.types.d.ts
@@ -17,7 +17,11 @@ export interface CcKvCommandHistoryEntry {
   success: boolean;
 }
 
-export type CcKvCommandContentItem = CcKvCommandContentItemCommandLine | CcKvCommandContentItemResultLine;
+export type CcKvCommandContentItem =
+  | CcKvCommandContentItemCommandLine
+  | CcKvCommandContentItemResultLine
+  | CcKvCommandContentItemPrompt
+  | CcKvCommandContentItemCaret;
 
 interface CcKvCommandContentItemCommandLine {
   id: string;
@@ -31,4 +35,16 @@ interface CcKvCommandContentItemResultLine {
   line: string;
   success: boolean;
   last: boolean;
+}
+
+interface CcKvCommandContentItemPrompt {
+  id: string;
+  type: 'prompt';
+  command: string;
+  running: boolean;
+}
+
+interface CcKvCommandContentItemCaret {
+  id: string;
+  type: 'caret';
 }

--- a/src/components/cc-kv-console/cc-kv-console.types.d.ts
+++ b/src/components/cc-kv-console/cc-kv-console.types.d.ts
@@ -16,3 +16,19 @@ export interface CcKvCommandHistoryEntry {
   result: Array<string>;
   success: boolean;
 }
+
+export type CcKvCommandContentItem = CcKvCommandContentItemCommandLine | CcKvCommandContentItemResultLine;
+
+interface CcKvCommandContentItemCommandLine {
+  id: string;
+  type: 'commandLine';
+  line: string;
+}
+
+interface CcKvCommandContentItemResultLine {
+  id: string;
+  type: 'resultLine';
+  line: string;
+  success: boolean;
+  last: boolean;
+}


### PR DESCRIPTION
This PR handles huge command history which can creates a huge amount of nodes in the DOM.

I tried to rely on a `lit-virtualizer` without succeed. Instead, this PR relies on `content-visibility: auto` css property.

This property is supported in every modern browser but is quiet new. So it can happen that the browser won't support it but nothing bad will happen.

### How to test

* check the code
* verify that huge history doesn't break your browser.
  * You can use the command `command` to test large command outputs.
* verify no focus loss handling is not broken
* verify scrolling behavior is not broken