### PR TITLE
feat(cc-block-detail): init cc-block-detail component

### DIFF
--- a/src/components/cc-block-detail/cc-block-details.js
+++ b/src/components/cc-block-detail/cc-block-details.js
@@ -1,0 +1,131 @@
+import { css, html, LitElement } from 'lit';
+import { iconRemixArrowDownSLine as iconArrowDown } from '../../assets/cc-remix.icons.js';
+import { dispatchCustomEvent } from '../../lib/events.js';
+import '../cc-icon/cc-icon.js';
+
+/**
+ * A display component with mostly HTML+CSS and an open/close toggle feature organized with slots to display information such as CLI commands.
+ * The main purpose is to be used with a cc-block.
+ *
+ * @cssdisplay block
+ *
+ * @fires {CustomEvent<boolean>} cc-block-details:is-open-change - Fires is-open state whenever it changes.
+ *
+ * @slot tab-title - The title of the tab. Try to only use text.
+ * @slot link - A zone dedicated to link, for example to documentation.
+ * @slot content - A zone dedicated to main content.
+ */
+
+export class CcBlockDetails extends LitElement {
+  static get properties() {
+    return {
+      isOpen: { type: Boolean, reflect: true, attribute: 'is-open' },
+    };
+  }
+
+  constructor() {
+    super();
+
+    /** @type {boolean} Sets the state of the toggle. */
+    this.isOpen = false;
+  }
+
+  _onClickToggle() {
+    this.isOpen = !this.isOpen;
+    dispatchCustomEvent(this, 'is-open-change', !this.isOpen);
+  }
+
+  render() {
+    return html`
+      <div class="wrapper">
+        <button class="button" aria-expanded="${this.isOpen}" aria-controls="content" @click=${this._onClickToggle}>
+          <slot name="button-text"></slot>
+          <cc-icon .icon="${iconArrowDown}"></cc-icon>
+        </button>
+        <div id="content" class="content"><slot name="content"></slot></div>
+        <div class="links">
+          <slot name="link"></slot>
+        </div>
+      </div>
+    `;
+  }
+
+  static get styles() {
+    return [
+      // language=CSS
+      css`
+        :host {
+          display: block;
+        }
+
+        .wrapper {
+          column-gap: 1em;
+          display: grid;
+          grid-template-areas: 'button links' 'content content';
+          justify-items: start;
+        }
+
+        .button {
+          align-items: center;
+          background-color: transparent;
+          border: solid 1px transparent;
+          display: flex;
+          font-family: inherit;
+          font-size: 1em;
+          grid-area: button;
+          padding: 0.25em 0.6em 0.35em;
+          transition: all 0.3s;
+        }
+
+        :host([is-open]) .button {
+          background-color: var(--cc-color-bg-default, #fff);
+          border-radius: var(--cc-border-radius-default, 0.25em) var(--cc-border-radius-default, 0.25em) 0 0;
+          margin-bottom: 0;
+        }
+
+        .button:hover {
+          border-radius: var(--cc-border-radius-default, 0.25em);
+        }
+
+        :host(:not([is-open])) .button:hover {
+          border: solid 1px var(--cc-color-border-neutral-strong, #8c8c8c);
+        }
+
+        .button cc-icon {
+          margin-left: 0.1em;
+          transition: all 0.3s;
+        }
+
+        :host([is-open]) .button cc-icon {
+          transform: rotate(180deg);
+        }
+
+        :host(:not([is-open])) .button:hover cc-icon {
+          transform: rotate(90deg);
+        }
+
+        .content {
+          background-color: var(--cc-color-bg-default, #fff);
+          border-radius: var(--cc-border-radius-default, 0.25em);
+          display: none;
+          grid-area: content;
+          padding: 1em;
+        }
+
+        :host([is-open]) .content {
+          display: block;
+        }
+
+        .links {
+          align-items: center;
+          display: flex;
+          gap: 0.5em;
+          grid-area: links;
+          justify-self: end;
+        }
+      `,
+    ];
+  }
+}
+
+window.customElements.define('cc-block-details', CcBlockDetails);

--- a/src/components/cc-block-detail/cc-block-details.stories.js
+++ b/src/components/cc-block-detail/cc-block-details.stories.js
@@ -1,0 +1,68 @@
+import { makeStory } from '../../stories/lib/make-story.js';
+import './cc-block-details.js';
+import '../cc-block/cc-block.js';
+
+export default {
+  tags: ['autodocs'],
+  title: '🧬 Molecules/<cc-block-details>',
+  component: 'cc-block-details',
+};
+
+const conf = {
+  component: 'cc-block',
+};
+
+const ccBlockHtmlExample = `
+  <div slot="header-title">This is my block</div>
+  <div slot="content">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque feugiat dui at leo porta dignissim. Etiam ut purus ultrices, pulvinar tellus quis, cursus massa. Mauris dignissim accumsan ex, at vestibulum lectus fermentum id. Quisque nec magna arcu. Quisque in metus sed erat sodales euismod eget id purus. Sed sagittis rhoncus mauris. Ut sit amet urna ac nunc semper porta. Nam ut felis eu velit luctus rutrum. Nam leo nisl, molestie a varius non, ullamcorper sit amet tortor. Donec in convallis ex. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Praesent hendrerit venenatis erat, eu malesuada nulla viverra eu. Curabitur porta risus augue, non rutrum lectus hendrerit a.</div>
+`;
+
+const defaultHtmlExample = `
+  ${ccBlockHtmlExample}
+  <cc-block-details slot="footer-left">
+    <div slot="button-text">Command line</div>
+    <a slot="link" href="">See documentation</a>
+    <div slot="content">Praesent tincidunt dapibus elit, sed posuere risus sodales quis. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Integer ultrices maximus ligula eu efficitur. Nulla luctus ipsum vitae dui gravida, sodales ornare dolor viverra. Vivamus pretium scelerisque ultricies. Nulla consectetur euismod euismod. Interdum et malesuada fames ac ante ipsum primis in faucibus. Cras dignissim id sapien non facilisis. Suspendisse vitae pretium orci. Nunc aliquam pellentesque nunc, at tincidunt nisi lobortis a. <a href="#">Fake link</a></div>
+  </cc-block-details>
+`;
+
+export const defaultStory = makeStory(conf, {
+  items: [
+    {
+      innerHTML: defaultHtmlExample,
+    },
+  ],
+});
+
+const openHtmlExample = `
+  ${ccBlockHtmlExample}
+  <cc-block-details is-open=true slot="footer-left">
+    <div slot="button-text">Command line</div>
+    <a slot="link" href="">See documentation</a>
+    <div slot="content">Praesent tincidunt dapibus elit, sed posuere risus sodales quis. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Integer ultrices maximus ligula eu efficitur. Nulla luctus ipsum vitae dui gravida, sodales ornare dolor viverra. Vivamus pretium scelerisque ultricies. Nulla consectetur euismod euismod. Interdum et malesuada fames ac ante ipsum primis in faucibus. Cras dignissim id sapien non facilisis. Suspendisse vitae pretium orci. Nunc aliquam pellentesque nunc, at tincidunt nisi lobortis a. <a href="#">Fake link</a></div>
+  </cc-block-details>
+`;
+
+export const openStory = makeStory(conf, {
+  items: [
+    {
+      innerHTML: openHtmlExample,
+    },
+  ],
+});
+
+const withoutLinkHtmlExample = `
+  ${ccBlockHtmlExample}
+  <cc-block-details slot="footer-left">
+    <div slot="button-text">Command line</div>
+    <div slot="content">Praesent tincidunt dapibus elit, sed posuere risus sodales quis. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Integer ultrices maximus ligula eu efficitur. Nulla luctus ipsum vitae dui gravida, sodales ornare dolor viverra. Vivamus pretium scelerisque ultricies. Nulla consectetur euismod euismod. Interdum et malesuada fames ac ante ipsum primis in faucibus. Cras dignissim id sapien non facilisis. Suspendisse vitae pretium orci. Nunc aliquam pellentesque nunc, at tincidunt nisi lobortis a. <a href="#">Fake link</a></div>
+  </cc-block-details>
+`;
+
+export const withoutLinkStory = makeStory(conf, {
+  items: [
+    {
+      innerHTML: withoutLinkHtmlExample,
+    },
+  ],
+});


### PR DESCRIPTION
Fix #1348 

# What does this PR do?

Introduce the `cc-block-detail` component. This component displays more information in the `cc-block` footer as command lines.

# How to review?
- Check the code
- Check the stories in the preview
- Check if the design is close enough to the [wireframe](https://www.figma.com/design/rC5NuHHEZ1E7HEEAbQyvuq/CC-Block-new?node-id=8-771&t=SkZ82Je83zrQ47OH-1) made by Marion