### PR TITLE
fix(cc-block): add css rules to the slot name="content-body

### DIFF
--- a/src/components/cc-addon-admin/cc-addon-admin.js
+++ b/src/components/cc-addon-admin/cc-addon-admin.js
@@ -127,7 +127,7 @@ export class CcAddonAdmin extends LitElement {
     const shouldShowVmText = !this.noDangerZoneVmText;
 
     return html`
-      <cc-block-section slot="content">
+      <cc-block-section slot="content-body">
         <div slot="title">${i18n('cc-addon-admin.heading.name')}</div>
         <div slot="info"></div>
         <div class="one-line-form">
@@ -150,7 +150,7 @@ export class CcAddonAdmin extends LitElement {
         </div>
       </cc-block-section>
 
-      <cc-block-section slot="content">
+      <cc-block-section slot="content-body">
         <div slot="title">${i18n('cc-addon-admin.heading.tags')}</div>
         <div slot="info">${i18n('cc-addon-admin.tags-description')}</div>
         <div class="one-line-form">
@@ -174,7 +174,7 @@ export class CcAddonAdmin extends LitElement {
         </div>
       </cc-block-section>
 
-      <cc-block-section slot="content">
+      <cc-block-section slot="content-body">
         <div slot="title" class="danger">${i18n('cc-addon-admin.danger-zone')}</div>
         <div slot="info" class="danger-desc">
           <p>${i18n('cc-addon-admin.delete-disclaimer')}</p>

--- a/src/components/cc-addon-backups/cc-addon-backups.js
+++ b/src/components/cc-addon-backups/cc-addon-backups.js
@@ -375,14 +375,14 @@ export class CcAddonBackups extends LitElement {
 
         ${this._displaySectionWithService(providerId)
           ? html`
-              <cc-block-section slot="content">
+              <cc-block-section slot="content-body">
                 <div slot="title">${this._getRestoreWithServiceTitle(providerId)}</div>
                 <div>${this._getRestoreWithServiceDescription(providerId, this._selectedBackup.url)}</div>
               </cc-block-section>
             `
           : ''}
 
-        <cc-block-section slot="content">
+        <cc-block-section slot="content-body">
           <div slot="title">${i18n('cc-addon-backups.restore.manual.title')}</div>
           <div>${this._getManualRestoreDescription(providerId)}</div>
           ${this._selectedBackup.restoreCommand != null
@@ -421,7 +421,7 @@ export class CcAddonBackups extends LitElement {
 
         ${this._displaySectionWithService(providerId)
           ? html`
-              <cc-block-section slot="content">
+              <cc-block-section slot="content-body">
                 <div slot="title">${i18n('cc-addon-backups.delete.with-service.title.es-addon')}</div>
                 <div>
                   ${i18n('cc-addon-backups.delete.with-service.description.es-addon', {
@@ -432,7 +432,7 @@ export class CcAddonBackups extends LitElement {
             `
           : ''}
 
-        <cc-block-section slot="content">
+        <cc-block-section slot="content-body">
           <div slot="title">${i18n('cc-addon-backups.delete.manual.title')}</div>
           <div>${this._getManualDeleteDescription(providerId)}</div>
           <cc-input-text readonly clipboard value="${this._selectedBackup.deleteCommand}"></cc-input-text>

--- a/src/components/cc-block-section/cc-block-section.stories.js
+++ b/src/components/cc-block-section/cc-block-section.stories.js
@@ -30,13 +30,13 @@ export const defaultStory = makeStory(conf, {
     {
       innerHTML: `
       <div slot="header-title">This is my block</div>
-      <cc-block-section slot="content">
+      <cc-block-section slot="content-body">
         <div slot="title">Subtitle Foo</div>
         <div slot="info">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque feugiat dui at leo porta dignissim. Etiam ut purus ultrices, pulvinar tellus quis, cursus massa. Mauris dignissim accumsan ex, at vestibulum lectus fermentum id.</div>
         <cc-input-text label="Name:"></cc-input-text>
         <cc-input-text label="Lastname:"></cc-input-text>
       </cc-block-section>
-      <cc-block-section slot="content">
+      <cc-block-section slot="content-body">
         <div slot="title">Subtitle Bar</div>
         <div slot="info">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque feugiat dui at leo porta dignissim. Etiam ut purus ultrices, pulvinar tellus quis, cursus massa. Mauris dignissim accumsan ex, at vestibulum lectus fermentum id.</div>
         <cc-input-text label="Name:"></cc-input-text>
@@ -44,7 +44,7 @@ export const defaultStory = makeStory(conf, {
         <cc-input-text label="Address:"></cc-input-text>
         <cc-button primary>ACTION!</cc-button>
       </cc-block-section>
-      <cc-block-section slot="content">
+      <cc-block-section slot="content-body">
         <div slot="title" class="danger">Danger section</div>
         <div slot="info">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque feugiat dui at leo porta dignissim. Etiam ut purus ultrices, pulvinar tellus quis, cursus massa. Mauris dignissim accumsan ex, at vestibulum lectus fermentum id.</div>
         <cc-button primary>THIRD!</cc-button>
@@ -59,13 +59,13 @@ export const infoWithEmptyColumn = makeStory(conf, {
     {
       innerHTML: `
       <div slot="header-title">This is my block</div>
-      <cc-block-section slot="content">
+      <cc-block-section slot="content-body">
         <div slot="title">Subtitle Foo</div>
         <div slot="info"></div>
         <cc-input-text label="Name:"></cc-input-text>
         <cc-input-text label="Lastname:"></cc-input-text>
       </cc-block-section>
-      <cc-block-section slot="content">
+      <cc-block-section slot="content-body">
         <div slot="title">Subtitle Bar</div>
         <div slot="info"></div>
         <cc-input-text label="Name:"></cc-input-text>
@@ -83,12 +83,12 @@ export const infoWithNoInfoColumn = makeStory(conf, {
     {
       innerHTML: `
       <div slot="header-title">This is my block</div>
-      <cc-block-section slot="content">
+      <cc-block-section slot="content-body">
         <div slot="title">Subtitle Foo</div>
         <cc-input-text label="Name:"></cc-input-text>
         <cc-input-text label="Lastname:"></cc-input-text>
       </cc-block-section>
-      <cc-block-section slot="content">
+      <cc-block-section slot="content-body">
         <div slot="title">Subtitle Bar</div>
         <cc-input-text label="Name:"></cc-input-text>
         <cc-input-text label="Lastname:"></cc-input-text>

--- a/src/components/cc-block/cc-block.js
+++ b/src/components/cc-block/cc-block.js
@@ -332,6 +332,11 @@ export class CcBlock extends LitElement {
           padding-block: 0.5em;
         }
 
+        slot[name='content-body'] {
+          display: grid;
+          gap: 1em;
+        }
+
         #content-and-footer {
           display: grid;
           gap: 1em;

--- a/src/components/cc-domain-management/cc-domain-management.js
+++ b/src/components/cc-domain-management/cc-domain-management.js
@@ -317,7 +317,7 @@ export class CcDomainManagement extends LitElement {
         <cc-block>
           <div slot="header-title">${i18n('cc-domain-management.main-heading')}</div>
 
-          <cc-block-section slot="content">
+          <cc-block-section slot="content-body">
             <div class="form-info">
               <p>${i18n('cc-domain-management.form.info.docs')}</p>
               <p>${i18n('cc-domain-management.form.info.cleverapps')}</p>
@@ -325,7 +325,7 @@ export class CcDomainManagement extends LitElement {
             <div>${this._renderForm(this.domainFormState)}</div>
           </cc-block-section>
 
-          <cc-block-section slot="content">
+          <cc-block-section slot="content-body">
             <div slot="title">
               ${i18n('cc-domain-management.list.heading')}
               ${this.domainListState.type === 'loaded'
@@ -368,7 +368,7 @@ export class CcDomainManagement extends LitElement {
 
         <cc-block class="dns-info">
           <div slot="header-title">${i18n('cc-domain-management.dns.heading')}</div>
-          <div slot="content">
+          <div slot="content-body">
             <div class="dns-info__desc">${i18n('cc-domain-management.dns.desc')}</div>
             <cc-notice intent="info" heading="${i18n('cc-domain-management.dns.info.heading')}">
               <div slot="message">
@@ -604,7 +604,7 @@ export class CcDomainManagement extends LitElement {
    */
   _renderDnsInfo(cnameRecord, aRecords) {
     return html`
-      <cc-block-section slot="content">
+      <cc-block-section slot="content-body">
         <div slot="title">${i18n('cc-domain-management.dns.cname.heading')}</div>
         <div slot="info">${i18n('cc-domain-management.dns.cname.desc')}</div>
         <cc-input-text
@@ -615,7 +615,7 @@ export class CcDomainManagement extends LitElement {
           value=${cnameRecord}
         ></cc-input-text>
       </cc-block-section>
-      <cc-block-section slot="content">
+      <cc-block-section slot="content-body">
         <div slot="title">${i18n('cc-domain-management.dns.a.heading')}</div>
         <div slot="info">${i18n('cc-domain-management.dns.a.desc')}</div>
         <div class="a-records">

--- a/src/components/cc-email-list/cc-email-list.js
+++ b/src/components/cc-email-list/cc-email-list.js
@@ -216,7 +216,7 @@ export class CcEmailList extends LitElement {
     const badgeIcon = verified ? iconVerified : iconUnverified;
 
     return html`
-      <cc-block-section slot="content">
+      <cc-block-section slot="content-body">
         <div slot="title">${i18n('cc-email-list.primary.title')}</div>
         <div slot="info">${i18n('cc-email-list.primary.description')}</div>
 
@@ -253,7 +253,7 @@ export class CcEmailList extends LitElement {
     const markingAsPrimary = addresses.some((item) => item.state === 'marking-as-primary');
 
     return html`
-      <cc-block-section slot="content">
+      <cc-block-section slot="content-body">
         <div slot="title">${i18n('cc-email-list.secondary.title')}</div>
         <div slot="info">${i18n('cc-email-list.secondary.description')}</div>
 

--- a/src/components/cc-grafana-info/cc-grafana-info.js
+++ b/src/components/cc-grafana-info/cc-grafana-info.js
@@ -94,7 +94,7 @@ export class CcGrafanaInfo extends LitElement {
 
         ${isSwitchingGrafanaStatus ? html` <cc-loader slot="overlay"></cc-loader> ` : ''}
 
-        <cc-block-section slot="content">
+        <cc-block-section slot="content-body">
           <div slot="title">${i18n('cc-grafana-info.documentation-title')}</div>
           <div slot="info">${i18n('cc-grafana-info.documentation-description')}</div>
           <div>
@@ -110,7 +110,7 @@ export class CcGrafanaInfo extends LitElement {
 
         ${this.state.type === 'loading'
           ? html`
-              <cc-block-section slot="content">
+              <cc-block-section slot="content-body">
                 <div slot="title">${i18n('cc-grafana-info.loading-title')}</div>
                 <div>
                   <cc-loader></cc-loader>
@@ -120,7 +120,7 @@ export class CcGrafanaInfo extends LitElement {
           : ''}
         ${this.state.type === 'error'
           ? html`
-              <cc-block-section slot="content">
+              <cc-block-section slot="content-body">
                 <div slot="title">${i18n('cc-grafana-info.loading-title')}</div>
                 <cc-notice intent="warning" message="${i18n('cc-grafana-info.error-loading')}"></cc-notice>
               </cc-block-section>
@@ -128,7 +128,7 @@ export class CcGrafanaInfo extends LitElement {
           : ''}
         ${isGrafanaDisabled
           ? html`
-              <cc-block-section slot="content">
+              <cc-block-section slot="content-body">
                 <div slot="title">${i18n('cc-grafana-info.enable-title')}</div>
                 <div slot="info">
                   <p>${i18n('cc-grafana-info.enable-description')}</p>
@@ -148,7 +148,7 @@ export class CcGrafanaInfo extends LitElement {
           : ''}
         ${isGrafanaEnabled
           ? html`
-              <cc-block-section slot="content">
+              <cc-block-section slot="content-body">
                 <div slot="title">${i18n('cc-grafana-info.grafana-link-title')}</div>
                 <div slot="info">
                   <p>${i18n('cc-grafana-info.grafana-link-description')}</p>
@@ -170,7 +170,7 @@ export class CcGrafanaInfo extends LitElement {
                     `}
               </cc-block-section>
 
-              <cc-block-section slot="content">
+              <cc-block-section slot="content-body">
                 <div slot="title">${i18n('cc-grafana-info.reset-title')}</div>
                 <div slot="info">${i18n('cc-grafana-info.reset-description')}</div>
                 <div>
@@ -190,7 +190,7 @@ export class CcGrafanaInfo extends LitElement {
           ? html`
               ${this._getDashboards().map(
                 (item) => html`
-                  <cc-block-section slot="content">
+                  <cc-block-section slot="content-body">
                     <div slot="title">${item.title}</div>
                     <div slot="info">${item.description}</div>
                     <div>
@@ -206,7 +206,7 @@ export class CcGrafanaInfo extends LitElement {
           : ''}
         ${isGrafanaEnabled
           ? html`
-              <cc-block-section slot="content">
+              <cc-block-section slot="content-body">
                 <div slot="title">${i18n('cc-grafana-info.disable-title')}</div>
                 <div slot="info">${i18n('cc-grafana-info.disable-description')}</div>
                 <div>

--- a/src/components/cc-invoice-list/cc-invoice-list.js
+++ b/src/components/cc-invoice-list/cc-invoice-list.js
@@ -84,12 +84,12 @@ export class CcInvoiceList extends LitElement {
 
     if (this.state.type === 'loading') {
       return this._renderView(html`
-        <cc-block-section slot="content">
+        <cc-block-section slot="content-body">
           <div slot="title">${i18n('cc-invoice-list.pending')}</div>
           <cc-invoice-table></cc-invoice-table>
         </cc-block-section>
 
-        <cc-block-section slot="content">
+        <cc-block-section slot="content-body">
           <div slot="title">${i18n('cc-invoice-list.processed')}</div>
           <cc-invoice-table></cc-invoice-table>
         </cc-block-section>
@@ -125,7 +125,7 @@ export class CcInvoiceList extends LitElement {
     const hasYearSelector = filteredProcessedInvoiceTableState.invoices.length > 0 && yearChoices.length > 1;
 
     return this._renderView(html`
-      <cc-block-section slot="content">
+      <cc-block-section slot="content-body">
         <div slot="title">${i18n('cc-invoice-list.pending')}</div>
         ${pendingInvoicesTableState.invoices.length > 0
           ? html` <cc-invoice-table .state=${pendingInvoicesTableState}></cc-invoice-table> `
@@ -137,14 +137,14 @@ export class CcInvoiceList extends LitElement {
 
       ${processingInvoicesTableState.invoices.length > 0
         ? html`
-            <cc-block-section slot="content">
+            <cc-block-section slot="content-body">
               <div slot="title">${i18n('cc-invoice-list.processing')}</div>
               <cc-invoice-table .state=${processingInvoicesTableState}></cc-invoice-table>
             </cc-block-section>
           `
         : ''}
 
-      <cc-block-section slot="content">
+      <cc-block-section slot="content-body">
         <div slot="title">${i18n('cc-invoice-list.processed')}</div>
         ${hasYearSelector
           ? html`

--- a/src/components/cc-invoice/cc-invoice.js
+++ b/src/components/cc-invoice/cc-invoice.js
@@ -61,18 +61,20 @@ export class CcInvoice extends LitElement {
         ${this.state.type !== 'error'
           ? html`
               <div slot="header-right">${ccLink(invoice.downloadUrl, i18n('cc-invoice.download-pdf'), skeleton)}</div>
-              <div slot="content-body" class="info">
-                <em class=${classMap({ skeleton })}>
-                  ${i18n('cc-invoice.info', {
-                    date: invoice.emissionDate,
-                    amount: invoice.amount,
-                    currency: invoice.currency,
-                  })}
-                </em>
+              <div slot="content">
+                <div class="info">
+                  <em class=${classMap({ skeleton })}>
+                    ${i18n('cc-invoice.info', {
+                      date: invoice.emissionDate,
+                      amount: invoice.amount,
+                      currency: invoice.currency,
+                    })}
+                  </em>
+                </div>
+                <cc-html-frame class="frame" ?loading="${skeleton}" iframe-title="${title}">
+                  ${invoice.invoiceHtml != null ? unsafeHTML(`<template>${invoice.invoiceHtml}</template>`) : ''}
+                </cc-html-frame>
               </div>
-              <cc-html-frame slot="content-body" class="frame" ?loading="${skeleton}" iframe-title="${title}">
-                ${invoice.invoiceHtml != null ? unsafeHTML(`<template>${invoice.invoiceHtml}</template>`) : ''}
-              </cc-html-frame>
             `
           : ''}
       </cc-block>

--- a/src/components/cc-jenkins-info/cc-jenkins-info.js
+++ b/src/components/cc-jenkins-info/cc-jenkins-info.js
@@ -52,7 +52,7 @@ export class CcJenkinsInfo extends LitElement {
         <div slot="ribbon">${i18n('cc-jenkins-info.info')}</div>
         <div slot="header" class="info-text">${i18n('cc-jenkins-info.text')}</div>
 
-        <cc-block-section slot="content">
+        <cc-block-section slot="content-body">
           <div slot="title">${i18n('cc-jenkins-info.open-jenkins.title')}</div>
           <div slot="info">${i18n('cc-jenkins-info.open-jenkins.text')}</div>
           <div class="one-line-form">
@@ -66,7 +66,7 @@ export class CcJenkinsInfo extends LitElement {
           </div>
         </cc-block-section>
 
-        <cc-block-section slot="content">
+        <cc-block-section slot="content-body">
           <div slot="title">${i18n('cc-jenkins-info.update.title')}</div>
           <div slot="info">${i18n('cc-jenkins-info.update.text')}</div>
           <div class="one-line-form">

--- a/src/components/cc-matomo-info/cc-matomo-info.js
+++ b/src/components/cc-matomo-info/cc-matomo-info.js
@@ -57,7 +57,7 @@ export class CcMatomoInfo extends LitElement {
         <div slot="ribbon">${i18n('cc-matomo-info.info')}</div>
         <div slot="header" class="info-text">${i18n('cc-matomo-info.heading')}</div>
 
-        <cc-block-section slot="content">
+        <cc-block-section slot="content-body">
           <div slot="title">${i18n('cc-matomo-info.open-matomo.title')}</div>
           <div slot="info">${i18n('cc-matomo-info.open-matomo.text')}</div>
           <div>
@@ -65,7 +65,7 @@ export class CcMatomoInfo extends LitElement {
           </div>
         </cc-block-section>
 
-        <cc-block-section slot="content">
+        <cc-block-section slot="content-body">
           <div slot="title">${i18n('cc-matomo-info.about.title')}</div>
           <div slot="info">${i18n('cc-matomo-info.about.text')}</div>
           <div class="application-list">

--- a/src/components/cc-orga-member-list/cc-orga-member-list.js
+++ b/src/components/cc-orga-member-list/cc-orga-member-list.js
@@ -340,7 +340,7 @@ export class CcOrgaMemberList extends LitElement {
 
         ${this.authorisations.invite ? this._renderInviteForm() : ''}
 
-        <cc-block-section slot="content">
+        <cc-block-section slot="content-body">
           <div slot="title" ${ref(this._memberListHeadingRef)} tabindex="-1">
             ${i18n('cc-orga-member-list.list.heading')}
             ${this.members.state === 'loaded'
@@ -381,7 +381,7 @@ export class CcOrgaMemberList extends LitElement {
     const isFormDisabled = this.inviteMemberFormState.type === 'inviting';
 
     return html`
-      <cc-block-section slot="content">
+      <cc-block-section slot="content-body">
         <div slot="title">${i18n('cc-orga-member-list.invite.heading')}</div>
         <p class="info">${i18n('cc-orga-member-list.invite.info')}</p>
 
@@ -481,7 +481,7 @@ export class CcOrgaMemberList extends LitElement {
    */
   _renderDangerZone(members) {
     return html`
-      <cc-block-section slot="content">
+      <cc-block-section slot="content-body">
         <div slot="title" class="danger">${i18n('cc-orga-member-list.leave.heading')}</div>
         <div class="leave">
           <p class="leave__text">${i18n('cc-orga-member-list.leave.text')}</p>

--- a/src/components/cc-ssh-key-list/cc-ssh-key-list.js
+++ b/src/components/cc-ssh-key-list/cc-ssh-key-list.js
@@ -158,7 +158,7 @@ export class CcSshKeyList extends LitElement {
         <div slot="header-title">${i18n('cc-ssh-key-list.title')}</div>
 
         <!-- creation form -->
-        <cc-block-section slot="content">
+        <cc-block-section slot="content-body">
           <div slot="title">${i18n('cc-ssh-key-list.add.title')}</div>
           <div slot="info">${i18n('cc-ssh-key-list.add.info')}</div>
 
@@ -166,7 +166,7 @@ export class CcSshKeyList extends LitElement {
         </cc-block-section>
 
         <!-- personal keys -->
-        <cc-block-section slot="content">
+        <cc-block-section slot="content-body">
           <div slot="title">
             <span>${i18n('cc-ssh-key-list.personal.title')}</span>
             ${this.keyData.state === 'loaded' && this.keyData.personalKeys.length > 2
@@ -194,7 +194,7 @@ export class CcSshKeyList extends LitElement {
         </cc-block-section>
 
         <!-- GitHub keys -->
-        <cc-block-section slot="content">
+        <cc-block-section slot="content-body">
           <div slot="title">
             <span>${i18n('cc-ssh-key-list.github.title')}</span>
             ${this.keyData.state === 'loaded' && this.keyData.isGithubLinked && this.keyData.githubKeys.length > 2


### PR DESCRIPTION
Fixes #1259

## What this PR do ?
- adds css rules to the `slot name="content-body"` in the `cc-block` component,
- adapt the stories of the `cc-block-section` using the slot,
- adapt other components using the slot.

## How to review?
- check the code,
- check the stories on the [preview](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-block-section/fix-separation-line/index.html) and compare with the [prod](https://www.clever-cloud.com/doc/clever-components/?path=/docs/readme--docs).