### PR TITLE
cc-addon-elasticsearch-options: support multi-currency and no monthly cost

### DIFF
--- a/src/components/cc-addon-elasticsearch-options/cc-addon-elasticsearch-options.stories.js
+++ b/src/components/cc-addon-elasticsearch-options/cc-addon-elasticsearch-options.stories.js
@@ -11,19 +11,38 @@ const conf = {
   component: 'cc-addon-elasticsearch-options',
 };
 
+/**
+ * @typedef {import('./cc-addon-elasticsearch-options.js').CcAddonElasticsearchOptions} CcAddonElasticsearchOptions
+ */
+
 export const defaultStory = makeStory(conf, {
+  /** @type {Partial<CcAddonElasticsearchOptions>[]} */
   items: [
     {
       options: [
         {
           name: 'kibana',
           enabled: false,
-          flavor: { name: 'L', mem: 8192, cpus: 6, gpus: 0, microservice: false, monthlyCost: 144 },
+          flavor: {
+            name: 'L',
+            mem: 8192,
+            cpus: 6,
+            gpus: 0,
+            microservice: false,
+            monthlyCost: { amount: 144, currency: 'EUR' },
+          },
         },
         {
           name: 'apm',
           enabled: false,
-          flavor: { name: 'M', mem: 4096, cpus: 4, gpus: 0, microservice: false, monthlyCost: 72 },
+          flavor: {
+            name: 'M',
+            mem: 4096,
+            cpus: 4,
+            gpus: 0,
+            microservice: false,
+            monthlyCost: { amount: 72, currency: 'EUR' },
+          },
         },
         {
           name: 'encryption',
@@ -34,40 +53,108 @@ export const defaultStory = makeStory(conf, {
   ],
 });
 
-export const noFlavorDetailsYet = makeStory(conf, {
-  items: [
-    {
-      options: [
-        {
-          name: 'kibana',
-          enabled: false,
-        },
-        {
-          name: 'apm',
-          enabled: false,
-        },
-        {
-          name: 'encryption',
-          enabled: false,
-        },
-      ],
-    },
-  ],
-});
-
-export const preselectedKibana = makeStory(conf, {
+export const dataLoadedWithPreselectedKibana = makeStory(conf, {
+  /** @type {Partial<CcAddonElasticsearchOptions>[]} */
   items: [
     {
       options: [
         {
           name: 'kibana',
           enabled: true,
-          flavor: { name: 'L', mem: 8192, cpus: 6, gpus: 0, microservice: false, monthlyCost: 144 },
+          flavor: {
+            name: 'L',
+            mem: 8192,
+            cpus: 6,
+            gpus: 0,
+            microservice: false,
+            monthlyCost: { amount: 144, currency: 'EUR' },
+          },
         },
         {
           name: 'apm',
           enabled: false,
-          flavor: { name: 'M', mem: 4096, cpus: 4, gpus: 0, microservice: false, monthlyCost: 72 },
+          flavor: {
+            name: 'M',
+            mem: 4096,
+            cpus: 4,
+            gpus: 0,
+            microservice: false,
+            monthlyCost: { amount: 72, currency: 'EUR' },
+          },
+        },
+        {
+          name: 'encryption',
+          enabled: false,
+        },
+      ],
+    },
+  ],
+});
+
+export const dataLoadedWithDollars = makeStory(conf, {
+  /** @type {Partial<CcAddonElasticsearchOptions>[]} */
+  items: [
+    {
+      options: [
+        {
+          name: 'kibana',
+          enabled: false,
+          flavor: {
+            name: 'L',
+            mem: 8192,
+            cpus: 6,
+            gpus: 0,
+            microservice: false,
+            monthlyCost: { amount: 144, currency: 'USD' },
+          },
+        },
+        {
+          name: 'apm',
+          enabled: false,
+          flavor: {
+            name: 'M',
+            mem: 4096,
+            cpus: 4,
+            gpus: 0,
+            microservice: false,
+            monthlyCost: { amount: 72, currency: 'USD' },
+          },
+        },
+        {
+          name: 'encryption',
+          enabled: false,
+        },
+      ],
+    },
+  ],
+});
+
+export const dataLoadedWithNoMonthlyCost = makeStory(conf, {
+  /** @type {Partial<CcAddonElasticsearchOptions>[]} */
+  items: [
+    {
+      options: [
+        {
+          name: 'kibana',
+          enabled: false,
+          flavor: {
+            name: 'L',
+            mem: 8192,
+            cpus: 6,
+            gpus: 0,
+            microservice: false,
+          },
+        },
+        {
+          name: 'apm',
+          enabled: false,
+          flavor: {
+            name: 'M',
+            mem: 4096,
+            cpus: 4,
+            gpus: 0,
+            microservice: false,
+          },
         },
         {
           name: 'encryption',

--- a/src/components/cc-tile-scalability/cc-tile-scalability.js
+++ b/src/components/cc-tile-scalability/cc-tile-scalability.js
@@ -9,8 +9,8 @@ import '../cc-icon/cc-icon.js';
 
 /** @type {Scalability} */
 const SKELETON_SCALABILITY = {
-  minFlavor: { name: '??', cpus: 0, gpus: 0, mem: 0, microservice: false, monthlyCost: 0 },
-  maxFlavor: { name: '?', cpus: 0, gpus: 0, mem: 0, microservice: false, monthlyCost: 0 },
+  minFlavor: { name: '??', cpus: 0, gpus: 0, mem: 0, microservice: false },
+  maxFlavor: { name: '?', cpus: 0, gpus: 0, mem: 0, microservice: false },
   minInstances: 0,
   maxInstances: 0,
 };

--- a/src/components/cc-tile-scalability/cc-tile-scalability.stories.js
+++ b/src/components/cc-tile-scalability/cc-tile-scalability.stories.js
@@ -20,9 +20,9 @@ const conf = {
 
 /**
  * @typedef {import('./cc-tile-scalability.js').CcTileScalability} CcTileScalability
- * @typedef {import('./cc-tile-scalability.type.js').TileScalabilityStateLoaded} TileScalabilityStateLoaded
- * @typedef {import('./cc-tile-scalability.type.js').TileScalabilityStateLoading} TileScalabilityStateLoading
- * @typedef {import('./cc-tile-scalability.type.js').TileScalabilityStateError} TileScalabilityStateError
+ * @typedef {import('./cc-tile-scalability.types.js').TileScalabilityStateLoaded} TileScalabilityStateLoaded
+ * @typedef {import('./cc-tile-scalability.types.js').TileScalabilityStateLoading} TileScalabilityStateLoading
+ * @typedef {import('./cc-tile-scalability.types.js').TileScalabilityStateError} TileScalabilityStateError
  * @typedef {import('../common.types.js').Flavor} Flavor
  * @typedef {import('../common.types.js').Scalability} Scalability
  */

--- a/src/components/common.types.d.ts
+++ b/src/components/common.types.d.ts
@@ -38,32 +38,33 @@ export interface Flavor {
   gpus: number;
   mem: number;
   microservice: boolean;
-  monthlyCost?: number | null;
 }
 
-export interface EncryptionAddonOption {
-  name: 'encryption';
-  enabled: boolean;
-}
-
-export interface ElasticAddonOption {
-  name: 'kibana' | 'apm';
-  enabled: boolean;
-  flavor?: Flavor;
-}
-
-export type AddonOption = EncryptionAddonOption | ElasticAddonOption;
+export type AddonOption = EncryptionAddonOption | ElasticAddonOption<Flavor | FlavorWithMonthlyCost>;
 
 export type AddonOptionWithMetadata = {
   icon?: IconModel;
-  title?: string | DocumentFragment;
+  title?: string | Node;
   logo?: string;
-  description: string | DocumentFragment | TemplateResult<1>;
-} & AddonOption;
+  description: string | Node | TemplateResult<1>;
+} & Pick<AddonOption, 'name' | 'enabled'>;
 
 export interface EncryptionAddonOption {
   name: 'encryption';
   enabled: boolean;
+}
+
+export interface ElasticAddonOption<FlavorType> {
+  name: 'kibana' | 'apm';
+  enabled: boolean;
+  flavor: FlavorType;
+}
+
+export interface FlavorWithMonthlyCost extends Flavor {
+  monthlyCost: {
+    amount: number;
+    currency: string;
+  };
 }
 
 export type AddonOptionStates = { [optionName: string]: boolean };

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -18,6 +18,7 @@ import { preparePlural } from '../lib/i18n/i18n-string.js';
 
 /**
  * @typedef {import('../components/common.types.js').Flavor} Flavor
+ * @typedef {import('../components/common.types.js').FlavorWithMonthlyCost} FlavorWithMonthlyCost
  */
 
 export const lang = 'en';
@@ -155,20 +156,24 @@ export const translations = {
   'cc-addon-credentials.title': /** @param {{name: string}} _ */ ({ name }) => `${name} credentials`,
   //#endregion
   //#region cc-addon-elasticsearch-options
-  'cc-addon-elasticsearch-options.description': () =>
-    sanitize`This add-on is part of the Elastic Stack offer which includes two options. Both these options will be deployed as applications, managed and updated by Clever Cloud on your behalf. They will appear as regular applications that you can stop, scale up or down automatically like one of your own applications. As such, <strong>enabling these options will result in an increase in credits consumption</strong> as well.`,
-  'cc-addon-elasticsearch-options.description.apm': () =>
+  'cc-addon-elasticsearch-options.additional-cost': () =>
+    sanitize`As such, <strong>enabling these options will result in an increase in credits consumption</strong> as well.`,
+  'cc-addon-elasticsearch-options.description': `This add-on is part of the Elastic Stack offer which includes two options. Both these options will be deployed as applications, managed and updated by Clever Cloud on your behalf. They will appear as regular applications that you can stop, scale up or down automatically like one of your own applications.`,
+  'cc-addon-elasticsearch-options.details.apm': () =>
     sanitize`Elastic APM server is an application performance monitoring system built on the Elastic Stack. Deploying this will allow you to automatically send APM metrics from any applications linked to the Elasticsearch add-on instance, providing you add the Elastic APM agent to the application code. Learn more in the <a href="https://www.elastic.co/guide/en/apm/get-started/current/overview.html">official APM server documentation</a>.`,
-  'cc-addon-elasticsearch-options.description.kibana': () =>
+  'cc-addon-elasticsearch-options.details.kibana': () =>
     sanitize`Kibana is the admin UI for the Elastic Stack. It lets you visualize your Elasticsearch data and navigate the stack so you can do anything from tracking query load to understanding the way requests flow through your apps. Learn more in the <a href="https://www.elastic.co/guide/en/kibana/master/index.html">official Kibana documentation</a>.`,
   'cc-addon-elasticsearch-options.error.icon-a11y-name': `Warning`,
   'cc-addon-elasticsearch-options.title': `Options for the Elastic Stack`,
-  'cc-addon-elasticsearch-options.warning.apm': `If you enable this option, we'll deploy and manage an Elastic APM server application for you, this will lead to additional costs.`,
-  'cc-addon-elasticsearch-options.warning.apm.details': /** @param {Flavor} flavor */ (flavor) =>
-    sanitize`By default, the app will start on a <strong title="${formatFlavor(flavor)}">${flavor.name} instance</strong> which costs around <strong>${formatCurrency(lang, flavor.monthlyCost)} per month</strong>.`,
-  'cc-addon-elasticsearch-options.warning.kibana': `If you enable this option, we'll deploy and manage a Kibana application for you, this will lead to additional costs.`,
-  'cc-addon-elasticsearch-options.warning.kibana.details': /** @param {Flavor} flavor */ (flavor) =>
-    sanitize`By default, the app will start on a <strong title="${formatFlavor(flavor)}">${flavor.name} instance</strong> which costs around <strong>${formatCurrency(lang, flavor.monthlyCost)} per month</strong>.`,
+  'cc-addon-elasticsearch-options.warning.apm': `If you enable this option, we'll deploy and manage an Elastic APM server application for you.`,
+  'cc-addon-elasticsearch-options.warning.flavor': /** @param {Flavor} flavor */ (flavor) =>
+    sanitize`By default, the application will start on a <strong title="${formatFlavor(flavor)}">${flavor.name} instance</strong>.`,
+  'cc-addon-elasticsearch-options.warning.kibana': `If you enable this option, we'll deploy and manage a Kibana application for you.`,
+  'cc-addon-elasticsearch-options.warning.monthly-cost': /** @param {FlavorWithMonthlyCost['monthlyCost']} _ */ ({
+    amount,
+    currency,
+  }) => sanitize`
+      This should cost around <strong>${formatCurrency(lang, amount, { currency })}</strong> per month.`,
   //#endregion
   //#region cc-addon-encryption-at-rest-option
   'cc-addon-encryption-at-rest-option.description': () =>

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -18,6 +18,7 @@ import { preparePlural } from '../lib/i18n/i18n-string.js';
 
 /**
  * @typedef {import('../components/common.types.js').Flavor} Flavor
+ * @typedef {import('../components/common.types.js').FlavorWithMonthlyCost} FlavorWithMonthlyCost
  */
 
 export const lang = 'fr';
@@ -166,20 +167,24 @@ export const translations = {
   'cc-addon-credentials.title': /** @param {{name: string}} _ */ ({ name }) => `Identifiants ${name}`,
   //#endregion
   //#region cc-addon-elasticsearch-options
-  'cc-addon-elasticsearch-options.description': () =>
-    sanitize`Cet add-on fait partie de l'offre Suite Elastic qui inclue deux options. Ces options sont déployées comme des applications et seront gérées et mises à jour par Clever Cloud. Elles apparaîtront donc comme des applications habituelles que vous pouvez arrêter, supprimer, scaler comme n'importe quelle autre application. <strong>Activer ces options augmentera votre consommation de crédits.</strong>`,
-  'cc-addon-elasticsearch-options.description.apm': () =>
+  'cc-addon-elasticsearch-options.additional-cost': () =>
+    sanitize`<strong>Activer ces options augmentera votre consommation de crédits.</strong>`,
+  'cc-addon-elasticsearch-options.description': `Cet add-on fait partie de l'offre Suite Elastic qui inclue deux options. Ces options sont déployées comme des applications et sont gérées et mises à jour par Clever Cloud. Elles apparaîtront donc comme des applications habituelles que vous pouvez arrêter, supprimer, scaler comme n'importe quelle autre application.`,
+  'cc-addon-elasticsearch-options.details.apm': () =>
     sanitize`Elastic APM est un serveur de monitoring de performance applicative pour la Suite Elastic. Déployer cette option permet d'envoyer automatiquement les métriques de toute application liée à cette instance d'add-on Elasticsearch, en supposant que vous utilisez bien l'agent Elastic APM dans les dépendances de vos applications. Retrouvez plus de détails dans <a href="https://www.elastic.co/guide/en/apm/get-started/current/overview.html">la documentation officielle de APM server</a>.`,
-  'cc-addon-elasticsearch-options.description.kibana': () =>
+  'cc-addon-elasticsearch-options.details.kibana': () =>
     sanitize`Kibana est l'interface d'administration de la Suite Elastic. Kibana vous permet de visualiser vos données Elasticsearch et de naviguer dans la Suite Elastic. Vous voulez effectuer le suivi de la charge de travail liée à la recherche ou comprendre le flux des requêtes dans vos applications ? Kibana est là pour ça. Retrouvez plus de détails dans <a href="https://www.elastic.co/guide/en/kibana/master/index.html">la documentation officielle de Kibana</a>.`,
   'cc-addon-elasticsearch-options.error.icon-a11y-name': `Avertissement`,
   'cc-addon-elasticsearch-options.title': `Options pour la Suite Elastic`,
-  'cc-addon-elasticsearch-options.warning.apm': `Si vous activez cette option, nous allons déployer et gérer pour vous un APM server, ce qui entraînera des coûts supplémentaires.`,
-  'cc-addon-elasticsearch-options.warning.apm.details': /** @param {Flavor} flavor */ (flavor) =>
-    sanitize`Par défaut, l'app sera démarrée sur une <strong title="${formatFlavor(flavor)}">instance ${flavor.name}</strong> qui coûte environ <strong>${formatCurrency(lang, flavor.monthlyCost)} par mois</strong>. `,
-  'cc-addon-elasticsearch-options.warning.kibana': `Si vous activez cette option, nous allons déployer et gérer pour vous un Kibana, ce qui entraînera des coûts supplémentaires.`,
-  'cc-addon-elasticsearch-options.warning.kibana.details': /** @param {Flavor} flavor */ (flavor) =>
-    sanitize`Par défaut, l'app sera démarrée sur une <strong title="${formatFlavor(flavor)}">instance ${flavor.name}</strong> qui coûte environ <strong>${formatCurrency(lang, flavor.monthlyCost)} par mois</strong>.`,
+  'cc-addon-elasticsearch-options.warning.apm': `Si vous activez cette option, nous allons déployer et gérer pour vous un APM server`,
+  'cc-addon-elasticsearch-options.warning.flavor': /** @param {Flavor} flavor */ (flavor) =>
+    sanitize`Par défaut, l'application sera démarrée sur une <strong title="${formatFlavor(flavor)}">instance ${flavor.name}</strong>.`,
+  'cc-addon-elasticsearch-options.warning.kibana': `Si vous activez cette option, nous allons déployer et gérer pour vous un Kibana.`,
+  'cc-addon-elasticsearch-options.warning.monthly-cost': /** @param {FlavorWithMonthlyCost['monthlyCost']} _ */ ({
+    amount,
+    currency,
+  }) =>
+    sanitize`Cela devrait coûter environ <strong>${formatCurrency(lang, amount, { currency: currency })} par mois</strong>.`,
   //#endregion
   //#region cc-addon-encryption-at-rest-option
   'cc-addon-encryption-at-rest-option.description': () =>


### PR DESCRIPTION
Fixes #1172 
Fixes #1230

## What does this PR do?

- Changes the format of `monthlyCost` from a simple number to an object that accepts a `currency` as well as some `amount`.
- Makes `monthlyCost` optional so that the component does not try to display any price in case no `monhtlyCost` is provided for a flavor (when billing is disabled).

## How to review?

- Check the commits,
- Check the [stories in preview](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-addon-elasticsearch-options/support-multi-currency/index.html?path=/story/%F0%9F%9B%A0-addon-cc-addon-elasticsearch-options--default-story) (especially the new ones).