### PR TITLE
fix(cc-addon-backups): make sure overlays are displayed on top of everything

### DIFF
--- a/src/components/cc-addon-backups/cc-addon-backups.js
+++ b/src/components/cc-addon-backups/cc-addon-backups.js
@@ -501,6 +501,8 @@ export class CcAddonBackups extends LitElement {
           position: fixed;
           transform: translateX(-50%);
           width: 90%;
+          /* temporary fix until we rely on the dialog element and the top layer */
+          z-index: 9999;
         }
 
         .overlay-close-btn {


### PR DESCRIPTION
Fixes #1334

## What does this PR do?

- Adds a high `z-index` value to make sure the modal is displayed over any other content
- I chose to go for `9999` because I cannot anticipate if there are other z-index values within the console. This is not something I like to do but since it's a temporary fix, I think it's fine :shrug: 

## How to review?

- Check the code,
- 1 reviewer should be enough for this one.