### PR TITLE
eslint: enable some rules from the import plugin in the generic clever cloud config

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -2,6 +2,7 @@ import { setCustomElementsManifest } from '@storybook/web-components';
 // Any CSS file import automagically generates a `<link rel="stylesheet" href="bundledCssFile">` in the story iframe
 import 'github-markdown-css/github-markdown.css';
 import 'highlight.js/styles/vs.css';
+// eslint-disable-next-line import/no-unresolved
 import customElementsManifest from '../dist/custom-elements.json';
 import { AutodocsTemplate } from '../src/stories/lib/autodocs-template.jsx';
 import '../src/stories/lib/i18n-control.js';

--- a/eslint/javascript/eslint-config-clever-cloud-esm.js
+++ b/eslint/javascript/eslint-config-clever-cloud-esm.js
@@ -37,7 +37,7 @@ export default {
     'import/no-unresolved': 'off',
     // quite a few false negative with this one
     'import/named': 'off',
-    'import/extensions': 'off',
+    'import/extensions': ['error', 'always'],
     'import/first': 'error',
     'import/newline-after-import': ['error', { count: 1 }],
     'import/no-useless-path-segments': ['error', { noUselessIndex: true }],

--- a/eslint/javascript/eslint-config-clever-cloud-esm.js
+++ b/eslint/javascript/eslint-config-clever-cloud-esm.js
@@ -33,10 +33,9 @@ export default {
     'no-new': 'off',
     'no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_', ignoreRestSiblings: true }],
     // import plugin
-    // some rules are disabled because TypeScript already handles it
-    'import/no-unresolved': 'off',
     // quite a few false negative with this one
     'import/named': 'off',
+    'import/no-unresolved': 'error',
     'import/extensions': ['error', 'always'],
     'import/first': 'error',
     'import/newline-after-import': ['error', { count: 1 }],

--- a/src/stories/lib/make-story.js
+++ b/src/stories/lib/make-story.js
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-unresolved
 import customElementsManifest from '../../../dist/custom-elements.json';
 import { setLanguage } from '../../lib/i18n/i18n.js';
 import { sequence } from './sequence.js';


### PR DESCRIPTION
## What does this PR do?

- Enables two rules from the `import` plugin in `eslint-config-clever-cloud-esm`:
  - `no-unresolved`: even though TypeScript already handles this fairly well, it's better to be safe than sorry + the config is meant to be generic and could be used in projects that don't have TypeScript enabled (thanks @Galimede for pointing that out),
  - `extensions`: same reason as above but TypeScript doesn't always handle the extension requirement (for plain imports like `import './my-component.js';`.

The `named` remains disabled because it doesn't seem to work well. We'll deal with that when we handle #1273 

## How to review?

- Checking the code should be enough,
- You can go to a component file and remove some extensions from imports if you want to see it working,
- 1 reviewer is enough for this one.