### PR TITLE
Storybook: remove unused `RewriteRule` from `.htaccess`

### DIFF
--- a/.storybook/.htaccess
+++ b/.storybook/.htaccess
@@ -5,9 +5,6 @@ RewriteCond %{DOCUMENT_ROOT}%{REQUEST_URI} -f [OR]
 RewriteCond %{DOCUMENT_ROOT}%{REQUEST_URI} -d
 RewriteRule ^ - [L]
 
-# If the requested resource doesn't exist, use index.html
-RewriteRule ^ /index.html
-
 <IfModule mod_headers.c>
   <FilesMatch "\.(js|html)$">
     Header set Cache-Control "no-cache"

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -3,7 +3,7 @@ import { setCustomElementsManifest } from '@storybook/web-components';
 import 'github-markdown-css/github-markdown.css';
 import 'highlight.js/styles/vs.css';
 // @ts-ignore not worth helping TS understand this is valid since we don't need to type check this module
-// eslint-disable-next-line import/no-unresolved
+// eslint-disable-next-line import/no-unresolved, n/no-missing-import
 import customElementsManifest from '../dist/custom-elements.json';
 import { AutodocsTemplate } from '../src/stories/lib/autodocs-template.jsx';
 import '../src/stories/lib/i18n-control.js';

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -66,6 +66,7 @@ export default [
       'wds/**/*.js',
       'src/stories/lib/smart-auth-plugin.js',
       'test-mocha/**/*.*js',
+      '.storybook/**/*.js',
     ],
     languageOptions: {
       globals: {


### PR DESCRIPTION
## What does this PR do?

- Removes the `RewriteRule` that is supposed to redirect to `index.html` when an asset is not found

<details>
  <summary>More info</summary>

This RewriteRule doesn't work for the prod app because the storybook assets are in `/doc/clever-components` and not directly at the root.

Ideally we would go for a `RewriteRule` that would take this into account but we cannot access the app environment variables from the `.htaccess` file so we would have to do something like this:

`RewriteRule ^ /doc/clever-components/index.html`

With this, any path after `doc/clever-components/` would be redirected to the `index.html`.

But we don't really want to maintain this hardcoded value.

Since all storybook pages rely on a queryParam on the root URL anyway, we don't really have to support this because someone typing:
`https://clever-cloud.com/doc/clever-components/toto` 

is very unlikely.

All our Storybook pages follow this format `https://clever-cloud.com/doc/clever-components/?path=...`

</details>

## How to review?

- No review necessary

