### PR TITLE
feat(cc-env-var-form): add public `hasUnsavedModifications` getter

### DIFF
--- a/src/components/cc-env-var-form/cc-env-var-form.js
+++ b/src/components/cc-env-var-form/cc-env-var-form.js
@@ -91,6 +91,15 @@ export class CcEnvVarForm extends LitElement {
     this._isPristine = true;
   }
 
+  /**
+   * Whether the form has unsaved variables.
+   *
+   * @return {boolean} True if there are unsaved changes, false otherwise.
+   */
+  get hasUnsavedModifications() {
+    return !this._isPristine;
+  }
+
   _getModes() {
     return [
       { label: i18n('cc-env-var-form.mode.simple'), value: 'SIMPLE' },


### PR DESCRIPTION
Fixes #1327

## What does this PR do?

- Adds a public `hasUnsavedModifications` getter so we can use it to trigger a navigation guard in the console.

## How to review?

- Check the commit,
- 1 reviewer should be enough for this one.