### PR TITLE
fix(cc-env-var-form): link exposed-config change

### DIFF
--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -441,7 +441,7 @@ export const translations = {
   'cc-env-var-form.description.env-var': /** @param {{appName: string}} _ */ ({ appName }) =>
     sanitize`These variables will be injected as environment variables in the application <strong>${appName}</strong>.`,
   'cc-env-var-form.description.exposed-config': /** @param {{appName: string}} _ */ ({ appName }) =>
-    sanitize`Configuration exposed to dependent applications. <a href="https://www.clever-cloud.com/doc/admin-console/service-dependencies/">Learn more</a><br>These variables won't be injected in the application <strong>${appName}</strong>, they will be injected as environment variables in applications that have <strong>${appName}</strong> in their service dependencies.`,
+    sanitize`Configuration exposed to dependent applications. <a href="https://developers.clever-cloud.com/doc/administrate/service-dependencies/#exposed-configuration">Learn more</a><br>These variables won't be injected in the application <strong>${appName}</strong>, they will be injected as environment variables in applications that have <strong>${appName}</strong> in their service dependencies.`,
   'cc-env-var-form.documentation.text': `Environment variables - Reference`,
   'cc-env-var-form.error.loading': `Something went wrong while loading variables.`,
   'cc-env-var-form.heading.config-provider': `Variables`,

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -450,7 +450,7 @@ export const translations = {
   'cc-env-var-form.description.env-var': /** @param {{appName: string}} _ */ ({ appName }) =>
     sanitize`Ces variables seront injectées en tant que variables d'environnement dans l'application <strong>${appName}</strong>.`,
   'cc-env-var-form.description.exposed-config': /** @param {{appName: string}} _ */ ({ appName }) =>
-    sanitize`Configuration publiée pour les applications dépendantes. <a href="https://www.clever-cloud.com/doc/admin-console/service-dependencies/">En savoir plus</a><br>Ces variables ne seront pas injectées dans l'application <strong>${appName}</strong>, elles seront injectées en tant que variables d'environnement dans les applications qui ont <strong>${appName}</strong> dans leurs services liés.`,
+    sanitize`Configuration publiée pour les applications dépendantes. <a href="https://developers.clever-cloud.com/doc/administrate/service-dependencies/#exposed-configuration">En savoir plus</a><br>Ces variables ne seront pas injectées dans l'application <strong>${appName}</strong>, elles seront injectées en tant que variables d'environnement dans les applications qui ont <strong>${appName}</strong> dans leurs services liés.`,
   'cc-env-var-form.documentation.text': `Variables d’environnement - Référence`,
   'cc-env-var-form.error.loading': `Une erreur est survenue pendant le chargement des variables.`,
   'cc-env-var-form.heading.config-provider': `Variables`,


### PR DESCRIPTION
Fixes #970 

# What does this PR do?

- Changes the link redirecting to the doc present in the `cc-env-var-form.description.exposed-config` translation key.

# How to review?

- Check the commits,
- Check the story `Data loaded (context exposed config)` in the preview.
- 1 reviewer should be enough.
