### PR TITLE
ci(code-quality): add a check on the commit messages

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -24,6 +24,9 @@ jobs:
       - name: '[Prepare] Install dependencies'
         run: npm ci
 
+      - name: '[Code quality] Check commit message'
+        if: github.event_name == 'pull_request'
+        run: node ./node_modules/@commitlint/cli/cli.js --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
       - name: '[Code quality] Check ESLint'
         run: npm run lint
       - name: '[Code quality] Check Lit'


### PR DESCRIPTION
# What this PR do?

This PR adds a check on the commit(s) message(s), ensuring that they respect conventional commit format.

If one doesn't activate the local git hook that ensures conventional commit messages, the CI will be there to verify it anyway.

# How to test?

* pull this branch
* add a commit with an invalid message (use `--no-verify` option in the commit command to bypass the local git hook)
  ```
  git commit --no-verify -m "invalid message"
  ```
* push
* See the Tests and build job fail.
* Please remove your commit and force push afterward ;)