### PR TITLE
feat(cc-date-range-selector): move custom date range form inside popover body

### DIFF
--- a/sandbox/cc-logs-app-runtime/cc-logs-app-runtime-sandbox.js
+++ b/sandbox/cc-logs-app-runtime/cc-logs-app-runtime-sandbox.js
@@ -71,9 +71,11 @@ class CcLogsAppRuntimeSandbox extends LitElement {
         <cc-button type="submit">Apply</cc-button>
       </form>
 
-      <cc-smart-container ${ref(this._smartContainerRef)}>
-        <cc-logs-app-runtime-beta class="cc-logs-app-runtime main"></cc-logs-app-runtime-beta>
-      </cc-smart-container>
+      <div class="main">
+        <cc-smart-container ${ref(this._smartContainerRef)}>
+          <cc-logs-app-runtime-beta class="cc-logs-app-runtime"></cc-logs-app-runtime-beta>
+        </cc-smart-container>
+      </div>
     `;
   }
 
@@ -94,14 +96,15 @@ class CcLogsAppRuntimeSandbox extends LitElement {
           min-height: 0;
         }
 
-        cc-smart-container {
+        .cc-logs-app-runtime {
           display: flex;
           flex: 1;
           flex-direction: column;
           min-height: 0;
         }
 
-        .cc-logs-app-runtime {
+        .main {
+          display: grid;
           flex: 1;
           min-height: 0;
         }

--- a/src/components/cc-logs-app-runtime/cc-logs-app-runtime.js
+++ b/src/components/cc-logs-app-runtime/cc-logs-app-runtime.js
@@ -216,7 +216,6 @@ export class CcLogsAppRuntime extends LitElement {
     return html`
       <div class=${classMap(overlay)}>
         <div class=${classMap(wrapper)}>
-          ${this._renderDateRangeSelection()} ${this._renderInstances()}
           <div class="logs-wrapper">${this._renderLogs()}</div>
           ${this._renderLoadingProgress()}
         </div>
@@ -254,6 +253,7 @@ export class CcLogsAppRuntime extends LitElement {
 
     return html`<cc-logs-instances-beta
       class="instances"
+      slot="left"
       .state=${state}
       @cc-logs-instances:selection-change=${this._onInstanceSelectionChange}
     ></cc-logs-instances-beta>`;
@@ -324,6 +324,8 @@ export class CcLogsAppRuntime extends LitElement {
         @cc-logs-control:option-change=${this._onLogsOptionChange}
       >
         <div slot="header" class="logs-header">
+          ${this._renderDateRangeSelection()}
+
           <cc-logs-message-filter-beta
             class="logs-message-filter"
             .filter=${this._messageFilter}
@@ -340,6 +342,8 @@ export class CcLogsAppRuntime extends LitElement {
             @cc-button:click=${this._onFullscreenToggle}
           ></cc-button>
         </div>
+
+        ${this._renderInstances()}
       </cc-logs-control-beta>
 
       ${this.state.type === 'loaded' &&
@@ -388,6 +392,8 @@ export class CcLogsAppRuntime extends LitElement {
       css`
         /* stylelint-disable no-duplicate-selectors */
         :host {
+          --instances-width: 20em;
+
           display: block;
         }
 
@@ -407,39 +413,31 @@ export class CcLogsAppRuntime extends LitElement {
         }
 
         .wrapper {
-          display: grid;
+          display: flex;
           flex: 1;
+          flex-direction: column;
           gap: 0.5em;
-          grid-auto-columns: 18em 1fr;
-          grid-auto-rows: auto 1fr auto;
-          grid-template-areas:
-            'date-range logs'
-            'instances  logs'
-            'progress   progress';
         }
 
         .wrapper.fullscreen {
-          background-color: var(--cc-color-bg-default);
-          border: 1px solid var(--cc-color-border-neutral);
-          border-radius: var(--cc-border-radius-default);
+          background-color: var(--cc-color-bg-default, #fff);
+          border: 1px solid var(--cc-color-border-neutral, #aaa);
+          border-radius: var(--cc-border-radius-default, 0.25em);
           margin: 1em;
           padding: 1em;
-        }
-
-        .date-range-selector {
-          grid-area: date-range;
         }
 
         .instances {
           background-color: var(--cc-color-bg-default, #fff);
           border: 1px solid var(--cc-color-border-neutral, #aaa);
           border-radius: var(--cc-border-radius-default, 0.25em);
-          grid-area: instances;
+          width: var(--instances-width);
         }
 
         .logs-wrapper {
           flex: 1;
           grid-area: logs;
+          min-height: 0;
           position: relative;
         }
 
@@ -471,7 +469,7 @@ export class CcLogsAppRuntime extends LitElement {
         }
 
         .overlay-logs-wrapper {
-          left: 50%;
+          left: calc(50% + var(--instances-width) / 2);
           position: absolute;
           top: 50%;
           transform: translate(-50%, -50%);

--- a/src/components/cc-logs-control/cc-logs-control.js
+++ b/src/components/cc-logs-control/cc-logs-control.js
@@ -76,6 +76,7 @@ const PALETTES = {
  * @fires {CustomEvent<LogsControlOption>} cc-logs-control:option-change - Fires a `LogsControlOption` whenever an `option` changes.
  *
  * @slot header - The content of the space on top of the logs block.
+ * @slot left - The content of the space on the left of the logs block.
  */
 export class CcLogsControl extends LitElement {
   static get properties() {
@@ -307,44 +308,49 @@ export class CcLogsControl extends LitElement {
 
   render() {
     return html`
-      <div class="header"><slot name="header"></slot></div>
+      <div class="header">
+        <slot name="header"></slot>
 
-      <cc-button
-        class="header-scroll-button"
-        .icon=${scrollToBottomIcon}
-        a11y-name="${i18n('cc-logs-control.scroll-to-bottom')}"
-        hide-text
-        @cc-button:click=${this._onScrollToBottomButtonClick}
-      ></cc-button>
+        <cc-button
+          class="header--scroll"
+          .icon=${scrollToBottomIcon}
+          a11y-name="${i18n('cc-logs-control.scroll-to-bottom')}"
+          hide-text
+          @cc-button:click=${this._onScrollToBottomButtonClick}
+        ></cc-button>
 
-      <cc-popover
-        class="header-options-popover"
-        .icon=${optionsIcon}
-        a11y-name="${i18n('cc-logs-control.show-logs-options')}"
-        hide-text
-        position="bottom-right"
-      >
-        <div class="options">
-          ${this._renderDisplayOptions()} ${this._renderDateOptions()} ${this._renderMetadataOptions()}
-        </div>
-      </cc-popover>
+        <cc-popover
+          class="header--options"
+          .icon=${optionsIcon}
+          a11y-name="${i18n('cc-logs-control.show-logs-options')}"
+          hide-text
+          position="bottom-right"
+        >
+          <div class="options">
+            ${this._renderDisplayOptions()} ${this._renderDateOptions()} ${this._renderMetadataOptions()}
+          </div>
+        </cc-popover>
+      </div>
 
-      <cc-logs-beta
-        class="logs"
-        ${ref(this._logsRef)}
-        .dateDisplay=${this.dateDisplay}
-        ?follow=${this.follow}
-        .limit=${this.limit}
-        .logs=${this.logs}
-        .messageFilter=${this.messageFilter}
-        .messageFilterMode=${this.messageFilterMode}
-        .metadataFilter=${this.metadataFilter}
-        .metadataRenderers=${this._resolvedMetadataRenderers}
-        ?strip-ansi=${this.stripAnsi}
-        style=${PALETTES[this.palette]}
-        .timezone=${this.timezone}
-        ?wrap-lines=${this.wrapLines}
-      ></cc-logs-beta>
+      <div class="center">
+        <slot name="left"></slot>
+        <cc-logs-beta
+          class="logs"
+          ${ref(this._logsRef)}
+          .dateDisplay=${this.dateDisplay}
+          ?follow=${this.follow}
+          .limit=${this.limit}
+          .logs=${this.logs}
+          .messageFilter=${this.messageFilter}
+          .messageFilterMode=${this.messageFilterMode}
+          .metadataFilter=${this.metadataFilter}
+          .metadataRenderers=${this._resolvedMetadataRenderers}
+          ?strip-ansi=${this.stripAnsi}
+          style=${PALETTES[this.palette]}
+          .timezone=${this.timezone}
+          ?wrap-lines=${this.wrapLines}
+        ></cc-logs-beta>
+      </div>
     `;
   }
 
@@ -437,32 +443,29 @@ export class CcLogsControl extends LitElement {
       // language=CSS
       css`
         :host {
-          align-items: center;
-          column-gap: 0.35em;
           display: grid;
-          grid-template-areas:
-            'header scroll-button options-popover'
-            'logs   logs          logs';
-          grid-template-columns: 1fr auto auto;
-          grid-template-rows: max-content 1fr;
-          row-gap: 0.5em;
+          gap: 0.5em;
+          grid-template-rows:
+            [header] auto
+            [center] 1fr;
         }
 
         .header {
-          grid-area: header;
+          align-items: center;
+          display: flex;
+          gap: 0.35em;
+          justify-content: end;
         }
 
-        .header-scroll-button {
-          grid-area: scroll-button;
-        }
-
-        .header-options-popover {
-          grid-area: options-popover;
+        .center {
+          display: flex;
+          gap: 0.5em;
+          justify-content: stretch;
+          min-height: 0;
         }
 
         .logs {
-          align-self: normal;
-          grid-area: logs;
+          flex: 1;
         }
 
         .options {

--- a/src/components/cc-logs-control/cc-logs-control.stories.js
+++ b/src/components/cc-logs-control/cc-logs-control.stories.js
@@ -135,3 +135,18 @@ export const withNonDefaultDateDisplay = makeStory(conf, {
     },
   ],
 });
+
+export const withLeftSlot = makeStory(conf, {
+  /** @type {Array<Partial<CcLogsControl>>} */
+  items: [
+    {
+      follow: true,
+      metadataDisplay: metadataDisplay,
+      metadataRenderers: CUSTOM_METADATA_RENDERERS,
+      logs: createFakeLogs(100, { longMessage: true, ansi: true }),
+      innerHTML: `
+        <div slot="left" style="width: 12em;">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque feugiat dui at leo porta dignissim. Etiam ut purus ultrices, pulvinar tellus quis, cursus massa. Mauris dignissim accumsan ex, at vestibulum lectus fermentum id. Quisque nec magna arcu. Quisque in metus sed erat sodales euismod eget id purus. Sed sagittis rhoncus mauris. Ut sit amet urna ac nunc semper porta. Nam ut felis eu velit luctus rutrum. Nam leo nisl, molestie a varius non, ullamcorper sit amet tortor. Donec in convallis ex. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Praesent hendrerit venenatis erat, eu malesuada nulla viverra eu. Curabitur porta risus augue, non rutrum lectus hendrerit a.</div>
+      `,
+    },
+  ],
+});

--- a/src/components/cc-logs-date-range-selector/cc-logs-date-range-selector.stories.js
+++ b/src/components/cc-logs-date-range-selector/cc-logs-date-range-selector.stories.js
@@ -19,7 +19,6 @@ const conf = {
   css: `
     cc-logs-date-range-selector-beta {
       height: 18em;
-      width: 18em;
       margin: 1em;
     }
   `,

--- a/src/components/cc-popover/cc-popover.js
+++ b/src/components/cc-popover/cc-popover.js
@@ -57,6 +57,8 @@ import '../cc-button/cc-button.js';
  * @cssprop {Size} --cc-popover-padding - Sets the padding of the floating area (default 0.5em).
  * @cssprop {Number} --cc-popover-z-index - Sets the z-index of the floating content (defaults: `999`).
  * @cssprop {Width} --cc-popover-trigger-button-width - Sets the width of the trigger button (defaults: `inherit`).
+ * @cssprop {FontWeight} --cc-popover-trigger-button-font-weight - Sets the font-weight CSS property of the trigger button (defaults: `bold`).
+ * @cssprop {TextTransform} --cc-popover-trigger-button-text-transform - Sets the text-transform CSS property of the trigger button (defaults: `uppercase`).
  */
 export class CcPopover extends LitElement {
   static get properties() {
@@ -212,6 +214,7 @@ export class CcPopover extends LitElement {
       <div class="wrapper">
         <cc-button
           ${ref(this._buttonRef)}
+          class="trigger-button"
           .a11yExpanded=${this.isOpen}
           .a11yName=${this.a11yName}
           ?hide-text=${this.hideText}
@@ -247,7 +250,10 @@ export class CcPopover extends LitElement {
           position: relative;
         }
 
-        cc-button {
+        .trigger-button {
+          --cc-button-font-weight: var(--cc-popover-trigger-button-font-weight);
+          --cc-button-text-transform: var(--cc-popover-trigger-button-text-transform);
+
           width: var(--cc-popover-trigger-button-width, inherit);
         }
 

--- a/src/components/cc-popover/cc-popover.js
+++ b/src/components/cc-popover/cc-popover.js
@@ -264,7 +264,8 @@ export class CcPopover extends LitElement {
           box-shadow:
             0 2px 4px rgb(38 38 38 / 25%),
             0 5px 15px rgb(38 38 38 / 25%);
-          overflow: hidden;
+          overflow: clip;
+          overflow-clip-margin: 3px;
           padding: var(--cc-popover-padding, 0.5em);
           position: absolute;
           z-index: var(--cc-popover-z-index, 999);


### PR DESCRIPTION
# Context

* When user selects a `custom` date range, a form containing the `since` and the `from` date inputs is displayed under the selector.
* This makes the component having a column based layout
* This layout fits well in the `cc-logs-app-runtime` component because it has got a left panel with the instances.
* But it doesn't fit with the future `cc-logs-addon-runtime` component which doesn't have a left column.
* It also wont fit the `cc-logs-app-access` component when we will integrate a date selection in it.

# What this PR do?

The main purpose of this PR is to change how the custom date range form is display inside the `cc-date-range-selector` component.

For the moment I left all the a11y considerations apart, I know there are a lot to do but this will be done in another PR.

So there are several commits:

* `cc-popover` needed two additional css props so that we can tweak the trigger button display without affecting the buttons inside the popover body
* Next commit is about changing the layout of the `cc-date-range-selector` component
* Next one is about adding a `left` slot on the `cc-logs-control` component so that we can put the instances panel
  * This was needed because we need to handle this layout:
![image](https://github.com/user-attachments/assets/238b72ec-a5a8-44d0-8cc6-73e26a010119)
* Last commit is about applying the change on `cc-logs-app-runtime` component

# How to review?

* check the code
* check the stories
* check the sandbox