### PR TITLE
fix(cc-domain-management): restore loader & error message in the DNS config section

### DIFF
--- a/src/components/cc-domain-management/cc-domain-management.js
+++ b/src/components/cc-domain-management/cc-domain-management.js
@@ -377,10 +377,14 @@ export class CcDomainManagement extends LitElement {
             </cc-notice>
           </div>
 
-          ${this.dnsInfoState.type === 'loading' ? html` <cc-loader></cc-loader> ` : ''}
+          ${this.dnsInfoState.type === 'loading' ? html` <cc-loader slot="content-body"></cc-loader> ` : ''}
           ${this.dnsInfoState.type === 'error'
             ? html`
-                <cc-notice intent="warning" message="${i18n('cc-domain-management.dns.loading-error')}"></cc-notice>
+                <cc-notice
+                  intent="warning"
+                  message="${i18n('cc-domain-management.dns.loading-error')}"
+                  slot="content-body"
+                ></cc-notice>
               `
             : ''}
           ${this.dnsInfoState.type === 'loaded'


### PR DESCRIPTION
Fixes #1261

## What does this PR do?

The "Configure your DNS" section used to display a loader / error message depending on its state but it no longer does
![image](https://github.com/user-attachments/assets/cfcc9e11-fdd3-4592-adcd-2c3e3078b690)

This PR restores the error message / loader display depending on the state.

## How to review?

- Check the code,
- Check the preview ([loading](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-domain-management/fix-dns-config-state/index.html?path=/story/%F0%9F%9B%A0-domains-cc-domain-management--loading) & [error](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-domain-management/fix-dns-config-state/index.html?path=/story/%F0%9F%9B%A0-domains-cc-domain-management--error)),
- 1 reviewer should be enough for this one.