### PR TITLE
feat(creation-tunnel): init plan components

### DIFF
--- a/src/components/cc-plan-item/cc-plan-item.js
+++ b/src/components/cc-plan-item/cc-plan-item.js
@@ -1,0 +1,177 @@
+import { css, html, LitElement } from 'lit';
+import { iconRemixCheckboxCircleFill as selectedIcon } from '../../assets/cc-remix.icons.js';
+import '../cc-badge/cc-badge.js';
+import '../cc-icon/cc-icon.js';
+
+/**
+ * @typedef {import('./cc-plan-item.types.js').PlanDetails} PlanDetails
+ * @typedef {import('./cc-plan-item.types.js').PlanBadge} PlanBadge
+ * @typedef {import('lit').TemplateResult<1>} TemplateResult
+ */
+
+/**
+ * A component displaying a card with relative plan information and details
+ *
+ * @cssdisplay flex
+ */
+export class CcPlanItem extends LitElement {
+  static get properties() {
+    return {
+      badge: { type: Object },
+      details: { type: Array },
+      disabled: { type: Boolean, reflect: true },
+      name: { type: String },
+      selected: { type: Boolean, reflect: true },
+    };
+  }
+
+  constructor() {
+    super();
+
+    /** @type {PlanBadge} Badge to display next to the plan name */
+    this.badge = null;
+
+    /** @type {PlanDetails[]} The details of the plan */
+    this.details = [];
+
+    /** @type {boolean} Whether the component should be disabled */
+    this.disabled = false;
+
+    /** @type {string} The plan name */
+    this.name = null;
+
+    /** @type {boolean} Whether the component should be selected */
+    this.selected = false;
+  }
+
+  render() {
+    return html`
+      <div class="title">
+        <div class="name">${this.name}</div>
+        ${this.badge != null ? html` <cc-badge .intent="${this.badge.intent}">${this.badge.content}</cc-badge> ` : ''}
+      </div>
+      <cc-icon class="icon-selected" .icon="${selectedIcon}" size="lg"></cc-icon>
+      ${this.details?.length > 0
+        ? html`<ul class="details">
+            ${this.details.map((detail) => this._renderDetail(detail))}
+          </ul>`
+        : ``}
+    `;
+  }
+
+  /**
+   * @param {PlanDetails} detail
+   * @returns TemplateResult
+   */
+  _renderDetail(detail) {
+    return html`
+      <li class="detail">
+        <span class="detail-icon"><cc-icon .icon="${detail.icon}" size="md"></cc-icon></span>
+        <span class="detail-value">${detail.value}</span>
+      </li>
+    `;
+  }
+
+  static get styles() {
+    return [
+      // language=CSS
+      css`
+        :host {
+          border: 2px solid var(--cc-color-border-neutral, #eee);
+          border-radius: var(--cc-border-radius-default, 0.25em);
+          display: block;
+          position: relative;
+        }
+
+        .title {
+          align-items: center;
+          column-gap: 0.375em;
+          display: inline-flex;
+          flex-wrap: wrap;
+          padding: 1em 1em 0.75em;
+        }
+
+        .name {
+          font-size: 1.25em;
+        }
+
+        :host([selected]) .name {
+          color: var(--cc-color-text-primary-strongest);
+        }
+
+        .icon-selected {
+          --cc-icon-color: var(--cc-color-bg-primary);
+
+          display: none;
+          position: absolute;
+          right: 0.5em;
+          top: 0.5em;
+        }
+
+        :host([selected]) .icon-selected {
+          display: block;
+        }
+
+        .details {
+          background-color: var(--cc-color-bg-neutral);
+          display: flex;
+          flex-direction: column;
+          gap: 0.25em 0;
+          margin: 0;
+          padding: 0.75em 1em;
+        }
+
+        :host([selected]) .details {
+          background-color: var(--cc-color-bg-primary-weak);
+        }
+
+        .detail {
+          display: inline-flex;
+          gap: 0.5em;
+        }
+
+        .detail-icon {
+          align-self: center;
+          color: var(--cc-color-text-weak);
+        }
+
+        :host([selected]) .detail-icon {
+          color: var(--cc-color-text-primary);
+        }
+
+        .detail-value {
+          color: var(--cc-color-text-weak);
+          font-size: 0.875em;
+        }
+
+        :host(:focus-visible) {
+          outline: var(--cc-focus-outline, #000 solid 2px);
+          outline-offset: 2px;
+        }
+
+        :host([selected]) {
+          border-color: var(--cc-color-bg-primary);
+        }
+
+        :host([selected]) .detail-value {
+          color: var(--cc-color-text-primary-strongest);
+        }
+
+        :host([disabled]) {
+          border-color: var(--cc-color-border-neutral-disabled, #777);
+          opacity: var(--cc-opacity-when-disabled, 0.65);
+        }
+
+        :host(:hover:not([disabled])) {
+          border-color: var(--cc-color-border-neutral-hovered, #777);
+        }
+
+        :host(:not([selected], [disabled])) {
+          cursor: pointer;
+        }
+      `,
+    ];
+  }
+}
+
+window.customElements.define('cc-plan-item', CcPlanItem);

--- a/src/components/cc-plan-item/cc-plan-item.stories.js
+++ b/src/components/cc-plan-item/cc-plan-item.stories.js
@@ -1,0 +1,116 @@
+import {
+  iconRemixUserForbidFill as iconConnectionLimit,
+  iconRemixCpuLine as iconCpu,
+  iconRemixDatabase_2Fill as iconDatabase,
+  iconRemixHardDrive_2Fill as iconDisk,
+  iconRemixRam_2Fill as iconMem,
+} from '../../assets/cc-remix.icons.js';
+import { makeStory } from '../../stories/lib/make-story.js';
+import '../cc-badge/cc-badge.js';
+import './cc-plan-item.js';
+
+export default {
+  tags: ['autodocs'],
+  title: '🛠 Creation Tunnel/<cc-plan-item>',
+  component: 'cc-plan-item',
+};
+
+/**
+ * @typedef {import('../cc-plan-picker/cc-plan-picker.types.js').PlanItem} PlanItem
+ * @typedef {import('./cc-plan-item.js').CcPlanItem} CcPlanItem
+ */
+
+const conf = {
+  component: 'cc-plan-item',
+};
+
+/** @type {Partial<PlanItem>} */
+const DEFAULT_ITEM = {
+  name: 'Base Plan',
+  details: [
+    {
+      icon: iconMem,
+      value: '512 MB memory',
+    },
+    {
+      icon: iconCpu,
+      value: '1 vCPUs',
+    },
+  ],
+};
+
+export const defaultStory = makeStory(conf, {
+  /** @type {Array<Partial<CcPlanItem>>} */
+  items: [DEFAULT_ITEM],
+});
+
+export const longName = makeStory(conf, {
+  /** @type {Array<Partial<CcPlanItem>>} */
+  // @ts-expect-error See https://github.com/microsoft/TypeScript/issues/38838 and https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style
+  items: [
+    { ...DEFAULT_ITEM, name: 'my very very very long name', style: 'width: 10em' },
+    { ...DEFAULT_ITEM, name: 'my very very very long name', style: 'width: 20em' },
+    { ...DEFAULT_ITEM, name: 'my very very very long name', style: 'width: 30em' },
+    { ...DEFAULT_ITEM, selected: true, name: 'my very very very long name', style: 'width: 10em' },
+    { ...DEFAULT_ITEM, selected: true, name: 'my very very very long name', style: 'width: 20em' },
+    { ...DEFAULT_ITEM, selected: true, name: 'my very very very long name', style: 'width: 30em' },
+  ],
+});
+
+export const withBadge = makeStory(conf, {
+  /** @type {Array<Partial<CcPlanItem>>} */
+  items: [
+    { ...DEFAULT_ITEM, badge: { content: 'Hello' } },
+    { ...DEFAULT_ITEM, selected: true, badge: { content: 'There!' } },
+    { ...DEFAULT_ITEM, disabled: true, badge: { content: 'General Kenobi' } },
+  ],
+});
+
+export const selected = makeStory(conf, {
+  /** @type {Array<Partial<CcPlanItem>>} */
+  items: [{ ...DEFAULT_ITEM, selected: true }],
+});
+
+export const disabled = makeStory(conf, {
+  /** @type {Array<Partial<CcPlanItem>>} */
+  items: [{ ...DEFAULT_ITEM, disabled: true }],
+});
+
+export const simpleDatabase = makeStory(conf, {
+  /** @type {Array<Partial<CcPlanItem>>} */
+  items: [
+    {
+      id: 'sample',
+      name: 'Sample Plan',
+      details: [
+        {
+          icon: iconDisk,
+          value: '256MB disk size',
+        },
+        {
+          icon: iconCpu,
+          value: '1 vCPUs',
+        },
+        {
+          icon: iconConnectionLimit,
+          value: '100 connections',
+        },
+        {
+          icon: iconDatabase,
+          value: '1 database',
+        },
+      ],
+    },
+  ],
+});
+
+export const thirdParty = makeStory(conf, {
+  /** @type {Array<Partial<CcPlanItem>>} */
+  items: [
+    {
+      id: 'third_party',
+      name: 'Third party',
+      details: [],
+    },
+  ],
+});

--- a/src/components/cc-plan-item/cc-plan-item.test.js
+++ b/src/components/cc-plan-item/cc-plan-item.test.js
@@ -1,0 +1,11 @@
+/* eslint-env node, mocha */
+
+import { testAccessibility } from '../../../test/helpers/accessibility.js';
+import { getStories } from '../../../test/helpers/get-stories.js';
+import * as storiesModule from './cc-plan-item.stories.js';
+
+const storiesToTest = getStories(storiesModule);
+
+describe(`Component: ${storiesModule.default.component}`, function () {
+  testAccessibility(storiesToTest);
+});

--- a/src/components/cc-plan-item/cc-plan-item.types.d.ts
+++ b/src/components/cc-plan-item/cc-plan-item.types.d.ts
@@ -1,0 +1,12 @@
+import { BadgeIntent } from '../cc-badge/cc-badge.types.js';
+import { IconModel } from '../common.types.js';
+
+export interface PlanBadge {
+  content: string;
+  intent?: BadgeIntent;
+}
+
+export interface PlanDetails {
+  icon: IconModel;
+  value: string;
+}

--- a/src/components/cc-plan-picker/cc-plan-picker.js
+++ b/src/components/cc-plan-picker/cc-plan-picker.js
@@ -1,0 +1,255 @@
+import { css, html } from 'lit';
+import { iconRemixServerLine as labelIcon } from '../../assets/cc-remix.icons.js';
+import { dispatchCustomEvent } from '../../lib/events.js';
+import { CcFormControlElement } from '../../lib/form/cc-form-control-element.abstract.js';
+import { i18n } from '../../lib/i18n/i18n.js';
+import { accessibilityStyles } from '../../styles/accessibility.js';
+import '../cc-plan-item/cc-plan-item.js';
+
+/**
+ * @typedef {import('lit').PropertyValues<CcPlanPicker>} CcPlanPickerPropertyValues
+ * @typedef {import('../../lib/events.types.js').EventWithTarget} EventWithTarget
+ * @typedef {import('../../lib/events.types.js').GenericEventWithTarget<InputEvent, HTMLInputElement>} HTMLInputElementEvent
+ * @typedef {import('./cc-plan-picker.types.js').PlanItem} PlanItem
+ * @typedef {import('lit').TemplateResult<1>} TemplateResult
+ */
+
+/**
+ * A form control element component that allows you to select a plan from a list of plans and refine your choice in a sub picker if needed
+ *
+ * @cssdisplay block
+ *
+ * @fires {CustomEvent<string>} cc-plan-picker:input - Fires the id of the selected plan
+ */
+export class CcPlanPicker extends CcFormControlElement {
+  static get properties() {
+    return {
+      ...super.properties,
+      legend: { type: String },
+      plans: { type: Array },
+      readonly: { type: Boolean },
+      value: { type: String },
+    };
+  }
+
+  constructor() {
+    super();
+
+    /** @type {string} The legend of the form control */
+    this.legend = null;
+
+    /** @type {PlanItem[]} List of plans */
+    this.plans = [];
+
+    /** @type {boolean} Whether all the form controls should be readonly */
+    this.readonly = false;
+
+    /** @type {string} current selected plan id */
+    this.value = null;
+
+    /** @type {string} */
+    this._currentPlanId = null;
+
+    /** @type {PlanItem[]} */
+    this._currentRelatedPlans = [];
+  }
+
+  // @ts-expect-error: We override this setter as the component doesn't handle error for now.
+  set errorMessage(_) {}
+
+  /**
+   * Find a plan by its ID in a list of plans.
+   *
+   * @param {PlanItem[]} plans - List of plans to search through
+   * @param {string} planId - ID of the plan to find
+   * @returns {PlanItem} The found plan or the first plan in the list if not found
+   * @private
+   */
+  _findPlan(plans, planId) {
+    // We're trying to find if the plan is a related plan or if the plan is a plan with no related plans
+    const exactPlan = plans.find((plan) => {
+      if (plan.relatedPlans == null || plan.relatedPlans.length === 0) {
+        return plan.id === planId;
+      }
+      return plan.relatedPlans.find((relatedPlan) => relatedPlan.id === planId);
+    });
+
+    // If it was the case we return the plan
+    if (exactPlan != null) {
+      return exactPlan;
+    }
+
+    // If it's not one of the case above we try to find the "parent" plan
+    const parentPlan = this.plans.find((plan) => {
+      return plan.id === planId;
+    });
+
+    if (parentPlan != null) {
+      return parentPlan;
+    }
+
+    // If we don't find anything, the id provided wasn't correct so we default to the first plan of the list
+    return plans[0];
+  }
+
+  /**
+   * @param {HTMLInputElementEvent} e
+   * @private
+   */
+  _onChangePlan(e) {
+    const currentPlan = this._findPlan(this.plans, e.target.value);
+    this._currentPlanId = e.target.value;
+    if (currentPlan.relatedPlans != null && currentPlan.relatedPlans.length > 0) {
+      this.value = currentPlan.relatedPlans[0].id;
+      this._currentRelatedPlans = currentPlan.relatedPlans;
+    } else {
+      this.value = this._currentPlanId;
+      this._currentRelatedPlans = [];
+    }
+
+    dispatchCustomEvent(this, 'input', this.value);
+  }
+
+  /**
+   * @param {HTMLInputElementEvent} e
+   * @private
+   */
+  _onChangeRelatedPlan(e) {
+    this.value = e.target.value;
+    dispatchCustomEvent(this, 'input', this.value);
+  }
+
+  /**
+   * @param {CcPlanPickerPropertyValues} changedProperties
+   */
+  willUpdate(changedProperties) {
+    if (changedProperties.has('plans') && changedProperties.has('value')) {
+      const currentPlan = this._findPlan(this.plans, this.value);
+      if (currentPlan.relatedPlans != null && currentPlan.relatedPlans.length > 0) {
+        const valueExistsInRelated = currentPlan.relatedPlans.some((plan) => plan.id === this.value);
+        this.value = valueExistsInRelated ? this.value : currentPlan.relatedPlans[0].id;
+      } else {
+        this.value = currentPlan.id;
+      }
+      this._currentPlanId = currentPlan.id;
+      this._currentRelatedPlans = currentPlan.relatedPlans;
+    }
+  }
+
+  render() {
+    const legendName = this.legend ?? i18n('cc-plan-picker.legend');
+
+    return html`
+      <fieldset @input="${this._onChangePlan}">
+        <legend>
+          <cc-icon class="plan-legend-icon" .icon="${labelIcon}" size="lg"></cc-icon>
+          <span class="plan-legend-text">${legendName}</span>
+        </legend>
+        <div class="form-controls">
+          ${this.plans.map((plan) => this._renderPlan(plan, this.name, this._currentPlanId))}
+        </div>
+      </fieldset>
+      ${this._currentRelatedPlans != null && this._currentRelatedPlans.length > 0
+        ? html`
+            <fieldset @input="${this._onChangeRelatedPlan}">
+              <legend>
+                <cc-icon class="plan-legend-icon" .icon="${labelIcon}" size="lg"></cc-icon>
+                <span class="plan-legend-text">${i18n('cc-plan-picker.legend.customize')}</span>
+              </legend>
+              <div class="form-controls">
+                ${this._currentRelatedPlans.map((plan) => this._renderPlan(plan, 'related-plan', this.value))}
+              </div>
+            </fieldset>
+          `
+        : ''}
+    `;
+  }
+
+  /**
+   * @param {PlanItem} plan - A plan item
+   * @param {string} name - Form control name
+   * @param {string} currentPlanId - Currently selected plan ID
+   * @returns {TemplateResult} The rendered plan radio input and label
+   * @private
+   */
+  _renderPlan(plan, name, currentPlanId) {
+    const isSelected = currentPlanId === plan.id;
+    const isDisabled = plan.disabled || (this.readonly && !isSelected);
+
+    return html`
+      <div>
+        <input
+          class="visually-hidden"
+          type="radio"
+          name="${name}"
+          .value="${plan.id}"
+          .disabled=${isDisabled}
+          .checked="${isSelected}"
+          id="${plan.id}"
+        />
+        <label for="${plan.id}">
+          <cc-plan-item
+            name="${plan.name}"
+            ?disabled=${isDisabled}
+            .details="${plan.details}"
+            .selected=${isSelected}
+            .badge="${plan.badge}"
+          >
+          </cc-plan-item>
+        </label>
+      </div>
+    `;
+  }
+
+  static get styles() {
+    return [
+      accessibilityStyles,
+      // language=CSS
+      css`
+        :host {
+          display: block;
+        }
+
+        legend {
+          display: flex;
+          gap: 0.25em;
+        }
+
+        fieldset {
+          border: none;
+          margin: 0;
+          padding: 0;
+        }
+
+        input[type='radio']:focus-visible + label cc-plan-item {
+          border-radius: var(--cc-border-radius-default, 0.25em);
+          outline: var(--cc-focus-outline, #000 solid 2px);
+          outline-offset: var(--cc-focus-outline-offset, 2px);
+        }
+
+        .plan-legend-icon {
+          --cc-icon-color: var(--cc-color-text-primary);
+
+          align-self: center;
+        }
+
+        .plan-legend-text {
+          color: var(--cc-color-text-primary-strongest);
+          font-family: var(--cc-ff-form-legend), inherit;
+          font-size: 1.625em;
+          font-weight: 500;
+        }
+
+        .form-controls {
+          display: grid;
+          gap: 1em;
+          grid-template-columns: repeat(auto-fill, minmax(13em, 1fr));
+          margin-block-start: 0.5em;
+          margin-inline-start: 34px;
+        }
+      `,
+    ];
+  }
+}
+
+window.customElements.define('cc-plan-picker', CcPlanPicker);

--- a/src/components/cc-plan-picker/cc-plan-picker.stories.js
+++ b/src/components/cc-plan-picker/cc-plan-picker.stories.js
@@ -1,0 +1,237 @@
+import {
+  iconRemixUserForbidFill as iconConnectionLimit,
+  iconRemixCpuLine as iconCpu,
+  iconRemixDatabase_2Fill as iconDatabase,
+  iconRemixHardDrive_2Fill as iconDisk,
+} from '../../assets/cc-remix.icons.js';
+import { DEFAULT_PLANS, THIRD_PARTY } from '../../stories/fixtures/plans.js';
+import { makeStory } from '../../stories/lib/make-story.js';
+import '../cc-badge/cc-badge.js';
+import './cc-plan-picker.js';
+
+export default {
+  tags: ['autodocs'],
+  title: '🛠 Creation Tunnel/<cc-plan-picker>',
+  component: 'cc-plan-picker',
+};
+
+/**
+ * @typedef {import('./cc-plan-picker.js').CcPlanPicker} CcPlanPicker
+ */
+
+const conf = {
+  component: 'cc-plan-picker',
+};
+
+export const defaultStory = makeStory(conf, {
+  /** @type {Array<Partial<CcPlanPicker>>} */
+  items: [
+    {
+      name: 'plan',
+      plans: DEFAULT_PLANS,
+      value: 'plan_12',
+    },
+  ],
+});
+
+export const readonly = makeStory(conf, {
+  /** @type {Array<Partial<CcPlanPicker>>} */
+  items: [
+    {
+      name: 'plan',
+      plans: DEFAULT_PLANS,
+      readonly: true,
+      value: 'plan_12',
+    },
+  ],
+});
+
+export const sampleDatabase = makeStory(conf, {
+  /** @type {Array<Partial<CcPlanPicker>>} **/
+  items: [
+    {
+      name: 'plan',
+      plans: [
+        {
+          name: 'S',
+          id: 's',
+          details: [
+            {
+              icon: iconDisk,
+              value: '128MB Disk Size',
+            },
+            {
+              icon: iconCpu,
+              value: '1 vCPUs',
+            },
+            {
+              icon: iconConnectionLimit,
+              value: '100 connections limit',
+            },
+            {
+              icon: iconDatabase,
+              value: '1 databases',
+            },
+          ],
+        },
+        {
+          name: 'M',
+          id: 'm',
+          details: [
+            {
+              icon: iconDisk,
+              value: '256MB Disk Size',
+            },
+            {
+              icon: iconCpu,
+              value: '1 vCPUs',
+            },
+            {
+              icon: iconConnectionLimit,
+              value: '250 connections limit',
+            },
+            {
+              icon: iconDatabase,
+              value: '5 databases',
+            },
+          ],
+        },
+
+        {
+          name: 'L',
+          id: 'l',
+          details: [
+            {
+              icon: iconDisk,
+              value: '512MB Disk Size',
+            },
+            {
+              icon: iconCpu,
+              value: '1 vCPUs',
+            },
+            {
+              icon: iconConnectionLimit,
+              value: '500 connections limit',
+            },
+            {
+              icon: iconDatabase,
+              value: '10 databases',
+            },
+          ],
+        },
+        {
+          name: 'XL',
+          id: 'xl',
+          details: [
+            {
+              icon: iconDisk,
+              value: '1GB Disk Size',
+            },
+            {
+              icon: iconCpu,
+              value: '1 vCPUs',
+            },
+            {
+              icon: iconConnectionLimit,
+              value: '500 connections limit',
+            },
+            {
+              icon: iconDatabase,
+              value: '10 databases',
+            },
+          ],
+        },
+        {
+          name: '2XL',
+          id: '2xl',
+          details: [
+            {
+              icon: iconDisk,
+              value: '2.5GB Disk Size',
+            },
+            {
+              icon: iconCpu,
+              value: '1 vCPUs',
+            },
+            {
+              icon: iconConnectionLimit,
+              value: '750 connections limit',
+            },
+            {
+              icon: iconDatabase,
+              value: '10 databases',
+            },
+          ],
+        },
+        {
+          name: '3XL',
+          id: '3xl',
+          details: [
+            {
+              icon: iconDisk,
+              value: '5GB Disk Size',
+            },
+            {
+              icon: iconCpu,
+              value: '1 vCPUs',
+            },
+            {
+              icon: iconConnectionLimit,
+              value: '1000 connections limit',
+            },
+            {
+              icon: iconDatabase,
+              value: '20 databases',
+            },
+          ],
+        },
+        {
+          name: '4XL',
+          id: '4xl',
+          details: [
+            {
+              icon: iconDisk,
+              value: '10GB Disk Size',
+            },
+            {
+              icon: iconCpu,
+              value: '1 vCPUs',
+            },
+            {
+              icon: iconConnectionLimit,
+              value: '1500 connections limit',
+            },
+            {
+              icon: iconDatabase,
+              value: '20 databases',
+            },
+          ],
+        },
+      ],
+      value: 's',
+    },
+  ],
+});
+
+export const thirdParty = makeStory(conf, {
+  /** @type {Array<Partial<CcPlanPicker>>} */
+  items: [
+    {
+      name: 'plan',
+      plans: THIRD_PARTY,
+      value: 'third_party_1',
+    },
+  ],
+});
+
+export const thirdPartyReadonly = makeStory(conf, {
+  /** @type {Array<Partial<CcPlanPicker>>} */
+  items: [
+    {
+      name: 'plan',
+      plans: THIRD_PARTY,
+      readonly: true,
+      value: 'third_party_1',
+    },
+  ],
+});

--- a/src/components/cc-plan-picker/cc-plan-picker.test.js
+++ b/src/components/cc-plan-picker/cc-plan-picker.test.js
@@ -1,0 +1,11 @@
+/* eslint-env node, mocha */
+
+import { testAccessibility } from '../../../test/helpers/accessibility.js';
+import { getStories } from '../../../test/helpers/get-stories.js';
+import * as storiesModule from './cc-plan-picker.stories.js';
+
+const storiesToTest = getStories(storiesModule);
+
+describe(`Component: ${storiesModule.default.component}`, function () {
+  testAccessibility(storiesToTest);
+});

--- a/src/components/cc-plan-picker/cc-plan-picker.types.d.ts
+++ b/src/components/cc-plan-picker/cc-plan-picker.types.d.ts
@@ -1,0 +1,11 @@
+import { PlanBadge, PlanDetails } from '../cc-plan-item/cc-plan-item.types.js';
+
+export interface PlanItem {
+  id: string;
+  badge?: PlanBadge;
+  name: string;
+  details?: PlanDetails[];
+  disabled?: boolean;
+  selected?: boolean;
+  relatedPlans?: Array<Omit<PlanItem, 'relatedPlans'>>;
+}

--- a/src/stories/fixtures/plans.js
+++ b/src/stories/fixtures/plans.js
@@ -1,0 +1,384 @@
+import {
+  iconRemixCpuLine as iconCpu,
+  iconRemixHardDrive_2Fill as iconDisk,
+  iconRemixRam_2Fill as iconMem,
+} from '../../assets/cc-remix.icons.js';
+
+/**
+* @typedef {import('../../../src/components/cc-plan-picker/cc-plan-picker.types.js').PlanItem} PlanItem
+*/
+
+/** @type {PlanItem[]}  **/
+export const DEFAULT_PLANS = [
+  {
+    id: 'plan_dev',
+    name: 'DEV',
+    details: [
+      {
+        icon: iconMem,
+        value: 'Shared memory',
+      },
+      {
+        value: '1 vCPUs',
+        icon: iconCpu,
+      },
+    ],
+    badge: { content: 'Free' },
+    relatedPlans: [],
+  },
+  {
+    name: 'XXS',
+    id: 'plan_1',
+    details: [
+      {
+        value: '512 MB memory',
+        icon: iconMem,
+      },
+      {
+        value: '1 vCPUs',
+        icon: iconCpu,
+      },
+    ],
+    relatedPlans: [
+      {
+        name: 'XXS Small Space',
+        id: 'plan_11',
+        details: [
+          {
+            value: '512 MB disk size',
+            icon: iconDisk,
+          },
+        ],
+      },
+      {
+        name: 'XXS Medium Space',
+        id: 'plan_12',
+        details: [
+          {
+            value: '1 GB disk size',
+            icon: iconDisk,
+          },
+        ],
+      },
+      {
+        name: 'XXS Big Space',
+        id: 'plan_13',
+        details: [
+          {
+            value: '2 GB disk size',
+            icon: iconDisk,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: 'XS',
+    id: 'plan_2',
+    details: [
+      {
+        value: '1 GB memory',
+        icon: iconMem,
+      },
+      {
+        value: '1 vCPUs',
+        icon: iconCpu,
+      },
+    ],
+    relatedPlans: [
+      {
+        name: 'XS Tiny Space',
+        id: 'plan_21',
+        details: [
+          {
+            value: '2 GB disk size',
+            icon: iconDisk,
+          },
+        ],
+      },
+      {
+        name: 'XS Small Space',
+        id: 'plan_22',
+        details: [
+          {
+            value: '5 GB disk size',
+            icon: iconDisk,
+          },
+        ],
+      },
+      {
+        name: 'XS Medium Space',
+        id: 'plan_23',
+        details: [
+          {
+            value: '10 GB disk size',
+            icon: iconDisk,
+          },
+        ],
+      },
+      {
+        name: 'XS Big Space',
+        id: 'plan_24',
+        details: [
+          {
+            value: '15 GB disk size',
+            icon: iconDisk,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: 'S',
+    id: 'plan_3',
+    details: [
+      {
+        value: '2 GB memory',
+        icon: iconMem,
+      },
+      {
+        value: '2 vCPUs',
+        icon: iconCpu,
+      },
+    ],
+    relatedPlans: [
+      {
+        name: 'S Small Space',
+        id: 'plan_31',
+        details: [
+          {
+            value: '512 MB disk size',
+            icon: iconDisk,
+          },
+        ],
+      },
+      {
+        name: 'S Medium Space',
+        id: 'plan_32',
+        details: [
+          {
+            value: '1 GB disk size',
+            icon: iconDisk,
+          },
+        ],
+      },
+      {
+        name: 'S Big Space',
+        id: 'plan_33',
+        details: [
+          {
+            value: '2 GB disk size',
+            icon: iconDisk,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: 'M',
+    id: 'plan_4',
+    details: [
+      {
+        value: '4 GB memory',
+        icon: iconMem,
+      },
+      {
+        value: '4 vCPUs',
+        icon: iconCpu,
+      },
+    ],
+    relatedPlans: [
+      {
+        name: 'M Small Space',
+        id: 'plan_41',
+        details: [
+          {
+            value: '512 MB disk size',
+            icon: iconDisk,
+          },
+        ],
+      },
+      {
+        name: 'M Medium Space',
+        id: 'plan_42',
+        details: [
+          {
+            value: '1 GB disk size',
+            icon: iconDisk,
+          },
+        ],
+      },
+      {
+        name: 'M Big Space',
+        id: 'plan_43',
+        details: [
+          {
+            value: '2 GB disk size',
+            icon: iconDisk,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: 'L',
+    id: 'plan_5',
+    details: [
+      {
+        value: '8 GB memory',
+        icon: iconMem,
+      },
+      {
+        value: '6 vCPUs',
+        icon: iconCpu,
+      },
+    ],
+    relatedPlans: [
+      {
+        name: 'L Small Space',
+        id: 'plan_51',
+        details: [
+          {
+            value: '512 MB disk size',
+            icon: iconDisk,
+          },
+        ],
+      },
+      {
+        name: 'L Medium Space',
+        id: 'plan_52',
+        details: [
+          {
+            value: '1 GB disk size',
+            icon: iconDisk,
+          },
+        ],
+      },
+      {
+        name: 'L Big Space',
+        id: 'plan_53',
+        details: [
+          {
+            value: '2 GB disk size',
+            icon: iconDisk,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: 'XL',
+    id: 'plan_6',
+    details: [
+      {
+        value: '16 GB memory',
+        icon: iconMem,
+      },
+      {
+        value: '8 vCPUs',
+        icon: iconCpu,
+      },
+    ],
+    relatedPlans: [
+      {
+        name: 'XL Small Space',
+        id: 'plan_61',
+        details: [
+          {
+            value: '5 GB disk size',
+            icon: iconDisk,
+          },
+        ],
+      },
+      {
+        name: 'XL Medium Space',
+        id: 'plan_62',
+        details: [
+          {
+            value: '10 GB disk size',
+            icon: iconDisk,
+          },
+        ],
+      },
+      {
+        name: 'XL Big Space',
+        id: 'plan_63',
+        details: [
+          {
+            value: '15 GB disk size',
+            icon: iconDisk,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: 'XXL',
+    id: 'plan_7',
+    details: [
+      {
+        value: '32 GB memory',
+        icon: iconMem,
+      },
+      {
+        value: '10 vCPUs',
+        icon: iconCpu,
+      },
+    ],
+    relatedPlans: [
+      {
+        name: 'XXL Small Space',
+        id: 'plan_71',
+        details: [
+          {
+            value: '5 GB disk size',
+            icon: iconDisk,
+          },
+        ],
+      },
+      {
+        name: 'XXL Medium Space',
+        id: 'plan_72',
+        details: [
+          {
+            value: '10 GB disk size',
+            icon: iconDisk,
+          },
+        ],
+      },
+      {
+        name: 'XXL Big Space',
+        id: 'plan_73',
+        details: [
+          {
+            value: '15 GB disk size',
+            icon: iconDisk,
+          },
+        ],
+      },
+    ],
+  },
+];
+
+/** @type {PlanItem[]}  **/
+export const THIRD_PARTY = [{
+    id: 'third_party_1',
+    name: 'Third party 1',
+    details: [],
+  },
+  {
+    id: 'third_party_2',
+    name: 'Third party 2',
+    details: [],
+  },
+  {
+    id: 'third_party_3',
+    name: 'Third party 3',
+    details: [],
+  },
+  {
+    id: 'third_party_4',
+    name: 'Third party 4',
+    details: [],
+  },
+];

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -1056,6 +1056,10 @@ export const translations = {
   'cc-payment-warning.orga.no-payment-method': `To avoid any suspension of your services and deletion of your data, please add a valid payment method and set it as default.`,
   'cc-payment-warning.orga.no-payment-method.title': `Beware! You don't have any registered payment method`,
   //#endregion
+  //#region cc-plan-picker
+  'cc-plan-picker.legend': `Select your plan`,
+  'cc-plan-picker.legend.customize': `Customize your plan`,
+  //#endregion
   //#region cc-pricing-estimation
   'cc-pricing-estimation.count.label': /** @param {{productCount: number}} _ */ ({ productCount }) =>
     plural(productCount, 'product'),

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -1068,6 +1068,10 @@ export const translations = {
   'cc-payment-warning.orga.no-payment-method': `Pour éviter tout risque de suspension de vos services et de suppression de vos données, merci d'ajouter un moyen de paiement valide et de le définir par défaut.`,
   'cc-payment-warning.orga.no-payment-method.title': `Attention ! Vous n'avez aucun moyen de paiement enregistré`,
   //#endregion
+  //#region cc-plan-picker
+  'cc-plan-picker.legend': `Sélectionnez votre plan`,
+  'cc-plan-picker.legend.customize': `Personnalisez votre plan`,
+  //#endregion
   //#region cc-pricing-estimation
   'cc-pricing-estimation.count.label': /** @param {{productCount: number}} _ */ ({ productCount }) =>
     plural(productCount, 'produit'),


### PR DESCRIPTION
## What does this PR do?

This PR introduces three new components for the new creation-tunnel:
* `cc-plan-item` => The base plan card
* `cc-plan-picker` => One plan picker 
* `cc-plan-configurator` => The form control element where you can refine your choice with two pickers

## How to review?

* Check the code
* Check the stories