### PR TITLE
refactor(cc-orga-member-list)!: rework properties to avoid impossible 

### DIFF
--- a/src/components/cc-orga-member-card/cc-orga-member-card.stories.js
+++ b/src/components/cc-orga-member-card/cc-orga-member-card.stories.js
@@ -1,12 +1,12 @@
 import { makeStory, storyWait } from '../../stories/lib/make-story.js';
 import './cc-orga-member-card.js';
 
+/** @type {OrgaMemberCardStateLoaded} */
 const baseMember = {
-  state: 'loaded',
+  type: 'loaded',
   id: 'user_c78e5148-a8c2-4c22-b180-2b88ec531f0a',
   email: 'john.doe@example.com',
   role: 'DEVELOPER',
-  newRole: 'DEVELOPER',
   name: 'John Doe',
   avatar: 'http://placekitten.com/200/200',
   jobTitle: 'Frontend Developer',
@@ -28,25 +28,31 @@ const conf = {
   component: 'cc-orga-member-card',
 };
 
+/**
+ * @typedef {import('./cc-orga-member-card.js').CcOrgaMemberCard} CcOrgaMemberCard
+ * @typedef {import('./cc-orga-member-card.types.js').OrgaMemberCardStateLoaded} OrgaMemberCardStateLoaded
+ */
+
 export const defaultStory = makeStory(conf, {
+  /** @type {Partial<CcOrgaMemberCard>[]} */
   items: [
     {
-      member: baseMember,
+      state: baseMember,
     },
     {
-      member: {
+      state: {
         ...baseMember,
         role: 'ADMIN',
       },
     },
     {
-      member: {
+      state: {
         ...baseMember,
         role: 'MANAGER',
       },
     },
     {
-      member: {
+      state: {
         ...baseMember,
         role: 'ACCOUNTING',
       },
@@ -55,10 +61,12 @@ export const defaultStory = makeStory(conf, {
 });
 
 export const dataLoadedWithEditAndDelete = makeStory(conf, {
+  /** @type {Partial<CcOrgaMemberCard>[]} */
   items: [
     {
-      member: { ...baseMember },
+      state: { ...baseMember },
       authorisations: {
+        invite: true,
         edit: true,
         delete: true,
       },
@@ -67,9 +75,10 @@ export const dataLoadedWithEditAndDelete = makeStory(conf, {
 });
 
 export const dataLoadedWithIsCurrentUser = makeStory(conf, {
+  /** @type {Partial<CcOrgaMemberCard>[]} */
   items: [
     {
-      member: {
+      state: {
         ...baseMember,
         isCurrentUser: true,
       },
@@ -78,9 +87,10 @@ export const dataLoadedWithIsCurrentUser = makeStory(conf, {
 });
 
 export const dataLoadedWithNoName = makeStory(conf, {
+  /** @type {Partial<CcOrgaMemberCard>[]} */
   items: [
     {
-      member: {
+      state: {
         ...baseMember,
         name: '',
       },
@@ -89,9 +99,10 @@ export const dataLoadedWithNoName = makeStory(conf, {
 });
 
 export const dataLoadedWithNoAvatar = makeStory(conf, {
+  /** @type {Partial<CcOrgaMemberCard>[]} */
   items: [
     {
-      member: {
+      state: {
         ...baseMember,
         avatar: null,
       },
@@ -100,9 +111,10 @@ export const dataLoadedWithNoAvatar = makeStory(conf, {
 });
 
 export const dataLoadedWithLongEmail = makeStory(conf, {
+  /** @type {Partial<CcOrgaMemberCard>[]} */
   items: [
     {
-      member: {
+      state: {
         ...baseMember,
         email: longEmail,
         name: longName,
@@ -112,9 +124,10 @@ export const dataLoadedWithLongEmail = makeStory(conf, {
 });
 
 export const dataLoadedWith2faEnabled = makeStory(conf, {
+  /** @type {Partial<CcOrgaMemberCard>[]} */
   items: [
     {
-      member: {
+      state: {
         ...baseMember,
         isMfaEnabled: true,
       },
@@ -123,9 +136,10 @@ export const dataLoadedWith2faEnabled = makeStory(conf, {
 });
 
 export const dataLoadedWithNoNameAndIsCurrentUser = makeStory(conf, {
+  /** @type {Partial<CcOrgaMemberCard>[]} */
   items: [
     {
-      member: {
+      state: {
         ...baseMember,
         name: null,
         isCurrentUser: true,
@@ -135,13 +149,15 @@ export const dataLoadedWithNoNameAndIsCurrentUser = makeStory(conf, {
 });
 
 export const editing = makeStory(conf, {
+  /** @type {Partial<CcOrgaMemberCard>[]} */
   items: [
     {
-      member: {
+      state: {
         ...baseMember,
-        state: 'editing',
+        type: 'editing',
       },
       authorisations: {
+        invite: true,
         edit: true,
         delete: true,
       },
@@ -151,16 +167,18 @@ export const editing = makeStory(conf, {
 
 export const errorWithStateLoaded = makeStory(conf, {
   docs: 'When the user tries to leave while they are the last admin, we display a message.',
+  /** @type {Partial<CcOrgaMemberCard>[]} */
   items: [
     {
-      member: {
+      state: {
         ...baseMember,
-        state: 'loaded',
+        type: 'loaded',
         role: 'ADMIN',
         error: true,
         isCurrentUser: true,
       },
       authorisations: {
+        invite: true,
         edit: true,
         delete: true,
       },
@@ -170,16 +188,18 @@ export const errorWithStateLoaded = makeStory(conf, {
 
 export const errorWithStateEditing = makeStory(conf, {
   docs: 'When the user tries to edit themselves while they are the last admin, we display a message.',
+  /** @type {Partial<CcOrgaMemberCard>[]} */
   items: [
     {
-      member: {
+      state: {
         ...baseMember,
-        state: 'editing',
+        type: 'editing',
         role: 'ADMIN',
         error: true,
         isCurrentUser: true,
       },
       authorisations: {
+        invite: true,
         edit: true,
         delete: true,
       },
@@ -188,13 +208,15 @@ export const errorWithStateEditing = makeStory(conf, {
 });
 
 export const updatingMemberRole = makeStory(conf, {
+  /** @type {Partial<CcOrgaMemberCard>[]} */
   items: [
     {
-      member: {
+      state: {
         ...baseMember,
-        state: 'updating',
+        type: 'updating',
       },
       authorisations: {
+        invite: true,
         edit: true,
         delete: true,
       },
@@ -203,13 +225,15 @@ export const updatingMemberRole = makeStory(conf, {
 });
 
 export const deletingMember = makeStory(conf, {
+  /** @type {Partial<CcOrgaMemberCard>[]} */
   items: [
     {
-      member: {
+      state: {
         ...baseMember,
-        state: 'deleting',
+        type: 'deleting',
       },
       authorisations: {
+        invite: true,
         edit: true,
         delete: true,
       },
@@ -218,37 +242,55 @@ export const deletingMember = makeStory(conf, {
 });
 
 export const simulations = makeStory(conf, {
+  /** @type {Partial<CcOrgaMemberCard>[]} */
   items: [
     {
-      member: baseMember,
+      state: baseMember,
       authorisations: {
+        invite: true,
         edit: true,
         delete: true,
       },
     },
   ],
   simulations: [
-    storyWait(2000, ([component]) => {
-      component.member = {
-        ...component.member,
-        state: 'editing',
-      };
-    }),
-    storyWait(1000, ([component]) => {
-      component._newRole = 'ACCOUNTING';
-    }),
-    storyWait(1000, ([component]) => {
-      component.member = {
-        ...component.member,
-        state: 'updating',
-      };
-    }),
-    storyWait(3000, ([component]) => {
-      component.member = {
-        ...component.member,
-        state: 'loaded',
-        role: 'ACCOUNTING',
-      };
-    }),
+    storyWait(
+      2000,
+      /** @param {Array<CcOrgaMemberCard>} components */
+      ([component]) => {
+        component.state = {
+          ...component.state,
+          type: 'editing',
+        };
+      },
+    ),
+    storyWait(
+      1000,
+      /** @param {Array<CcOrgaMemberCard>} components */
+      ([component]) => {
+        component._newRole = 'ACCOUNTING';
+      },
+    ),
+    storyWait(
+      1000,
+      /** @param {Array<CcOrgaMemberCard>} components */
+      ([component]) => {
+        component.state = {
+          ...component.state,
+          type: 'updating',
+        };
+      },
+    ),
+    storyWait(
+      3000,
+      /** @param {Array<CcOrgaMemberCard>} components */
+      ([component]) => {
+        component.state = {
+          ...component.state,
+          type: 'loaded',
+          role: 'ACCOUNTING',
+        };
+      },
+    ),
   ],
 });

--- a/src/components/cc-orga-member-card/cc-orga-member-card.types.d.ts
+++ b/src/components/cc-orga-member-card/cc-orga-member-card.types.d.ts
@@ -21,21 +21,21 @@ export type OrgaMemberCardState =
   | OrgaMemberCardStateDeleting;
 
 export interface OrgaMemberCardStateLoaded extends OrgaMember {
-  state: 'loaded';
+  type: 'loaded';
   error?: boolean;
 }
 
 export interface OrgaMemberCardStateEditing extends OrgaMember {
-  state: 'editing';
+  type: 'editing';
   error?: boolean;
 }
 
 export interface OrgaMemberCardStateUpdating extends OrgaMember {
-  state: 'updating';
+  type: 'updating';
 }
 
 export interface OrgaMemberCardStateDeleting extends OrgaMember {
-  state: 'deleting';
+  type: 'deleting';
 }
 /*endregion*/
 
@@ -45,7 +45,7 @@ interface ToggleEditing {
   newState: 'editing' | 'loaded';
 }
 
-interface Authorisations {
+interface CardAuthorisations {
   edit: boolean;
   delete: boolean;
 }

--- a/src/components/cc-orga-member-list/cc-orga-member-list.stories.js
+++ b/src/components/cc-orga-member-list/cc-orga-member-list.stories.js
@@ -2,9 +2,10 @@ import longMemberList from '../../stories/fixtures/long-member-list.js';
 import { makeStory, storyWait } from '../../stories/lib/make-story.js';
 import './cc-orga-member-list.js';
 
+/** @type {OrgaMemberListStateLoaded['memberList']} */
 const baseMemberList = [
   {
-    state: 'loaded',
+    type: 'loaded',
     id: 'member1',
     name: 'John Doe',
     isCurrentUser: true,
@@ -14,7 +15,7 @@ const baseMemberList = [
     isMfaEnabled: false,
   },
   {
-    state: 'loaded',
+    type: 'loaded',
     id: 'member2',
     avatar: 'http://placekitten.com/202/202',
     name: 'Jane Doe',
@@ -22,34 +23,39 @@ const baseMemberList = [
     role: 'DEVELOPER',
     email: 'jane.doe@example.com',
     isMfaEnabled: true,
+    isCurrentUser: false,
   },
   {
-    state: 'loaded',
+    type: 'loaded',
     id: 'member3',
     avatar: 'http://placekitten.com/205/205',
     role: 'ACCOUNTING',
     email: 'june.doe@example.com',
     isMfaEnabled: false,
+    isCurrentUser: false,
   },
   {
-    state: 'loaded',
+    type: 'loaded',
     id: 'member4',
     name: 'Veryveryveryveryveryveryveryveryvery long name',
     role: 'MANAGER',
     email: 'very-very-very-long-email-address@very-very-very-very-very-very-very-long.example.com',
     isMfaEnabled: true,
+    isCurrentUser: false,
   },
 ];
+/** @type {Authorisations} */
 const authorisationsAdmin = {
   invite: true,
   edit: true,
   delete: true,
 };
+/** @type {Partial<CcOrgaMemberList>} */
 const baseItem = {
   authorisations: authorisationsAdmin,
-  members: {
-    state: 'loaded',
-    value: baseMemberList,
+  memberListState: {
+    type: 'loaded',
+    memberList: baseMemberList,
     identityFilter: '',
     mfaDisabledOnlyFilter: false,
     dangerZoneState: 'idle',
@@ -64,6 +70,9 @@ export default {
 
 /**
  * @typedef {import('./cc-orga-member-list.js').CcOrgaMemberList} CcOrgaMemberList
+ * @typedef {import('./cc-orga-member-list.types.js').OrgaMemberListStateLoaded} OrgaMemberListStateLoaded
+ * @typedef {import('./cc-orga-member-list.types.js').Authorisations} Authorisations
+ * @typedef {import('../cc-input-text/cc-input-text.js').CcInputText} CcInputText
  */
 
 const conf = {
@@ -71,11 +80,12 @@ const conf = {
 };
 
 export const defaultStory = makeStory(conf, {
+  /** @type {Partial<CcOrgaMemberList>[]} */
   items: [
     {
-      members: {
-        state: 'loaded',
-        value: baseMemberList.map((member) => {
+      memberListState: {
+        type: 'loaded',
+        memberList: baseMemberList.map((member) => {
           return member.isCurrentUser ? { ...member, role: 'DEVELOPER' } : member;
         }),
         identityFilter: '',
@@ -87,23 +97,25 @@ export const defaultStory = makeStory(conf, {
 });
 
 export const loading = makeStory(conf, {
+  /** @type {Partial<CcOrgaMemberList>[]} */
   items: [
     {
-      members: { state: 'loading' },
+      memberListState: { type: 'loading' },
     },
   ],
 });
 
 export const waitingWithLeavingAsSimpleUser = makeStory(conf, {
+  /** @type {Partial<CcOrgaMemberList>[]} */
   items: [
     {
-      members: {
-        state: 'loaded',
-        value: baseMemberList.map((baseMember) => {
+      memberListState: {
+        type: 'loaded',
+        memberList: baseMemberList.map((baseMember) => {
           if (baseMember.isCurrentUser) {
             return {
               ...baseMember,
-              state: 'deleting',
+              type: 'deleting',
               role: 'ACCOUNTING',
             };
           }
@@ -125,16 +137,17 @@ export const waitingWithLeavingAsSimpleUser = makeStory(conf, {
 });
 
 export const waitingWithLeavingAsAdmin = makeStory(conf, {
+  /** @type {Partial<CcOrgaMemberList>[]} */
   items: [
     {
       authorisations: authorisationsAdmin,
-      members: {
-        state: 'loaded',
-        value: baseMemberList.map((baseMember) => {
+      memberListState: {
+        type: 'loaded',
+        memberList: baseMemberList.map((baseMember) => {
           if (baseMember.isCurrentUser) {
             return {
               ...baseMember,
-              state: 'deleting',
+              type: 'deleting',
             };
           }
 
@@ -155,12 +168,13 @@ export const waitingWithLeavingAsAdmin = makeStory(conf, {
 });
 
 export const waitingWithInvitingMember = makeStory(conf, {
+  /** @type {Partial<CcOrgaMemberList>[]} */
   items: [
     {
       authorisations: authorisationsAdmin,
-      members: {
-        state: 'loaded',
-        value: [baseMemberList[0]],
+      memberListState: {
+        type: 'loaded',
+        memberList: [baseMemberList[0]],
         identityFilter: '',
         mfaDisabledOnlyFilter: false,
         dangerZoneState: 'idle',
@@ -168,26 +182,29 @@ export const waitingWithInvitingMember = makeStory(conf, {
       inviteMemberFormState: { type: 'inviting' },
     },
   ],
+  /** @param {CcOrgaMemberList} component */
   onUpdateComplete: (component) => {
     component._inviteMemberFormRef.value.email.value = 'june.doe@example.com';
   },
 });
 
 export const errorWithLoadingMemberList = makeStory(conf, {
+  /** @type {Partial<CcOrgaMemberList>[]} */
   items: [
     {
-      members: { state: 'error' },
+      memberListState: { type: 'error' },
     },
   ],
 });
 
 export const errorWithLeavingFromDangerZoneAsLastAdmin = makeStory(conf, {
+  /** @type {Partial<CcOrgaMemberList>[]} */
   items: [
     {
       authorisations: authorisationsAdmin,
-      members: {
-        state: 'loaded',
-        value: baseMemberList,
+      memberListState: {
+        type: 'loaded',
+        memberList: baseMemberList,
         identityFilter: '',
         mfaDisabledOnlyFilter: false,
         dangerZoneState: 'error',
@@ -197,12 +214,13 @@ export const errorWithLeavingFromDangerZoneAsLastAdmin = makeStory(conf, {
 });
 
 export const errorWithLeavingFromCardAsLastAdmin = makeStory(conf, {
+  /** @type {Partial<CcOrgaMemberList>[]} */
   items: [
     {
       authorisations: authorisationsAdmin,
-      members: {
-        state: 'loaded',
-        value: baseMemberList.map((baseMember) => {
+      memberListState: {
+        type: 'loaded',
+        memberList: baseMemberList.map((baseMember) => {
           if (baseMember.role === 'ADMIN') {
             return {
               ...baseMember,
@@ -220,16 +238,17 @@ export const errorWithLeavingFromCardAsLastAdmin = makeStory(conf, {
 });
 
 export const errorWithEditingYourselfAsLastAdmin = makeStory(conf, {
+  /** @type {Partial<CcOrgaMemberList>[]} */
   items: [
     {
       authorisations: authorisationsAdmin,
-      members: {
-        state: 'loaded',
-        value: baseMemberList.map((baseMember) => {
+      memberListState: {
+        type: 'loaded',
+        memberList: baseMemberList.map((baseMember) => {
           if (baseMember.isCurrentUser) {
             return {
               ...baseMember,
-              state: 'editing',
+              type: 'editing',
               role: 'DEVELOPER',
               error: true,
             };
@@ -245,38 +264,51 @@ export const errorWithEditingYourselfAsLastAdmin = makeStory(conf, {
 });
 
 export const errorWithInviteEmptyEmail = makeStory(conf, {
+  /** @type {Partial<CcOrgaMemberList>[]} */
   items: [baseItem],
+  /** @param {CcOrgaMemberList} component */
   onUpdateComplete: (component) => {
-    component._inviteMemberFormRef.value.email.value = '';
-    component._inviteMemberFormRef.value.email.validate();
-    component._inviteMemberFormRef.value.email.reportInlineValidity();
+    /** @type {CcInputText} */
+    const emailInput = component._inviteMemberFormRef.value.email;
+    emailInput.value = '';
+    emailInput.validate();
+    emailInput.reportInlineValidity();
   },
 });
 
 export const errorWithInviteInvalidEmailFormat = makeStory(conf, {
+  /** @type {Partial<CcOrgaMemberList>[]} */
   items: [baseItem],
+  /** @param {CcOrgaMemberList} component */
   onUpdateComplete: (component) => {
-    component._inviteMemberFormRef.value.email.value = 'jane.doe';
-    component._inviteMemberFormRef.value.email.validate();
-    component._inviteMemberFormRef.value.email.reportInlineValidity();
+    /** @type {CcInputText} */
+    const emailInput = component._inviteMemberFormRef.value.email;
+    emailInput.value = 'jane.doe';
+    emailInput.validate();
+    emailInput.reportInlineValidity();
   },
 });
 
 export const errorWithInviteMemberAlreadyInsideOrganisation = makeStory(conf, {
+  /** @type {Partial<CcOrgaMemberList>[]} */
   items: [baseItem],
+  /** @param {CcOrgaMemberList} component */
   onUpdateComplete: (component) => {
-    component._inviteMemberFormRef.value.email.value = 'june.doe@example.com';
-    component._inviteMemberFormRef.value.email.validate();
-    component._inviteMemberFormRef.value.email.reportInlineValidity();
+    /** @type {CcInputText} */
+    const emailInput = component._inviteMemberFormRef.value.email;
+    emailInput.value = 'june.doe@example.com';
+    emailInput.validate();
+    emailInput.reportInlineValidity();
   },
 });
 
 export const dataLoaded = makeStory(conf, {
+  /** @type {Partial<CcOrgaMemberList>[]} */
   items: [
     {
-      members: {
-        state: 'loaded',
-        value: baseMemberList.map((member) => {
+      memberListState: {
+        type: 'loaded',
+        memberList: baseMemberList.map((member) => {
           if (member.isCurrentUser) {
             return {
               ...member,
@@ -302,12 +334,13 @@ export const dataLoaded = makeStory(conf, {
 });
 
 export const dataLoadedWithCurrentUserAdmin = makeStory(conf, {
+  /** @type {Partial<CcOrgaMemberList>[]} */
   items: [
     {
       authorisations: authorisationsAdmin,
-      members: {
-        state: 'loaded',
-        value: baseMemberList,
+      memberListState: {
+        type: 'loaded',
+        memberList: baseMemberList,
         identityFilter: '',
         mfaDisabledOnlyFilter: false,
         dangerZoneState: 'idle',
@@ -317,20 +350,25 @@ export const dataLoadedWithCurrentUserAdmin = makeStory(conf, {
 });
 
 export const dataLoadedWithInviteFormWithLongEmail = makeStory(conf, {
+  /** @type {Partial<CcOrgaMemberList>[]} */
   items: [baseItem],
+  /** @param {CcOrgaMemberList} component */
   onUpdateComplete: (component) => {
-    component._inviteMemberFormRef.value.email.value =
+    /** @type {CcInputText} */
+    const emailInput = component._inviteMemberFormRef.value.email;
+    emailInput.value =
       'very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-email-address@very-very-very-very-very-very-very-long.example.com';
   },
 });
 
 export const dataLoadedWithOnlyOneMember = makeStory(conf, {
+  /** @type {Partial<CcOrgaMemberList>[]} */
   items: [
     {
       authorisations: authorisationsAdmin,
-      members: {
-        state: 'loaded',
-        value: [baseMemberList[0]],
+      memberListState: {
+        type: 'loaded',
+        memberList: [baseMemberList[0]],
         identityFilter: '',
         mfaDisabledOnlyFilter: false,
         dangerZoneState: 'idle',
@@ -340,11 +378,12 @@ export const dataLoadedWithOnlyOneMember = makeStory(conf, {
 });
 
 export const dataLoadedWithLongMemberList = makeStory(conf, {
+  /** @type {Partial<CcOrgaMemberList>[]} */
   items: [
     {
-      members: {
-        state: 'loaded',
-        value: longMemberList,
+      memberListState: {
+        type: 'loaded',
+        memberList: longMemberList,
         identityFilter: '',
         mfaDisabledOnlyFilter: false,
         dangerZoneState: 'idle',
@@ -354,12 +393,13 @@ export const dataLoadedWithLongMemberList = makeStory(conf, {
 });
 
 export const dataLoadedWithLongMemberListAndCurrentUserAdmin = makeStory(conf, {
+  /** @type {Partial<CcOrgaMemberList>[]} */
   items: [
     {
       authorisations: authorisationsAdmin,
-      members: {
-        state: 'loaded',
-        value: longMemberList.map((member) => {
+      memberListState: {
+        type: 'loaded',
+        memberList: longMemberList.map((member) => {
           if (member.id === 'member1') {
             return {
               ...member,
@@ -377,12 +417,13 @@ export const dataLoadedWithLongMemberListAndCurrentUserAdmin = makeStory(conf, {
 });
 
 export const dataLoadedWithNameFilter = makeStory(conf, {
+  /** @type {Partial<CcOrgaMemberList>[]} */
   items: [
     {
       authorisations: authorisationsAdmin,
-      members: {
-        state: 'loaded',
-        value: baseMemberList,
+      memberListState: {
+        type: 'loaded',
+        memberList: baseMemberList,
         identityFilter: 'very',
         mfaDisabledOnlyFilter: false,
         dangerZoneState: 'idle',
@@ -392,93 +433,108 @@ export const dataLoadedWithNameFilter = makeStory(conf, {
 });
 
 export const dataLoadedWithTwoFactorAuthDisabledFilter = makeStory(conf, {
+  /** @type {Partial<CcOrgaMemberList>[]} */
   items: [
     {
       authorisations: authorisationsAdmin,
-      members: {
-        state: 'loaded',
-        value: baseMemberList,
+      memberListState: {
+        type: 'loaded',
+        memberList: baseMemberList,
         identityFilter: '',
         mfaDisabledOnlyFilter: true,
+        dangerZoneState: 'idle',
       },
     },
   ],
 });
 
 export const dataLoadedWithNoResultFilters = makeStory(conf, {
+  /** @type {Partial<CcOrgaMemberList>[]} */
   items: [
     {
       authorisations: authorisationsAdmin,
-      members: {
-        state: 'loaded',
-        value: baseMemberList,
+      memberListState: {
+        type: 'loaded',
+        memberList: baseMemberList,
         identityFilter: 'no results',
         mfaDisabledOnlyFilter: true,
+        dangerZoneState: 'idle',
       },
     },
   ],
 });
 
 export const simulationWithLoadingAsSimpleUser = makeStory(conf, {
+  /** @type {Partial<CcOrgaMemberList>[]} */
   items: [
     {
-      members: {
-        state: 'loading',
+      memberListState: {
+        type: 'loading',
       },
     },
   ],
   simulations: [
-    storyWait(1000, ([component]) => {
-      component.members = {
-        ...component.members,
-        state: 'loaded',
-        value: baseMemberList.map((member) => {
-          if (member.isCurrentUser) {
-            return {
-              ...member,
-              role: 'ACCOUNTING',
-            };
-          }
-          return member;
-        }),
-        identityFilter: '',
-        mfaDisabledOnlyFilter: false,
-        dangerZoneState: 'idle',
-      };
-    }),
+    storyWait(
+      1000,
+      /** @param {Array<CcOrgaMemberList>} components */
+      ([component]) => {
+        component.memberListState = {
+          ...component.memberListState,
+          type: 'loaded',
+          memberList: baseMemberList.map((member) => {
+            if (member.isCurrentUser) {
+              return {
+                ...member,
+                role: 'ACCOUNTING',
+              };
+            }
+            return member;
+          }),
+          identityFilter: '',
+          mfaDisabledOnlyFilter: false,
+          dangerZoneState: 'idle',
+        };
+      },
+    ),
   ],
 });
 
 export const simulationWithLoadingAsAdmin = makeStory(conf, {
+  /** @type {Partial<CcOrgaMemberList>[]} */
   items: [
     {
-      members: {
-        state: 'loading',
+      memberListState: {
+        type: 'loading',
       },
     },
   ],
   simulations: [
-    storyWait(1000, ([component]) => {
-      component.authorisations = authorisationsAdmin;
-      component.members = {
-        ...component.members,
-        state: 'loaded',
-        value: baseMemberList,
-        identityFilter: '',
-        mfaDisabledOnlyFilter: false,
-        dangerZoneState: 'idle',
-      };
-    }),
+    storyWait(
+      1000,
+      /** @param {Array<CcOrgaMemberList>} components */
+      ([component]) => {
+        component.authorisations = authorisationsAdmin;
+        component.memberListState = {
+          ...component.memberListState,
+          type: 'loaded',
+          memberList: baseMemberList,
+          identityFilter: '',
+          mfaDisabledOnlyFilter: false,
+          dangerZoneState: 'idle',
+        };
+      },
+    ),
   ],
 });
 
 export const simulationWithInviteMember = makeStory(conf, {
+  /** @type {Partial<CcOrgaMemberList>[]} */
   items: [
     {
       authorisations: authorisationsAdmin,
-      members: {
-        state: 'loaded',
-        value: baseMemberList,
+      memberListState: {
+        type: 'loaded',
+        memberList: baseMemberList,
         identityFilter: '',
         mfaDisabledOnlyFilter: false,
         dangerZoneState: 'idle',
@@ -486,29 +542,50 @@ export const simulationWithInviteMember = makeStory(conf, {
     },
   ],
   simulations: [
-    storyWait(1000, ([component]) => {
-      component._inviteMemberFormRef.value.email.value = 'john.doe@example.com';
-    }),
-    storyWait(1000, ([component]) => {
-      component._inviteMemberFormRef.value.role.value = 'ADMIN';
-    }),
-    storyWait(500, ([component]) => {
-      component.inviteMemberFormState = { type: 'inviting' };
-    }),
-    storyWait(2000, ([component]) => {
-      component.resetInviteMemberForm();
-      component.inviteMemberFormState = { type: 'idle' };
-    }),
+    storyWait(
+      1000,
+      /** @param {Array<CcOrgaMemberList>} components */
+      ([component]) => {
+        /** @type {CcInputText} */
+        const emailInput = component._inviteMemberFormRef.value.querySelector('[name="email"]');
+        emailInput.value = 'john.doe@example.com';
+      },
+    ),
+    storyWait(
+      1000,
+      /** @param {Array<CcOrgaMemberList>} components */
+      ([component]) => {
+        /** @type {CcInputText} */
+        const roleInput = component._inviteMemberFormRef.value.querySelector('[name="role"]');
+        roleInput.value = 'ADMIN';
+      },
+    ),
+    storyWait(
+      500,
+      /** @param {Array<CcOrgaMemberList>} components */
+      ([component]) => {
+        component.inviteMemberFormState = { type: 'inviting' };
+      },
+    ),
+    storyWait(
+      2000,
+      /** @param {Array<CcOrgaMemberList>} components */
+      ([component]) => {
+        component.resetInviteMemberForm();
+        component.inviteMemberFormState = { type: 'idle' };
+      },
+    ),
   ],
 });
 
 export const simulationWithEditMember = makeStory(conf, {
+  /** @type {Partial<CcOrgaMemberList>[]} */
   items: [
     {
       authorisations: authorisationsAdmin,
-      members: {
-        state: 'loaded',
-        value: baseMemberList,
+      memberListState: {
+        type: 'loaded',
+        memberList: baseMemberList,
         identityFilter: '',
         mfaDisabledOnlyFilter: false,
         dangerZoneState: 'idle',
@@ -516,75 +593,92 @@ export const simulationWithEditMember = makeStory(conf, {
     },
   ],
   simulations: [
-    storyWait(2000, ([component]) => {
-      component.members = {
-        ...component.members,
-        value: baseMemberList.map((member) => {
-          if (member.id === 'member2') {
-            return {
-              ...member,
-              state: 'editing',
-            };
-          }
-          return member;
-        }),
-      };
-    }),
-    storyWait(2000, ([component]) => {
-      component.members = {
-        ...component.members,
-        value: baseMemberList.map((member) => {
-          if (member.id === 'member2') {
-            return {
-              ...member,
-              state: 'editing',
-              role: 'ADMIN',
-            };
-          }
-          return member;
-        }),
-      };
-    }),
-    storyWait(2000, ([component]) => {
-      component.members = {
-        ...component.members,
-        value: baseMemberList.map((member) => {
-          if (member.id === 'member2') {
-            return {
-              ...member,
-              state: 'updating',
-              role: 'ADMIN',
-            };
-          }
-          return member;
-        }),
-      };
-    }),
-    storyWait(2000, ([component]) => {
-      component.members = {
-        ...component.members,
-        value: baseMemberList.map((member) => {
-          if (member.id === 'member2') {
-            return {
-              ...member,
-              state: 'loaded',
-              role: 'ADMIN',
-            };
-          }
-          return member;
-        }),
-      };
-    }),
+    storyWait(
+      2000,
+      /** @param {Array<CcOrgaMemberList & { members: { state: OrgaMemberListStateLoaded }}>} components */
+      ([component]) => {
+        component.memberListState = {
+          ...component.memberListState,
+          memberList: baseMemberList.map((member) => {
+            if (member.id === 'member2') {
+              return {
+                ...member,
+                type: 'editing',
+              };
+            }
+            return member;
+          }),
+        };
+      },
+    ),
+    storyWait(
+      2000,
+      /** @param {Array<CcOrgaMemberList & { members: { state: OrgaMemberListStateLoaded }}>} components */
+      ([component]) => {
+        component.memberListState = {
+          ...component.memberListState,
+          memberList: baseMemberList.map((member) => {
+            if (member.id === 'member2') {
+              return {
+                ...member,
+                type: 'editing',
+                role: 'ADMIN',
+              };
+            }
+            return member;
+          }),
+        };
+      },
+    ),
+    storyWait(
+      2000,
+      /** @param {Array<CcOrgaMemberList & { members: { state: OrgaMemberListStateLoaded }}>} components */
+      ([component]) => {
+        component.memberListState = {
+          ...component.memberListState,
+          memberList: baseMemberList.map((member) => {
+            if (member.id === 'member2') {
+              return {
+                ...member,
+                type: 'updating',
+                role: 'ADMIN',
+              };
+            }
+            return member;
+          }),
+        };
+      },
+    ),
+    storyWait(
+      2000,
+      /** @param {Array<CcOrgaMemberList & { members: { state: OrgaMemberListStateLoaded }}>} components */
+      ([component]) => {
+        component.memberListState = {
+          ...component.memberListState,
+          memberList: baseMemberList.map((member) => {
+            if (member.id === 'member2') {
+              return {
+                ...member,
+                type: 'loaded',
+                role: 'ADMIN',
+              };
+            }
+            return member;
+          }),
+        };
+      },
+    ),
   ],
 });
 
 export const simulationWithRemovingMember = makeStory(conf, {
+  /** @type {Partial<CcOrgaMemberList>[]} */
   items: [
     {
       authorisations: authorisationsAdmin,
-      members: {
-        state: 'loaded',
-        value: baseMemberList,
+      memberListState: {
+        type: 'loaded',
+        memberList: baseMemberList,
         identityFilter: '',
         mfaDisabledOnlyFilter: false,
         dangerZoneState: 'idle',
@@ -592,35 +686,44 @@ export const simulationWithRemovingMember = makeStory(conf, {
     },
   ],
   simulations: [
-    storyWait(2000, ([component]) => {
-      component.members = {
-        ...component.members,
-        value: baseMemberList.map((member) => {
-          if (member.id === 'member2') {
-            return {
-              ...member,
-              state: 'deleting',
-            };
-          }
-          return member;
-        }),
-      };
-    }),
-    storyWait(2000, ([component]) => {
-      component.members = {
-        ...component.members,
-        value: baseMemberList.filter((member) => member.id !== 'member2'),
-      };
-    }),
+    storyWait(
+      2000,
+      /** @param {Array<CcOrgaMemberList & { members: { state: OrgaMemberListStateLoaded }}>} components */
+      ([component]) => {
+        component.memberListState = {
+          ...component.memberListState,
+          memberList: baseMemberList.map((member) => {
+            if (member.id === 'member2') {
+              return {
+                ...member,
+                type: 'deleting',
+              };
+            }
+            return member;
+          }),
+        };
+      },
+    ),
+    storyWait(
+      2000,
+      /** @param {Array<CcOrgaMemberList & { members: { state: OrgaMemberListStateLoaded }}>} components */
+      ([component]) => {
+        component.memberListState = {
+          ...component.memberListState,
+          memberList: baseMemberList.filter((member) => member.id !== 'member2'),
+        };
+      },
+    ),
   ],
 });
 
 export const simulationWithLeavingAsSimpleUser = makeStory(conf, {
+  /** @type {Partial<CcOrgaMemberList>[]} */
   items: [
     {
-      members: {
-        state: 'loaded',
-        value: baseMemberList.map((baseMember) => {
+      memberListState: {
+        type: 'loaded',
+        memberList: baseMemberList.map((baseMember) => {
           if (baseMember.id === 'member1') {
             return {
               ...baseMember,
@@ -643,39 +746,44 @@ export const simulationWithLeavingAsSimpleUser = makeStory(conf, {
     },
   ],
   simulations: [
-    storyWait(2000, ([component]) => {
-      component.members = {
-        ...component.members,
-        value: baseMemberList.map((baseMember) => {
-          if (baseMember.id === 'member1') {
-            return {
-              ...baseMember,
-              state: 'deleting',
-              role: 'ACCOUNTING',
-            };
-          }
+    storyWait(
+      2000,
+      /** @param {Array<CcOrgaMemberList & { members: { state: OrgaMemberListStateLoaded }}>} components */
+      ([component]) => {
+        component.memberListState = {
+          ...component.memberListState,
+          memberList: baseMemberList.map((baseMember) => {
+            if (baseMember.id === 'member1') {
+              return {
+                ...baseMember,
+                type: 'deleting',
+                role: 'ACCOUNTING',
+              };
+            }
 
-          if (baseMember.id === 'member2') {
-            return {
-              ...baseMember,
-              role: 'ADMIN',
-            };
-          }
-          return baseMember;
-        }),
-        dangerZoneState: 'leaving',
-      };
-    }),
+            if (baseMember.id === 'member2') {
+              return {
+                ...baseMember,
+                role: 'ADMIN',
+              };
+            }
+            return baseMember;
+          }),
+          dangerZoneState: 'leaving',
+        };
+      },
+    ),
   ],
 });
 
 export const simulationWithLeavingAsAdmin = makeStory(conf, {
+  /** @type {Partial<CcOrgaMemberList>[]} */
   items: [
     {
       authorisations: authorisationsAdmin,
-      members: {
-        state: 'loaded',
-        value: baseMemberList.map((baseMember) => {
+      memberListState: {
+        type: 'loaded',
+        memberList: baseMemberList.map((baseMember) => {
           if (baseMember.id === 'member2') {
             return {
               ...baseMember,
@@ -691,27 +799,31 @@ export const simulationWithLeavingAsAdmin = makeStory(conf, {
     },
   ],
   simulations: [
-    storyWait(2000, ([component]) => {
-      component.members = {
-        ...component.members,
-        value: baseMemberList.map((baseMember) => {
-          if (baseMember.id === 'member1') {
-            return {
-              ...baseMember,
-              state: 'deleting',
-            };
-          }
+    storyWait(
+      2000,
+      /** @param {Array<CcOrgaMemberList & { members: { state: OrgaMemberListStateLoaded }}>} components */
+      ([component]) => {
+        component.memberListState = {
+          ...component.memberListState,
+          memberList: baseMemberList.map((baseMember) => {
+            if (baseMember.id === 'member1') {
+              return {
+                ...baseMember,
+                type: 'deleting',
+              };
+            }
 
-          if (baseMember.id === 'member2') {
-            return {
-              ...baseMember,
-              role: 'ADMIN',
-            };
-          }
-          return baseMember;
-        }),
-        dangerZoneState: 'leaving',
-      };
-    }),
+            if (baseMember.id === 'member2') {
+              return {
+                ...baseMember,
+                role: 'ADMIN',
+              };
+            }
+            return baseMember;
+          }),
+          dangerZoneState: 'leaving',
+        };
+      },
+    ),
   ],
 });

--- a/src/components/cc-orga-member-list/cc-orga-member-list.types.d.ts
+++ b/src/components/cc-orga-member-list/cc-orga-member-list.types.d.ts
@@ -3,19 +3,19 @@ import { OrgaMemberCardState } from '../cc-orga-member-card/cc-orga-member-card.
 export type OrgaMemberListState = OrgaMemberListStateLoading | OrgaMemberListStateLoaded | OrgaMemberListStateError;
 
 interface OrgaMemberListStateLoading {
-  state: 'loading';
+  type: 'loading';
 }
 
 interface OrgaMemberListStateLoaded {
-  state: 'loaded';
-  value: OrgaMemberCardState[];
+  type: 'loaded';
+  memberList: OrgaMemberCardState[];
   identityFilter: string;
   mfaDisabledOnlyFilter: boolean;
   dangerZoneState: 'idle' | 'leaving' | 'error';
 }
 
 interface OrgaMemberListStateError {
-  state: 'error';
+  type: 'error';
 }
 
 export interface InviteMember {
@@ -23,7 +23,7 @@ export interface InviteMember {
   role: string;
 }
 
-interface Authorisations {
+interface ListAuthorisations {
   invite: boolean;
   edit: boolean;
   delete: boolean;

--- a/src/stories/fixtures/long-member-list.js
+++ b/src/stories/fixtures/long-member-list.js
@@ -1,3 +1,4 @@
+/** @type {import('../../components/cc-orga-member-list/cc-orga-member-list.types.js').OrgaMemberListStateLoaded['value']} */
 export default [
   {
     name: 'Cole Boyd',
@@ -6,8 +7,7 @@ export default [
     isMfaEnabled: false,
     isCurrentUser: true,
     role: 'DEVELOPER',
-    newRole: 'DEVELOPER',
-    state: 'loaded',
+    type: 'loaded',
     avatar: 'http://placekitten.com/202/202',
   },
   {
@@ -16,9 +16,9 @@ export default [
     id: 'member2',
     isMfaEnabled: false,
     role: 'ADMIN',
-    newRole: 'ADMIN',
-    state: 'loaded',
+    type: 'loaded',
     avatar: 'http://placekitten.com/202/202',
+    isCurrentUser: false
   },
   {
     name: 'Florence Nicholson',
@@ -26,9 +26,9 @@ export default [
     id: 'member3',
     isMfaEnabled: false,
     role: 'DEVELOPER',
-    newRole: 'DEVELOPER',
-    state: 'loaded',
+    type: 'loaded',
     avatar: 'http://placekitten.com/205/205',
+    isCurrentUser: false
   },
   {
     name: 'Paki Williams',
@@ -36,9 +36,9 @@ export default [
     id: 'member4',
     isMfaEnabled: true,
     role: 'DEVELOPER',
-    newRole: 'DEVELOPER',
-    state: 'loaded',
+    type: 'loaded',
     avatar: 'http://placekitten.com/205/205',
+    isCurrentUser: false
   },
   {
     name: 'Kenyon Calderon',
@@ -46,9 +46,9 @@ export default [
     id: 'member5',
     isMfaEnabled: false,
     role: 'MANAGER',
-    newRole: 'MANAGER',
-    state: 'loaded',
+    type: 'loaded',
     avatar: 'http://placekitten.com/207/207',
+    isCurrentUser: false
   },
   {
     name: 'Dalton Fowler',
@@ -56,9 +56,9 @@ export default [
     id: 'member6',
     isMfaEnabled: false,
     role: 'MANAGER',
-    newRole: 'MANAGER',
-    state: 'loaded',
+    type: 'loaded',
     avatar: 'http://placekitten.com/207/207',
+    isCurrentUser: false
   },
   {
     name: 'Malachi Vinson',
@@ -66,9 +66,9 @@ export default [
     id: 'member7',
     isMfaEnabled: true,
     role: 'ACCOUNTING',
-    newRole: 'ACCOUNTING',
-    state: 'loaded',
+    type: 'loaded',
     avatar: 'http://placekitten.com/202/202',
+    isCurrentUser: false
   },
   {
     name: 'Ahmed Ratliff',
@@ -76,9 +76,9 @@ export default [
     id: 'member8',
     isMfaEnabled: true,
     role: 'ACCOUNTING',
-    newRole: 'ACCOUNTING',
-    state: 'loaded',
+    type: 'loaded',
     avatar: 'http://placekitten.com/202/202',
+    isCurrentUser: false
   },
   {
     name: 'Laith May',
@@ -86,9 +86,9 @@ export default [
     id: 'member9',
     isMfaEnabled: false,
     role: 'ADMIN',
-    newRole: 'ADMIN',
-    state: 'loaded',
+    type: 'loaded',
     avatar: 'http://placekitten.com/205/205',
+    isCurrentUser: false
   },
   {
     name: 'Amity Dean',
@@ -96,9 +96,9 @@ export default [
     id: 'member10',
     isMfaEnabled: false,
     role: 'ADMIN',
-    newRole: 'ADMIN',
-    state: 'loaded',
+    type: 'loaded',
     avatar: 'http://placekitten.com/205/205',
+    isCurrentUser: false
   },
   {
     name: 'Tasha Camacho',
@@ -106,9 +106,9 @@ export default [
     id: 'member11',
     isMfaEnabled: false,
     role: 'DEVELOPER',
-    newRole: 'DEVELOPER',
-    state: 'loaded',
+    type: 'loaded',
     avatar: 'http://placekitten.com/207/207',
+    isCurrentUser: false
   },
   {
     name: 'Dane Freeman',
@@ -116,9 +116,9 @@ export default [
     id: 'member12',
     isMfaEnabled: false,
     role: 'DEVELOPER',
-    newRole: 'DEVELOPER',
-    state: 'loaded',
+    type: 'loaded',
     avatar: 'http://placekitten.com/207/207',
+    isCurrentUser: false
   },
   {
     name: 'Karly Valdez',
@@ -126,9 +126,9 @@ export default [
     id: 'member13',
     isMfaEnabled: false,
     role: 'MANAGER',
-    newRole: 'MANAGER',
-    state: 'loaded',
+    type: 'loaded',
     avatar: 'http://placekitten.com/202/202',
+    isCurrentUser: false
   },
   {
     name: 'Neville Sanders',
@@ -136,9 +136,9 @@ export default [
     id: 'member14',
     isMfaEnabled: true,
     role: 'MANAGER',
-    newRole: 'MANAGER',
-    state: 'loaded',
+    type: 'loaded',
     avatar: 'http://placekitten.com/202/202',
+    isCurrentUser: false
   },
   {
     name: 'Natalie Keith',
@@ -146,9 +146,9 @@ export default [
     id: 'member15',
     isMfaEnabled: true,
     role: 'ACCOUNTING',
-    newRole: 'ACCOUNTING',
-    state: 'loaded',
+    type: 'loaded',
     avatar: 'http://placekitten.com/205/205',
+    isCurrentUser: false
   },
   {
     name: 'Malachi Lloyd',
@@ -156,9 +156,9 @@ export default [
     id: 'member16',
     isMfaEnabled: false,
     role: 'ACCOUNTING',
-    newRole: 'ACCOUNTING',
-    state: 'loaded',
+    type: 'loaded',
     avatar: 'http://placekitten.com/205/205',
+    isCurrentUser: false
   },
   {
     name: 'Brooke Ward',
@@ -166,9 +166,9 @@ export default [
     id: 'member17',
     isMfaEnabled: false,
     role: 'ADMIN',
-    newRole: 'ADMIN',
-    state: 'loaded',
+    type: 'loaded',
     avatar: 'http://placekitten.com/207/207',
+    isCurrentUser: false
   },
   {
     name: 'Roth Bass',
@@ -176,9 +176,9 @@ export default [
     id: 'member18',
     isMfaEnabled: true,
     role: 'ADMIN',
-    newRole: 'ADMIN',
-    state: 'loaded',
+    type: 'loaded',
     avatar: 'http://placekitten.com/207/207',
+    isCurrentUser: false
   },
   {
     name: 'Keaton Stevens',
@@ -186,9 +186,9 @@ export default [
     id: 'member19',
     isMfaEnabled: false,
     role: 'DEVELOPER',
-    newRole: 'DEVELOPER',
-    state: 'loaded',
+    type: 'loaded',
     avatar: 'http://placekitten.com/202/202',
+    isCurrentUser: false
   },
   {
     name: 'Tyrone Blake',
@@ -196,9 +196,9 @@ export default [
     id: 'member20',
     isMfaEnabled: false,
     role: 'DEVELOPER',
-    newRole: 'DEVELOPER',
-    state: 'loaded',
+    type: 'loaded',
     avatar: 'http://placekitten.com/202/202',
+    isCurrentUser: false
   },
   {
     name: 'Kamal Kemp',
@@ -206,9 +206,9 @@ export default [
     id: 'member21',
     isMfaEnabled: false,
     role: 'MANAGER',
-    newRole: 'MANAGER',
-    state: 'loaded',
+    type: 'loaded',
     avatar: 'http://placekitten.com/205/205',
+    isCurrentUser: false
   },
   {
     name: 'Briar Garner',
@@ -216,9 +216,9 @@ export default [
     id: 'member22',
     isMfaEnabled: true,
     role: 'MANAGER',
-    newRole: 'MANAGER',
-    state: 'loaded',
+    type: 'loaded',
     avatar: 'http://placekitten.com/205/205',
+    isCurrentUser: false
   },
   {
     name: 'Herman Nixon',
@@ -226,9 +226,9 @@ export default [
     id: 'member23',
     isMfaEnabled: false,
     role: 'ACCOUNTING',
-    newRole: 'ACCOUNTING',
-    state: 'loaded',
+    type: 'loaded',
     avatar: 'http://placekitten.com/207/207',
+    isCurrentUser: false
   },
   {
     name: 'Kylan Freeman',
@@ -236,9 +236,9 @@ export default [
     id: 'member24',
     isMfaEnabled: false,
     role: 'ACCOUNTING',
-    newRole: 'ACCOUNTING',
-    state: 'loaded',
+    type: 'loaded',
     avatar: 'http://placekitten.com/207/207',
+    isCurrentUser: false
   },
   {
     name: 'Eric Page',
@@ -246,9 +246,9 @@ export default [
     id: 'member25',
     isMfaEnabled: true,
     role: 'ADMIN',
-    newRole: 'ADMIN',
-    state: 'loaded',
+    type: 'loaded',
     avatar: 'http://placekitten.com/202/202',
+    isCurrentUser: false
   },
   {
     name: 'Macaulay Nelson',
@@ -256,9 +256,9 @@ export default [
     id: 'member26',
     isMfaEnabled: true,
     role: 'ADMIN',
-    newRole: 'ADMIN',
-    state: 'loaded',
+    type: 'loaded',
     avatar: 'http://placekitten.com/202/202',
+    isCurrentUser: false
   },
   {
     name: 'Tana Briggs',
@@ -266,9 +266,9 @@ export default [
     id: 'member27',
     isMfaEnabled: false,
     role: 'DEVELOPER',
-    newRole: 'DEVELOPER',
-    state: 'loaded',
+    type: 'loaded',
     avatar: 'http://placekitten.com/205/205',
+    isCurrentUser: false
   },
   {
     name: 'Lois Reynolds',
@@ -276,9 +276,9 @@ export default [
     id: 'member28',
     isMfaEnabled: true,
     role: 'DEVELOPER',
-    newRole: 'DEVELOPER',
-    state: 'loaded',
+    type: 'loaded',
     avatar: 'http://placekitten.com/205/205',
+    isCurrentUser: false
   },
   {
     name: 'Shelby Wall',
@@ -286,9 +286,9 @@ export default [
     id: 'member29',
     isMfaEnabled: true,
     role: 'MANAGER',
-    newRole: 'MANAGER',
-    state: 'loaded',
+    type: 'loaded',
     avatar: 'http://placekitten.com/207/207',
+    isCurrentUser: false
   },
   {
     name: 'Jesse Morris',
@@ -296,9 +296,9 @@ export default [
     id: 'member30',
     isMfaEnabled: false,
     role: 'MANAGER',
-    newRole: 'MANAGER',
-    state: 'loaded',
+    type: 'loaded',
     avatar: 'http://placekitten.com/207/207',
+    isCurrentUser: false
   },
   {
     name: 'Jamalia Fields',
@@ -306,9 +306,9 @@ export default [
     id: 'member31',
     isMfaEnabled: false,
     role: 'ACCOUNTING',
-    newRole: 'ACCOUNTING',
-    state: 'loaded',
+    type: 'loaded',
     avatar: 'http://placekitten.com/202/202',
+    isCurrentUser: false
   },
   {
     name: 'Clayton Welch',
@@ -316,9 +316,9 @@ export default [
     id: 'member32',
     isMfaEnabled: true,
     role: 'ACCOUNTING',
-    newRole: 'ACCOUNTING',
-    state: 'loaded',
+    type: 'loaded',
     avatar: 'http://placekitten.com/202/202',
+    isCurrentUser: false
   },
   {
     name: 'Anthony Webb',
@@ -326,9 +326,9 @@ export default [
     id: 'member33',
     isMfaEnabled: false,
     role: 'ADMIN',
-    newRole: 'ADMIN',
-    state: 'loaded',
+    type: 'loaded',
     avatar: 'http://placekitten.com/205/205',
+    isCurrentUser: false
   },
   {
     name: 'Riley Barr',
@@ -336,9 +336,9 @@ export default [
     id: 'member34',
     isMfaEnabled: false,
     role: 'ADMIN',
-    newRole: 'ADMIN',
-    state: 'loaded',
+    type: 'loaded',
     avatar: 'http://placekitten.com/205/205',
+    isCurrentUser: false
   },
   {
     name: 'Martin Hammond',
@@ -346,9 +346,9 @@ export default [
     id: 'member35',
     isMfaEnabled: false,
     role: 'DEVELOPER',
-    newRole: 'DEVELOPER',
-    state: 'loaded',
+    type: 'loaded',
     avatar: 'http://placekitten.com/207/207',
+    isCurrentUser: false
   },
   {
     name: 'Stone Velasquez',
@@ -356,9 +356,9 @@ export default [
     id: 'member36',
     isMfaEnabled: false,
     role: 'DEVELOPER',
-    newRole: 'DEVELOPER',
-    state: 'loaded',
+    type: 'loaded',
     avatar: 'http://placekitten.com/207/207',
+    isCurrentUser: false
   },
   {
     name: 'Noble Willis',
@@ -366,9 +366,9 @@ export default [
     id: 'member37',
     isMfaEnabled: false,
     role: 'MANAGER',
-    newRole: 'MANAGER',
-    state: 'loaded',
+    type: 'loaded',
     avatar: 'http://placekitten.com/202/202',
+    isCurrentUser: false
   },
   {
     name: 'Gary Moreno',
@@ -376,9 +376,9 @@ export default [
     id: 'member38',
     isMfaEnabled: true,
     role: 'MANAGER',
-    newRole: 'MANAGER',
-    state: 'loaded',
+    type: 'loaded',
     avatar: 'http://placekitten.com/202/202',
+    isCurrentUser: false
   },
   {
     name: 'Bert Campos',
@@ -386,9 +386,9 @@ export default [
     id: 'member39',
     isMfaEnabled: true,
     role: 'ACCOUNTING',
-    newRole: 'ACCOUNTING',
-    state: 'loaded',
+    type: 'loaded',
     avatar: 'http://placekitten.com/205/205',
+    isCurrentUser: false
   },
   {
     name: 'Abbot Garrett',
@@ -396,8 +396,8 @@ export default [
     id: 'member40',
     isMfaEnabled: true,
     role: 'ACCOUNTING',
-    newRole: 'ACCOUNTING',
-    state: 'loaded',
+    type: 'loaded',
     avatar: 'http://placekitten.com/205/205',
+    isCurrentUser: false
   },
 ];


### PR DESCRIPTION
Fixes #1164

## What does this PR do?

- Migrates the `cc-orga-member-list` component to the new state API.

## How to review?

- Check the commit,
- Check the [preview](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-orga-member/migrate-to-new-state/index.html?path=/story/%F0%9F%9B%A0-organisation-cc-orga-member-list--default-story) vs [prod](https://www.clever-cloud.com/doc/clever-components/?path=/story/%F0%9F%9B%A0-organisation-cc-orga-member-list--default-story) stories,
- Run locally and check `demo-smart` to see if all features still work properly,
- 3 reviewers would be nice (breaking change + smart impact, better safe than sorry).