### PR TITLE
refactor(cem): silent doc generation

### DIFF
--- a/cem/support-typedef-jsdoc.js
+++ b/cem/support-typedef-jsdoc.js
@@ -114,12 +114,10 @@ export default function supportTypedefJsdoc() {
       moduleTypeCache.clear();
 
       const componentName = node.name.escapedText;
-      console.log(`\n⌛ Generating docs for ${componentName}`);
 
       const types = getTypesFromClass(node, ts);
 
       if (types.length === 0) {
-        console.info('✅ Successfully generated documentation.');
         return;
       }
 
@@ -137,7 +135,7 @@ export default function supportTypedefJsdoc() {
 
         // If an import is not correct, warn the plugin user.
         if (typePath == null) {
-          console.warn(`There's a problem with one of your @typedef - ${tag.getText()}`);
+          console.warn(`[${componentName}] - There's a problem with one of your @typedef - ${tag.getText()}`);
           process.exitCode = 1;
           return;
         }
@@ -162,8 +160,6 @@ export default function supportTypedefJsdoc() {
       const declaration = moduleDoc.declarations.find((declaration) => declaration.name === node.name.getText());
 
       declaration.description = declaration.description + '\n\n' + displayText;
-
-      console.info('✅ Successfully generated documentation.');
     },
   };
 }


### PR DESCRIPTION
Fixes #1150 

## What does this PR do?

* This PR removes the log that were produced when generating doc types of a component.
* Now, only the errors when writing a `typedef` will be displayed.
* Note: we couldn't add a `--silent` flag to the plugin as the CLI parameters are handled by CEM directly. 

## How to review?

* Run some tests, the logs shouldn't be there anymore.
* In a component try changing a `@typedef` to something like  `@tyedef` with a typo.
* Run the script `npm run component:docs`, it should show an error.
* One or two reviewer should be enough.