### PR TITLE
docs(cc-ssh-key-list): fix types of github ssh keys

### DIFF
--- a/src/components/cc-ssh-key-list/cc-ssh-key-list.js
+++ b/src/components/cc-ssh-key-list/cc-ssh-key-list.js
@@ -57,6 +57,7 @@ class SshPublicKeyValidator {
 /**
  * @typedef {import('./cc-ssh-key-list.types.js').SshKeyListState} SshKeyListState
  * @typedef {import('./cc-ssh-key-list.types.js').SshKeyState} SshKeyState
+ * @typedef {import('./cc-ssh-key-list.types.js').GithubSshKeyState} GithubSshKeyState
  * @typedef {import('./cc-ssh-key-list.types.js').CreateSshKeyFormState} CreateSshKeyFormState
  * @typedef {import('./cc-ssh-key-list.types.js').NewKey} NewKey
  * @typedef {import('./cc-ssh-key-list.types.js').SshKey} SshKey
@@ -138,14 +139,14 @@ export class CcSshKeyList extends LitElement {
     }
   }
 
-  /** @param {SshKeyState} sshKeyState */
+  /** @param {SshKeyState|GithubSshKeyState} sshKeyState */
   _onDeleteKey(sshKeyState) {
     // removing state property that belongs to internal component implementation
     const { type: state, ...sshKey } = sshKeyState;
     dispatchCustomEvent(this, 'delete', sshKey);
   }
 
-  /** @param {SshKeyState} sshKeyState */
+  /** @param {GithubSshKeyState} sshKeyState */
   _onImportKey(sshKeyState) {
     // removing state property that belongs to internal component implementation
     const { type: state, ...sshKey } = sshKeyState;
@@ -274,7 +275,7 @@ export class CcSshKeyList extends LitElement {
 
   /**
    * @param {"personal"|"github"|"skeleton"} type
-   * @param {SshKeyState[]} keys
+   * @param {SshKeyState[]|GithubSshKeyState[]} keys
    * @return {TemplateResult}
    */
   _renderKeyList(type, keys) {
@@ -324,7 +325,7 @@ export class CcSshKeyList extends LitElement {
                   ${type === 'github'
                     ? html`
                         <cc-button
-                          @cc-button:click=${() => this._onImportKey(key)}
+                          @cc-button:click=${() => this._onImportKey(/** @type GithubSshKeyState */ (key))}
                           a11y-name="${i18n('cc-ssh-key-list.github.import.a11y', { name })}"
                           class="key__button key__button--github"
                           .icon="${iconAdd}"

--- a/src/components/cc-ssh-key-list/cc-ssh-key-list.smart.js
+++ b/src/components/cc-ssh-key-list/cc-ssh-key-list.smart.js
@@ -17,6 +17,7 @@ import './cc-ssh-key-list.js';
 /**
  * @typedef {import('./cc-ssh-key-list.js').CcSshKeyList} CcSshKeyList
  * @typedef {import('./cc-ssh-key-list.types.js').SshKey} SshKey
+ * @typedef {import('./cc-ssh-key-list.types.js').GithubSshKey} GithubSshKey
  * @typedef {import('./cc-ssh-key-list.types.js').CreateSshKeyFormState} CreateSshKeyFormState
  * @typedef {import('./cc-ssh-key-list.types.js').SshKeyListStateLoadedAndLinked} SshKeyListStateLoadedAndLinked
  * @typedef {import('./cc-ssh-key-list.types.js').SshKeyListStateLoadedAndUnlinked} SshKeyListStateLoadedAndUnlinked
@@ -158,7 +159,7 @@ defineSmartComponent({
  * @return {Promise<{
  *   isGithubLinked: boolean,
  *   personalKeys: Array<SshKey>,
- *   githubKeys: Array<SshKey>,
+ *   githubKeys: Array<GithubSshKey>,
  * }>}
  */
 async function fetchAllKeys({ apiConfig, signal, cacheDelay }) {

--- a/src/components/cc-ssh-key-list/cc-ssh-key-list.types.d.ts
+++ b/src/components/cc-ssh-key-list/cc-ssh-key-list.types.d.ts
@@ -35,7 +35,7 @@ interface SshKeyListStateLoadedAndLinked {
   type: 'loaded';
   isGithubLinked: true;
   personalKeys: SshKeyState[];
-  githubKeys: SshKeyState[];
+  githubKeys: GithubSshKeyState[];
 }
 
 // when an error has occurred
@@ -52,6 +52,13 @@ export interface SshKey {
   fingerprint: string;
 }
 interface SshKeyState extends SshKey {
-  type: 'idle' | 'deleting' | 'importing';
+  type: 'idle' | 'deleting';
+}
+
+export interface GithubSshKey extends SshKey {
+  key: string;
+}
+interface GithubSshKeyState extends GithubSshKey {
+  type: 'idle' | 'importing';
 }
 //#endregion


### PR DESCRIPTION
Fixes #1336

# What this PR do?

This PR fixes types of github keys and also fixes possible state types for ssh keys:
- github keys have an additionnal `key` property.
- only github keys can be imported
- only personal keys can be deleted