### PR TITLE
fix(cc-kv-terminal): handle huge command history using lit-virtualizer

### DIFF
--- a/src/components/cc-kv-terminal/cc-kv-terminal.types.d.ts
+++ b/src/components/cc-kv-terminal/cc-kv-terminal.types.d.ts
@@ -16,3 +16,20 @@ export interface CcKvCommandHistoryEntry {
   result: Array<string>;
   success: boolean;
 }
+
+export type CcKvCommandContentItem = CcKvCommandContentItemCommandLine | CcKvCommandContentItemResultLine;
+
+interface CcKvCommandContentItemCommandLine {
+  id: string;
+  type: 'commandLine';
+  line: string;
+  hasResult: boolean;
+}
+
+interface CcKvCommandContentItemResultLine {
+  id: string;
+  type: 'resultLine';
+  line: string;
+  success: boolean;
+  last: boolean;
+}


### PR DESCRIPTION
## What this PR do ?

This PR moves the history of commands and their results into a lit virtualizer so that browser can handle huge command history.

## How to review ?

- Check the code
- Use the command `command` to get huge result output
- Try to scroll up and check that you don't loose focus
- Check that when running command (hitting Enter), the view always scroll to bottom properly
- Verify on all browsers