### PR TITLE
Small component fixes

### DIFF
--- a/src/components/cc-addon-backups/cc-addon-backups.js
+++ b/src/components/cc-addon-backups/cc-addon-backups.js
@@ -494,7 +494,9 @@ export class CcAddonBackups extends LitElement {
         .overlay {
           box-shadow: 0 0 1em rgb(0 0 0 / 40%);
           left: 50%;
+          max-height: 80vh;
           max-width: 50em;
+          overflow: auto;
           padding-inline: 0;
           position: fixed;
           transform: translateX(-50%);

--- a/src/components/cc-addon-backups/cc-addon-backups.js
+++ b/src/components/cc-addon-backups/cc-addon-backups.js
@@ -44,7 +44,7 @@ const SKELETON_BACKUPS = {
  *
  * * If the retention is not standard (customized by the user), the `expiresAt` backup property should be nullish
  *
- * @cssdisplay grid
+ * @cssdisplay block
  */
 export class CcAddonBackups extends LitElement {
   static get properties() {

--- a/src/components/cc-addon-linked-apps/cc-addon-linked-apps.stories.js
+++ b/src/components/cc-addon-linked-apps/cc-addon-linked-apps.stories.js
@@ -1,15 +1,6 @@
 import { makeStory, storyWait } from '../../stories/lib/make-story.js';
 import './cc-addon-linked-apps.smart.js';
 
-/**
- * @typedef {import('./cc-addon-linked-apps.js').CcAddonLinkedApps} CcAddonLinkedApps
- * @typedef {import('./cc-addon-linked-apps.types.js').AddonLinkedAppsStateLoaded} AddonLinkedAppsStateLoaded
- * @typedef {import('./cc-addon-linked-apps.types.js').AddonLinkedAppsStateLoading} AddonLinkedAppsStateLoading
- * @typedef {import('./cc-addon-linked-apps.types.js').AddonLinkedAppsStateError} AddonLinkedAppsStateError
- * @typedef {import('./cc-addon-linked-apps.types.js').LinkedApplication} LinkedApplication
- * @typedef {import('../cc-zone/cc-zone.types.js').ZoneStateLoaded} ZoneStateLoaded
- */
-
 export default {
   tags: ['autodocs'],
   title: '🛠 Addon/<cc-addon-linked-apps>',
@@ -19,6 +10,15 @@ export default {
 const conf = {
   component: 'cc-addon-linked-apps',
 };
+
+/**
+ * @typedef {import('./cc-addon-linked-apps.js').CcAddonLinkedApps} CcAddonLinkedApps
+ * @typedef {import('./cc-addon-linked-apps.types.js').AddonLinkedAppsStateLoaded} AddonLinkedAppsStateLoaded
+ * @typedef {import('./cc-addon-linked-apps.types.js').AddonLinkedAppsStateLoading} AddonLinkedAppsStateLoading
+ * @typedef {import('./cc-addon-linked-apps.types.js').AddonLinkedAppsStateError} AddonLinkedAppsStateError
+ * @typedef {import('./cc-addon-linked-apps.types.js').LinkedApplication} LinkedApplication
+ * @typedef {import('../cc-zone/cc-zone.types.js').ZoneStateLoaded} ZoneStateLoaded
+ */
 
 /** @type {ZoneStateLoaded} */
 const ZONE_PAR = {


### PR DESCRIPTION
Fixes #1269 
Fixes #1268 
Fixes #1267 

## What does this PR do?

- Updates the docs of `cc-addon-backups` so that the documented default display matches the reality (`block` and not `grid`),
- Sets `max-height` & `overflow: auto` to `cc-addon-backups` overlays so that their content can still be accessed when viewport is narrow.
- Move `@typedefs` comments in the `cc-addon-linked-apps` stories to fix the Storybook docs.

## How to review?

- Check the code,
- Check the preview ([`cc-addon-backups`](https://clever-components-preview.cellar-c2.services.clever-cloud.com/misc/small-component-fixes/index.html?path=/story/%F0%9F%9B%A0-addon-cc-addon-backups--default-story) with reduced viewport width & height, [`cc-addon-linked-apps`](https://clever-components-preview.cellar-c2.services.clever-cloud.com/misc/small-component-fixes/index.html?path=/docs/%F0%9F%9B%A0-addon-cc-addon-linked-apps--docs) docs),
- 1 reviewer should be enough for this one.