### PR TITLE
make-story: typecheck

### DIFF
--- a/src/components/cc-domain-management/cc-domain-management.stories.js
+++ b/src/components/cc-domain-management/cc-domain-management.stories.js
@@ -1,5 +1,5 @@
 import { baseDnsInfo, baseDomains, httpOnlyDomain, longBaseDomains } from '../../stories/fixtures/domains.js';
-import { makeStory, storyWait } from '../../stories/lib/make-story.js';
+import { makeStory } from '../../stories/lib/make-story.js';
 import './cc-domain-management.js';
 
 export default {
@@ -11,30 +11,20 @@ export default {
 /**
  * @typedef {import('./cc-domain-management.types.js').DomainStateDeleting} DomainStateDeleting
  * @typedef {import('./cc-domain-management.types.js').DomainStateMarkingPrimary} DomainStateMarkingPrimary
- * @typedef {import('./cc-domain-management.types.js').DomainManagementDnsInfoStateLoaded} DomainManagementDnsInfoStateLoaded
- * @typedef {import('./cc-domain-management.types.js').DomainManagementDnsInfoStateLoading} DomainManagementDnsInfoStateLoading
- * @typedef {import('./cc-domain-management.types.js').DomainManagementDnsInfoStateError} DomainManagementDnsInfoStateError
  * @typedef {import('./cc-domain-management.types.js').DomainManagementListStateLoaded} DomainManagementListStateLoaded
- * @typedef {import('./cc-domain-management.types.js').DomainManagementListStateLoading} DomainManagementListStateLoading
- * @typedef {import('./cc-domain-management.types.js').DomainManagementListStateError} DomainManagementListStateError
- * @typedef {import('./cc-domain-management.types.js').DomainManagementFormStateIdle} DomainManagementFormStateIdle
- * @typedef {import('./cc-domain-management.types.js').DomainManagementFormStateAdding} DomainManagementFormStateAdding
- * @typedef {import('./cc-domain-management.js').CcDomainManagement} CcDomainManagement
  */
 
-const conf = {
+const conf = /** @type {const} */ ({
   component: 'cc-domain-management',
-};
+});
 
 export const defaultStory = makeStory(conf, {
   items: [
     {
-      /** @type {DomainManagementListStateLoaded} */
       domainListState: {
         type: 'loaded',
         domains: [...baseDomains.slice(0, 2), ...baseDomains.slice(-1)],
       },
-      /** @type {DomainManagementDnsInfoStateLoaded} */
       dnsInfoState: baseDnsInfo,
     },
   ],
@@ -43,12 +33,10 @@ export const defaultStory = makeStory(conf, {
 export const dataLoadedWithMoreDomains = makeStory(conf, {
   items: [
     {
-      /** @type {DomainManagementListStateLoaded} */
       domainListState: {
         type: 'loaded',
         domains: baseDomains,
       },
-      /** @type {DomainManagementDnsInfoStateLoaded} */
       dnsInfoState: baseDnsInfo,
     },
   ],
@@ -57,12 +45,10 @@ export const dataLoadedWithMoreDomains = makeStory(conf, {
 export const dataLoadedWithHttpOnlyDomain = makeStory(conf, {
   items: [
     {
-      /** @type {DomainManagementListStateLoaded} */
       domainListState: {
         type: 'loaded',
         domains: [...baseDomains, httpOnlyDomain],
       },
-      /** @type {DomainManagementDnsInfoStateLoaded} */
       dnsInfoState: baseDnsInfo,
     },
   ],
@@ -71,12 +57,10 @@ export const dataLoadedWithHttpOnlyDomain = makeStory(conf, {
 export const dataLoadedWithLongDomains = makeStory(conf, {
   items: [
     {
-      /** @type {DomainManagementListStateLoaded} */
       domainListState: {
         type: 'loaded',
         domains: [...baseDomains, httpOnlyDomain, ...longBaseDomains],
       },
-      /** @type {DomainManagementDnsInfoStateLoaded} */
       dnsInfoState: baseDnsInfo,
     },
   ],
@@ -85,12 +69,10 @@ export const dataLoadedWithLongDomains = makeStory(conf, {
 export const empty = makeStory(conf, {
   items: [
     {
-      /** @type {DomainManagementListStateLoaded} */
       domainListState: {
         type: 'loaded',
         domains: [],
       },
-      /** @type {DomainManagementDnsInfoStateLoaded} */
       dnsInfoState: baseDnsInfo,
     },
   ],
@@ -99,9 +81,7 @@ export const empty = makeStory(conf, {
 export const loading = makeStory(conf, {
   items: [
     {
-      /** @type {DomainManagementListStateLoading} */
       domainListState: { type: 'loading' },
-      /** @type {DomainManagementDnsInfoStateLoading} */
       dnsInfoState: { type: 'loading' },
     },
   ],
@@ -110,7 +90,6 @@ export const loading = makeStory(conf, {
 export const waitingWithAdding = makeStory(conf, {
   items: [
     {
-      /** @type {DomainManagementFormStateAdding} */
       domainFormState: {
         type: 'adding',
         hostname: {
@@ -120,12 +99,10 @@ export const waitingWithAdding = makeStory(conf, {
           value: '/api',
         },
       },
-      /** @type {DomainManagementListStateLoaded} */
       domainListState: {
         type: 'loaded',
         domains: baseDomains,
       },
-      /** @type {DomainManagementDnsInfoStateLoaded} */
       dnsInfoState: baseDnsInfo,
     },
   ],
@@ -134,7 +111,6 @@ export const waitingWithAdding = makeStory(conf, {
 export const waitingWithDeleting = makeStory(conf, {
   items: [
     {
-      /** @type {DomainManagementListStateLoaded} */
       domainListState: {
         type: 'loaded',
         domains: baseDomains.map((domain, index) => {
@@ -149,7 +125,6 @@ export const waitingWithDeleting = makeStory(conf, {
           return domain;
         }),
       },
-      /** @type {DomainManagementDnsInfoStateLoaded} */
       dnsInfoState: baseDnsInfo,
     },
   ],
@@ -158,7 +133,6 @@ export const waitingWithDeleting = makeStory(conf, {
 export const waitingWithMarkingAsPrimary = makeStory(conf, {
   items: [
     {
-      /** @type {DomainManagementListStateLoaded} */
       domainListState: {
         type: 'loaded',
         domains: baseDomains.map((domain, index) => {
@@ -173,7 +147,6 @@ export const waitingWithMarkingAsPrimary = makeStory(conf, {
           return domain;
         }),
       },
-      /** @type {DomainManagementDnsInfoStateLoaded} */
       dnsInfoState: baseDnsInfo,
     },
   ],
@@ -182,9 +155,7 @@ export const waitingWithMarkingAsPrimary = makeStory(conf, {
 export const error = makeStory(conf, {
   items: [
     {
-      /** @type {DomainManagementListStateError} */
       domainListState: { type: 'error' },
-      /** @type {DomainManagementDnsInfoStateError} */
       dnsInfoState: { type: 'error' },
     },
   ],
@@ -193,7 +164,6 @@ export const error = makeStory(conf, {
 export const errorWithEmpty = makeStory(conf, {
   items: [
     {
-      /** @type {DomainManagementFormStateIdle} */
       domainFormState: {
         type: 'idle',
         hostname: {
@@ -204,12 +174,10 @@ export const errorWithEmpty = makeStory(conf, {
           value: '',
         },
       },
-      /** @type {DomainManagementListStateLoaded} */
       domainListState: {
         type: 'loaded',
         domains: baseDomains,
       },
-      /** @type {DomainManagementDnsInfoStateLoaded} */
       dnsInfoState: baseDnsInfo,
     },
   ],
@@ -218,7 +186,6 @@ export const errorWithEmpty = makeStory(conf, {
 export const errorWithPathWithinDomain = makeStory(conf, {
   items: [
     {
-      /** @type {DomainManagementFormStateIdle} */
       domainFormState: {
         type: 'idle',
         hostname: {
@@ -228,16 +195,13 @@ export const errorWithPathWithinDomain = makeStory(conf, {
           value: '',
         },
       },
-      /** @type {DomainManagementListStateLoaded} */
       domainListState: {
         type: 'loaded',
         domains: baseDomains,
       },
-      /** @type {DomainManagementDnsInfoStateLoaded} */
       dnsInfoState: baseDnsInfo,
     },
   ],
-  /** @type {(component: CcDomainManagement) => void} */
   onUpdateComplete: (component) => {
     // this is temporary, when we move to Element Internals, the component will expose its form anyway
     component.shadowRoot.querySelector('form').requestSubmit();
@@ -247,7 +211,6 @@ export const errorWithPathWithinDomain = makeStory(conf, {
 export const errorWithInvalidDomain = makeStory(conf, {
   items: [
     {
-      /** @type {DomainManagementFormStateIdle} */
       domainFormState: {
         type: 'idle',
         hostname: {
@@ -258,12 +221,10 @@ export const errorWithInvalidDomain = makeStory(conf, {
           value: '',
         },
       },
-      /** @type {DomainManagementListStateLoaded} */
       domainListState: {
         type: 'loaded',
         domains: baseDomains,
       },
-      /** @type {DomainManagementDnsInfoStateLoaded} */
       dnsInfoState: baseDnsInfo,
     },
   ],
@@ -272,7 +233,6 @@ export const errorWithInvalidDomain = makeStory(conf, {
 export const errorWithInvalidWildcard = makeStory(conf, {
   items: [
     {
-      /** @type {DomainManagementFormStateIdle} */
       domainFormState: {
         type: 'idle',
         hostname: {
@@ -283,12 +243,10 @@ export const errorWithInvalidWildcard = makeStory(conf, {
           value: '',
         },
       },
-      /** @type {DomainManagementListStateLoaded} */
       domainListState: {
         type: 'loaded',
         domains: baseDomains,
       },
-      /** @type {DomainManagementDnsInfoStateLoaded} */
       dnsInfoState: baseDnsInfo,
     },
   ],
@@ -297,63 +255,59 @@ export const errorWithInvalidWildcard = makeStory(conf, {
 export const simulationsWithAddingSuccess = makeStory(conf, {
   items: [{}],
   simulations: [
-    storyWait(
-      2000,
-      /** @param {CcDomainManagement[]} components */
-      ([component]) => {
+    {
+      delay: 2000,
+      callback: ([component]) => {
         component.domainListState = {
           type: 'loaded',
           domains: baseDomains,
         };
         component.dnsInfoState = baseDnsInfo;
       },
-    ),
-    storyWait(
-      1000,
-      /** @param {CcDomainManagement[]} components */
-      ([component]) => {
+    },
+    {
+      delay: 1000,
+      callback: ([component]) => {
         component.domainFormState = {
           type: 'idle',
           hostname: { value: 'example.com' },
           pathPrefix: { value: '' },
         };
       },
-    ),
-    storyWait(
-      1000,
-      /** @param {CcDomainManagement[]} components */
-      ([component]) => {
+    },
+    {
+      delay: 1000,
+      callback: ([component]) => {
         component.domainFormState = {
           type: 'idle',
           hostname: { value: 'example.com' },
           pathPrefix: { value: '/api' },
         };
       },
-    ),
-    storyWait(
-      1000,
-      /** @param {CcDomainManagement[]} components */
-      ([component]) => {
+    },
+    {
+      delay: 1000,
+      callback: ([component]) => {
         component.domainFormState = {
           type: 'adding',
           hostname: { value: 'example.com' },
           pathPrefix: { value: '/api/v2' },
         };
       },
-    ),
-    storyWait(
-      1000,
-      /** @param {(CcDomainManagement & { domainListState: DomainManagementListStateLoaded })[]} components */
-      ([component]) => {
+    },
+    {
+      delay: 1000,
+      callback: ([component]) => {
         component.domainFormState = {
           type: 'idle',
           hostname: { value: '' },
           pathPrefix: { value: '' },
         };
+        const domainListStateLoaded = /** @type {DomainManagementListStateLoaded} */ (component.domainListState);
         component.domainListState = {
-          ...component.domainListState,
+          ...domainListStateLoaded,
           domains: [
-            ...component.domainListState.domains,
+            ...domainListStateLoaded.domains,
             {
               id: 'm53xpmuw4ra',
               type: 'idle',
@@ -365,49 +319,45 @@ export const simulationsWithAddingSuccess = makeStory(conf, {
           ],
         };
       },
-    ),
+    },
   ],
 });
 
 export const simulationsWithLoadingSuccess = makeStory(conf, {
   items: [{}],
   simulations: [
-    storyWait(
-      2000,
-      /** @param {CcDomainManagement[]} components */
-      ([component]) => {
+    {
+      delay: 2000,
+      callback: ([component]) => {
         component.domainListState = {
           type: 'loaded',
           domains: baseDomains,
         };
       },
-    ),
-    storyWait(
-      1000,
-      /** @param {CcDomainManagement[]} components */
-      ([component]) => {
+    },
+    {
+      delay: 1000,
+      callback: ([component]) => {
         component.dnsInfoState = baseDnsInfo;
       },
-    ),
+    },
   ],
 });
 
 export const simulationsWithLoadingError = makeStory(conf, {
   items: [{}],
   simulations: [
-    storyWait(
-      2000,
-      /** @param {CcDomainManagement[]} components */
-      ([component]) => {
+    {
+      delay: 2000,
+      callback: ([component]) => {
         component.domainListState = { type: 'error' };
       },
-    ),
-    storyWait(
-      1000,
-      /** @param {CcDomainManagement[]} components */
-      ([component]) => {
+    },
+    {
+      delay: 1000,
+      callback: ([component]) => {
         component.dnsInfoState = { type: 'error' };
       },
-    ),
+    },
   ],
 });

--- a/src/components/cc-domain-management/cc-domain-management.types.d.ts
+++ b/src/components/cc-domain-management/cc-domain-management.types.d.ts
@@ -1,3 +1,5 @@
+import { CcDomainManagement } from './cc-domain-management.js';
+
 export type DomainManagementFormState = DomainManagementFormStateIdle | DomainManagementFormStateAdding;
 
 interface DomainManagementFormStateIdle {
@@ -92,4 +94,10 @@ interface DomainManagementDnsInfoStateLoading {
 
 interface DomainManagementDnsInfoStateError {
   type: 'error';
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'cc-domain-management': CcDomainManagement;
+  }
 }

--- a/src/components/common.types.d.ts
+++ b/src/components/common.types.d.ts
@@ -438,3 +438,7 @@ export interface RawAddonProvider {
       | string;
   }[];
 }
+
+export type Entries<T> = {
+  [K in keyof T]: [K, T[K]];
+}[keyof T][];

--- a/src/stories/lib/custom-elements-manifest.types.d.ts
+++ b/src/stories/lib/custom-elements-manifest.types.d.ts
@@ -1,0 +1,12 @@
+export interface CustomElementDeclaration {
+  tagName?: string;
+  events?: Array<{
+    name: string;
+  }>;
+}
+
+export interface CustomElementsManifest {
+  modules: Array<{
+    declarations: CustomElementDeclaration[];
+  }>;
+}

--- a/src/stories/lib/make-story.types.d.ts
+++ b/src/stories/lib/make-story.types.d.ts
@@ -1,0 +1,78 @@
+import { StoryFn as StoryFnFromStorybook } from '@storybook/web-components';
+import { CSSResult, LitElement } from 'lit';
+import { CcBeta } from 'src/components/cc-beta/cc-beta.js';
+
+export function MakeStory<TagName extends keyof HTMLElementTagNameMap>(
+  defaultConfig: Config<TagName>,
+  storyConfig: Config<TagName>,
+): StoryFnCleverComponents<keyof HTMLElementTagNameMap>;
+
+type ComponentProps<TagName extends keyof HTMLElementTagNameMap> = Partial<HTMLElementTagNameMap[TagName]>;
+type Component<TagName extends keyof HTMLElementTagNameMap> = HTMLElementTagNameMap[TagName];
+
+interface Config<TagName extends keyof HTMLElementTagNameMap> {
+  name?: string;
+  docs?: string;
+  css?: string | CSSResult;
+  dom?: (container: HTMLElement) => void;
+  component?: TagName;
+  items?: ComponentProps<TagName>[] | (() => ComponentProps<TagName>[]);
+  simulations?: Array<ReturnType<typeof StoryWait<TagName>>>;
+  argTypes?: StoryFnFromStorybook['argTypes'];
+  displayMode?: 'block' | 'flex-wrap';
+  beta?: boolean;
+  onUpdateComplete?: (component: Component<TagName>, index: number) => void;
+}
+
+export function StoryWait<TagName extends keyof HTMLElementTagNameMap>(
+  delay: number,
+  callback: (components: Component<TagName>[]) => void,
+): {
+  delay: number;
+  callback: (components: Component<TagName>[]) => void;
+};
+
+type StoryWaitReturnType<TagName extends keyof HTMLElementTagNameMap> = ReturnType<typeof StoryWait<TagName>>;
+
+type StoryFnParams = Parameters<StoryFnFromStorybook>;
+
+export type StoryFnCleverComponents<TagName extends keyof HTMLElementTagNameMap> = {
+  args: ComponentProps<TagName>;
+  argTypes: Config<TagName>['argTypes'];
+  parameters?: {
+    docs: {
+      description: {
+        story: Config<TagName>['docs'] | '';
+      };
+      source: {
+        code: string;
+      };
+    };
+  };
+  docs?: Config<TagName>['docs'];
+  css?: Config<TagName>['css'];
+  component?: TagName;
+  items?: ComponentProps<TagName>[];
+  storyName: Config<TagName>['name'];
+  (
+    storyArgs: Parameters<StoryFnFromStorybook>[0],
+    context: Parameters<StoryFnFromStorybook>[1],
+  ): HTMLElement | LitElement | CcBeta;
+};
+
+export function GetSourceCode<TagName extends keyof HTMLElementTagNameMap>(
+  component: TagName,
+  items: ComponentProps<TagName>,
+  dom: Config<TagName>['dom'],
+): string;
+
+export function CreateStoryItem<TagName extends keyof HTMLElementTagNameMap>(
+  storyFn: StoryFnCleverComponents<TagName>,
+  props: ComponentProps<TagName>,
+  itemIndex: number,
+): Component<TagName>;
+
+export function AssignPropsToElement<ElementToAssign extends Element>(
+  element: ElementToAssign,
+  props: Partial<ElementToAssign>,
+): ElementToAssign;

--- a/src/stories/lib/sequence.js
+++ b/src/stories/lib/sequence.js
@@ -1,9 +1,21 @@
+/**
+ * Creates a promise that resolves after a specified delay
+ *
+ * @param {number} delay - The delay time in milliseconds
+ * @returns {Promise<void>} Promise that resolves after the delay
+ */
 function wait(delay) {
   return new Promise((resolve) => {
     setTimeout(resolve, delay);
   });
 }
 
+/**
+ * Run the sequence if we have simulations
+ *
+ * @param {function(typeof wait): Promise<void>} callback - Function to wait for specified delay.
+ * @returns {void}
+ */
 export function sequence(callback) {
   setTimeout(() => callback(wait), 50);
 }


### PR DESCRIPTION
EDIT: do not review, probably going to turn this into some RFC to discuss makeStory refactoring because the typechecking doesn't exactly match the implementation.

## What does this PR do?

- Typechecks the `makeStory` helper with generics so that we don't have to add casts everywhere in our story files,
- Adapts the `cc-domain-management.stories.js` to show that it works and how these changes impact stories.

**Note**: the next step is to adapt all story files as well as all `d.ts` files. I have already done that but I chose not to include that in this PR so we can focus on reviewing the typechecking and not the refactoring.
The refactoring will be made in a separate PR that we won't need to review heavily because it won't impact visuals, only typechecking and it will be checked in CI anyway. 

## How to review?

- Check the commits (the `d.ts` types are not always easy to review so don't hesitate to ask questions if you feel some stuff is weird),
- Play with the `cc-domain-management.stories.js` file locally to check typechecking works + you can try to adapt another story file if you want.

> [!CAUTION]
>  Things to discuss: I had to change / simplify how we deal with simulations because I couldn't make TypeScript understand that types used in `storyWait` depend on the context they are used within (an array of simulations used in a Config object that is related to a specific Component). This is even tricky to explain. I tried many options but none of them worked, you always had to cast the `storyWait` function to remind TypeScript that in this context, the `components` used in the callback of `storyWait` were components whose `tagName` matched the one provided in `conf`.
> I have a few things I still want to try but in this PR I went for the easiest solution.