### PR TITLE
Use the `checked` property instead of the attribute

### DIFF
--- a/eslint/lit/eslint-config-lit-clever-cloud.js
+++ b/eslint/lit/eslint-config-lit-clever-cloud.js
@@ -10,6 +10,7 @@ export default {
     ...litPlugin.configs['flat/recommended'].rules,
     'lit/attribute-names': 'error',
     'lit/lifecycle-super': 'error',
+    'lit/ban-attributes': ['error', 'checked'],
     'lit/no-classfield-shadowing': 'error',
     'lit/no-invalid-escape-sequences': 'error',
     'lit/no-legacy-imports': 'error',

--- a/src/components/cc-zone-picker/cc-zone-picker.js
+++ b/src/components/cc-zone-picker/cc-zone-picker.js
@@ -116,7 +116,7 @@ export class CcZonePicker extends CcFormControlElement {
         name="zone"
         .value="${zone.code}"
         ?disabled=${disabled}
-        ?checked="${isZoneSelected}"
+        .checked="${isZoneSelected}"
         id="${zone.code}"
         aria-describedby="${ifDefined(zoneSectionHeaderId)}"
       />


### PR DESCRIPTION
Fixes #1265

## What does this PR do?

- Enables some ESLint rule to prevent devs from using the `checked` attribute and force them to use the `checked` property instead,
- Fixes the `cc-zone-picker` component to use the `checked` property instead of the attribute.

## How to review?

- Check the commits,
- It should be enough considering the changes, no need to do more.
- 1 reviewer should be enough for this one.