### PR TITLE
feat(cc-session-tokens): init

### DIFF
--- a/src/components/cc-token-session-list/cc-token-session-list.js
+++ b/src/components/cc-token-session-list/cc-token-session-list.js
@@ -1,0 +1,425 @@
+import { LitElement, css, html } from 'lit';
+import { classMap } from 'lit/directives/class-map.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { createRef, ref } from 'lit/directives/ref.js';
+import {
+  iconRemixCalendar_2Fill as iconCreation,
+  iconRemixRadioButtonLine as iconCurrentSession,
+  iconRemixDeleteBinLine as iconDelete,
+  iconRemixInformationLine as iconExpiration,
+  iconRemixHistoryLine as iconLastUsed,
+} from '../../assets/cc-remix.icons.js';
+import { LostFocusController } from '../../controllers/lost-focus-controller.js';
+import { ResizeController } from '../../controllers/resize-controller.js';
+import { dispatchCustomEvent } from '../../lib/events.js';
+import { isExpirationClose } from '../../lib/tokens.js';
+import { i18n } from '../../translations/translation.js';
+import '../cc-badge/cc-badge.js';
+import '../cc-block/cc-block.js';
+import '../cc-button/cc-button.js';
+import '../cc-icon/cc-icon.js';
+import '../cc-loader/cc-loader.js';
+import '../cc-notice/cc-notice.js';
+
+/**
+ * @typedef {import('./cc-token-session-list.types.js').SessionTokenState} SessionTokenState
+ * @typedef {import('./cc-token-session-list.types.js').TokenSessionListState} TokenSessionListState
+ * @typedef {import('./cc-token-session-list.types.js').SessionToken} SessionToken
+ * @typedef {import('lit').TemplateResult<1>} TemplateResult
+ * @typedef {import('lit').PropertyValues<CcTokenSessionList>} CcSessionTokensPropertyValues
+ * @typedef {import('lit/directives/ref.js').Ref<HTMLLIElement>} RefHTMLLIElement
+ */
+
+/**
+ * A component that displays and manages user sessions.
+ *
+ * This component allows users to view their active session and revoke individual tokens or all tokens at once.
+ * It displays information about each session including creation date, last used date, and expiration date.
+ * Sessions are displayed in a list sorted by creation date (newest first).
+ *
+ * @fires {CustomEvent<void>} cc-token-session-list:revoke-all-session-tokens - Dispatched when a user requests to revoke all tokens
+ * @fires {CustomEvent<string>} cc-token-session-list:revoke-session-token - Dispatched when a user requests to revoke a specific token, with the token ID as payload
+ */
+export class CcTokenSessionList extends LitElement {
+  static get properties() {
+    return {
+      state: { type: Object },
+    };
+  }
+
+  constructor() {
+    super();
+
+    /** @type {TokenSessionListState} The current state of the component */
+    this.state = { type: 'loading' };
+
+    /** @type {RefHTMLLIElement} */
+    this._currentSessionCardRef = createRef();
+
+    new ResizeController(this, {
+      widthBreakpoints: [995, 730],
+    });
+
+    new LostFocusController(this, '.session-token-card__action-revoke', ({ suggestedElement }) => {
+      if (suggestedElement instanceof HTMLElement) {
+        suggestedElement.focus();
+      } else {
+        this._currentSessionCardRef.value?.focus();
+      }
+    });
+
+    new LostFocusController(this, '.revoke-all-sessions-button', () => {
+      this._currentSessionCardRef.value?.focus();
+    });
+  }
+
+  /**
+   * @param {string} tokenId
+   * @return {boolean}
+   * @private
+   */
+  _isCurrentSessionToken(tokenId) {
+    if (this.state.type === 'loading' || this.state.type === 'error') {
+      return false;
+    }
+    return this.state.currentSessionToken.id === tokenId;
+  }
+
+  /**
+   * Handles the revocation of all tokens
+   *
+   * @private
+   */
+  _onRevokeAllTokens() {
+    dispatchCustomEvent(this, 'revoke-all-session-tokens');
+  }
+
+  /**
+   * Handles the revocation of a specific token
+   *
+   * @param {string} tokenId - The ID of the token to be revoked
+   * @private
+   */
+  _onRevokeToken(tokenId) {
+    dispatchCustomEvent(this, 'revoke-session-token', tokenId);
+  }
+
+  render() {
+    if (this.state.type === 'error') {
+      return html`<cc-notice intent="warning" message="${i18n('cc-token-session-list.error')}"></cc-notice>`;
+    }
+
+    const hasTokens =
+      (this.state.type === 'loaded' || this.state.type === 'revoking-all') && this.state.otherSessionTokens.length > 0;
+
+    const sortedSessionTokens =
+      this.state.type === 'loaded' || this.state.type === 'revoking-all'
+        ? [this.state.currentSessionToken, ...this.state.otherSessionTokens].sort(
+            (tokenA, tokenB) => tokenB.creationDate.getTime() - tokenA.creationDate.getTime(),
+          )
+        : [];
+
+    return html`
+      <cc-block>
+        <div slot="header-title">${i18n('cc-token-session-list.main-heading')}</div>
+        <div slot="header-right">
+          ${hasTokens
+            ? html`
+                <cc-button
+                  class="revoke-all-sessions-button"
+                  danger
+                  outlined
+                  ?waiting=${this.state.type === 'revoking-all'}
+                  @cc-button:click=${this._onRevokeAllTokens}
+                >
+                  ${i18n('cc-token-session-list.revoke-all-sessions')}
+                </cc-button>
+              `
+            : ''}
+        </div>
+        <div slot="content">
+          <p>${i18n('cc-token-session-list.intro')}</p>
+          <div class="session-tokens-wrapper">
+            ${this.state.type === 'loading' ? html`<cc-loader></cc-loader>` : ''}
+            ${this.state.type === 'loaded' || this.state.type === 'revoking-all'
+              ? html`
+                  <!-- TODO: A11Y when we add headings inside cards (User Agent / IP Address or whatever), we should remove the ul / li structure -->
+                  <ul class="session-tokens-wrapper__list">
+                    ${sortedSessionTokens.map((token, index) => this._renderTokenCard(token, index))}
+                  </ul>
+                `
+              : ''}
+          </div>
+        </div>
+      </cc-block>
+    `;
+  }
+
+  /**
+   * Renders an individual token card
+   *
+   * @param {SessionTokenState|SessionToken} token - The token data to render
+   * @param {number} index - The index of the token in the list
+   * @returns {TemplateResult} The rendered token card
+   * @private
+   */
+  _renderTokenCard(token, index) {
+    const { id, creationDate, expirationDate, lastUsedDate, isCleverTeam } = token;
+    const isCurrentSession = this._isCurrentSessionToken(id);
+    const isRevoking = 'type' in token && token.type === 'revoking';
+    const tabIndex = isCurrentSession ? -1 : null;
+    const hasExpirationWarning = isExpirationClose({
+      creationDate: token.creationDate,
+      expirationDate: token.expirationDate,
+    });
+
+    return html`
+      <li
+        class="session-token-card ${classMap({ 'is-revoking': isRevoking })}"
+        tabindex=${ifDefined(tabIndex)}
+        ${isCurrentSession ? ref(this._currentSessionCardRef) : ''}
+      >
+        ${isCurrentSession || isCleverTeam || hasExpirationWarning
+          ? this._renderCardHeader({
+              isCurrentSession,
+              isCleverTeam,
+              hasExpirationWarning,
+            })
+          : ''}
+        <dl class="session-token-card__info-list">
+          <div class="session-token-card__info-list__item session-token-card__info-list__item--italic">
+            <dt>
+              <cc-icon .icon=${iconLastUsed}></cc-icon>
+              <span>${i18n('cc-token-session-list.card.label.last-used')}</span>
+            </dt>
+            <dd>${i18n('cc-token-session-list.card.human-friendly-date', { date: lastUsedDate })}</dd>
+          </div>
+          <div class="session-token-card__info-list__item">
+            <dt>
+              <cc-icon .icon=${iconCreation}></cc-icon>
+              <span>${i18n('cc-token-session-list.card.label.creation')}</span>
+            </dt>
+            <dd>${i18n('cc-token-session-list.card.human-friendly-date', { date: creationDate })}</dd>
+          </div>
+          <div class="session-token-card__info-list__item session-token-card__info-list__item--bold">
+            <dt>
+              <cc-icon .icon=${iconExpiration}></cc-icon>
+              <span>${i18n('cc-token-session-list.card.label.expiration')}</span>
+            </dt>
+            <dd>
+              <span>${i18n('cc-token-session-list.card.human-friendly-date', { date: expirationDate })}</span>
+            </dd>
+          </div>
+        </dl>
+        ${!isCurrentSession
+          ? html`
+              <cc-button
+                class="session-token-card__action-revoke"
+                danger
+                outlined
+                hide-text
+                .icon=${iconDelete}
+                circle
+                ?waiting=${isRevoking}
+                @cc-button:click=${() => this._onRevokeToken(id)}
+              >
+                ${i18n('cc-token-session-list.revoke-session', { tokenNumber: index + 1 })}
+              </cc-button>
+            `
+          : ''}
+      </li>
+    `;
+  }
+
+  /** @param {{ isCleverTeam: boolean, hasExpirationWarning: boolean, isCurrentSession: boolean }} params */
+  _renderCardHeader({ isCurrentSession, isCleverTeam, hasExpirationWarning }) {
+    return html`
+      <div class="session-token-card__header">
+        ${isCurrentSession
+          ? html`
+              <div class="session-token-card__header__current-session">
+                <cc-icon .icon=${iconCurrentSession}></cc-icon>
+                <span>${i18n('cc-token-session-list.card.current-session')}</span>
+              </div>
+            `
+          : ''}
+        ${isCleverTeam
+          ? html` <cc-badge intent="info">${i18n('cc-token-session-list.card.clever-team')}</cc-badge> `
+          : ''}
+        ${!isCleverTeam && hasExpirationWarning
+          ? html` <cc-badge intent="warning">${i18n('cc-token-session-list.card.expires-soon')}</cc-badge> `
+          : ''}
+      </div>
+    `;
+  }
+
+  static get styles() {
+    return css`
+      :host {
+        display: block;
+      }
+
+      /* Reset default margins and paddings */
+      ul,
+      li,
+      dl,
+      dd,
+      dt {
+        margin: 0;
+        padding: 0;
+      }
+
+      li {
+        list-style: none;
+      }
+
+      p {
+        margin: 0;
+      }
+
+      .is-revoking > :not(cc-button) {
+        opacity: var(--cc-opacity-when-disabled, 0.65);
+      }
+
+      /* When all other sessions are revoked, focus may return to the current session card */
+      .session-token-card:focus-visible {
+        outline: var(--cc-focus-outline);
+        outline-offset: var(--cc-focus-outline-offset, 2px);
+      }
+
+      .session-tokens-wrapper {
+        margin-top: 2.5em;
+      }
+
+      .session-tokens-wrapper__list {
+        display: grid;
+        gap: 1.5em;
+      }
+
+      @supports (grid-template-columns: subgrid) {
+        .session-tokens-wrapper__list {
+          grid-template-columns: [card-start info-start] max-content max-content 1fr [info-end actions-start] auto [actions-end card-end];
+        }
+
+        :host([w-lt-995]) .session-tokens-wrapper__list {
+          grid-template-columns: [card-start info-start] 1fr 1fr 1fr [info-end actions-start] auto [actions-end card-end];
+        }
+
+        :host([w-lt-730]) .session-tokens-wrapper__list {
+          grid-template-columns: [card-start info-start] 1fr [info-end actions-start] auto [actions-end card-end];
+        }
+      }
+
+      .session-token-card {
+        align-items: center;
+        border: solid 1px var(--cc-color-border-neutral-weak, #e6e6e6);
+        border-radius: var(--cc-border-radius-default, 0.25em);
+        column-gap: 1em;
+        display: grid;
+        grid-template-columns: [card-start info-start] 1fr [info-end actions-start] max-content [actions-end card-end];
+        padding: 1em;
+      }
+
+      @supports (grid-template-columns: subgrid) {
+        .session-token-card {
+          display: grid;
+          grid-column: card-start / card-end;
+          grid-template-columns: subgrid;
+        }
+      }
+
+      .session-token-card__header {
+        --cc-icon-size: 1.2em;
+
+        align-items: center;
+        column-gap: 1em;
+        display: flex;
+        flex-wrap: wrap;
+        grid-column: info-start / info-end;
+        margin-bottom: 1em;
+        row-gap: 0.5em;
+      }
+
+      .session-token-card__header__current-session {
+        align-items: center;
+        color: var(--cc-color-text-success, #318051);
+        display: flex;
+        font-weight: bold;
+        gap: 0.5em;
+      }
+
+      .session-token-card__info-list {
+        display: flex;
+        gap: 1em;
+        grid-column: info-start / info-end;
+      }
+
+      :host([w-lt-730]) .session-token-card__info-list {
+        display: grid;
+        row-gap: 0.5em;
+      }
+
+      @supports (grid-template-columns: subgrid) {
+        .session-token-card__info-list {
+          display: grid;
+          grid-column: info-start / info-end;
+          grid-template-columns: subgrid;
+        }
+
+        :host([w-lt-730]) .session-token-card__info-list {
+          row-gap: 0.5em;
+        }
+      }
+
+      .session-token-card__info-list__item {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5em;
+      }
+
+      @supports (grid-template-columns: subgrid) {
+        :host([w-lt-995]) .session-token-card__info-list__item {
+          display: grid;
+        }
+
+        :host([w-lt-730]) .session-token-card__info-list__item {
+          display: flex;
+        }
+      }
+
+      .session-token-card__info-list__item--italic {
+        font-style: italic;
+      }
+
+      .session-token-card__info-list__item--bold {
+        font-weight: bold;
+      }
+
+      dt {
+        --line-height: 1.2em;
+        --cc-icon-size: var(--line-height);
+
+        align-items: center;
+        display: flex;
+        gap: 0.5em;
+        line-height: var(--line-height);
+      }
+
+      dd {
+        align-items: center;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5em;
+      }
+
+      .session-token-card cc-button {
+        align-self: start;
+        grid-column: actions-start / actions-end;
+        grid-row: 1 / -1;
+        justify-self: end;
+      }
+    `;
+  }
+}
+
+customElements.define('cc-token-session-list', CcTokenSessionList);

--- a/src/components/cc-token-session-list/cc-token-session-list.smart.js
+++ b/src/components/cc-token-session-list/cc-token-session-list.smart.js
@@ -1,0 +1,234 @@
+// prettier-ignore
+// @ts-expect-error FIXME: remove when clever-client exports types
+import { todo_listSelfTokens as getAllTokens,todo_revokeSelfToken as revokeToken } from '@clevercloud/client/esm/api/v2/user.js';
+import { notifyError, notifySuccess } from '../../lib/notifications.js';
+import { sendToApi } from '../../lib/send-to-api.js';
+import { defineSmartComponent } from '../../lib/smart/define-smart-component.js';
+import { i18n } from '../../translations/translation.js';
+import '../cc-smart-container/cc-smart-container.js';
+import './cc-token-session-list.js';
+
+/**
+ * @typedef {import('./cc-token-session-list.js').CcTokenSessionList} CcTokenSessionList
+ * @typedef {import('./cc-token-session-list.types.js').SessionToken} SessionToken
+ * @typedef {import('./cc-token-session-list.types.js').SessionTokenState} SessionTokenState
+ * @typedef {import('./cc-token-session-list.types.js').SessionTokenStateIdle} SessionTokenStateIdle
+ * @typedef {import('./cc-token-session-list.types.js').TokenSessionListStateLoaded} TokenSessionListStateLoaded
+ * @typedef {import('./cc-token-session-list.types.js').TokenSessionListStateRevokingAll} TokenSessionListStateRevokingAll
+ * @typedef {import('./cc-token-session-list.types.js').RawTokenData} RawTokenData
+ * @typedef {import('../../lib/send-to-api.types.js').ApiConfig} ApiConfig
+ * @typedef {import('../../lib/smart/smart-component.types.js').OnContextUpdateArgs<CcTokenSessionList>} OnContextUpdateArgs
+ */
+
+defineSmartComponent({
+  selector: 'cc-token-session-list',
+  params: {
+    apiConfig: { type: Object },
+  },
+  /** @param {OnContextUpdateArgs} args */
+  onContextUpdate({ component, context, onEvent, updateComponent }) {
+    const { apiConfig } = context;
+    const api = new Api(apiConfig);
+
+    /**
+     * Updates a single session token
+     *
+     * @param {string} sessionTokenId The ID of the token to update
+     * @param {function(SessionTokenState): void} callback A callback function to execute with the updated token
+     */
+    function updateOneToken(sessionTokenId, callback) {
+      updateComponent(
+        'state',
+        /** @param {TokenSessionListStateLoaded} state */
+        (state) => {
+          const sessionTokenToUpdate = state.otherSessionTokens.find((token) => token.id === sessionTokenId);
+
+          if (sessionTokenToUpdate != null) {
+            callback(sessionTokenToUpdate);
+          }
+        },
+      );
+    }
+
+    updateComponent('state', { type: 'loading' });
+
+    api
+      .getSessionTokens()
+      .then((tokens) => {
+        const currentSessionToken = tokens.find((token) => token.id === apiConfig.API_OAUTH_TOKEN);
+
+        const otherSessionTokens = tokens
+          .filter((token) => token.id !== apiConfig.API_OAUTH_TOKEN)
+          .map((token) => {
+            /** @type {SessionTokenStateIdle} */
+            const formattedToken = {
+              type: 'idle',
+              ...token,
+            };
+            return formattedToken;
+          });
+
+        updateComponent('state', {
+          type: 'loaded',
+          currentSessionToken,
+          otherSessionTokens,
+        });
+      })
+      .catch((error) => {
+        console.error(error);
+        updateComponent('state', { type: 'error' });
+      });
+
+    onEvent(
+      'cc-token-session-list:revoke-session-token',
+      /** @param {string} sessionTokenId */
+      (sessionTokenId) => {
+        updateOneToken(sessionTokenId, (sessionTokenState) => {
+          sessionTokenState.type = 'revoking';
+        });
+
+        api
+          .revokeSessionToken(sessionTokenId)
+          .then(() => {
+            updateComponent(
+              'state',
+              /** @param {TokenSessionListStateLoaded} state */
+              (state) => {
+                state.otherSessionTokens = state.otherSessionTokens.filter((token) => token.id !== sessionTokenId);
+              },
+            );
+            notifySuccess(i18n('cc-token-session-list.revoke-session.success'));
+          })
+          .catch((error) => {
+            console.error(error);
+            updateOneToken(sessionTokenId, (sessionTokenState) => {
+              sessionTokenState.type = 'idle';
+            });
+            notifyError(i18n('cc-token-session-list.revoke-session.error'));
+          });
+      },
+    );
+
+    onEvent('cc-token-session-list:revoke-all-session-tokens', () => {
+      updateComponent(
+        'state',
+        /** @param {TokenSessionListStateLoaded} state */
+        (state) =>
+          /** @type {TokenSessionListStateRevokingAll} */ ({
+            ...state,
+            type: 'revoking-all',
+            otherSessionTokens: state.otherSessionTokens.map((token) => ({ ...token, type: 'revoking' })),
+          }),
+      );
+
+      const tokens = /** @type {TokenSessionListStateLoaded} */ (component.state).otherSessionTokens;
+
+      api.revokeAllSessionTokens(tokens).then(({ remainingTokens, errors, revokedTokens }) => {
+        updateComponent('state', (state) => {
+          state.type = 'loaded';
+
+          /** @type {TokenSessionListStateLoaded} */
+          (state).otherSessionTokens = remainingTokens.map((token) => ({
+            ...token,
+            type: 'idle',
+          }));
+
+          return state;
+        });
+
+        if (errors.length === 0) {
+          notifySuccess(i18n('cc-token-session-list.revoke-all-sessions.success'));
+        } else if (revokedTokens.length > 0) {
+          notifyError(i18n('cc-token-session-list.revoke-all-sessions.partial-error'));
+        } else {
+          notifyError(i18n('cc-token-session-list.revoke-all-sessions.error'));
+        }
+      });
+    });
+  },
+});
+
+class Api {
+  /** @param {ApiConfig} apiConfig */
+  constructor(apiConfig) {
+    this._apiConfig = apiConfig;
+  }
+
+  /**
+   * Fetches and formats session tokens
+   *
+   * @returns {Promise<SessionToken[]>} A promise that resolves to an array of formatted session tokens
+   */
+  getSessionTokens() {
+    return getAllTokens()
+      .then(sendToApi({ apiConfig: this._apiConfig }))
+      .then(
+        /** @param {Array<RawTokenData>} tokens */
+        (tokens) => {
+          const filteredTokens = tokens
+            /*
+             * Only keep sessions related to the console in use and all login as sessions (those with an employeeId).
+             * We cannot keep only login as sessions for the console in use because the login as OAuth consumer
+             * is always the prod console OAuth consumer
+             */
+            .filter((token) => token.consumer.key === this._apiConfig.OAUTH_CONSUMER_KEY || token.employeeId != null)
+            .map((token) => {
+              /** @type {SessionToken} */
+              const formattedToken = {
+                id: token.token,
+                isCleverTeam: token.employeeId != null,
+                creationDate: new Date(token.creationDate),
+                expirationDate: new Date(token.expirationDate),
+                lastUsedDate: new Date(token.lastUtilisation),
+              };
+              return formattedToken;
+            });
+
+          return filteredTokens;
+        },
+      );
+  }
+
+  /**
+   * Revokes a session token
+   *
+   * @param {string} sessionTokenId - The ID of the token to revoke
+   * @returns {Promise<void>} A promise that resolves when the token is revoked
+   */
+  revokeSessionToken(sessionTokenId) {
+    return revokeToken({ token: sessionTokenId }).then(sendToApi({ apiConfig: this._apiConfig }));
+  }
+
+  /**
+   * Revokes all session tokens
+   * We cannot rely on the dedicated API endpoint for this operation because it revokes all tokens, including the current session token and tokens coming from other consumers (oAuth tokens).
+   * This is why we revoke each token individually and use `Promise.allSettled` to handle errors gracefully.
+   *
+   * @param {SessionTokenState[]} tokensToRevoke - An array of all session tokens
+   * @returns {Promise<{ remainingTokens: SessionTokenState[], revokedTokens: string[], errors: any[] }>} A promise that resolves when all tokens are revoked
+   */
+  revokeAllSessionTokens(tokensToRevoke) {
+    let errors = [];
+    /** @type {string[]} */
+    let revokedTokens = [];
+
+    return Promise.allSettled(
+      tokensToRevoke.map((token) => this.revokeSessionToken(token.id).then(() => token.id)),
+    ).then(
+      /** @param {PromiseSettledResult<string>[]} results */
+      (results) => {
+        revokedTokens = results
+          .filter(
+            /** @returns {result is PromiseFulfilledResult<string>} */
+            (result) => result.status === 'fulfilled',
+          )
+          .map(({ value }) => value);
+        errors = results.filter((result) => result.status === 'rejected');
+
+        const remainingTokens = tokensToRevoke.filter((token) => !revokedTokens.includes(token.id));
+
+        return { remainingTokens, revokedTokens, errors };
+      },
+    );
+  }
+}

--- a/src/components/cc-token-session-list/cc-token-session-list.smart.md
+++ b/src/components/cc-token-session-list/cc-token-session-list.smart.md
@@ -1,0 +1,51 @@
+---
+kind: '🛠 Profile/<cc-token-session-list>'
+title: '💡 Smart'
+---
+
+# 💡 Smart `<cc-token-session-list>`
+
+## ℹ️ Details
+
+<table>
+  <tr><td><strong>Component    </strong> <td><a href="https://www.clever-cloud.com/doc/clever-components/?path=/docs/🛠-profile-cc-token-session-list--default-story"><code>&lt;cc-token-session-list&gt;</code></a>
+  <tr><td><strong>Selector     </strong> <td><code>cc-token-session-list</code>
+  <tr><td><strong>Requires auth</strong> <td>Yes
+</table>
+
+## ⚙️ Params
+
+| Name        | Type        | Details                                                 | Default |
+|-------------|-------------|---------------------------------------------------------|---------|
+| `apiConfig` | `ApiConfig` | Object with API configuration (target host, tokens...)  |         |
+
+```ts
+interface ApiConfig {
+  API_HOST: string,
+  API_OAUTH_TOKEN: string,
+  API_OAUTH_TOKEN_SECRET: string,
+  OAUTH_CONSUMER_KEY: string,
+  OAUTH_CONSUMER_SECRET: string,
+}
+```
+
+## 🌐 API endpoints
+
+| Method   | Type                    | Cache?  |
+|----------|:------------------------|---------|
+| `GET`    | `/v2/self/tokens`       | Default |
+| `POST`   | `/v2/self/tokens/revoke`| Default |
+
+```html
+<cc-smart-container context='{
+    "apiConfig": {
+      API_HOST: "",
+      API_OAUTH_TOKEN: "",
+      API_OAUTH_TOKEN_SECRET: "",
+      OAUTH_CONSUMER_KEY: "",
+      OAUTH_CONSUMER_SECRET: "",
+    }
+}'>
+    <cc-token-session-list></cc-token-session-list>
+<cc-smart-container>
+```

--- a/src/components/cc-token-session-list/cc-token-session-list.stories.js
+++ b/src/components/cc-token-session-list/cc-token-session-list.stories.js
@@ -1,0 +1,323 @@
+import { makeStory, storyWait } from '../../stories/lib/make-story.js';
+import './cc-token-session-list.js';
+
+export default {
+  tags: ['autodocs'],
+  title: '🛠 Profile/<cc-token-session-list>',
+  component: 'cc-token-session-list',
+};
+
+/**
+ * @typedef {import('./cc-token-session-list.js').CcTokenSessionList} CcTokenSessionList
+ * @typedef {import('./cc-token-session-list.types.js').SessionTokenStateIdle} SessionTokenStateIdle
+ * @typedef {import('./cc-token-session-list.types.js').SessionToken} SessionToken
+ */
+
+const conf = {
+  component: 'cc-token-session-list',
+};
+
+const ONE_DAY = 24 * 60 * 60 * 1000;
+
+/** @type {SessionToken} */
+const currentSession = {
+  id: '2',
+  creationDate: new Date(Date.now() - 89 * ONE_DAY), // medium-aged token (90 days old)
+  expirationDate: new Date(Date.now() + 32 * ONE_DAY), // does not expire soon (32 days)
+  lastUsedDate: new Date(Date.now() - 7 * ONE_DAY), // recent use (7 days ago)
+  isCleverTeam: false,
+};
+
+/** @type {Array<SessionTokenStateIdle>} */
+const otherSessions = [
+  {
+    type: 'idle',
+    id: '1',
+    creationDate: new Date(Date.now() - 180 * ONE_DAY), // long-lived token (180 days old)
+    expirationDate: new Date(Date.now() + 32 * ONE_DAY), // does not expire soon (32 days)
+    lastUsedDate: new Date(Date.now() - 30 * ONE_DAY), // 30 days ago
+    isCleverTeam: false,
+  },
+  {
+    type: 'idle',
+    id: '3',
+    creationDate: new Date(Date.now() - 240 * ONE_DAY), // very old token (240 days old)
+    expirationDate: new Date(Date.now() + 6 * ONE_DAY), // expires soon (6 days)
+    lastUsedDate: new Date(Date.now() - 10 * ONE_DAY), // 10 days ago
+    isCleverTeam: false,
+  },
+  {
+    type: 'idle',
+    id: '4',
+    creationDate: new Date(Date.now() - 350 * ONE_DAY), // extremely old token (350 days old)
+    expirationDate: new Date(Date.now() + 2 * ONE_DAY), // expires soon (2 days)
+    lastUsedDate: new Date(Date.now() - 2 * ONE_DAY), // very recent use (2 days ago)
+    isCleverTeam: false,
+  },
+  {
+    type: 'idle',
+    id: '5',
+    creationDate: new Date(Date.now() - 70 * ONE_DAY), // newer token (70 days old)
+    expirationDate: new Date(Date.now() + 45 * ONE_DAY), // does not expire soon (45 days)
+    lastUsedDate: new Date(Date.now() - 1 * ONE_DAY), // very recent use (1 day ago)
+    isCleverTeam: false,
+  },
+  {
+    type: 'idle',
+    id: '6',
+    creationDate: new Date(Date.now() - 80 * ONE_DAY), // medium-aged token (80 days old)
+    expirationDate: new Date(Date.now() + 6 * 60 * 60 * 1000), // expires soon (0.25 days)
+    lastUsedDate: new Date(Date.now() - 5 * ONE_DAY), // recent use (5 days ago)
+    isCleverTeam: true,
+  },
+];
+
+export const defaultStory = makeStory(conf, {
+  /** @type {Partial<CcTokenSessionList>[]} */
+  items: [
+    {
+      state: {
+        type: 'loaded',
+        currentSessionToken: currentSession,
+        otherSessionTokens: otherSessions,
+      },
+    },
+  ],
+});
+
+export const loading = makeStory(conf, {
+  /** @type {Partial<CcTokenSessionList>[]} */
+  items: [{ state: { type: 'loading' } }],
+});
+
+export const error = makeStory(conf, {
+  /** @type {Partial<CcTokenSessionList>[]} */
+  items: [{ state: { type: 'error' } }],
+});
+
+export const waitingWithRevokingOneToken = makeStory(conf, {
+  /** @type {Partial<CcTokenSessionList>[]} */
+  items: [
+    {
+      state: {
+        type: 'loaded',
+        currentSessionToken: currentSession,
+        otherSessionTokens: otherSessions.map((token, index) => {
+          if (index === 3) {
+            return {
+              ...token,
+              type: 'revoking',
+            };
+          }
+
+          return token;
+        }),
+      },
+    },
+  ],
+});
+
+export const waitingWithRevokingAllTokens = makeStory(conf, {
+  /** @type {Partial<CcTokenSessionList>[]} */
+  items: [
+    {
+      state: {
+        type: 'revoking-all',
+        currentSessionToken: currentSession,
+        otherSessionTokens: otherSessions.map((token) => ({
+          ...token,
+          type: 'revoking',
+        })),
+      },
+    },
+  ],
+});
+
+export const dataLoadedWithOnlyCurrentSession = makeStory(conf, {
+  /** @type {Partial<CcTokenSessionList>[]} */
+  items: [
+    {
+      state: {
+        type: 'loaded',
+        currentSessionToken: currentSession,
+        otherSessionTokens: [],
+      },
+    },
+  ],
+});
+
+export const dataLoadedWithCleverTeamAsCurrentSession = makeStory(conf, {
+  /** @type {Partial<CcTokenSessionList>[]} */
+  items: [
+    {
+      state: {
+        type: 'loaded',
+        currentSessionToken: {
+          ...currentSession,
+          isCleverTeam: true,
+        },
+        otherSessionTokens: otherSessions,
+      },
+    },
+  ],
+});
+
+export const dataLoadedWithCleverTeamAndExpirationCloseNoVisibleWarning = makeStory(conf, {
+  /** @type {Partial<CcTokenSessionList>[]} */
+  items: [
+    {
+      state: {
+        type: 'loaded',
+        currentSessionToken: {
+          ...currentSession,
+        },
+        otherSessionTokens: otherSessions.map((session) => {
+          if (session.isCleverTeam) {
+            return {
+              ...session,
+              expirationDate: new Date(Date.now() + 6 * ONE_DAY), // expires soon (6 days)
+            };
+          }
+
+          return { ...session };
+        }),
+      },
+    },
+  ],
+});
+
+export const dataLoadedWithCleverTeamAsCurrentSessionAndExpirationCloseNoVisibleWarning = makeStory(conf, {
+  /** @type {Partial<CcTokenSessionList>[]} */
+  items: [
+    {
+      state: {
+        type: 'loaded',
+        currentSessionToken: {
+          ...currentSession,
+          isCleverTeam: true,
+          expirationDate: new Date(Date.now() + 6 * ONE_DAY), // expires soon (6 days)
+        },
+        otherSessionTokens: otherSessions,
+      },
+    },
+  ],
+});
+
+export const simulationsWithLoadingSuccess = makeStory(conf, {
+  /** @type {Partial<CcTokenSessionList>[]} */
+  items: [{ state: { type: 'loading' } }],
+  simulations: [
+    storyWait(
+      2000,
+      /** @param {CcTokenSessionList[]} components */
+      ([component]) => {
+        component.state = {
+          type: 'loaded',
+          currentSessionToken: currentSession,
+          otherSessionTokens: otherSessions,
+        };
+      },
+    ),
+  ],
+});
+
+export const simulationsWithLoadingError = makeStory(conf, {
+  /** @type {Partial<CcTokenSessionList>[]} */
+  items: [{ state: { type: 'loading' } }],
+  simulations: [
+    storyWait(
+      2000,
+      /** @param {CcTokenSessionList[]} components */
+      ([component]) => {
+        component.state = {
+          type: 'error',
+        };
+      },
+    ),
+  ],
+});
+
+export const simulationsWithRevokingToken = makeStory(conf, {
+  /** @type {Partial<CcTokenSessionList>[]} */
+  items: [
+    {
+      state: {
+        type: 'loaded',
+        currentSessionToken: currentSession,
+        otherSessionTokens: otherSessions,
+      },
+    },
+  ],
+  simulations: [
+    storyWait(
+      1000,
+      /** @param {CcTokenSessionList[]} components */
+      ([component]) => {
+        component.state = {
+          type: 'loaded',
+          currentSessionToken: currentSession,
+          otherSessionTokens: otherSessions.map((token, index) => {
+            if (index === 3) {
+              return {
+                ...token,
+                type: 'revoking',
+              };
+            }
+            return token;
+          }),
+        };
+      },
+    ),
+    storyWait(
+      3000,
+      /** @param {CcTokenSessionList[]} components */
+      ([component]) => {
+        component.state = {
+          type: 'loaded',
+          currentSessionToken: currentSession,
+          otherSessionTokens: otherSessions.filter((_, index) => index !== 3),
+        };
+      },
+    ),
+  ],
+});
+
+export const simulationsWithRevokingAllTokens = makeStory(conf, {
+  /** @type {Partial<CcTokenSessionList>[]} */
+  items: [
+    {
+      state: {
+        type: 'loaded',
+        currentSessionToken: currentSession,
+        otherSessionTokens: otherSessions,
+      },
+    },
+  ],
+  simulations: [
+    storyWait(
+      1000,
+      /** @param {CcTokenSessionList[]} components */
+      ([component]) => {
+        component.state = {
+          type: 'revoking-all',
+          currentSessionToken: currentSession,
+          otherSessionTokens: otherSessions.map((token) => ({
+            ...token,
+            type: 'revoking',
+          })),
+        };
+      },
+    ),
+    storyWait(
+      3000,
+      /** @param {CcTokenSessionList[]} components */
+      ([component]) => {
+        component.state = {
+          type: 'loaded',
+          currentSessionToken: currentSession,
+          otherSessionTokens: [],
+        };
+      },
+    ),
+  ],
+});

--- a/src/components/cc-token-session-list/cc-token-session-list.types.d.ts
+++ b/src/components/cc-token-session-list/cc-token-session-list.types.d.ts
@@ -1,0 +1,88 @@
+export type TokenSessionListState =
+  | TokenSessionListStateLoaded
+  | TokenSessionListStateLoading
+  | TokenSessionListStateError
+  | TokenSessionListStateRevokingAll;
+
+export interface TokenSessionListStateLoaded {
+  type: 'loaded';
+  currentSessionToken: SessionToken;
+  otherSessionTokens: Array<SessionTokenState>;
+}
+
+export interface TokenSessionListStateRevokingAll {
+  type: 'revoking-all';
+  currentSessionToken: SessionToken;
+  otherSessionTokens: Array<SessionTokenStateRevoking>;
+}
+
+export interface TokenSessionListStateLoading {
+  type: 'loading';
+}
+
+export interface TokenSessionListStateError {
+  type: 'error';
+}
+
+export type SessionTokenState = SessionTokenStateIdle | SessionTokenStateRevoking;
+
+export interface SessionTokenStateIdle extends SessionToken {
+  type: 'idle';
+}
+
+interface SessionTokenStateRevoking extends SessionToken {
+  type: 'revoking';
+}
+
+interface SessionToken {
+  id: string;
+  creationDate: Date;
+  expirationDate: Date;
+  lastUsedDate: Date;
+  isCleverTeam: boolean;
+}
+
+// FIXME: remove when clever-client exposes types
+export interface RawTokenData {
+  token: string;
+  consumer: {
+    name: string;
+    description: string;
+    key: string;
+    url: string;
+    picture: string;
+    baseUrl: string;
+    rights: {
+      almighty: boolean;
+      access_organisations: boolean;
+      manage_organisations: boolean;
+      manage_organisations_services: boolean;
+      manage_organisations_applications: boolean;
+      manage_organisations_members: boolean;
+      access_organisations_bills: boolean;
+      access_organisations_credit_count: boolean;
+      access_organisations_consumption_statistics: boolean;
+      access_personal_information: boolean;
+      manage_personal_information: boolean;
+      manage_ssh_keys: boolean;
+    };
+  };
+  creationDate: number;
+  expirationDate: number;
+  lastUtilisation: number;
+  rights: {
+    almighty: boolean;
+    access_organisations: boolean;
+    manage_organisations: boolean;
+    manage_organisations_services: boolean;
+    manage_organisations_applications: boolean;
+    manage_organisations_members: boolean;
+    access_organisations_bills: boolean;
+    access_organisations_credit_count: boolean;
+    access_organisations_consumption_statistics: boolean;
+    access_personal_information: boolean;
+    manage_personal_information: boolean;
+    manage_ssh_keys: boolean;
+  };
+  employeeId: string | null;
+}

--- a/src/lib/i18n/i18n.types.d.ts
+++ b/src/lib/i18n/i18n.types.d.ts
@@ -8,7 +8,7 @@ export type TranslateFunction = (data: any) => Translated;
 
 export type Translated = string | Node;
 
-export type DateInput = number | string;
+export type DateInput = number | string | Date;
 
 export type DateFormatter = (dateInput: DateInput) => string;
 

--- a/src/lib/tokens.js
+++ b/src/lib/tokens.js
@@ -1,0 +1,63 @@
+/**
+ * @typedef {import("./tokens.types.js").ExpirationWarningThresholds} ExpirationWarningThresholds
+ */
+
+/** @type {ExpirationWarningThresholds} */
+const DEFAULT_THRESHOLDS = [
+  { maxApplicableTokenLifetimeInDays: 7, warningThresholdInDays: 2 },
+  { maxApplicableTokenLifetimeInDays: 30, warningThresholdInDays: 7 },
+  { maxApplicableTokenLifetimeInDays: 60, warningThresholdInDays: 10 },
+  { maxApplicableTokenLifetimeInDays: 90, warningThresholdInDays: 20 },
+  { maxApplicableTokenLifetimeInDays: 365, warningThresholdInDays: 30 },
+];
+
+/**
+ * Checks if a token is close to expiration based on its lifetime.
+ *
+ * Uses a tiered threshold system where tokens with longer lifespans have larger
+ * warning thresholds. For example, 7-day tokens warn at 2 days remaining, while
+ * 90-day tokens warn at 20 days remaining.
+ *
+ * Uses DEFAULT_THRESHOLDS by default, but custom thresholds can be provided.
+ * Falls back to highest threshold for tokens exceeding defined lifespans.
+ *
+ * @param {Object} tokenInfo - Creation & expiration date
+ * @param {Date} tokenInfo.creationDate - The creation date of the token
+ * @param {Date} tokenInfo.expirationDate - The expiration date of the token
+ * @param {ExpirationWarningThresholds} [thresholds] - Optional custom thresholds configuration
+ * @returns {boolean} True if the token is close to expiration
+ */
+export function isExpirationClose({ creationDate, expirationDate }, thresholds = DEFAULT_THRESHOLDS) {
+  const now = new Date();
+  const MILLISECONDS_PER_DAY = 1000 * 60 * 60 * 24;
+
+  // Calculate token's total lifetime and remaining days
+  const expirationTimestamp = expirationDate.getTime();
+  const creationTimestamp = creationDate.getTime();
+  const totalTokenLifetimeInDays = Math.floor((expirationTimestamp - creationTimestamp) / MILLISECONDS_PER_DAY);
+
+  // Calculate days remaining until expiration
+  const daysUntilExpiration = (expirationDate.getTime() - now.getTime()) / MILLISECONDS_PER_DAY;
+
+  // Sort thresholds by maxApplicableTokenLifetimeInDays in ascending order to find the appropriate
+  // threshold based on the token's total lifetime
+  const sortedThresholds = [...thresholds].sort(
+    (a, b) => a.maxApplicableTokenLifetimeInDays - b.maxApplicableTokenLifetimeInDays,
+  );
+
+  // Find the first threshold that applies to this token's lifetime
+  const thresholdToApply = sortedThresholds.find((threshold) => {
+    return totalTokenLifetimeInDays <= threshold.maxApplicableTokenLifetimeInDays;
+  });
+
+  // If no matching threshold found, use the one with the highest max days as fallback
+  const highestThreshold = sortedThresholds[sortedThresholds.length - 1];
+
+  // Determine the appropriate warning threshold in days
+  const warningThreshold = thresholdToApply
+    ? thresholdToApply.warningThresholdInDays
+    : highestThreshold.warningThresholdInDays;
+
+  // Return true if remaining time is less than or equal to the warning threshold
+  return daysUntilExpiration <= warningThreshold;
+}

--- a/src/lib/tokens.types.d.ts
+++ b/src/lib/tokens.types.d.ts
@@ -1,0 +1,6 @@
+export type ExpirationWarningThresholds = Array<{
+  /** Number of days representing the maximum lifetime for which the given threshold is applicable */
+  maxApplicableTokenLifetimeInDays: number;
+  /** Number of days below which the token is considered close to expiration (must be lower than maxApplicableTokenLifetimeInDays) */
+  warningThresholdInDays: number;
+}>;

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -1467,6 +1467,28 @@ export const translations = {
   'cc-toast.icon-alt.success': `Success`,
   'cc-toast.icon-alt.warning': `Warning`,
   //#endregion
+  //#region cc-token-session-list
+  'cc-token-session-list.card.clever-team': `Clever Cloud Team`,
+  'cc-token-session-list.card.current-session': `Current session`,
+  'cc-token-session-list.card.expires-soon': `Expires soon`,
+  'cc-token-session-list.card.human-friendly-date': /** @param {{ date: Date }} _ */ ({ date }) => formatDatetime(date),
+  'cc-token-session-list.card.label.creation': `Creation: `,
+  'cc-token-session-list.card.label.expiration': `Expiration: `,
+  'cc-token-session-list.card.label.last-used': `Last used: `,
+  'cc-token-session-list.error': `Something went wrong while loading sessions`,
+  'cc-token-session-list.intro': `Below is the list of registered sessions for your account, which you can revoke (except the current session):`,
+  'cc-token-session-list.main-heading': `Console sessions`,
+  'cc-token-session-list.revoke-all-sessions': `Revoke all sessions`,
+  'cc-token-session-list.revoke-all-sessions.error': () =>
+    sanitize`Something went wrong while revoking all sessions.<br>None of your sessions have been revoked`,
+  'cc-token-session-list.revoke-all-sessions.partial-error': () =>
+    sanitize`Something went wrong while revoking all sessions.<br>Only some sessions have been revoked successfully`,
+  'cc-token-session-list.revoke-all-sessions.success': `All sessions have been revoked successfully`,
+  'cc-token-session-list.revoke-session': /** @param {{ tokenNumber: number}} _ */ ({ tokenNumber }) =>
+    `Revoke session ${tokenNumber}`,
+  'cc-token-session-list.revoke-session.error': `Something went wrong while revoking the session`,
+  'cc-token-session-list.revoke-session.success': `The session has been revoked successfully`,
+  //#endregion
   //#region cc-zone
   'cc-zone.country': /** @param {{code: string, name: string}} _ */ ({ code, name }) =>
     getCountryName(lang, code, name),

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -1491,6 +1491,30 @@ export const translations = {
   'cc-toast.icon-alt.success': `Succès`,
   'cc-toast.icon-alt.warning': `Avertissement`,
   //#endregion
+  //#region cc-token-session-list
+  'cc-token-session-list.card.clever-team': `Équipe Clever Cloud`,
+  'cc-token-session-list.card.current-session': `Session actuelle`,
+  'cc-token-session-list.card.expires-soon': `Expire bientôt`,
+  'cc-token-session-list.card.human-friendly-date': /** @param {{ date: string|number }} _ */ ({ date }) =>
+    formatDatetime(date),
+  'cc-token-session-list.card.label.creation': () => sanitize`Création&nbsp;: `,
+  'cc-token-session-list.card.label.expiration': () => sanitize`Expiration&nbsp;: `,
+  'cc-token-session-list.card.label.last-used': () => sanitize`Dernière utilisation&nbsp;: `,
+  'cc-token-session-list.error': `Une erreur est survenue pendant le chargement des sessions`,
+  'cc-token-session-list.intro': () =>
+    sanitize`Ci-dessous la liste des sessions enregistrées pour votre compte, que vous pouvez révoquer (excepté celle en cours)&nbsp;:`,
+  'cc-token-session-list.main-heading': `Sessions de connexion à la Console`,
+  'cc-token-session-list.revoke-all-sessions': `Révoquer toutes les sessions`,
+  'cc-token-session-list.revoke-all-sessions.error': () =>
+    sanitize`Une erreur est survenue pendant la révocation de toutes les sessions.<br>Aucune session n'a été révoquée`,
+  'cc-token-session-list.revoke-all-sessions.partial-error': () =>
+    sanitize`Une erreur est survenue pendant la révocation de toutes les sessions.<br>Seules certaines sessions ont été révoquées avec succès`,
+  'cc-token-session-list.revoke-all-sessions.success': `Toutes les sessions ont été révoquées avec succès`,
+  'cc-token-session-list.revoke-session': /** @param {{ tokenNumber: number}} _ */ ({ tokenNumber }) =>
+    `Révoquer la session ${tokenNumber}`,
+  'cc-token-session-list.revoke-session.error': `Une erreur est survenue pendant la révocation de la session`,
+  'cc-token-session-list.revoke-session.success': `La session a été révoquée avec succès`,
+  //#endregion
   //#region cc-zone
   'cc-zone.country': /** @param {{code: string, name: string}} _ */ ({ code, name }) =>
     getCountryName(lang, code, name),

--- a/test/tokens/tokens.test.js
+++ b/test/tokens/tokens.test.js
@@ -1,0 +1,153 @@
+import { expect } from '@bundled-es-modules/chai';
+import { isExpirationClose } from '../../src/lib/tokens.js';
+
+describe('isExpirationClose function', () => {
+  const now = new Date();
+  const oneDay = 24 * 60 * 60 * 1000; // milliseconds in a day
+
+  describe('with default thresholds', () => {
+    // Test for default threshold: maxApplicableTokenLifetimeInDays: 7, warningThresholdInDays: 2
+    it('should return true for short-term tokens within threshold (7 days token, 1 day left)', () => {
+      const creationDate = new Date(now.getTime() - 6 * oneDay);
+      const expirationDate = new Date(now.getTime() + oneDay);
+
+      expect(isExpirationClose({ creationDate, expirationDate })).to.be.true;
+    });
+
+    it('should return false for short-term tokens outside threshold (7 days token, 3 days left)', () => {
+      const creationDate = new Date(now.getTime() - 4 * oneDay);
+      const expirationDate = new Date(now.getTime() + 3 * oneDay);
+
+      expect(isExpirationClose({ creationDate, expirationDate })).to.be.false;
+    });
+
+    // Test for default threshold: maxApplicableTokenLifetimeInDays: 30, warningThresholdInDays: 7
+    it('should return true for medium-term tokens within threshold (30 days token, 5 days left)', () => {
+      const creationDate = new Date(now.getTime() - 25 * oneDay);
+      const expirationDate = new Date(now.getTime() + 5 * oneDay);
+
+      expect(isExpirationClose({ creationDate, expirationDate })).to.be.true;
+    });
+
+    it('should return false for medium-term tokens outside threshold (30 days token, 10 days left)', () => {
+      const creationDate = new Date(now.getTime() - 20 * oneDay);
+      const expirationDate = new Date(now.getTime() + 10 * oneDay);
+
+      expect(isExpirationClose({ creationDate, expirationDate })).to.be.false;
+    });
+
+    // Test for default threshold: maxApplicableTokenLifetimeInDays: 90, warningThresholdInDays: 20
+    it('should return true for long-term tokens within threshold (85 days token, 15 days left)', () => {
+      const creationDate = new Date(now.getTime() - 70 * oneDay);
+      const expirationDate = new Date(now.getTime() + 15 * oneDay);
+
+      expect(isExpirationClose({ creationDate, expirationDate })).to.be.true;
+    });
+
+    it('should return false for long-term tokens outside threshold (85 days token, 25 days left)', () => {
+      const creationDate = new Date(now.getTime() - 60 * oneDay);
+      const expirationDate = new Date(now.getTime() + 25 * oneDay);
+
+      expect(isExpirationClose({ creationDate, expirationDate })).to.be.false;
+    });
+
+    // Test for tokens just under one year
+    it('should return true for tokens just under one year within threshold (350 days token, 25 days left)', () => {
+      const creationDate = new Date(now.getTime() - 325 * oneDay);
+      const expirationDate = new Date(now.getTime() + 25 * oneDay);
+
+      expect(isExpirationClose({ creationDate, expirationDate })).to.be.true;
+    });
+
+    // Test for tokens over one year
+    it('should use 365-day threshold for tokens over one year (400 days token, 27 days left)', () => {
+      const creationDate = new Date(now.getTime() - 365 * oneDay);
+      const expirationDate = new Date(now.getTime() + 27 * oneDay);
+
+      expect(isExpirationClose({ creationDate, expirationDate })).to.be.true;
+    });
+
+    it('should return false for tokens over one year outside threshold (400 days token, 31 days left)', () => {
+      const creationDate = new Date(now.getTime() - 355 * oneDay);
+      const expirationDate = new Date(now.getTime() + 31 * oneDay);
+
+      expect(isExpirationClose({ creationDate, expirationDate })).to.be.false;
+    });
+  });
+
+  describe('with custom thresholds', () => {
+    // Custom thresholds for all tests
+    const customThresholds = [
+      { maxApplicableTokenLifetimeInDays: 7, warningThresholdInDays: 3 },
+      { maxApplicableTokenLifetimeInDays: 30, warningThresholdInDays: 8 },
+      { maxApplicableTokenLifetimeInDays: 90, warningThresholdInDays: 25 },
+      { maxApplicableTokenLifetimeInDays: 365, warningThresholdInDays: 40 },
+    ];
+
+    // Custom threshold tests with same scenarios as default threshold tests
+    it('should return true for short-term tokens within custom threshold (7 days token, 2 days left)', () => {
+      const creationDate = new Date(now.getTime() - 5 * oneDay);
+      const expirationDate = new Date(now.getTime() + 2 * oneDay);
+
+      expect(isExpirationClose({ creationDate, expirationDate }, customThresholds)).to.be.true;
+    });
+
+    it('should return false for short-term tokens outside custom threshold (7 days token, 4 days left)', () => {
+      const creationDate = new Date(now.getTime() - 3 * oneDay);
+      const expirationDate = new Date(now.getTime() + 4 * oneDay);
+
+      expect(isExpirationClose({ creationDate, expirationDate }, customThresholds)).to.be.false;
+    });
+
+    it('should return true for medium-term tokens within custom threshold (30 days token, 7 days left)', () => {
+      const creationDate = new Date(now.getTime() - 23 * oneDay);
+      const expirationDate = new Date(now.getTime() + 7 * oneDay);
+
+      expect(isExpirationClose({ creationDate, expirationDate }, customThresholds)).to.be.true;
+    });
+
+    it('should return false for medium-term tokens outside custom threshold (30 days token, 9 days left)', () => {
+      const creationDate = new Date(now.getTime() - 21 * oneDay);
+      const expirationDate = new Date(now.getTime() + 9 * oneDay);
+
+      expect(isExpirationClose({ creationDate, expirationDate }, customThresholds)).to.be.false;
+    });
+
+    it('should return true for long-term tokens within custom threshold (85 days token, 20 days left)', () => {
+      const creationDate = new Date(now.getTime() - 65 * oneDay);
+      const expirationDate = new Date(now.getTime() + 20 * oneDay);
+
+      expect(isExpirationClose({ creationDate, expirationDate }, customThresholds)).to.be.true;
+    });
+
+    it('should return false for long-term tokens outside custom threshold (85 days token, 30 days left)', () => {
+      const creationDate = new Date(now.getTime() - 55 * oneDay);
+      const expirationDate = new Date(now.getTime() + 30 * oneDay);
+
+      expect(isExpirationClose({ creationDate, expirationDate }, customThresholds)).to.be.false;
+    });
+
+    // Test token with duration just under 1 year
+    it('should use 365-day threshold for tokens just under one year (360 days token, 35 days left)', () => {
+      const creationDate = new Date(now.getTime() - 325 * oneDay);
+      const expirationDate = new Date(now.getTime() + 35 * oneDay);
+
+      expect(isExpirationClose({ creationDate, expirationDate }, customThresholds)).to.be.true;
+    });
+
+    // Test token with duration over 1 year
+    it('should use 365-day threshold for tokens over one year (400 days token, 35 days left)', () => {
+      const creationDate = new Date(now.getTime() - 365 * oneDay);
+      const expirationDate = new Date(now.getTime() + 35 * oneDay);
+
+      expect(isExpirationClose({ creationDate, expirationDate }, customThresholds)).to.be.true;
+    });
+
+    it('should return false for tokens over one year outside threshold (400 days token, 45 days left)', () => {
+      const creationDate = new Date(now.getTime() - 355 * oneDay);
+      const expirationDate = new Date(now.getTime() + 45 * oneDay);
+
+      expect(isExpirationClose({ creationDate, expirationDate }, customThresholds)).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
Fixes #1360

## What does this PR do?

- Adds a `cc-session-tokens` component


## How to review?

> [!IMPORTANT]
>  - We don't have info about the user agent / IP address of the session so we can only show the dates,
>  - The component doesn't handle expired tokens because the API is only supposed to provide alive sessions,
>  - There can only be one current session and there should always be one. It's very difficult to reflect this with types:
>    - I do have something that gets really close to that with recursive types but it's difficult to read so I chose to stay simple,
>    - We could add something to throw an error if we don't have 1 (exactly 1) current session at runtime. (Usually it's not something we do but I've broken the smart a few times when refactoring :shrug:).
>  - The list of sessions can never be empty since there's always your current session,
>  - There is no sandbox / demo-smart because only almighty consumers may list tokens.

- review the commit,
  - unit tests have been AI generated and reworked :angel:,
  - I'm not sure about the `isExpirationClose` helper.
    - The UX is validated, we need different thresholds depending on the token lifetime (the longer the lifetime is, the higher the threshold is).
    - Maybe I overcomplicated the code and namings are wrong, feel free to suggest rework or improvements :raised_hands:.
- check all the stories within the [preview](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-session-tokens/init/index.html?path=/story/%F0%9F%9B%A0-profile-cc-token-session-list--default-story),
- proceed with the QA in the usual google drive :wink: 

## TODO Before merging

- [x] Remove MockApi from the smart,
- [x] Remove @ts-ignore eslint-disable comments,
- [x] Only order sessions by creation date, no specific treatment for current sessions.
 