### PR TITLE
refactor(cc-email-list)!: rework properties to avoid impossible states

### DIFF
--- a/src/components/cc-email-list/cc-email-list.js
+++ b/src/components/cc-email-list/cc-email-list.js
@@ -29,7 +29,7 @@ import '../cc-notice/cc-notice.js';
 
 /** @type {PrimaryAddressState} */
 const SKELETON_PRIMARY_EMAIL = {
-  state: 'idle',
+  type: 'idle',
   address: fakeString(35),
   verified: false,
 };
@@ -88,7 +88,7 @@ export class CcEmailList extends LitElement {
   static get properties() {
     return {
       addEmailFormState: { type: Object, attribute: false },
-      emails: { type: Object },
+      emailListState: { type: Object, attribute: false },
     };
   }
 
@@ -99,7 +99,7 @@ export class CcEmailList extends LitElement {
     this.addEmailFormState = { type: 'idle' };
 
     /** @type {EmailListState} State of the component. */
-    this.emails = { state: 'loading' };
+    this.emailListState = { type: 'loading' };
 
     /** @type {CcInputTextRef} */
     this._addressInputRef = createRef();
@@ -133,8 +133,8 @@ export class CcEmailList extends LitElement {
   }
 
   _onSendConfirmationEmail() {
-    if (this.emails.state === 'loaded') {
-      dispatchCustomEvent(this, 'send-confirmation-email', this.emails.value.primaryAddress.address);
+    if (this.emailListState.type === 'loaded') {
+      dispatchCustomEvent(this, 'send-confirmation-email', this.emailListState.emailList.primaryAddress.address);
     }
   }
 
@@ -181,19 +181,19 @@ export class CcEmailList extends LitElement {
       <cc-block>
         <div slot="header-title">${i18n('cc-email-list.title')}</div>
 
-        ${this.emails.state === 'loading'
+        ${this.emailListState.type === 'loading'
           ? html`
               ${this._renderPrimarySection(SKELETON_PRIMARY_EMAIL, true)}
               ${this._renderSecondarySection(SKELETON_SECONDARY_EMAILS)}
             `
           : ''}
-        ${this.emails.state === 'loaded'
+        ${this.emailListState.type === 'loaded'
           ? html`
-              ${this._renderPrimarySection(this.emails.value.primaryAddress)}
-              ${this._renderSecondarySection(this.emails.value.secondaryAddresses)}
+              ${this._renderPrimarySection(this.emailListState.emailList.primaryAddress)}
+              ${this._renderSecondarySection(this.emailListState.emailList.secondaryAddresses)}
             `
           : ''}
-        ${this.emails.state === 'error'
+        ${this.emailListState.type === 'error'
           ? html`
               <cc-notice slot="content" intent="warning" message="${i18n('cc-email-list.loading.error')}"></cc-notice>
             `
@@ -233,7 +233,7 @@ export class CcEmailList extends LitElement {
           ? html`
               <cc-button
                 @cc-button:click=${this._onSendConfirmationEmail}
-                ?waiting=${primaryAddressState.state === 'sending-confirmation-email'}
+                ?waiting=${primaryAddressState.type === 'sending-confirmation-email'}
                 link
               >
                 ${i18n('cc-email-list.primary.action.resend-confirmation-email')}
@@ -250,7 +250,7 @@ export class CcEmailList extends LitElement {
    */
   _renderSecondarySection(secondaryAddressStates) {
     const addresses = [...secondaryAddressStates].sort(sortBy('address'));
-    const isOneRowMarkingPrimary = addresses.some((item) => item.state === 'marking-as-primary');
+    const isOneRowMarkingPrimary = addresses.some((item) => item.type === 'marking-as-primary');
 
     return html`
       <cc-block-section slot="content-body">
@@ -259,8 +259,8 @@ export class CcEmailList extends LitElement {
 
         <ul class="secondary-addresses">
           ${addresses.map((secondaryAddress) => {
-            const isBusy = secondaryAddress.state === 'marking-as-primary' || secondaryAddress.state === 'deleting';
-            const isDisabled = (isOneRowMarkingPrimary || isBusy) && secondaryAddress.state !== 'marking-as-primary';
+            const isBusy = secondaryAddress.type === 'marking-as-primary' || secondaryAddress.type === 'deleting';
+            const isDisabled = (isOneRowMarkingPrimary || isBusy) && secondaryAddress.type !== 'marking-as-primary';
 
             return html`
               <li class="address-line secondary">
@@ -271,7 +271,7 @@ export class CcEmailList extends LitElement {
                 <div class="buttons">
                   <cc-button
                     @cc-button:click=${() => this._onMarkAsPrimary(secondaryAddress.address)}
-                    ?waiting="${secondaryAddress.state === 'marking-as-primary'}"
+                    ?waiting="${secondaryAddress.type === 'marking-as-primary'}"
                     ?disabled="${isDisabled}"
                     a11y-name="${i18n('cc-email-list.secondary.action.mark-as-primary.accessible-name', {
                       address: secondaryAddress.address,
@@ -285,8 +285,8 @@ export class CcEmailList extends LitElement {
                     outlined
                     .icon=${iconDelete}
                     @cc-button:click=${() => this._onDelete(secondaryAddress.address)}
-                    ?waiting="${secondaryAddress.state === 'deleting'}"
-                    ?disabled="${isBusy && secondaryAddress.state !== 'deleting'}"
+                    ?waiting="${secondaryAddress.type === 'deleting'}"
+                    ?disabled="${isBusy && secondaryAddress.type !== 'deleting'}"
                     a11y-name="${i18n('cc-email-list.secondary.action.delete.accessible-name', {
                       address: secondaryAddress.address,
                     })}"

--- a/src/components/cc-email-list/cc-email-list.stories.js
+++ b/src/components/cc-email-list/cc-email-list.stories.js
@@ -8,19 +8,20 @@ const SECONDARY_ADDRESS_2 = 'john.doe.holidays@example.com';
 const HUGE_ADDRESS = `john${'.doe'.repeat(30)}@example.com`;
 
 /** @type {PrimaryAddressState} */
-const primaryAddress = { state: 'idle', address: PRIMARY_ADDRESS, verified: true };
+const primaryAddress = { type: 'idle', address: PRIMARY_ADDRESS, verified: true };
 /** @type {PrimaryAddressState} */
-const primaryUnverified = { state: 'idle', address: PRIMARY_ADDRESS, verified: false };
+const primaryUnverified = { type: 'idle', address: PRIMARY_ADDRESS, verified: false };
 /** @type {Array<SecondaryAddressState>} */
 const secondaryAddresses = [
-  { state: 'idle', address: SECONDARY_ADDRESS_1, verified: true },
-  { state: 'idle', address: SECONDARY_ADDRESS_2, verified: true },
+  { type: 'idle', address: SECONDARY_ADDRESS_1, verified: true },
+  { type: 'idle', address: SECONDARY_ADDRESS_2, verified: true },
 ];
 
+/** @type {Partial<CcEmailList>} */
 const baseItem = {
-  emails: {
-    state: 'loaded',
-    value: {
+  emailListState: {
+    type: 'loaded',
+    emailList: {
       primaryAddress,
       secondaryAddresses,
     },
@@ -35,6 +36,7 @@ export default {
 
 /**
  * @typedef {import('./cc-email-list.js').CcEmailList} CcEmailList
+ * @typedef {import('./cc-email-list.types.js').EmailListStateLoaded} EmailsListStateLoaded
  * @typedef {import('./cc-email-list.types.js').PrimaryAddressState} PrimaryAddressState
  * @typedef {import('./cc-email-list.types.js').SecondaryAddressState} SecondaryAddressState
  */
@@ -42,36 +44,41 @@ export default {
 const conf = {
   component: 'cc-email-list',
 };
+
 export const defaultStory = makeStory(conf, {
+  /** @type {Partial<CcEmailList>[]} */
   items: [baseItem],
 });
 
 export const skeleton = makeStory(conf, {
+  /** @type {Partial<CcEmailList>[]} */
   items: [
     {
-      emails: {
-        state: 'loading',
+      emailListState: {
+        type: 'loading',
       },
     },
   ],
 });
 
 export const errorWithLoading = makeStory(conf, {
+  /** @type {Partial<CcEmailList>[]} */
   items: [
     {
-      emails: {
-        state: 'error',
+      emailListState: {
+        type: 'error',
       },
     },
   ],
 });
 
 export const dataLoadedWithUnverifiedPrimaryEmailAddress = makeStory(conf, {
+  /** @type {Partial<CcEmailList>[]} */
   items: [
     {
-      emails: {
-        state: 'loaded',
-        value: {
+      emailListState: {
+        type: 'loaded',
+        emailList: {
           primaryAddress: primaryUnverified,
           secondaryAddresses: [],
         },
@@ -81,15 +88,16 @@ export const dataLoadedWithUnverifiedPrimaryEmailAddress = makeStory(conf, {
 });
 
 export const dataLoadedWithHugeEmail = makeStory(conf, {
+  /** @type {Partial<CcEmailList>[]} */
   items: [
     {
-      emails: {
-        state: 'loaded',
-        value: {
-          primaryAddress: { state: 'idle', address: HUGE_ADDRESS, verified: true },
+      emailListState: {
+        type: 'loaded',
+        emailList: {
+          primaryAddress: { type: 'idle', address: HUGE_ADDRESS, verified: true },
           secondaryAddresses: [
-            { state: 'idle', address: HUGE_ADDRESS, verified: true },
-            { state: 'idle', address: HUGE_ADDRESS, verified: true },
+            { type: 'idle', address: HUGE_ADDRESS, verified: true },
+            { type: 'idle', address: HUGE_ADDRESS, verified: true },
           ],
         },
       },
@@ -98,11 +106,12 @@ export const dataLoadedWithHugeEmail = makeStory(conf, {
 });
 
 export const dataLoadedWithNoSecondaryEmails = makeStory(conf, {
+  /** @type {Partial<CcEmailList>[]} */
   items: [
     {
-      emails: {
-        state: 'loaded',
-        value: {
+      emailListState: {
+        type: 'loaded',
+        emailList: {
           primaryAddress,
           secondaryAddresses: [],
         },
@@ -112,12 +121,13 @@ export const dataLoadedWithNoSecondaryEmails = makeStory(conf, {
 });
 
 export const loadingWithSendingConfirmationEmail = makeStory(conf, {
+  /** @type {Partial<CcEmailList>[]} */
   items: [
     {
-      emails: {
-        state: 'loaded',
-        value: {
-          primaryAddress: { ...primaryUnverified, state: 'sending-confirmation-email' },
+      emailListState: {
+        type: 'loaded',
+        emailList: {
+          primaryAddress: { ...primaryUnverified, type: 'sending-confirmation-email' },
           secondaryAddresses,
         },
       },
@@ -126,27 +136,28 @@ export const loadingWithSendingConfirmationEmail = makeStory(conf, {
 });
 
 export const loadingWithDeletingSecondary = makeStory(conf, {
+  /** @type {Partial<CcEmailList>[]} */
   items: [
     {
-      emails: {
-        state: 'loaded',
-        value: {
+      emailListState: {
+        type: 'loaded',
+        emailList: {
           primaryAddress,
           secondaryAddresses: [
-            { state: 'deleting', address: SECONDARY_ADDRESS_1, verified: true },
-            { state: 'idle', address: SECONDARY_ADDRESS_2, verified: true },
+            { type: 'deleting', address: SECONDARY_ADDRESS_1, verified: true },
+            { type: 'idle', address: SECONDARY_ADDRESS_2, verified: true },
           ],
         },
       },
     },
     {
-      emails: {
-        state: 'loaded',
-        value: {
+      emailListState: {
+        type: 'loaded',
+        emailList: {
           primaryAddress,
           secondaryAddresses: [
-            { state: 'deleting', address: SECONDARY_ADDRESS_1, verified: true },
-            { state: 'deleting', address: SECONDARY_ADDRESS_2, verified: true },
+            { type: 'deleting', address: SECONDARY_ADDRESS_1, verified: true },
+            { type: 'deleting', address: SECONDARY_ADDRESS_2, verified: true },
           ],
         },
       },
@@ -155,15 +166,16 @@ export const loadingWithDeletingSecondary = makeStory(conf, {
 });
 
 export const loadingWithMarkingSecondaryAsPrimary = makeStory(conf, {
+  /** @type {Partial<CcEmailList>[]} */
   items: [
     {
-      emails: {
-        state: 'loaded',
-        value: {
+      emailListState: {
+        type: 'loaded',
+        emailList: {
           primaryAddress,
           secondaryAddresses: [
-            { state: 'marking-as-primary', address: SECONDARY_ADDRESS_1, verified: true },
-            { state: 'idle', address: SECONDARY_ADDRESS_2, verified: true },
+            { type: 'marking-as-primary', address: SECONDARY_ADDRESS_1, verified: true },
+            { type: 'idle', address: SECONDARY_ADDRESS_2, verified: true },
           ],
         },
       },
@@ -172,19 +184,23 @@ export const loadingWithMarkingSecondaryAsPrimary = makeStory(conf, {
 });
 
 export const loadingWithSecondaryEmailIsBeingAdded = makeStory(conf, {
+  /** @type {Partial<CcEmailList>[]} */
   items: [
     {
       ...baseItem,
       addEmailFormState: { type: 'adding' },
     },
   ],
+  /** @param {CcEmailList} component */
   onUpdateComplete: (component) => {
     component._formRef.value.address.value = 'john.doe.extra@example.com';
   },
 });
 
 export const errorWithWhenSecondaryEmailIsEmpty = makeStory(conf, {
+  /** @type {Partial<CcEmailList>[]} */
   items: [baseItem],
+  /** @param {CcEmailList} component */
   onUpdateComplete: (component) => {
     component._formRef.value.address.value = '';
     component._formRef.value.address.validate();
@@ -193,7 +209,9 @@ export const errorWithWhenSecondaryEmailIsEmpty = makeStory(conf, {
 });
 
 export const errorWithWhenSecondaryEmailIsInvalid = makeStory(conf, {
+  /** @type {Partial<CcEmailList>[]} */
   items: [baseItem],
+  /** @param {CcEmailList} component */
   onUpdateComplete: (component) => {
     component._formRef.value.address.value = 'invalid address email';
     component._formRef.value.address.validate();
@@ -202,6 +220,7 @@ export const errorWithWhenSecondaryEmailIsInvalid = makeStory(conf, {
 });
 
 export const errorWithWhenSecondaryEmailIsAlreadyDefined = makeStory(conf, {
+  /** @type {Partial<CcEmailList>[]} */
   items: [
     {
       ...baseItem,
@@ -213,12 +232,14 @@ export const errorWithWhenSecondaryEmailIsAlreadyDefined = makeStory(conf, {
       },
     },
   ],
+  /** @param {CcEmailList} component */
   onUpdateComplete: (component) => {
     component._formRef.value.address.value = SECONDARY_ADDRESS_1;
   },
 });
 
 export const errorWithWhenSecondaryEmailIsUsed = makeStory(conf, {
+  /** @type {Partial<CcEmailList>[]} */
   items: [
     {
       ...baseItem,
@@ -230,6 +251,7 @@ export const errorWithWhenSecondaryEmailIsUsed = makeStory(conf, {
       },
     },
   ],
+  /** @param {CcEmailList} component */
   onUpdateComplete: (component) => {
     component._formRef.value.address.value = 'used-by-another-user@example.com';
   },

--- a/src/components/cc-email-list/cc-email-list.types.d.ts
+++ b/src/components/cc-email-list/cc-email-list.types.d.ts
@@ -1,15 +1,15 @@
 //# region state
 interface EmailListStateLoading {
-  state: 'loading';
+  type: 'loading';
 }
 
 interface EmailListStateError {
-  state: 'error';
+  type: 'error';
 }
 
 interface EmailListStateLoaded {
-  state: 'loaded';
-  value: EmailList;
+  type: 'loaded';
+  emailList: EmailList;
 }
 
 export type EmailListState = EmailListStateLoading | EmailListStateError | EmailListStateLoaded;
@@ -22,11 +22,11 @@ interface EmailList {
 }
 
 export interface PrimaryAddressState extends EmailAddress {
-  state: 'idle' | 'sending-confirmation-email';
+  type: 'idle' | 'sending-confirmation-email';
 }
 
 export interface SecondaryAddressState extends EmailAddress {
-  state: 'idle' | 'marking-as-primary' | 'deleting';
+  type: 'idle' | 'marking-as-primary' | 'deleting';
 }
 
 interface EmailAddress {


### PR DESCRIPTION
Fixes #1163

## What does this PR do?

- Migrates the `cc-email-list` component to the new state API.

## How to review?

- Check the commit,
- Check the [preview](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-email-list/migrate-to-new-state/index.html?path=/story/%F0%9F%9B%A0-profile-cc-email-list--default-story) vs [prod](https://www.clever-cloud.com/doc/clever-components/?path=/story/%F0%9F%9B%A0-profile-cc-email-list--default-story) stories,
- Run locally and check `demo-smart` to see if all features still work properly,
- 3 reviewers would be nice (breaking change + smart impact, better safe than sorry).