### PR TITLE
refactor(cc-grafana-info): avoid setting both `disabled` & `waiting` at the same time

### DIFF
--- a/src/components/cc-grafana-info/cc-grafana-info.js
+++ b/src/components/cc-grafana-info/cc-grafana-info.js
@@ -137,7 +137,7 @@ export class CcGrafanaInfo extends LitElement {
                   <cc-button
                     success
                     ?waiting=${isSwitchingGrafanaStatus}
-                    ?disabled=${isFormDisabled}
+                    ?disabled=${isFormDisabled && !isSwitchingGrafanaStatus}
                     @cc-button:click=${this._onEnableSubmit}
                   >
                     ${i18n('cc-grafana-info.enable-title')}
@@ -176,7 +176,7 @@ export class CcGrafanaInfo extends LitElement {
                 <div>
                   <cc-button
                     primary
-                    ?disabled=${isFormDisabled}
+                    ?disabled=${isFormDisabled && !isResetting}
                     ?waiting=${isResetting}
                     @cc-button:click=${this._onResetSubmit}
                   >
@@ -214,7 +214,7 @@ export class CcGrafanaInfo extends LitElement {
                     ?waiting=${isSwitchingGrafanaStatus}
                     danger
                     delay="3"
-                    ?disabled=${isFormDisabled}
+                    ?disabled=${isFormDisabled && !isSwitchingGrafanaStatus}
                     @cc-button:click=${this._onDisableSubmit}
                   >
                     ${i18n('cc-grafana-info.disable-title')}


### PR DESCRIPTION
Fixes #1124

## Context

- Adapts the `cc-grafana-info` component so that `disabled` & `waiting` are never set to `true` at the same time. I simply forgot to handle this component in #1297.

How am I sure no other components are missing?

The following log appears in local tests when there are issues of this type:

> `waiting` and `disabled` cannot be set to true at the same time, see https://github.com/CleverCloud/clever-components/issues/1124 for more info

![screenshot of the error quoted above in the test results](https://github.com/user-attachments/assets/8b0fd185-f28b-461f-ac70-04a40c5f9b1f)

This time I ran all component tests locally and searched for the message to make sure there was none left.

**Note**: ideally I'd like these errors to make tests fails but I'm not sure how to do that at the moment? If you have ideas feel free to weigh in!

**Note**: this is a `refactor` commit and not a `fix` because the issue it fixes has not been released yet. 

## How to review?

- Check the commit,
- If you want, you may run the tests locally and check that the error message is not part of the results,
- 1 reviewer should be enough.
