### PR TITLE
`cc-addon-elasticsearch-options`: support multi-currency and disabled billing

### DIFF
--- a/src/components/cc-addon-elasticsearch-options/cc-addon-elasticsearch-options.js
+++ b/src/components/cc-addon-elasticsearch-options/cc-addon-elasticsearch-options.js
@@ -1,4 +1,5 @@
 import { css, html, LitElement } from 'lit';
+import { classMap } from 'lit/directives/class-map.js';
 import { iconRemixAlertFill as iconAlert } from '../../assets/cc-remix.icons.js';
 import { dispatchCustomEvent } from '../../lib/events.js';
 import { ccAddonEncryptionAtRestOption } from '../../templates/cc-addon-encryption-at-rest-option/cc-addon-encryption-at-rest-option.js';
@@ -8,11 +9,29 @@ import '../cc-addon-option-form/cc-addon-option-form.js';
 const KIBANA_LOGO_URL = 'https://assets.clever-cloud.com/logos/elasticsearch-kibana.svg';
 const APM_LOGO_URL = 'https://assets.clever-cloud.com/logos/elasticsearch-apm.svg';
 
+/** @type {Flavor} */
+const SKELETON_FLAVOR_WITHOUT_MONTHLY_COST = {
+  name: '?',
+  mem: 0,
+  cpus: 0,
+  gpus: 0,
+  microservice: false,
+};
+
+/** @type {FlavorWithMonthlyCost} */
+const SKELETON_FLAVOR_WITH_MONTHLY_COST = {
+  ...SKELETON_FLAVOR_WITHOUT_MONTHLY_COST,
+  monthlyCost: { amount: 0, currency: 'EUR' },
+};
+
 /**
+ * @typedef {import('./cc-addon-elasticsearch-options.types.js').AddonElasticsearchOptionsState} AddonElasticsearchOptionsState
  * @typedef {import('../common.types.js').AddonOptionStates} AddonOptionStates
- * @typedef {import('../common.types.js').AddonOption} AddonOption
- * @typedef {import('../common.types.js').ElasticAddonOption} ElasticAddonOption
+ * @typedef {import('../common.types.js').EncryptionAddonOption} AddonOption
  * @typedef {import('../common.types.js').AddonOptionWithMetadata} AddonOptionWithMetadata
+ * @typedef {import('../common.types.js').FlavorWithMonthlyCost} FlavorWithMonthlyCost
+ * @typedef {import('../common.types.js').ElasticAddonOption<Flavor | FlavorWithMonthlyCost | null>} ElasticAddonOption
+ * @typedef {import('../common.types.js').Flavor} Flavor
  */
 
 /**
@@ -25,15 +44,15 @@ const APM_LOGO_URL = 'https://assets.clever-cloud.com/logos/elasticsearch-apm.sv
 export class CcAddonElasticsearchOptions extends LitElement {
   static get properties() {
     return {
-      options: { type: Array },
+      state: { type: Object },
     };
   }
 
   constructor() {
     super();
 
-    /** @type {Array<AddonOption>} List of options for this add-on. */
-    this.options = [];
+    /** @type {AddonElasticsearchOptionsState} Sets the state of the component */
+    this.state = { type: 'loading', hasMonthlyCost: true, options: [] };
   }
 
   /** @param {CustomEvent<AddonOptionStates>} event */
@@ -42,71 +61,105 @@ export class CcAddonElasticsearchOptions extends LitElement {
   }
 
   /**
-   * @param {ElasticAddonOption} addonOption
-   * @returns {AddonOptionWithMetadata}
+   * Returns the metadata for an Elasticsearch option (APM or Kibana) including title, warning message, details, and logo URL
+   *
+   * @param {ElasticAddonOption['name']} elasticOptionName
+   * @returns {{ title: string, warning: string, details: Node, logo: string }}
    */
-  _getApmOption({ enabled, flavor }) {
-    const description = html`
-      <div class="option-details">${i18n('cc-addon-elasticsearch-options.description.apm')}</div>
-      <div class="option-warning">
-        <cc-icon
-          .icon="${iconAlert}"
-          a11y-name="${i18n('cc-addon-elasticsearch-options.error.icon-a11y-name')}"
-          class="icon-warning"
-        ></cc-icon>
-        <p>
-          ${i18n('cc-addon-elasticsearch-options.warning.apm')}
-          ${flavor != null ? html` ${i18n('cc-addon-elasticsearch-options.warning.apm.details', flavor)} ` : ''}
-        </p>
-      </div>
-    `;
+  _getElasticsearchOptionData(elasticOptionName) {
+    switch (elasticOptionName) {
+      case 'apm':
+        return {
+          title: 'APM',
+          warning: i18n('cc-addon-elasticsearch-options.warning.apm'),
+          details: i18n('cc-addon-elasticsearch-options.details.apm'),
+          logo: APM_LOGO_URL,
+        };
+      case 'kibana':
+        return {
+          title: 'Kibana',
+          warning: i18n('cc-addon-elasticsearch-options.warning.kibana'),
+          details: i18n('cc-addon-elasticsearch-options.details.kibana'),
+          logo: KIBANA_LOGO_URL,
+        };
+    }
+  }
 
-    return {
-      title: 'APM',
-      logo: APM_LOGO_URL,
-      description,
-      enabled,
-      name: 'apm',
-    };
+  /**
+   * Returns the appropriate flavor object based on skeleton state and whether monthly cost is enabled
+   *
+   * @param {boolean} skeleton - Whether the component is in loading state
+   * @param {boolean} hasMonthlyCost - Whether monthly cost should be included
+   * @param {Flavor|FlavorWithMonthlyCost} [flavor] - The flavor object to return if not in skeleton state
+   * @returns {Flavor|FlavorWithMonthlyCost} The appropriate flavor object
+   */
+  _getElasticsearchOptionFlavor(skeleton, hasMonthlyCost, flavor) {
+    if (skeleton && hasMonthlyCost) {
+      return SKELETON_FLAVOR_WITH_MONTHLY_COST;
+    }
+
+    if (skeleton) {
+      return SKELETON_FLAVOR_WITHOUT_MONTHLY_COST;
+    }
+
+    return flavor;
   }
 
   /**
    * @param {ElasticAddonOption} addonOption
    * @returns {AddonOptionWithMetadata}
    */
-  _getKibanaOption({ enabled, flavor }) {
+  _getElasticAddonOption(addonOption) {
+    const { title, warning, details, logo } = this._getElasticsearchOptionData(addonOption.name);
+    const skeleton = this.state.type === 'loading';
+    const flavor = this._getElasticsearchOptionFlavor(
+      this.state.type === 'loading',
+      this.state.hasMonthlyCost,
+      addonOption.flavor,
+    );
+
     const description = html`
-      <div class="option-details">${i18n('cc-addon-elasticsearch-options.description.kibana')}</div>
+      <div class="option-details">${details}</div>
       <div class="option-warning">
         <cc-icon
           .icon="${iconAlert}"
           a11y-name="${i18n('cc-addon-elasticsearch-options.error.icon-a11y-name')}"
           class="icon-warning"
         ></cc-icon>
-        <p>
-          ${i18n('cc-addon-elasticsearch-options.warning.kibana')}
-          ${flavor != null ? html` ${i18n('cc-addon-elasticsearch-options.warning.kibana.details', flavor)} ` : ''}
-        </p>
+        <div>
+          <p>${warning}</p>
+          <p>
+            <span class="options-warning ${classMap({ skeleton })}">
+              ${i18n('cc-addon-elasticsearch-options.warning.flavor', flavor)}
+            </span>
+            ${this.state.hasMonthlyCost && 'monthlyCost' in flavor
+              ? html`
+                  <span class="options-warning ${classMap({ skeleton })}">
+                    ${i18n('cc-addon-elasticsearch-options.warning.monthly-cost', flavor.monthlyCost)}
+                  </span>
+                `
+              : ''}
+          </p>
+        </div>
       </div>
     `;
 
     return {
-      title: 'Kibana',
-      logo: KIBANA_LOGO_URL,
+      title,
+      logo,
       description,
-      enabled,
-      name: 'kibana',
+      enabled: addonOption.enabled,
+      name: addonOption.name,
     };
   }
 
   _getFormOptions() {
-    return this.options
+    return this.state.options
       .map((option) => {
         switch (option.name) {
           case 'apm':
-            return this._getApmOption(option);
           case 'kibana':
-            return this._getKibanaOption(option);
+            return this._getElasticAddonOption(option);
           case 'encryption':
             return ccAddonEncryptionAtRestOption(option);
           default:
@@ -117,16 +170,16 @@ export class CcAddonElasticsearchOptions extends LitElement {
   }
 
   render() {
-    const options = this._getFormOptions();
-    const heading = i18n('cc-addon-elasticsearch-options.title');
-
     return html`
       <cc-addon-option-form
-        heading="${heading}"
-        .options=${options}
+        heading="${i18n('cc-addon-elasticsearch-options.title')}"
+        .options=${this._getFormOptions()}
         @cc-addon-option-form:submit="${this._onFormOptionsSubmit}"
       >
-        <div slot="description">${i18n('cc-addon-elasticsearch-options.description')}</div>
+        <div slot="description">
+          ${i18n('cc-addon-elasticsearch-options.description')}
+          ${this.state.hasMonthlyCost ? i18n('cc-addon-elasticsearch-options.additional-cost') : ''}
+        </div>
       </cc-addon-option-form>
     `;
   }

--- a/src/components/cc-addon-elasticsearch-options/cc-addon-elasticsearch-options.js
+++ b/src/components/cc-addon-elasticsearch-options/cc-addon-elasticsearch-options.js
@@ -90,7 +90,7 @@ export class CcAddonElasticsearchOptions extends LitElement {
    *
    * @param {boolean} skeleton - Whether the component is in loading state
    * @param {boolean} hasMonthlyCost - Whether monthly cost should be included
-   * @param {Flavor|FlavorWithMonthlyCost} [flavor] - The flavor object to return if not in skeleton state
+   * @param {Flavor|FlavorWithMonthlyCost} flavor - The flavor object to return if not in skeleton state
    * @returns {Flavor|FlavorWithMonthlyCost} The appropriate flavor object
    */
   _getElasticsearchOptionFlavor(skeleton, hasMonthlyCost, flavor) {

--- a/src/components/cc-addon-elasticsearch-options/cc-addon-elasticsearch-options.stories.js
+++ b/src/components/cc-addon-elasticsearch-options/cc-addon-elasticsearch-options.stories.js
@@ -83,6 +83,32 @@ export const loading = makeStory(conf, {
   ],
 });
 
+export const loadingWithNoMonthlyCost = makeStory(conf, {
+  /** @type {Partial<CcAddonElasticsearchOptions>[]} */
+  items: [
+    {
+      state: {
+        type: 'loading',
+        hasMonthlyCost: false,
+        options: [
+          {
+            name: 'kibana',
+            enabled: false,
+          },
+          {
+            name: 'apm',
+            enabled: false,
+          },
+          {
+            name: 'encryption',
+            enabled: false,
+          },
+        ],
+      },
+    },
+  ],
+});
+
 export const dataLoadedWithPreselectedKibana = makeStory(conf, {
   /** @type {Partial<CcAddonElasticsearchOptions>[]} */
   items: [

--- a/src/components/cc-addon-elasticsearch-options/cc-addon-elasticsearch-options.stories.js
+++ b/src/components/cc-addon-elasticsearch-options/cc-addon-elasticsearch-options.stories.js
@@ -11,69 +11,198 @@ const conf = {
   component: 'cc-addon-elasticsearch-options',
 };
 
+/**
+ * @typedef {import('./cc-addon-elasticsearch-options.js').CcAddonElasticsearchOptions} CcAddonElasticsearchOptions
+ */
+
 export const defaultStory = makeStory(conf, {
+  /** @type {Partial<CcAddonElasticsearchOptions>[]} */
   items: [
     {
-      options: [
-        {
-          name: 'kibana',
-          enabled: false,
-          flavor: { name: 'L', mem: 8192, cpus: 6, gpus: 0, microservice: false, monthlyCost: 144 },
-        },
-        {
-          name: 'apm',
-          enabled: false,
-          flavor: { name: 'M', mem: 4096, cpus: 4, gpus: 0, microservice: false, monthlyCost: 72 },
-        },
-        {
-          name: 'encryption',
-          enabled: false,
-        },
-      ],
+      state: {
+        type: 'loaded',
+        hasMonthlyCost: true,
+        options: [
+          {
+            name: 'kibana',
+            enabled: false,
+            flavor: {
+              name: 'L',
+              mem: 8192,
+              cpus: 6,
+              gpus: 0,
+              microservice: false,
+              monthlyCost: { amount: 144, currency: 'EUR' },
+            },
+          },
+          {
+            name: 'apm',
+            enabled: false,
+            flavor: {
+              name: 'M',
+              mem: 4096,
+              cpus: 4,
+              gpus: 0,
+              microservice: false,
+              monthlyCost: { amount: 72, currency: 'EUR' },
+            },
+          },
+          {
+            name: 'encryption',
+            enabled: false,
+          },
+        ],
+      },
     },
   ],
 });
 
-export const noFlavorDetailsYet = makeStory(conf, {
+export const loading = makeStory(conf, {
+  /** @type {Partial<CcAddonElasticsearchOptions>[]} */
   items: [
     {
-      options: [
-        {
-          name: 'kibana',
-          enabled: false,
-        },
-        {
-          name: 'apm',
-          enabled: false,
-        },
-        {
-          name: 'encryption',
-          enabled: false,
-        },
-      ],
+      state: {
+        type: 'loading',
+        hasMonthlyCost: true,
+        options: [
+          {
+            name: 'kibana',
+            enabled: false,
+          },
+          {
+            name: 'apm',
+            enabled: false,
+          },
+          {
+            name: 'encryption',
+            enabled: false,
+          },
+        ],
+      },
     },
   ],
 });
 
-export const preselectedKibana = makeStory(conf, {
+export const dataLoadedWithPreselectedKibana = makeStory(conf, {
+  /** @type {Partial<CcAddonElasticsearchOptions>[]} */
   items: [
     {
-      options: [
-        {
-          name: 'kibana',
-          enabled: true,
-          flavor: { name: 'L', mem: 8192, cpus: 6, gpus: 0, microservice: false, monthlyCost: 144 },
-        },
-        {
-          name: 'apm',
-          enabled: false,
-          flavor: { name: 'M', mem: 4096, cpus: 4, gpus: 0, microservice: false, monthlyCost: 72 },
-        },
-        {
-          name: 'encryption',
-          enabled: false,
-        },
-      ],
+      state: {
+        type: 'loaded',
+        hasMonthlyCost: true,
+        options: [
+          {
+            name: 'kibana',
+            enabled: true,
+            flavor: {
+              name: 'L',
+              mem: 8192,
+              cpus: 6,
+              gpus: 0,
+              microservice: false,
+              monthlyCost: { amount: 144, currency: 'EUR' },
+            },
+          },
+          {
+            name: 'apm',
+            enabled: false,
+            flavor: {
+              name: 'M',
+              mem: 4096,
+              cpus: 4,
+              gpus: 0,
+              microservice: false,
+              monthlyCost: { amount: 72, currency: 'EUR' },
+            },
+          },
+          {
+            name: 'encryption',
+            enabled: false,
+          },
+        ],
+      },
+    },
+  ],
+});
+
+export const dataLoadedWithDollars = makeStory(conf, {
+  /** @type {Partial<CcAddonElasticsearchOptions>[]} */
+  items: [
+    {
+      state: {
+        type: 'loaded',
+        hasMonthlyCost: true,
+        options: [
+          {
+            name: 'kibana',
+            enabled: false,
+            flavor: {
+              name: 'L',
+              mem: 8192,
+              cpus: 6,
+              gpus: 0,
+              microservice: false,
+              monthlyCost: { amount: 144, currency: 'USD' },
+            },
+          },
+          {
+            name: 'apm',
+            enabled: false,
+            flavor: {
+              name: 'M',
+              mem: 4096,
+              cpus: 4,
+              gpus: 0,
+              microservice: false,
+              monthlyCost: { amount: 72, currency: 'USD' },
+            },
+          },
+          {
+            name: 'encryption',
+            enabled: false,
+          },
+        ],
+      },
+    },
+  ],
+});
+
+export const dataLoadedWithNoMonthlyCost = makeStory(conf, {
+  /** @type {Partial<CcAddonElasticsearchOptions>[]} */
+  items: [
+    {
+      state: {
+        type: 'loaded',
+        hasMonthlyCost: false,
+        options: [
+          {
+            name: 'kibana',
+            enabled: false,
+            flavor: {
+              name: 'L',
+              mem: 8192,
+              cpus: 6,
+              gpus: 0,
+              microservice: false,
+            },
+          },
+          {
+            name: 'apm',
+            enabled: false,
+            flavor: {
+              name: 'M',
+              mem: 4096,
+              cpus: 4,
+              gpus: 0,
+              microservice: false,
+            },
+          },
+          {
+            name: 'encryption',
+            enabled: false,
+          },
+        ],
+      },
     },
   ],
 });

--- a/src/components/cc-addon-elasticsearch-options/cc-addon-elasticsearch-options.types.d.ts
+++ b/src/components/cc-addon-elasticsearch-options/cc-addon-elasticsearch-options.types.d.ts
@@ -1,0 +1,28 @@
+import { ElasticAddonOption, EncryptionAddonOption, Flavor, FlavorWithMonthlyCost } from '../common.types.js';
+
+export type AddonElasticsearchOptionsState =
+  | AddonElasticsearchOptionsStateLoaded
+  | AddonElasticsearchOptionsStateLoadedWithoutMonthlyCost
+  | AddonElasticsearchOptionsStateLoading;
+
+type ElasticAddonOptionWithPaidFlavor = ElasticAddonOption<FlavorWithMonthlyCost>;
+type ElasticAddonOptionWithFreeFlavor = ElasticAddonOption<Flavor>;
+type ElasticAddonOptionWithoutFlavor = ElasticAddonOption<null>;
+
+export interface AddonElasticsearchOptionsStateLoaded {
+  type: 'loaded';
+  hasMonthlyCost: true; // enables the display of monthly cost for APM and Kibana options
+  options: Array<ElasticAddonOptionWithPaidFlavor | EncryptionAddonOption>; // since monthly cost is enabled, flavors in options need to have a `monthlyCost` object
+}
+
+export interface AddonElasticsearchOptionsStateLoadedWithoutMonthlyCost {
+  type: 'loaded';
+  hasMonthlyCost: false; // disables the display of monthly cost for APM and Kibana options
+  options: Array<ElasticAddonOptionWithFreeFlavor | EncryptionAddonOption>; // since monthly cost is disabled, flavors in options should not contain any `monthlyCost` object
+}
+
+export interface AddonElasticsearchOptionsStateLoading {
+  type: 'loading';
+  hasMonthlyCost: boolean; // since we rely on skeletons during loading phase, setting this to `true` shows a skeleton for the instance cost data
+  options: Array<EncryptionAddonOption | ElasticAddonOptionWithoutFlavor>; // since instance data and its cost are loading, options should not contain any `flavor` object
+}

--- a/src/components/cc-addon-option-form/cc-addon-option-form.js
+++ b/src/components/cc-addon-option-form/cc-addon-option-form.js
@@ -1,5 +1,6 @@
 import { css, html, LitElement } from 'lit';
 import { dispatchCustomEvent } from '../../lib/events.js';
+import { skeletonStyles } from '../../styles/skeleton.js';
 import { linkStyles } from '../../templates/cc-link/cc-link.js';
 import { i18n } from '../../translations/translation.js';
 import '../cc-addon-option/cc-addon-option.js';
@@ -91,6 +92,7 @@ export class CcAddonOptionForm extends LitElement {
   static get styles() {
     return [
       linkStyles,
+      skeletonStyles,
       // language=CSS
       css`
         :host {
@@ -127,6 +129,17 @@ export class CcAddonOptionForm extends LitElement {
           color: var(--cc-color-text-warning);
 
           --cc-icon-size: 1.25em;
+        }
+
+        /* Temporary workaround for cc-addon-elasticsearch-options because the skeleton parts should only be the <strong> elements but they are nested inside i18n strings */
+        .option-warning .skeleton {
+          color: var(--cc-color-text-weak);
+        }
+
+        /* Temporary workaround for cc-addon-elasticsearch-options because the skeleton parts should only be the <strong> elements but they are nested inside i18n strings */
+        .skeleton strong {
+          background-color: #bbb;
+          color: transparent;
         }
       `,
     ];

--- a/src/components/cc-addon-option-form/cc-addon-option-form.js
+++ b/src/components/cc-addon-option-form/cc-addon-option-form.js
@@ -131,12 +131,12 @@ export class CcAddonOptionForm extends LitElement {
           --cc-icon-size: 1.25em;
         }
 
-        /* Temporary workaround for cc-addon-elasticsearch-options because the skeleton parts should only be the <strong> elements but they are nested inside i18n strings */
+        /* FIXME: Temporary workaround for cc-addon-elasticsearch-options because the skeleton parts should only be the <strong> elements but they are nested inside i18n strings */
         .option-warning .skeleton {
           color: var(--cc-color-text-weak);
         }
 
-        /* Temporary workaround for cc-addon-elasticsearch-options because the skeleton parts should only be the <strong> elements but they are nested inside i18n strings */
+        /* FIXME: Temporary workaround for cc-addon-elasticsearch-options because the skeleton parts should only be the <strong> elements but they are nested inside i18n strings */
         .skeleton strong {
           background-color: #bbb;
           color: transparent;

--- a/src/components/cc-tile-scalability/cc-tile-scalability.js
+++ b/src/components/cc-tile-scalability/cc-tile-scalability.js
@@ -9,8 +9,8 @@ import '../cc-icon/cc-icon.js';
 
 /** @type {Scalability} */
 const SKELETON_SCALABILITY = {
-  minFlavor: { name: '??', cpus: 0, gpus: 0, mem: 0, microservice: false, monthlyCost: 0 },
-  maxFlavor: { name: '?', cpus: 0, gpus: 0, mem: 0, microservice: false, monthlyCost: 0 },
+  minFlavor: { name: '??', cpus: 0, gpus: 0, mem: 0, microservice: false },
+  maxFlavor: { name: '?', cpus: 0, gpus: 0, mem: 0, microservice: false },
   minInstances: 0,
   maxInstances: 0,
 };

--- a/src/components/cc-tile-scalability/cc-tile-scalability.stories.js
+++ b/src/components/cc-tile-scalability/cc-tile-scalability.stories.js
@@ -20,9 +20,9 @@ const conf = {
 
 /**
  * @typedef {import('./cc-tile-scalability.js').CcTileScalability} CcTileScalability
- * @typedef {import('./cc-tile-scalability.type.js').TileScalabilityStateLoaded} TileScalabilityStateLoaded
- * @typedef {import('./cc-tile-scalability.type.js').TileScalabilityStateLoading} TileScalabilityStateLoading
- * @typedef {import('./cc-tile-scalability.type.js').TileScalabilityStateError} TileScalabilityStateError
+ * @typedef {import('./cc-tile-scalability.types.js').TileScalabilityStateLoaded} TileScalabilityStateLoaded
+ * @typedef {import('./cc-tile-scalability.types.js').TileScalabilityStateLoading} TileScalabilityStateLoading
+ * @typedef {import('./cc-tile-scalability.types.js').TileScalabilityStateError} TileScalabilityStateError
  * @typedef {import('../common.types.js').Flavor} Flavor
  * @typedef {import('../common.types.js').Scalability} Scalability
  */

--- a/src/components/common.types.d.ts
+++ b/src/components/common.types.d.ts
@@ -38,32 +38,33 @@ export interface Flavor {
   gpus: number;
   mem: number;
   microservice: boolean;
-  monthlyCost?: number | null;
 }
 
-export interface EncryptionAddonOption {
-  name: 'encryption';
-  enabled: boolean;
-}
-
-export interface ElasticAddonOption {
-  name: 'kibana' | 'apm';
-  enabled: boolean;
-  flavor?: Flavor;
-}
-
-export type AddonOption = EncryptionAddonOption | ElasticAddonOption;
+export type AddonOption = EncryptionAddonOption | ElasticAddonOption<Flavor | FlavorWithMonthlyCost | null>;
 
 export type AddonOptionWithMetadata = {
   icon?: IconModel;
-  title?: string | DocumentFragment;
+  title?: string | Node;
   logo?: string;
-  description: string | DocumentFragment | TemplateResult<1>;
-} & AddonOption;
+  description: string | Node | TemplateResult<1>;
+} & Pick<AddonOption, 'name' | 'enabled'>;
 
 export interface EncryptionAddonOption {
   name: 'encryption';
   enabled: boolean;
+}
+
+export interface ElasticAddonOption<FlavorType> {
+  name: 'kibana' | 'apm';
+  enabled: boolean;
+  flavor?: FlavorType;
+}
+
+export interface FlavorWithMonthlyCost extends Flavor {
+  monthlyCost: {
+    amount: number;
+    currency: string;
+  };
 }
 
 export type AddonOptionStates = { [optionName: string]: boolean };

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -18,6 +18,7 @@ import { preparePlural } from '../lib/i18n/i18n-string.js';
 
 /**
  * @typedef {import('../components/common.types.js').Flavor} Flavor
+ * @typedef {import('../components/common.types.js').FlavorWithMonthlyCost} FlavorWithMonthlyCost
  */
 
 export const lang = 'en';
@@ -155,20 +156,24 @@ export const translations = {
   'cc-addon-credentials.title': /** @param {{name: string}} _ */ ({ name }) => `${name} credentials`,
   //#endregion
   //#region cc-addon-elasticsearch-options
-  'cc-addon-elasticsearch-options.description': () =>
-    sanitize`This add-on is part of the Elastic Stack offer which includes two options. Both these options will be deployed as applications, managed and updated by Clever Cloud on your behalf. They will appear as regular applications that you can stop, scale up or down automatically like one of your own applications. As such, <strong>enabling these options will result in an increase in credits consumption</strong> as well.`,
-  'cc-addon-elasticsearch-options.description.apm': () =>
+  'cc-addon-elasticsearch-options.additional-cost': () =>
+    sanitize`As such, <strong>enabling these options will result in an increase in credits consumption</strong> as well.`,
+  'cc-addon-elasticsearch-options.description': `This add-on is part of the Elastic Stack offer which includes two options. Both these options will be deployed as applications, managed and updated by Clever Cloud on your behalf. They will appear as regular applications that you can stop, scale up or down automatically like one of your own applications.`,
+  'cc-addon-elasticsearch-options.details.apm': () =>
     sanitize`Elastic APM server is an application performance monitoring system built on the Elastic Stack. Deploying this will allow you to automatically send APM metrics from any applications linked to the Elasticsearch add-on instance, providing you add the Elastic APM agent to the application code. Learn more in the <a href="https://www.elastic.co/guide/en/apm/get-started/current/overview.html">official APM server documentation</a>.`,
-  'cc-addon-elasticsearch-options.description.kibana': () =>
+  'cc-addon-elasticsearch-options.details.kibana': () =>
     sanitize`Kibana is the admin UI for the Elastic Stack. It lets you visualize your Elasticsearch data and navigate the stack so you can do anything from tracking query load to understanding the way requests flow through your apps. Learn more in the <a href="https://www.elastic.co/guide/en/kibana/master/index.html">official Kibana documentation</a>.`,
   'cc-addon-elasticsearch-options.error.icon-a11y-name': `Warning`,
   'cc-addon-elasticsearch-options.title': `Options for the Elastic Stack`,
-  'cc-addon-elasticsearch-options.warning.apm': `If you enable this option, we'll deploy and manage an Elastic APM server application for you, this will lead to additional costs.`,
-  'cc-addon-elasticsearch-options.warning.apm.details': /** @param {Flavor} flavor */ (flavor) =>
-    sanitize`By default, the app will start on a <strong title="${formatFlavor(flavor)}">${flavor.name} instance</strong> which costs around <strong>${formatCurrency(lang, flavor.monthlyCost)} per month</strong>.`,
-  'cc-addon-elasticsearch-options.warning.kibana': `If you enable this option, we'll deploy and manage a Kibana application for you, this will lead to additional costs.`,
-  'cc-addon-elasticsearch-options.warning.kibana.details': /** @param {Flavor} flavor */ (flavor) =>
-    sanitize`By default, the app will start on a <strong title="${formatFlavor(flavor)}">${flavor.name} instance</strong> which costs around <strong>${formatCurrency(lang, flavor.monthlyCost)} per month</strong>.`,
+  'cc-addon-elasticsearch-options.warning.apm': `If you enable this option, we'll deploy and manage an Elastic APM server application for you.`,
+  'cc-addon-elasticsearch-options.warning.flavor': /** @param {Flavor} flavor */ (flavor) =>
+    sanitize`By default, the app will start on a <strong title="${formatFlavor(flavor)}">${flavor.name} instance</strong>.`,
+  'cc-addon-elasticsearch-options.warning.kibana': `If you enable this option, we'll deploy and manage a Kibana application for you.`,
+  'cc-addon-elasticsearch-options.warning.monthly-cost': /** @param {FlavorWithMonthlyCost['monthlyCost']} _ */ ({
+    amount,
+    currency,
+  }) => sanitize`
+      This should cost around <strong>${formatCurrency(lang, amount, { currency })}</strong> per month.`,
   //#endregion
   //#region cc-addon-encryption-at-rest-option
   'cc-addon-encryption-at-rest-option.description': () =>

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -18,6 +18,7 @@ import { preparePlural } from '../lib/i18n/i18n-string.js';
 
 /**
  * @typedef {import('../components/common.types.js').Flavor} Flavor
+ * @typedef {import('../components/common.types.js').FlavorWithMonthlyCost} FlavorWithMonthlyCost
  */
 
 export const lang = 'fr';
@@ -166,20 +167,24 @@ export const translations = {
   'cc-addon-credentials.title': /** @param {{name: string}} _ */ ({ name }) => `Identifiants ${name}`,
   //#endregion
   //#region cc-addon-elasticsearch-options
-  'cc-addon-elasticsearch-options.description': () =>
-    sanitize`Cet add-on fait partie de l'offre Suite Elastic qui inclue deux options. Ces options sont déployées comme des applications et seront gérées et mises à jour par Clever Cloud. Elles apparaîtront donc comme des applications habituelles que vous pouvez arrêter, supprimer, scaler comme n'importe quelle autre application. <strong>Activer ces options augmentera votre consommation de crédits.</strong>`,
-  'cc-addon-elasticsearch-options.description.apm': () =>
+  'cc-addon-elasticsearch-options.additional-cost': () =>
+    sanitize`<strong>Activer ces options augmentera votre consommation de crédits.</strong>`,
+  'cc-addon-elasticsearch-options.description': `Cet add-on fait partie de l'offre Suite Elastic qui inclue deux options. Ces options sont déployées comme des applications et seront gérées et mises à jour par Clever Cloud. Elles apparaîtront donc comme des applications habituelles que vous pouvez arrêter, supprimer, scaler comme n'importe quelle autre application.`,
+  'cc-addon-elasticsearch-options.details.apm': () =>
     sanitize`Elastic APM est un serveur de monitoring de performance applicative pour la Suite Elastic. Déployer cette option permet d'envoyer automatiquement les métriques de toute application liée à cette instance d'add-on Elasticsearch, en supposant que vous utilisez bien l'agent Elastic APM dans les dépendances de vos applications. Retrouvez plus de détails dans <a href="https://www.elastic.co/guide/en/apm/get-started/current/overview.html">la documentation officielle de APM server</a>.`,
-  'cc-addon-elasticsearch-options.description.kibana': () =>
+  'cc-addon-elasticsearch-options.details.kibana': () =>
     sanitize`Kibana est l'interface d'administration de la Suite Elastic. Kibana vous permet de visualiser vos données Elasticsearch et de naviguer dans la Suite Elastic. Vous voulez effectuer le suivi de la charge de travail liée à la recherche ou comprendre le flux des requêtes dans vos applications ? Kibana est là pour ça. Retrouvez plus de détails dans <a href="https://www.elastic.co/guide/en/kibana/master/index.html">la documentation officielle de Kibana</a>.`,
   'cc-addon-elasticsearch-options.error.icon-a11y-name': `Avertissement`,
   'cc-addon-elasticsearch-options.title': `Options pour la Suite Elastic`,
-  'cc-addon-elasticsearch-options.warning.apm': `Si vous activez cette option, nous allons déployer et gérer pour vous un APM server, ce qui entraînera des coûts supplémentaires.`,
-  'cc-addon-elasticsearch-options.warning.apm.details': /** @param {Flavor} flavor */ (flavor) =>
-    sanitize`Par défaut, l'app sera démarrée sur une <strong title="${formatFlavor(flavor)}">instance ${flavor.name}</strong> qui coûte environ <strong>${formatCurrency(lang, flavor.monthlyCost)} par mois</strong>. `,
-  'cc-addon-elasticsearch-options.warning.kibana': `Si vous activez cette option, nous allons déployer et gérer pour vous un Kibana, ce qui entraînera des coûts supplémentaires.`,
-  'cc-addon-elasticsearch-options.warning.kibana.details': /** @param {Flavor} flavor */ (flavor) =>
-    sanitize`Par défaut, l'app sera démarrée sur une <strong title="${formatFlavor(flavor)}">instance ${flavor.name}</strong> qui coûte environ <strong>${formatCurrency(lang, flavor.monthlyCost)} par mois</strong>.`,
+  'cc-addon-elasticsearch-options.warning.apm': `Si vous activez cette option, nous allons déployer et gérer pour vous un APM server`,
+  'cc-addon-elasticsearch-options.warning.flavor': /** @param {Flavor} flavor */ (flavor) =>
+    sanitize`Par défaut, l'app sera démarrée sur une <strong title="${formatFlavor(flavor)}">instance ${flavor.name}</strong>.`,
+  'cc-addon-elasticsearch-options.warning.kibana': `Si vous activez cette option, nous allons déployer et gérer pour vous un Kibana.`,
+  'cc-addon-elasticsearch-options.warning.monthly-cost': /** @param {FlavorWithMonthlyCost['monthlyCost']} _ */ ({
+    amount,
+    currency,
+  }) =>
+    sanitize`Cela devrait coûter environ <strong>${formatCurrency(lang, amount, { currency: currency })} par mois</strong>.`,
   //#endregion
   //#region cc-addon-encryption-at-rest-option
   'cc-addon-encryption-at-rest-option.description': () =>


### PR DESCRIPTION
Fixes #1172 
Fixes #1230 

## What does this PR do?

- Adapts the `cc-addon-elasticsearch-options` component to support other currencies,
- Adapts the `cc-addon-elasticsearch-options` component to support cases where billing is disabled. In this case, sentences mentionning additional costs should be hidden, including in `loading` state when the cost is in skeleton mode while we fetch info.
- Both these changes led to some refactoring and **breaking changes**:
  - other `cc-addon-*-options` components do not fetch any data, they update data when you enable / disable options but there is no loading vs loaded logic.
  - on the contrary the `cc-addon-elasticsearch-options` component does fetch data and has a `loaded` vs `loading` logic:
    - we need to fetch what is the default instance of a Kibana and an APM instance,
    - if billing is enabled, we need to fetch the cost of the default instance of a Kibana and an APM instance.
  - this is why a `state` property was added. The types may look too complex for such a tiny component, feel free to suggest improvements but bear in mind that the subject is not as simple as it looks (there are comments that should help within the component & its types).

Note: the `skeleton` display is fairly broken right now, just like in `cc-invoice-list` but there's already an issue about this (see #1293)

## How to review?

- Check the code,
- Check the [stories](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-addon-elasticsearch-options/support-multi-currency/index.html?path=/story/%F0%9F%9B%A0-addon-cc-addon-elasticsearch-options--default-story) (including the 2 new stories: `loading` & `no monthly cost`),
- 2 or 3 reviewers should be enough for this one.