### PR TITLE
chore(prettier): remove Lit property sorting plugin from Prettier config

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,6 @@
 {
   "arrowParens": "always",
-  "plugins": ["prettier-plugin-organize-imports", "./prettier-rules/sort-lit-get-properties.js"],
+  "plugins": ["prettier-plugin-organize-imports"],
   "printWidth": 120,
   "tabWidth": 2,
   "singleQuote": true

--- a/sandbox/cc-logs-app-access/cc-logs-app-access-sandbox.js
+++ b/sandbox/cc-logs-app-access/cc-logs-app-access-sandbox.js
@@ -1,8 +1,8 @@
 import { css, html, LitElement } from 'lit';
 import { createRef, ref } from 'lit/directives/ref.js';
-import '../../src/components/cc-logs-app-access/cc-logs-app-access.smart.js';
 import '../../src/components/cc-button/cc-button.js';
 import '../../src/components/cc-input-text/cc-input-text.js';
+import '../../src/components/cc-logs-app-access/cc-logs-app-access.smart.js';
 import '../../src/components/cc-select/cc-select.js';
 import { formSubmit } from '../../src/lib/form/form-submit-directive.js';
 import { sandboxStyles } from '../sandbox-styles.js';

--- a/src/components/cc-block-detail/cc-block-details.stories.js
+++ b/src/components/cc-block-detail/cc-block-details.stories.js
@@ -1,6 +1,6 @@
 import { makeStory } from '../../stories/lib/make-story.js';
-import './cc-block-details.js';
 import '../cc-block/cc-block.js';
+import './cc-block-details.js';
 
 export default {
   tags: ['autodocs'],

--- a/src/components/cc-grafana-info/cc-grafana-info.smart.js
+++ b/src/components/cc-grafana-info/cc-grafana-info.smart.js
@@ -1,16 +1,15 @@
+import {
+  createGrafanaOrganisation,
+  deleteGrafanaOrganisation,
+  getGrafanaOrganisation,
+  resetGrafanaOrganisation,
+} from '@clevercloud/client/esm/api/v4/saas.js';
 import { notifyError, notifySuccess } from '../../lib/notifications.js';
 import { sendToApi } from '../../lib/send-to-api.js';
 import { defineSmartComponent } from '../../lib/smart/define-smart-component.js';
 import { i18n } from '../../translations/translation.js';
 import '../cc-smart-container/cc-smart-container.js';
 import './cc-grafana-info.js';
-import {
-  createGrafanaOrganisation,
-  deleteGrafanaOrganisation,
-  getGrafanaOrganisation,
-  resetGrafanaOrganisation,
-  // @ts-expect-error FIXME: remove when clever-client exports types
-} from '@clevercloud/client/esm/api/v4/saas.js';
 
 /**
  * @typedef {import('./cc-grafana-info.js').CcGrafanaInfo} CcGrafanaInfo

--- a/src/components/cc-logs-addon-runtime/cc-logs-addon-runtime.js
+++ b/src/components/cc-logs-addon-runtime/cc-logs-addon-runtime.js
@@ -5,6 +5,7 @@ import {
   iconRemixFullscreenExitLine as fullscreenExitIcon,
   iconRemixFullscreenLine as fullscreenIcon,
 } from '../../assets/cc-remix.icons.js';
+import { dispatchCustomEvent } from '../../lib/events.js';
 import { i18n } from '../../translations/translation.js';
 import '../cc-loader/cc-loader.js';
 import '../cc-logs-control/cc-logs-control.js';
@@ -14,7 +15,6 @@ import { buildLogsLoadingProgressState } from '../cc-logs-loading-progress/cc-lo
 import '../cc-logs-loading-progress/cc-logs-loading-progress.js';
 import '../cc-logs-message-filter/cc-logs-message-filter.js';
 import '../cc-notice/cc-notice.js';
-import { dispatchCustomEvent } from '../../lib/events.js';
 
 /**
  * @typedef {import('./cc-logs-addon-runtime.types.js').LogsAddonRuntimeState} LogsAddonRuntimeState

--- a/src/components/cc-logs-app-access/cc-logs-app-access.smart.js
+++ b/src/components/cc-logs-app-access/cc-logs-app-access.smart.js
@@ -2,9 +2,9 @@
 import { ApplicationAccessLogStream } from '@clevercloud/client/esm/streams/access-logs.js';
 import { LogsStream } from '../../lib/logs/logs-stream.js';
 import { defineSmartComponent } from '../../lib/smart/define-smart-component.js';
+import { dateRangeSelectionToDateRange } from '../cc-logs-date-range-selector/date-range-selection.js';
 import '../cc-smart-container/cc-smart-container.js';
 import './cc-logs-app-access.js';
-import { dateRangeSelectionToDateRange } from '../cc-logs-date-range-selector/date-range-selection.js';
 
 /**
  * @typedef {import('./cc-logs-app-access.js').CcLogsAppAccess} CcLogsAppAccess

--- a/src/components/cc-logs-app-runtime/cc-logs-app-runtime.smart.js
+++ b/src/components/cc-logs-app-runtime/cc-logs-app-runtime.smart.js
@@ -2,13 +2,11 @@
 import { getDeployment as getDeploymentV2 } from '@clevercloud/client/esm/api/v2/application.js';
 // @ts-expect-error FIXME: remove when clever-client exports types
 import { ApplicationLogStream } from '@clevercloud/client/esm/streams/application-logs.js';
-import {
-  getAllApplicationInstances as getApplicationInstancesV4,
-  getInstance as getInstanceV4,
-  // @ts-expect-error FIXME: remove when clever-client exports types
-} from '@clevercloud/client/esm/api/v4/instance.js';
 // @ts-expect-error FIXME: remove when clever-client exports types
 import { getApplicationDeployment as getDeploymentV4 } from '@clevercloud/client/esm/api/v4/deployment.js';
+// prettier-ignore
+// @ts-expect-error FIXME: remove when clever-client exports types
+import { getAllApplicationInstances as getApplicationInstancesV4,getInstance as getInstanceV4 } from '@clevercloud/client/esm/api/v4/instance.js';
 import { isLive, lastXDays } from '../../lib/date/date-range-utils.js';
 import { LogsStream } from '../../lib/logs/logs-stream.js';
 import { sendToApi } from '../../lib/send-to-api.js';

--- a/src/components/cc-logs-app-runtime/cc-logs-app-runtime.stories.js
+++ b/src/components/cc-logs-app-runtime/cc-logs-app-runtime.stories.js
@@ -1,7 +1,7 @@
-import { makeStory } from '../../stories/lib/make-story.js';
-import './cc-logs-app-runtime.js';
 import { randomPick } from '../../lib/utils.js';
 import { createDeployment, createInstance } from '../../stories/fixtures/logs-instance.js';
+import { makeStory } from '../../stories/lib/make-story.js';
+import './cc-logs-app-runtime.js';
 
 export default {
   tags: ['autodocs'],

--- a/src/components/cc-logs-date-range-selector/cc-logs-date-range-selector.js
+++ b/src/components/cc-logs-date-range-selector/cc-logs-date-range-selector.js
@@ -9,9 +9,9 @@ import {
   iconRemixArrowLeftSLine as iconShiftLeft,
   iconRemixArrowRightSLine as iconShiftRight,
 } from '../../assets/cc-remix.icons.js';
+import { DateFormatter } from '../../lib/date/date-formatter.js';
 import { isLive, isRightDateRangeAfterNow, shiftDateRange } from '../../lib/date/date-range-utils.js';
 import { dispatchCustomEvent } from '../../lib/events.js';
-import { DateFormatter } from '../../lib/date/date-formatter.js';
 import { formSubmit } from '../../lib/form/form-submit-directive.js';
 import { focusFirstFormControlWithError } from '../../lib/form/form-utils.js';
 import { i18n } from '../../translations/translation.js';

--- a/src/components/cc-logs-instances/cc-logs-instances.stories.js
+++ b/src/components/cc-logs-instances/cc-logs-instances.stories.js
@@ -1,5 +1,5 @@
-import { makeStory, storyWait } from '../../stories/lib/make-story.js';
 import { createDeployment, createGhostInstance, createInstance } from '../../stories/fixtures/logs-instance.js';
+import { makeStory, storyWait } from '../../stories/lib/make-story.js';
 import './cc-logs-instances.js';
 
 /**

--- a/test-mocha/prettier/sort-lit-get-properties.test.js
+++ b/test-mocha/prettier/sort-lit-get-properties.test.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
+import dedent from 'dedent';
 import { describe } from 'mocha';
 import { format } from 'prettier';
-import dedent from 'dedent';
 
 describe('Prettier sort props from "static get properties()"', () => {
   it('should sort properties properly', async () => {


### PR DESCRIPTION
## What does this PR do?

* This PR disables temporarily the plugin that sorts the Lit properties in our components.
* This has been done because Prettier can't handle multiple plugins that modify its AST.
* That's why we decided to remove the Lit properties sort plugin in favor for the import one for now.
* The PR also sorts the unsorted imports due to the plugin not functioning.
* Note: We plan to activate the Lit sort plugin again when we'll find a workaround. 

## How to review?

* Check the code.
* Do a `npm run format:check`, no warnings should come out.
* 2 reviewers should be enough.