### PR TITLE
feat(cc-order-summary): improve configuration item implementation

### DIFF
--- a/src/components/cc-order-summary/cc-order-summary.js
+++ b/src/components/cc-order-summary/cc-order-summary.js
@@ -1,5 +1,6 @@
 import { css, html, LitElement } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 import { dispatchCustomEvent } from '../../lib/events.js';
 import { isStringBlank, isStringEmpty } from '../../lib/utils.js';
 import { skeletonStyles } from '../../styles/skeleton.js';
@@ -110,16 +111,16 @@ export class CcOrderSummary extends LitElement {
   }
 
   _renderSummaryBody() {
-    const { configuration, skeleton } = this.orderSummary;
-
     return html`<dl class="body">
-      ${configuration?.map((configItem) => {
-        const { label, value } = configItem;
-        return html`<div class="body--item">
+      ${this.orderSummary.configuration?.map((/** @type {ConfigurationItem} */ configItem) => {
+        const { label, value, a11yLive, skeleton, skeletonValueOnly } = configItem;
+        const ariaLive = a11yLive ? 'polite' : null;
+        const ariaAtomic = a11yLive ? 'false' : null;
+        return html`<div class="body--item" aria-live="${ifDefined(ariaLive)}" aria-atomic="${ifDefined(ariaAtomic)}">
           <dt class="body--label">
             <span class="${classMap({ skeleton })}">${label}</span>
           </dt>
-          <dd class="body--value ${classMap({ skeleton })}">
+          <dd class="body--value ${classMap({ skeleton: skeleton || skeletonValueOnly })}">
             <span>${value}</span>
           </dd>
         </div>`;
@@ -136,7 +137,7 @@ export class CcOrderSummary extends LitElement {
           display: block;
         }
 
-        /* region elements > reset */
+        /* region reset */
         dl {
           margin-block: 0;
         }

--- a/src/components/cc-order-summary/cc-order-summary.stories.js
+++ b/src/components/cc-order-summary/cc-order-summary.stories.js
@@ -7,6 +7,11 @@ export default {
   component: 'cc-order-summary-beta',
 };
 
+/**
+ * @typedef {import('./cc-order-summary.types.js').ConfigurationItem} ConfigurationItem
+ * @typedef {import('./cc-order-summary.types.js').OrderSummary} OrderSummary
+ */
+
 const conf = {
   component: 'cc-order-summary-beta',
   // language=CSS
@@ -31,18 +36,38 @@ const conf = {
   `,
 };
 
+/** @type Array<ConfigurationItem> */
+const appBaseConfigDatas = [
+  { label: 'Instance count', value: '1' },
+  { label: 'Instance size', value: 'XS' },
+  { label: 'Zone', value: 'Paris (par)' },
+  { label: 'Estimated price for 30 days', value: '16.00€' },
+];
+
+/** @type Array<ConfigurationItem> */
+const appBaseSkeletonConfigDatas = [
+  { label: 'Instance count', value: '1' },
+  { label: 'Instance size', value: 'XS' },
+  { label: 'Zone', value: 'Paris (par)' },
+  { label: 'Estimated price for 30 days', value: '16.00€', skeleton: true },
+];
+
+/** @type Array<ConfigurationItem> */
+const appBaseAriaLiveConfigDatas = [
+  { label: 'Instance count', value: '1' },
+  { label: 'Instance size', value: 'XS' },
+  { label: 'Zone', value: 'Paris (par)' },
+  { label: 'Estimated price for 30 days', value: '16.00€', a11yLive: true },
+];
+
+/** @type OrderSummary */
 const appBaseDatas = {
   name: 'Front-end application',
   logo: {
     url: 'https://assets.clever-cloud.com/logos/nodejs.svg',
     alt: 'NodeJS logo',
   },
-  configuration: [
-    { label: 'Instance count', value: '1' },
-    { label: 'Instance size', value: 'XS' },
-    { label: 'Zone', value: 'Paris (par)' },
-    { label: 'Estimated price for 30 days', value: '16.00€' },
-  ],
+  configuration: appBaseConfigDatas,
   tags: ['A.I.', 'preprod', '   '],
 };
 const appInnerHTML = `
@@ -50,6 +75,7 @@ const appInnerHTML = `
   <div slot="detail">The tags related to your zone are <code>for:applications</code>, <code>infra:clever-cloud</code>.</div>
 `;
 
+/** @type OrderSummary */
 const addonBaseDatas = {
   name: 'Customer orders database',
   logo: {
@@ -100,7 +126,31 @@ export const defaultStory = makeStory(conf, {
   ],
 });
 
-export const loadingModes = makeStory(conf, {
+export const skeleton = makeStory(conf, {
+  items: [
+    {
+      orderSummary: {
+        ...appBaseDatas,
+        configuration: appBaseSkeletonConfigDatas,
+      },
+      innerHTML: appInnerHTML,
+    },
+    {
+      orderSummary: {
+        ...appBaseDatas,
+        configuration: [
+          { label: 'Instance count', value: '1' },
+          { label: 'Instance size', value: 'XS' },
+          { label: 'Zone', value: 'Paris (par)' },
+          { label: 'Estimated price for 30 days', value: '16.00€', skeletonValueOnly: true },
+        ],
+      },
+      innerHTML: appInnerHTML,
+    },
+  ],
+});
+
+export const waitingAndDisabled = makeStory(conf, {
   items: [
     {
       orderSummary: {
@@ -116,10 +166,15 @@ export const loadingModes = makeStory(conf, {
       },
       innerHTML: appInnerHTML,
     },
+  ],
+});
+
+export const withAriaLive = makeStory(conf, {
+  items: [
     {
       orderSummary: {
         ...appBaseDatas,
-        skeleton: true,
+        configuration: appBaseAriaLiveConfigDatas,
       },
       innerHTML: appInnerHTML,
     },

--- a/src/components/cc-order-summary/cc-order-summary.types.d.ts
+++ b/src/components/cc-order-summary/cc-order-summary.types.d.ts
@@ -4,7 +4,6 @@ export interface OrderSummary {
   logo?: LogoInfos;
   configuration?: Array<ConfigurationItem>;
   submitStatus?: 'disabled' | 'waiting';
-  skeleton: boolean;
 }
 
 export interface LogoInfos {
@@ -15,4 +14,7 @@ export interface LogoInfos {
 export interface ConfigurationItem {
   label: string;
   value: string;
+  a11yLive?: boolean;
+  skeleton?: boolean;
+  skeletonValueOnly?: boolean;
 }


### PR DESCRIPTION
Fixes #1346

## What does this PR do?

For each line of the "configuration" part (aka the main part):
- Adds a `skeleton` property 
- Adds a `ariaLive` property

## How to review?

- Check the commits,
- Check the stories in [preview](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-order-summary/improve-configuration-item/index.html?path=/story/%F0%9F%9A%A7-beta-%F0%9F%9B%A0-creation-tunnel-cc-order-summary-beta--default-story), especially the "Skeleton" and "With aria live" ones.

Two should be enough, with a mandatory one from @florian-sanders-cc. :hand_with_index_finger_and_thumb_crossed: 

## Thoughts

At some point, I considered making skeleton state on label & value separately but I'm not sure if it's worth the complexity. Maybe later if really needed.