### PR TITLE
refactor(cc-kv-terminal): catch `disconnected` errors

### DIFF
--- a/src/components/cc-kv-terminal/cc-kv-terminal.js
+++ b/src/components/cc-kv-terminal/cc-kv-terminal.js
@@ -229,9 +229,17 @@ export class CcKvTerminal extends LitElement {
    */
   async updated(changedProperties) {
     if (changedProperties.has('state') && this.state.type === 'idle') {
-      await this._scrollToBottom();
-      // don't ask me why, but we really need to call it twice to make sure it really scrolls to the bottom
-      await this._scrollToBottom();
+      try {
+        await this._scrollToBottom();
+        // don't ask me why, but we really need to call it twice to make sure it really scrolls to the bottom
+        await this._scrollToBottom();
+      } catch (error) {
+        // only catch `disconnected` errors that happen when the component is dismounted before the scrolling takes place
+        // https://github.com/CleverCloud/clever-components/issues/1311
+        if (error !== 'disconnected') {
+          throw error;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #1311

## What does this PR do?

- Catches `disconnected` errors inside the `updated` lifecycle of `cc-kv-terminal`. These errors seem to happen when the component is removed from the DOM but a scrolling promise is pending?

**Note**: this is a `refactor` commit and not a `fix` because the issue it fixes has not been released yet. 

## How to review?

- Check the commit,
- Run `npm run test src/components/cc-kv-terminal/cc-kv-terminal.test.js`, you should only have `Resize Observer` logs. (the resize observer logs will soon be gone, I handled this subject when refactoring a11y tests). 