### PR TITLE
fix(cc-logs-app-runtime): fix instance selection in live mode

### DIFF
--- a/src/components/cc-logs-app-runtime/cc-logs-app-runtime.js
+++ b/src/components/cc-logs-app-runtime/cc-logs-app-runtime.js
@@ -147,24 +147,6 @@ export class CcLogsAppRuntime extends LitElement {
   }
 
   /**
-   * @param {CustomEvent<Array<string>>} event
-   */
-  _onInstanceSelectionChange(event) {
-    if (this.state.type === 'errorInstances' || this.state.type === 'loadingInstances') {
-      return;
-    }
-
-    if (this.dateRangeSelection.type !== 'live') {
-      dispatchCustomEvent(this, 'instance-selection-change', event.detail);
-    } else {
-      this.state = {
-        ...this.state,
-        selection: event.detail,
-      };
-    }
-  }
-
-  /**
    * @param {Object} event
    * @param {LogsControlOption} event.detail
    */
@@ -251,12 +233,7 @@ export class CcLogsAppRuntime extends LitElement {
       };
     }
 
-    return html`<cc-logs-instances-beta
-      class="instances"
-      slot="left"
-      .state=${state}
-      @cc-logs-instances:selection-change=${this._onInstanceSelectionChange}
-    ></cc-logs-instances-beta>`;
+    return html`<cc-logs-instances-beta class="instances" slot="left" .state=${state}></cc-logs-instances-beta>`;
   }
 
   /**

--- a/src/components/cc-logs-app-runtime/cc-logs-app-runtime.smart.js
+++ b/src/components/cc-logs-app-runtime/cc-logs-app-runtime.smart.js
@@ -73,7 +73,7 @@ defineSmartComponent({
     );
 
     onEvent(
-      'cc-logs-app-runtime:instance-selection-change',
+      'cc-logs-instances:selection-change',
       /** @param {Array<string>} instances */
       (instances) => {
         controller.setNewInstanceSelection(instances);
@@ -127,7 +127,7 @@ class SmartController extends LogsStream {
     this._selection = [];
     /** @type {DateRange} */
     this._dateRange = null;
-
+    /** @type {CcLogsAppRuntime} */
     this._component = component;
     this._updateComponent = updateComponent;
     this._instancesManager = new InstancesManager(
@@ -415,7 +415,17 @@ class SmartController extends LogsStream {
     // store the new selection
     this._selection = selection;
 
-    this.openLogsStream(this._dateRange);
+    if (isLive(this._dateRange)) {
+      // in live mode, we just change the component state
+      this._updateState((state) => {
+        if (state.type === 'loaded') {
+          state.selection = selection;
+        }
+      });
+    } else {
+      // otherwise, we start a fresh new stream
+      this.openLogsStream(this._dateRange);
+    }
   }
 
   /**

--- a/src/components/cc-logs/cc-logs.js
+++ b/src/components/cc-logs/cc-logs.js
@@ -826,20 +826,23 @@ export class CcLogs extends LitElement {
         : null;
 
     /**
-     * @param {Log} it
+     * @param {Log} log
      * @return {string}
      */
-    function keyFunction(it) {
-      return it.id;
+    function keyFunction(log) {
+      return log?.id;
     }
 
     /**
-     * @param {Log} item
+     * @param {Log} log
      * @param {number} index
      * @return {TemplateResult}
      */
-    const renderItem = (item, index) => {
-      return this._renderLog(item, index);
+    const renderItem = (log, index) => {
+      if (log == null) {
+        return null;
+      }
+      return this._renderLog(log, index);
     };
 
     return html`


### PR DESCRIPTION
# What this PR do?

Fixes #1366 

There is also an additional commit that I wanted to tackle a long time ago. It is more like a workaround to something I don't understand with `lit-virtualizer`. Sometimes, `lit-virtualizer` asks for a `null` item to be rendered.

# How to review?

* Use the sandbox
* Select live mode
* Play with instance selection
* Instance selection should not be reset when new logs arrive

