### PR TITLE
fix(cc-zone-picker): use `@input` instead of `@change` for event

### DIFF
--- a/src/components/cc-zone-picker/cc-zone-picker.js
+++ b/src/components/cc-zone-picker/cc-zone-picker.js
@@ -73,7 +73,7 @@ export class CcZonePicker extends CcFormControlElement {
 
   render() {
     return html`
-      <fieldset @change="${this._onZoneSelect}">
+      <fieldset @input="${this._onZoneSelect}">
         <legend>
           <cc-icon class="zone-legend-icon" .icon="${zoneIcon}" size="lg"></cc-icon>
           <span class="zone-legend-text"> ${i18n('cc-zone-picker.legend')} </span>


### PR DESCRIPTION
## What does this PR do?

* This PR changes the event from `@change` to `@input`

## Why?

* A `@change` event on a fieldset won't work reliably because the fieldset element itself doesn't emit change events directly. 
* This caused some value desync while working on the creation tunnel in the console

## How to review?

* Check the code
* Check the preview
* One reviewer should be enough 