### PR TITLE
refactor(cc-ssh-key-list)!: rework properties to avoid impossible states

### DIFF
--- a/src/components/cc-ssh-key-list/cc-ssh-key-list.js
+++ b/src/components/cc-ssh-key-list/cc-ssh-key-list.js
@@ -34,7 +34,7 @@ const SSH_KEY_DOCUMENTATION = 'https://developers.clever-cloud.com/doc/account/s
  */
 const SKELETON_KEYS = [
   {
-    state: 'idle',
+    type: 'idle',
     name: fakeString(15),
     fingerprint: fakeString(32),
   },
@@ -55,7 +55,7 @@ class SshPublicKeyValidator {
 }
 
 /**
- * @typedef {import('./cc-ssh-key-list.types.js').KeyDataState} KeyDataState
+ * @typedef {import('./cc-ssh-key-list.types.js').SshKeyListState} SshKeyListState
  * @typedef {import('./cc-ssh-key-list.types.js').SshKeyState} SshKeyState
  * @typedef {import('./cc-ssh-key-list.types.js').CreateSshKeyFormState} CreateSshKeyFormState
  * @typedef {import('./cc-ssh-key-list.types.js').NewKey} NewKey
@@ -86,7 +86,7 @@ export class CcSshKeyList extends LitElement {
   static get properties() {
     return {
       createKeyFormState: { type: Object, attribute: false },
-      keyData: { type: Object, attribute: 'key-data' },
+      keyListState: { type: Object, attribute: false },
     };
   }
 
@@ -96,8 +96,8 @@ export class CcSshKeyList extends LitElement {
     /** @type {CreateSshKeyFormState} create key form state. */
     this.createKeyFormState = { type: 'idle' };
 
-    /** @type {KeyDataState} personal and GitHub lists of registered SSH keys. */
-    this.keyData = { state: 'loading' };
+    /** @type {SshKeyListState} personal and GitHub lists of registered SSH keys. */
+    this.keyListState = { type: 'loading' };
 
     /** @type {HTMLFormElementRef} */
     this._createFormRef = createRef();
@@ -141,14 +141,14 @@ export class CcSshKeyList extends LitElement {
   /** @param {SshKeyState} sshKeyState */
   _onDeleteKey(sshKeyState) {
     // removing state property that belongs to internal component implementation
-    const { state, ...sshKey } = sshKeyState;
+    const { type: state, ...sshKey } = sshKeyState;
     dispatchCustomEvent(this, 'delete', sshKey);
   }
 
   /** @param {SshKeyState} sshKeyState */
   _onImportKey(sshKeyState) {
     // removing state property that belongs to internal component implementation
-    const { state, ...sshKey } = sshKeyState;
+    const { type: state, ...sshKey } = sshKeyState;
     dispatchCustomEvent(this, 'import', sshKey);
   }
 
@@ -169,26 +169,26 @@ export class CcSshKeyList extends LitElement {
         <cc-block-section slot="content-body">
           <div slot="title">
             <span>${i18n('cc-ssh-key-list.personal.title')}</span>
-            ${this.keyData.state === 'loaded' && this.keyData.personalKeys.length > 2
-              ? html` <cc-badge circle>${this.keyData.personalKeys.length}</cc-badge> `
+            ${this.keyListState.type === 'loaded' && this.keyListState.personalKeys.length > 2
+              ? html` <cc-badge circle>${this.keyListState.personalKeys.length}</cc-badge> `
               : ''}
           </div>
           <div slot="info">${i18n('cc-ssh-key-list.personal.info')}</div>
 
-          ${this.keyData.state === 'loading' ? html` ${this._renderKeyList('skeleton', SKELETON_KEYS)} ` : ''}
-          ${this.keyData.state === 'loaded'
+          ${this.keyListState.type === 'loading' ? html` ${this._renderKeyList('skeleton', SKELETON_KEYS)} ` : ''}
+          ${this.keyListState.type === 'loaded'
             ? html`
-                ${this.keyData.personalKeys.length === 0
+                ${this.keyListState.personalKeys.length === 0
                   ? html`
                       <p class="info-msg" id="personal-keys-empty-msg" tabindex="-1">
                         ${i18n('cc-ssh-key-list.personal.empty')}
                       </p>
                     `
                   : ''}
-                ${this._renderKeyList('personal', this.keyData.personalKeys)}
+                ${this._renderKeyList('personal', this.keyListState.personalKeys)}
               `
             : ''}
-          ${this.keyData.state === 'error'
+          ${this.keyListState.type === 'error'
             ? html` <cc-notice intent="warning" message="${i18n('cc-ssh-key-list.error.loading')}"></cc-notice> `
             : ''}
         </cc-block-section>
@@ -197,29 +197,31 @@ export class CcSshKeyList extends LitElement {
         <cc-block-section slot="content-body">
           <div slot="title">
             <span>${i18n('cc-ssh-key-list.github.title')}</span>
-            ${this.keyData.state === 'loaded' && this.keyData.isGithubLinked && this.keyData.githubKeys.length > 2
-              ? html` <cc-badge circle>${this.keyData.githubKeys.length}</cc-badge> `
+            ${this.keyListState.type === 'loaded' &&
+            this.keyListState.isGithubLinked &&
+            this.keyListState.githubKeys.length > 2
+              ? html` <cc-badge circle>${this.keyListState.githubKeys.length}</cc-badge> `
               : ''}
           </div>
           <div slot="info">${i18n('cc-ssh-key-list.github.info')}</div>
 
-          ${this.keyData.state === 'loading' ? html` ${this._renderKeyList('skeleton', SKELETON_KEYS)} ` : ''}
-          ${this.keyData.state === 'loaded' && !this.keyData.isGithubLinked
+          ${this.keyListState.type === 'loading' ? html` ${this._renderKeyList('skeleton', SKELETON_KEYS)} ` : ''}
+          ${this.keyListState.type === 'loaded' && !this.keyListState.isGithubLinked
             ? html` <p class="info-msg">${i18n('cc-ssh-key-list.github.unlinked')}</p> `
             : ''}
-          ${this.keyData.state === 'loaded' && this.keyData.isGithubLinked
+          ${this.keyListState.type === 'loaded' && this.keyListState.isGithubLinked
             ? html`
-                ${this.keyData.githubKeys.length === 0
+                ${this.keyListState.githubKeys.length === 0
                   ? html`
                       <p class="info-msg" id="github-keys-empty-msg" tabindex="-1">
                         ${i18n('cc-ssh-key-list.github.empty')}
                       </p>
                     `
                   : ''}
-                ${this._renderKeyList('github', this.keyData.githubKeys)}
+                ${this._renderKeyList('github', this.keyListState.githubKeys)}
               `
             : ''}
-          ${this.keyData.state === 'error'
+          ${this.keyListState.type === 'error'
             ? html` <cc-notice intent="warning" message="${i18n('cc-ssh-key-list.error.loading')}"></cc-notice> `
             : ''}
         </cc-block-section>
@@ -285,7 +287,7 @@ export class CcSshKeyList extends LitElement {
           (key) => key.name,
           (key) => {
             const name = key.name;
-            const isWaiting = !skeleton && key.state !== 'idle';
+            const isWaiting = !skeleton && key.type !== 'idle';
             const classes = {
               'key--personal': type === 'personal',
               'key--github': type === 'github',

--- a/src/components/cc-ssh-key-list/cc-ssh-key-list.stories.js
+++ b/src/components/cc-ssh-key-list/cc-ssh-key-list.stories.js
@@ -3,9 +3,10 @@ import { makeStory, storyWait } from '../../stories/lib/make-story.js';
 import './cc-ssh-key-list.js';
 import './cc-ssh-key-list.smart.js';
 
+/** @type {NewKey} */
 const NEW_KEY = {
   name: 'Work laptop',
-  key: 'ssh-ed25519 ACABC3NzaCxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxltMkfjBkNv',
+  publicKey: 'ssh-ed25519 ACABC3NzaCxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxltMkfjBkNv',
 };
 
 const PRIVATE_KEY = `-----BEGIN OPENSSH PRIVATE KEY-----
@@ -17,25 +18,30 @@ xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx5jb20B
 -----END OPENSSH PRIVATE KEY-----
 `;
 
+/** @type {SshKeyState} */
 const DUMMY_KEY_1 = {
-  state: 'idle',
+  type: 'idle',
   name: 'Work laptop',
   fingerprint: 'SHA256:tk3u9yxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxlTIKLk',
 };
+
+/** @type {SshKeyState} */
 const DUMMY_KEY_2 = {
-  state: 'idle',
+  type: 'idle',
   name: 'Work PC',
   fingerprint: 'SHA256:nfIaqPxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx57zFs',
 };
+/** @type {SshKeyState} */
 const DUMMY_KEY_3 = {
-  state: 'idle',
+  type: 'idle',
   name: 'Macbook Air Pro',
   fingerprint: '00:03:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:xx:7f:62',
 };
 
+/** @type {Partial<CcSshKeyList>} */
 const baseItem = {
-  keyData: {
-    state: 'loaded',
+  keyListState: {
+    type: 'loaded',
     isGithubLinked: true,
     personalKeys: [DUMMY_KEY_1],
     githubKeys: [DUMMY_KEY_2],
@@ -50,6 +56,10 @@ export default {
 
 /**
  * @typedef {import('./cc-ssh-key-list.js').CcSshKeyList} CcSshKeyList
+ * @typedef {import('./cc-ssh-key-list.types.js').SshKeyState} SshKeyState
+ * @typedef {import('./cc-ssh-key-list.types.js').SshKeyListStateLoadedAndLinked} SshKeyListStateLoadedAndLinked
+ * @typedef {import('./cc-ssh-key-list.types.js').NewKey} NewKey
+ * @typedef {import('../cc-input-text/cc-input-text.js').CcInputText} CcInputText
  */
 
 const conf = {
@@ -57,14 +67,16 @@ const conf = {
 };
 
 export const defaultStory = makeStory(conf, {
+  /** @type {Partial<CcSshKeyList>[]} */
   items: [baseItem],
 });
 
 export const emptyStory = makeStory(conf, {
+  /** @type {Partial<CcSshKeyList>[]} */
   items: [
     {
-      keyData: {
-        state: 'loaded',
+      keyListState: {
+        type: 'loaded',
         isGithubLinked: true,
         personalKeys: [],
         githubKeys: [],
@@ -74,10 +86,11 @@ export const emptyStory = makeStory(conf, {
 });
 
 export const dataLoadedWithMultipleItems = makeStory(conf, {
+  /** @type {Partial<CcSshKeyList>[]} */
   items: [
     {
-      keyData: {
-        state: 'loaded',
+      keyListState: {
+        type: 'loaded',
         isGithubLinked: true,
         personalKeys: [DUMMY_KEY_1, DUMMY_KEY_2, DUMMY_KEY_3],
         githubKeys: [DUMMY_KEY_1, DUMMY_KEY_2, DUMMY_KEY_3],
@@ -87,10 +100,11 @@ export const dataLoadedWithMultipleItems = makeStory(conf, {
 });
 
 export const dataLoadedWithLongNames = makeStory(conf, {
+  /** @type {Partial<CcSshKeyList>[]} */
   items: [
     {
-      keyData: {
-        state: 'loaded',
+      keyListState: {
+        type: 'loaded',
         isGithubLinked: true,
         personalKeys: [
           {
@@ -118,10 +132,11 @@ export const dataLoadedWithLongNames = makeStory(conf, {
 });
 
 export const dataLoadedWithGithubUnlinked = makeStory(conf, {
+  /** @type {Partial<CcSshKeyList>[]} */
   items: [
     {
-      keyData: {
-        state: 'loaded',
+      keyListState: {
+        type: 'loaded',
         isGithubLinked: false,
         personalKeys: [DUMMY_KEY_1],
       },
@@ -130,39 +145,47 @@ export const dataLoadedWithGithubUnlinked = makeStory(conf, {
 });
 
 export const skeleton = makeStory(conf, {
+  /** @type {Partial<CcSshKeyList>[]} */
   items: [
     {
-      keyData: {
-        state: 'loading',
+      keyListState: {
+        type: 'loading',
       },
     },
   ],
 });
 
 export const waitingWithAddingPersonalKey = makeStory(conf, {
+  /** @type {Partial<CcSshKeyList>[]} */
   items: [
     {
       ...baseItem,
       createKeyFormState: { type: 'creating' },
     },
   ],
+  /** @param {CcSshKeyList} component */
   onUpdateComplete: (component) => {
-    component._createFormRef.value.name.value = NEW_KEY.name;
-    component._createFormRef.value.publicKey.value = NEW_KEY.key;
+    /** @type {CcInputText} */
+    const nameInputElement = component._createFormRef.value.querySelector('[name="name"]');
+    /** @type {CcInputText} */
+    const publicKeyInputElement = component._createFormRef.value.querySelector('[name="publicKey"]');
+    nameInputElement.value = NEW_KEY.name;
+    publicKeyInputElement.value = NEW_KEY.publicKey;
   },
 });
 
 export const waitingWithDeletingPersonalKey = makeStory(conf, {
+  /** @type {Partial<CcSshKeyList>[]} */
   items: [
     {
-      keyData: {
-        state: 'loaded',
+      keyListState: {
+        type: 'loaded',
         isGithubLinked: true,
         personalKeys: [
           DUMMY_KEY_1,
           {
             ...DUMMY_KEY_2,
-            state: 'deleting',
+            type: 'deleting',
           },
           DUMMY_KEY_3,
         ],
@@ -173,16 +196,17 @@ export const waitingWithDeletingPersonalKey = makeStory(conf, {
 });
 
 export const waitingWithImportingGithubKey = makeStory(conf, {
+  /** @type {Partial<CcSshKeyList>[]} */
   items: [
     {
-      keyData: {
-        state: 'loaded',
+      keyListState: {
+        type: 'loaded',
         isGithubLinked: true,
         personalKeys: [DUMMY_KEY_1, DUMMY_KEY_3],
         githubKeys: [
           {
             ...DUMMY_KEY_2,
-            state: 'importing',
+            type: 'importing',
           },
         ],
       },
@@ -191,64 +215,90 @@ export const waitingWithImportingGithubKey = makeStory(conf, {
 });
 
 export const errorWithWhenListingKeys = makeStory(conf, {
+  /** @type {Partial<CcSshKeyList>[]} */
   items: [
     {
-      keyData: {
-        state: 'error',
+      keyListState: {
+        type: 'error',
       },
     },
   ],
 });
 
 export const errorWithWhenNameIsEmpty = makeStory(conf, {
+  /** @type {Partial<CcSshKeyList>[]} */
   items: [baseItem],
+  /** @param {CcSshKeyList} component */
   onUpdateComplete: (component) => {
-    component._createFormRef.value.name.value = '';
-    component._createFormRef.value.publicKey.value = NEW_KEY.key;
-    component._createFormRef.value.name.validate();
-    component._createFormRef.value.name.reportInlineValidity();
+    /** @type {CcInputText} */
+    const nameInputElement = component._createFormRef.value.querySelector('[name="name"]');
+    /** @type {CcInputText} */
+    const publicKeyInputElement = component._createFormRef.value.querySelector('[name="publicKey"]');
+    nameInputElement.value = '';
+    publicKeyInputElement.value = NEW_KEY.publicKey;
+    nameInputElement.validate();
+    nameInputElement.reportInlineValidity();
   },
 });
 
 export const errorWithWhenPublicKeyIsEmpty = makeStory(conf, {
+  /** @type {Partial<CcSshKeyList>[]} */
   items: [baseItem],
+  /** @param {CcSshKeyList} component */
   onUpdateComplete: (component) => {
-    component._createFormRef.value.name.value = NEW_KEY.name;
-    component._createFormRef.value.publicKey.value = '';
-    component._createFormRef.value.publicKey.validate();
-    component._createFormRef.value.publicKey.reportInlineValidity();
+    /** @type {CcInputText} */
+    const nameInputElement = component._createFormRef.value.querySelector('[name="name"]');
+    /** @type {CcInputText} */
+    const publicKeyInputElement = component._createFormRef.value.querySelector('[name="publicKey"]');
+    nameInputElement.value = NEW_KEY.name;
+    publicKeyInputElement.value = '';
+    publicKeyInputElement.validate();
+    publicKeyInputElement.reportInlineValidity();
   },
 });
 
 export const errorWithWhenAllInputsAreEmpty = makeStory(conf, {
+  /** @type {Partial<CcSshKeyList>[]} */
   items: [baseItem],
+  /** @param {CcSshKeyList} component */
   onUpdateComplete: (component) => {
-    component._createFormRef.value.name.value = '';
-    component._createFormRef.value.publicKey.value = '';
-    component._createFormRef.value.name.validate();
-    component._createFormRef.value.name.reportInlineValidity();
-    component._createFormRef.value.publicKey.validate();
-    component._createFormRef.value.publicKey.reportInlineValidity();
+    /** @type {CcInputText} */
+    const nameInputElement = component._createFormRef.value.querySelector('[name="name"]');
+    /** @type {CcInputText} */
+    const publicKeyInputElement = component._createFormRef.value.querySelector('[name="publicKey"]');
+    nameInputElement.value = '';
+    publicKeyInputElement.value = '';
+    nameInputElement.validate();
+    nameInputElement.reportInlineValidity();
+    publicKeyInputElement.validate();
+    publicKeyInputElement.reportInlineValidity();
   },
 });
 
 export const errorWithWhenPublicKeyIsPrivate = makeStory(conf, {
+  /** @type {Partial<CcSshKeyList>[]} */
   items: [baseItem],
+  /** @param {CcSshKeyList} component */
   onUpdateComplete: (component) => {
-    component._createFormRef.value.name.value = NEW_KEY.name;
-    component._createFormRef.value.publicKey.value = PRIVATE_KEY;
-    component._createFormRef.value.name.validate();
-    component._createFormRef.value.name.reportInlineValidity();
-    component._createFormRef.value.publicKey.validate();
-    component._createFormRef.value.publicKey.reportInlineValidity();
+    /** @type {CcInputText} */
+    const nameInputElement = component._createFormRef.value.querySelector('[name="name"]');
+    /** @type {CcInputText} */
+    const publicKeyInputElement = component._createFormRef.value.querySelector('[name="publicKey"]');
+    nameInputElement.value = NEW_KEY.name;
+    publicKeyInputElement.value = PRIVATE_KEY;
+    nameInputElement.validate();
+    nameInputElement.reportInlineValidity();
+    publicKeyInputElement.validate();
+    publicKeyInputElement.reportInlineValidity();
   },
 });
 
 export const simulationWithAddingKey = makeStory(conf, {
+  /** @type {Partial<CcSshKeyList>[]} */
   items: [
     {
-      keyData: {
-        state: 'loaded',
+      keyListState: {
+        type: 'loaded',
         isGithubLinked: true,
         personalKeys: [DUMMY_KEY_2],
         githubKeys: [DUMMY_KEY_3],
@@ -256,30 +306,55 @@ export const simulationWithAddingKey = makeStory(conf, {
     },
   ],
   simulations: [
-    storyWait(1000, ([component]) => {
-      component._createFormRef.value.name.value = NEW_KEY.name;
-    }),
-    storyWait(500, ([component]) => {
-      component._createFormRef.value.publicKey.value = NEW_KEY.key;
-    }),
-    storyWait(1500, ([component]) => {
-      component.createKeyFormState = { type: 'creating' };
-    }),
-    storyWait(2000, ([component]) => {
-      component.resetCreateKeyForm();
-      component.createKeyFormState = { type: 'idle' };
-      component.keyData = produce(component.keyData, (keyData) => {
-        keyData.personalKeys.push(DUMMY_KEY_1);
-      });
-    }),
+    storyWait(
+      1000,
+      /** @param {Array<CcSshKeyList>} components */
+      ([component]) => {
+        /** @type {CcInputText} */
+        const nameInputElement = component._createFormRef.value.querySelector('[name="name"]');
+        nameInputElement.value = NEW_KEY.name;
+      },
+    ),
+    storyWait(
+      500,
+      /** @param {Array<CcSshKeyList>} components */
+      ([component]) => {
+        /** @type {CcInputText} */
+        const publicKeyInputElement = component._createFormRef.value.querySelector('[name="publicKey"]');
+        publicKeyInputElement.value = NEW_KEY.publicKey;
+      },
+    ),
+    storyWait(
+      1500,
+      /** @param {Array<CcSshKeyList>} components */
+      ([component]) => {
+        component.createKeyFormState = { type: 'creating' };
+      },
+    ),
+    storyWait(
+      2000,
+      /** @param {Array<CcSshKeyList>} components */
+      ([component]) => {
+        component.resetCreateKeyForm();
+        component.createKeyFormState = { type: 'idle' };
+        component.keyListState = produce(
+          component.keyListState,
+          /** @param {SshKeyListStateLoadedAndLinked} state */
+          (state) => {
+            state.personalKeys.push(DUMMY_KEY_1);
+          },
+        );
+      },
+    ),
   ],
 });
 
 export const simulationWithDeletingKey = makeStory(conf, {
+  /** @type {Partial<CcSshKeyList>[]} */
   items: [
     {
-      keyData: {
-        state: 'loaded',
+      keyListState: {
+        type: 'loaded',
         isGithubLinked: true,
         personalKeys: [DUMMY_KEY_1, DUMMY_KEY_2],
         githubKeys: [DUMMY_KEY_3],
@@ -287,24 +362,41 @@ export const simulationWithDeletingKey = makeStory(conf, {
     },
   ],
   simulations: [
-    storyWait(1000, ([component]) => {
-      component.keyData = produce(component.keyData, (keyData) => {
-        keyData.personalKeys[1].state = 'deleting';
-      });
-    }),
-    storyWait(1500, ([component]) => {
-      component.keyData = produce(component.keyData, (keyData) => {
-        keyData.personalKeys = [DUMMY_KEY_1];
-      });
-    }),
+    storyWait(
+      1000,
+      /** @param {Array<CcSshKeyList>} components */
+      ([component]) => {
+        component.keyListState = produce(
+          component.keyListState,
+          /** @param {SshKeyListStateLoadedAndLinked} state */
+          (state) => {
+            state.personalKeys[1].type = 'deleting';
+          },
+        );
+      },
+    ),
+    storyWait(
+      1500,
+      /** @param {Array<CcSshKeyList>} components */
+      ([component]) => {
+        component.keyListState = produce(
+          component.keyListState,
+          /** @param {SshKeyListStateLoadedAndLinked} state */
+          (state) => {
+            state.personalKeys = [DUMMY_KEY_1];
+          },
+        );
+      },
+    ),
   ],
 });
 
 export const simulationWithImportingGithubKey = makeStory(conf, {
+  /** @type {Partial<CcSshKeyList>[]} */
   items: [
     {
-      keyData: {
-        state: 'loaded',
+      keyListState: {
+        type: 'loaded',
         isGithubLinked: true,
         personalKeys: [DUMMY_KEY_1],
         githubKeys: [DUMMY_KEY_2, DUMMY_KEY_3],
@@ -312,16 +404,32 @@ export const simulationWithImportingGithubKey = makeStory(conf, {
     },
   ],
   simulations: [
-    storyWait(1000, ([component]) => {
-      component.keyData = produce(component.keyData, (keyData) => {
-        keyData.githubKeys[0].state = 'importing';
-      });
-    }),
-    storyWait(1500, ([component]) => {
-      component.keyData = produce(component.keyData, (keyData) => {
-        keyData.personalKeys = [DUMMY_KEY_1, DUMMY_KEY_2];
-        keyData.githubKeys = [DUMMY_KEY_3];
-      });
-    }),
+    storyWait(
+      1000,
+      /** @param {Array<CcSshKeyList>} components */
+      ([component]) => {
+        component.keyListState = produce(
+          component.keyListState,
+          /** @param {SshKeyListStateLoadedAndLinked} state */
+          (state) => {
+            state.githubKeys[0].type = 'importing';
+          },
+        );
+      },
+    ),
+    storyWait(
+      1500,
+      /** @param {Array<CcSshKeyList>} components */
+      ([component]) => {
+        component.keyListState = produce(
+          component.keyListState,
+          /** @param {SshKeyListStateLoadedAndLinked} state */
+          (state) => {
+            state.personalKeys = [DUMMY_KEY_1, DUMMY_KEY_2];
+            state.githubKeys = [DUMMY_KEY_3];
+          },
+        );
+      },
+    ),
   ],
 });

--- a/src/components/cc-ssh-key-list/cc-ssh-key-list.types.d.ts
+++ b/src/components/cc-ssh-key-list/cc-ssh-key-list.types.d.ts
@@ -11,36 +11,36 @@ export interface CreateSshKeyFormState {
 //#endregion
 
 //#region key lists
-export type KeyDataState =
-  | KeyDataStateLoading
-  | KeyDataStateLoadedAndUnlinked
-  | KeyDataStateLoadedAndLinked
-  | KeyDataStateError;
+export type SshKeyListState =
+  | SshKeyListStateLoading
+  | SshKeyListStateLoadedAndUnlinked
+  | SshKeyListStateLoadedAndLinked
+  | SshKeyListStateError;
 
 // when exchange with API is occurring = loading SSH keys
 // - is the initial state
-interface KeyDataStateLoading {
-  state: 'loading';
+interface SshKeyListStateLoading {
+  type: 'loading';
 }
 
 // when ready to receive user inputs (personal keys only)
-interface KeyDataStateLoadedAndUnlinked {
-  state: 'loaded';
+interface SshKeyListStateLoadedAndUnlinked {
+  type: 'loaded';
   isGithubLinked: false;
   personalKeys: SshKeyState[];
 }
 
 // when ready to receive user inputs (personal keys & GitHub keys)
-interface KeyDataStateLoadedAndLinked {
-  state: 'loaded';
+interface SshKeyListStateLoadedAndLinked {
+  type: 'loaded';
   isGithubLinked: true;
   personalKeys: SshKeyState[];
   githubKeys: SshKeyState[];
 }
 
 // when an error has occurred
-interface KeyDataStateError {
-  state: 'error';
+interface SshKeyListStateError {
+  type: 'error';
 }
 //#endregion
 
@@ -52,6 +52,6 @@ export interface SshKey {
   fingerprint: string;
 }
 interface SshKeyState extends SshKey {
-  state: 'idle' | 'deleting' | 'importing';
+  type: 'idle' | 'deleting' | 'importing';
 }
 //#endregion


### PR DESCRIPTION
Fixes #1165

## What does this PR do?

- Migrates the `cc-ssh-key-list` component to the new state API.

## How to review?

- Check the commit,
- Check the [preview](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-ssh-key-list/migrate-to-new-state/index.html?path=/story/%F0%9F%9B%A0-profile-cc-ssh-key-list--default-story) vs [prod](https://www.clever-cloud.com/doc/clever-components/?path=/story/%F0%9F%9B%A0-profile-cc-ssh-key-list--default-story) stories,
- Run locally and check `demo-smart` to see if all features still work properly (I couldn't check for accounts that are linked to GitHub because it seems the CLI oAuth Consumer is not allowed to fetch data for such cases, the error is already present in master even though it works fine in the console, which makes me think it's related to the CLI oAuth Consumer :shrug: ),
- 3 reviewers would be nice (breaking change + smart impact, better safe than sorry).