### PR TITLE
feat(cc-logs-app-access): add date range selector

### DIFF
--- a/sandbox/cc-logs-app-access/cc-logs-app-access-sandbox.js
+++ b/sandbox/cc-logs-app-access/cc-logs-app-access-sandbox.js
@@ -7,6 +7,16 @@ import '../../src/components/cc-select/cc-select.js';
 import { formSubmit } from '../../src/lib/form/form-submit-directive.js';
 import { sandboxStyles } from '../sandbox-styles.js';
 
+const DATE_RANGE_SELECTION_OPTIONS = [
+  { label: 'none', value: 'none', range: null },
+  { label: 'live', value: 'live', range: { type: 'live' } },
+  { label: 'lastHour', value: 'lastHour', range: { type: 'preset', preset: 'lastHour' } },
+  { label: 'last4Hours', value: 'last4Hours', range: { type: 'preset', preset: 'last4Hours' } },
+  { label: 'last7Days', value: 'last7Days', range: { type: 'preset', preset: 'last7Days' } },
+  { label: 'today', value: 'today', range: { type: 'preset', preset: 'today' } },
+  { label: 'yesterday', value: 'yesterday', range: { type: 'preset', preset: 'yesterday' } },
+];
+
 // test app
 const INITIAL_OWNER = 'orga_540caeb6-521c-4a19-a955-efe6da35d142';
 const INITIAL_APP = 'app_46ec6a5c-1512-401f-ad40-1864ad5050f0';
@@ -39,6 +49,7 @@ class CcLogsAppAccessSandbox extends LitElement {
     this._smartContainerRef.value.context = {
       ownerId: formData.ownerId,
       appId: formData.applicationId,
+      dateRangeSelection: DATE_RANGE_SELECTION_OPTIONS.find((o) => o.value === formData.dateRangeSelection)?.range,
     };
   }
 
@@ -47,12 +58,20 @@ class CcLogsAppAccessSandbox extends LitElement {
       <form class="ctrl-top" style="align-items: normal" ${ref(this._formRef)} ${formSubmit(this._onFormSubmit)}>
         <cc-input-text label="ownerId" name="ownerId" value=${INITIAL_OWNER} required></cc-input-text>
         <cc-input-text label="applicationId" name="applicationId" value=${INITIAL_APP} required></cc-input-text>
+        <cc-select
+          .options=${DATE_RANGE_SELECTION_OPTIONS}
+          label="dateRangeSelection"
+          name="dateRangeSelection"
+          value="none"
+        ></cc-select>
         <cc-button type="submit">Apply</cc-button>
       </form>
 
-      <cc-smart-container ${ref(this._smartContainerRef)}>
-        <cc-logs-app-access-beta class="cc-logs-app-access main"></cc-logs-app-access-beta>
-      </cc-smart-container>
+      <div class="main">
+        <cc-smart-container ${ref(this._smartContainerRef)}>
+          <cc-logs-app-access-beta class="cc-logs-app-access"></cc-logs-app-access-beta>
+        </cc-smart-container>
+      </div>
     `;
   }
 
@@ -76,14 +95,15 @@ class CcLogsAppAccessSandbox extends LitElement {
           min-height: 0;
         }
 
-        cc-smart-container {
+        .cc-logs-app-access {
           display: flex;
           flex: 1;
           flex-direction: column;
           min-height: 0;
         }
 
-        .cc-logs-app-access {
+        .main {
+          display: grid;
           flex: 1;
           min-height: 0;
         }

--- a/src/components/cc-logs-app-access/cc-logs-app-access.js
+++ b/src/components/cc-logs-app-access/cc-logs-app-access.js
@@ -92,11 +92,14 @@ const CUSTOM_METADATA_RENDERERS = {
 /**
  * A component displaying application access logs.
  *
+ * @cssdisplay block
+ *
  * @beta
  */
 export class CcLogsAppAccess extends LitElement {
   static get properties() {
     return {
+      dateRangeSelection: { type: Object, attribute: 'date-range-selection' },
       limit: { type: Number },
       options: { type: Object },
       state: { type: Object },
@@ -107,6 +110,11 @@ export class CcLogsAppAccess extends LitElement {
 
   constructor() {
     super();
+
+    /** @type {LogsDateRangeSelection} The date range selection. */
+    this.dateRangeSelection = {
+      type: 'live',
+    };
 
     /** @type {number} The maximum number of logs to display. */
     this.limit = 1000;
@@ -178,8 +186,14 @@ export class CcLogsAppAccess extends LitElement {
   /* region Event handlers */
 
   /**
-   * @param {Object} event
-   * @param {LogsControlOption} event.detail
+   * @param {CustomEvent<LogsDateRangeSelectionChangeEventData>} event
+   */
+  _onDateRangeSelectionChange(event) {
+    this.dateRangeSelection = event.detail.selection;
+  }
+
+  /**
+   * @param {CustomEvent<LogsControlOption>} event
    */
   _onLogsOptionChange({ detail }) {
     this.options = {
@@ -261,6 +275,11 @@ export class CcLogsAppAccess extends LitElement {
         @cc-logs-control:option-change=${this._onLogsOptionChange}
       >
         <div slot="header" class="logs-header">
+          <cc-logs-date-range-selector-beta
+            .value=${this.dateRangeSelection}
+            @cc-logs-date-range-selector:change=${this._onDateRangeSelectionChange}
+          ></cc-logs-date-range-selector-beta>
+
           <cc-logs-message-filter-beta
             class="logs-message-filter"
             .filter=${this._messageFilter}

--- a/src/components/cc-logs-app-access/cc-logs-app-access.smart.md
+++ b/src/components/cc-logs-app-access/cc-logs-app-access.smart.md
@@ -15,11 +15,12 @@ title: '💡 Smart'
 
 ## ⚙️ Params
 
-| Name           |    Type     | Required | Details                                     | Default |
-|----------------|:-----------:|:--------:|---------------------------------------------|---------|
-| `apiConfig`    | `ApiConfig` |   Yes    | Object with API configuration (target host) |         |
-| `ownerId`      |  `string`   |   Yes    | UUID prefixed with `orga_` or `user_`       |         |
-| `appId`        |  `string`   |   Yes    | UUID prefixed with `app_`                   |         |
+| Name                 |           Type           | Required | Details                                     | Default |
+|----------------------|:------------------------:|:--------:|---------------------------------------------|---------|
+| `apiConfig`          |       `ApiConfig`        |   Yes    | Object with API configuration (target host) |         |
+| `ownerId`            |         `string`         |   Yes    | UUID prefixed with `orga_` or `user_`       |         |
+| `appId`              |         `string`         |   Yes    | UUID prefixed with `app_`                   |         |
+| `dateRangeSelection` | `LogsDateRangeSelection` |    No    | Initial date range                          |         |
 
 ```ts
 interface ApiConfig {
@@ -28,6 +29,26 @@ interface ApiConfig {
   API_OAUTH_TOKEN_SECRET: string,
   OAUTH_CONSUMER_KEY: string,
   OAUTH_CONSUMER_SECRET: string,
+}
+
+type LogsDateRangeSelection =
+  | LogsDateRangeSelectionLive
+  | LogsDateRangeSelectionPreset
+  | LogsDateRangeSelectionCustom;
+
+interface LogsDateRangeSelectionLive {
+  type: 'live';
+}
+
+interface LogsDateRangeSelectionPreset {
+  type: 'preset';
+  preset: LogsDateRangePresetType;
+}
+
+interface LogsDateRangeSelectionCustom {
+  type: 'custom';
+  since: string;
+  until: string;
 }
 ```
 


### PR DESCRIPTION
# What this PR do?

* This PR adds a date range selector to the `cc-logs-app-access`.
* It allows also to set the date range from the smart context, so that we will be able to store and restore date range selection using the Settings API.

# How to review?

* check the code
* check the stories
* check the sandbox