### PR TITLE
fix: revert `top` a11y visually-hidden style

### DIFF
--- a/src/components/cc-kv-terminal/cc-kv-terminal.js
+++ b/src/components/cc-kv-terminal/cc-kv-terminal.js
@@ -384,6 +384,7 @@ export class CcKvTerminal extends LitElement {
           align-items: center;
           display: flex;
           gap: 0.2em;
+          position: relative;
         }
 
         .prompt input {

--- a/src/styles/accessibility.js
+++ b/src/styles/accessibility.js
@@ -8,7 +8,6 @@ export const accessibilityStyles = css`
     height: 1px;
     overflow: hidden;
     position: absolute;
-    top: 0; /* this fixes a bug in Chrome when this style is used into a grid element (and has overflow) */
     white-space: nowrap;
     width: 1px;
   }


### PR DESCRIPTION
## What does this PR do? 

* This PR reverts the changes that were initially fixing the issue #1200 
* Instead we're directly making the fix on `cc-kv-terminal`

## Why?

* While using `top: 0px` works and fixes the problem for `cc-kv-terminal`, it caused problems on other components using the `visually-hidden` styles, especially `cc-zone-picker` and `cc-plan-picker`
* It made these components scroll to top as the inputs were not correctly positioned anymore.
* That's why this PR reverts the fix and fixes `cc-kv-terminal` directly instead.

## How to review?

* Check the code
* Ideally check the sandbox of `cc-kv-explorer` to be sure that the problem doesn't appear anymore.