### PR TITLE
chore(cc-tile-status-codes): filter out status codes below `100`

### DIFF
--- a/src/components/cc-tile-status-codes/cc-tile-status-codes.js
+++ b/src/components/cc-tile-status-codes/cc-tile-status-codes.js
@@ -146,7 +146,10 @@ export class CcTileStatusCodes extends LitElement {
               // Add official english title of the HTTP status code
               title: ([context]) => {
                 const statusCode = this._labels[context.dataIndex];
-                return `HTTP ${statusCode}: ${status.message[statusCode]}`;
+                const statusMessage = status.message[statusCode];
+                return statusMessage != null
+                  ? `HTTP ${statusCode}: ${status.message[statusCode]}`
+                  : `HTTP ${statusCode}`;
               },
               // Display number of requests and percentage
               label: (context) => {

--- a/src/components/cc-tile-status-codes/cc-tile-status-codes.smart.js
+++ b/src/components/cc-tile-status-codes/cc-tile-status-codes.smart.js
@@ -62,7 +62,15 @@ async function fetchStatusCodes({ apiConfig, signal, ownerId, appId }) {
   const warpToken = await getWarp10AccessLogsToken({ orgaId: ownerId }).then(
     sendToApi({ apiConfig, signal, cacheDelay: ONE_DAY }),
   );
-  return getStatusCodesFromWarp10({ warpToken, ownerId, appId }).then(
-    sendToWarp({ apiConfig, signal, timeout: THIRTY_SECONDS }),
-  );
+  return getStatusCodesFromWarp10({ warpToken, ownerId, appId })
+    .then(sendToWarp({ apiConfig, signal, timeout: THIRTY_SECONDS }))
+    .then((/** @type {Record<string, string>} */ data) => {
+      for (const statusCode in data) {
+        const statusCodeNumber = parseInt(statusCode);
+        if (statusCodeNumber < 100) {
+          delete data[statusCode];
+        }
+      }
+      return data;
+    });
 }

--- a/src/components/cc-tile-status-codes/cc-tile-status-codes.stories.js
+++ b/src/components/cc-tile-status-codes/cc-tile-status-codes.stories.js
@@ -49,6 +49,14 @@ export const dataLoaded = makeStory(conf, {
   ],
 });
 
+export const unknownCode = makeStory(conf, {
+  items: [
+    { state: { type: 'loaded', statusCodes: { ...DATA[0], 600: 5000, 700: 10000 } } },
+    { state: { type: 'loaded', statusCodes: { ...DATA[1], 600: 50, 700: 100 } } },
+    { state: { type: 'loaded', statusCodes: { ...DATA[2], 600: 50, 700: 100 } } },
+  ],
+});
+
 export const simulations = makeStory(conf, {
   items: [{}, {}],
   simulations: [


### PR DESCRIPTION
## What does this PR do?

* This PR filters out `0` status codes returned by the backend.
![image](https://github.com/user-attachments/assets/a41290bd-84c1-42e8-901f-1afc8ac8af77)
* It's a really small PR, one reviewer should be enough. :wink: 

## How to review?

* Check the code
* Test on a local storybook on the `/demo-smart` page that the `0` status codes are filtered.