### PR TITLE
`cc-token-oauth-list`: init

### DIFF
--- a/src/components/cc-token-oauth-list/cc-token-oauth-list.js
+++ b/src/components/cc-token-oauth-list/cc-token-oauth-list.js
@@ -1,0 +1,367 @@
+import { LitElement, css, html } from 'lit';
+import { classMap } from 'lit/directives/class-map.js';
+import { createRef, ref } from 'lit/directives/ref.js';
+import {
+  iconRemixCalendar_2Fill as iconCreation,
+  iconRemixDeleteBinLine as iconDelete,
+  iconRemixInformationLine as iconExpiration,
+  iconRemixHistoryLine as iconLastUsed,
+} from '../../assets/cc-remix.icons.js';
+import { LostFocusController } from '../../controllers/lost-focus-controller.js';
+import { ResizeController } from '../../controllers/resize-controller.js';
+import { isExpirationClose } from '../../lib/tokens.js';
+import { i18n } from '../../translations/translation.js';
+import '../cc-badge/cc-badge.js';
+import '../cc-block/cc-block.js';
+import '../cc-loader/cc-loader.js';
+import '../cc-notice/cc-notice.js';
+import { CcTokenRevokeEvent, CcTokensRevokeAllEvent } from '../common.events.js';
+
+/**
+ * @typedef {import('./cc-token-oauth-list.types.js').TokenOauthListState} TokenOauthListState
+ * @typedef {import('./cc-token-oauth-list.types.js').OauthTokenState} OauthTokenState
+ * @typedef {import('lit/directives/ref.js').Ref<HTMLDivElement>} RefHTMLDivElement
+ */
+
+/**
+ * A component that displays and manages OAuth tokens.
+ *
+ * This component allows users to view their active OAuth tokens and revoke individual tokens or all tokens at once.
+ * It displays information about each token including consumer name, creation date, last used date, and expiration date.
+ * Tokens are displayed in a list sorted by creation date (newest first).
+ */
+export class CcTokenOauthList extends LitElement {
+  static get properties() {
+    return {
+      state: { type: Object },
+    };
+  }
+
+  constructor() {
+    super();
+
+    /** @type {TokenOauthListState} The state of the component */
+    this.state = { type: 'loading' };
+
+    /** @type {RefHTMLDivElement} */
+    this._emptyMessageRef = createRef();
+
+    new ResizeController(this, {
+      widthBreakpoints: [995, 730],
+    });
+
+    new LostFocusController(
+      this,
+      '.oauth-token-card__action-revoke, .revoke-all-tokens-button',
+      ({ suggestedElement }) => {
+        if (suggestedElement instanceof HTMLElement) {
+          suggestedElement.focus();
+        } else {
+          this._emptyMessageRef.value.focus();
+        }
+      },
+    );
+  }
+
+  _onRevokeAllOauthTokens() {
+    this.dispatchEvent(new CcTokensRevokeAllEvent());
+  }
+
+  /** @param {string} tokenId */
+  _onRevokeToken(tokenId) {
+    this.dispatchEvent(new CcTokenRevokeEvent(tokenId));
+  }
+
+  render() {
+    if (this.state.type === 'error') {
+      return html`<cc-notice intent="warning" message="${i18n('cc-token-oauth-list.error')}"></cc-notice>`;
+    }
+
+    const isEmpty = this.state.type === 'loaded' && this.state.oauthTokens.length === 0;
+    const shouldDisplayRevokeAllButton =
+      this.state.type === 'revoking-all' || (!isEmpty && this.state.type !== 'loading');
+    const sortedOauthTokens =
+      this.state.type === 'loaded' || this.state.type === 'revoking-all'
+        ? [...this.state.oauthTokens].sort(
+            (tokenA, tokenB) => tokenB.creationDate.getTime() - tokenA.creationDate.getTime(),
+          )
+        : [];
+
+    return html`
+      <cc-block>
+        <div slot="header-title">${i18n('cc-token-oauth-list.main-heading')}</div>
+        <div slot="header-right">
+          ${shouldDisplayRevokeAllButton
+            ? html`
+                <cc-button
+                  class="revoke-all-tokens-button"
+                  danger
+                  outlined
+                  ?waiting=${this.state.type === 'revoking-all'}
+                  @cc-click=${this._onRevokeAllOauthTokens}
+                >
+                  ${i18n('cc-token-oauth-list.revoke-all-tokens')}
+                </cc-button>
+              `
+            : ''}
+        </div>
+        <div slot="content">
+          <p>${i18n('cc-token-oauth-list.intro')}</p>
+          <div class="oauth-token-list-wrapper">
+            ${this.state.type === 'loading' ? html`<cc-loader></cc-loader>` : ''}
+            ${isEmpty
+              ? html`<p class="empty" tabindex="-1" ${ref(this._emptyMessageRef)}>
+                  ${i18n('cc-token-oauth-list.empty')}
+                </p>`
+              : ''}
+            ${!isEmpty
+              ? html`
+                  <div class="oauth-token-list-wrapper__list">
+                    ${sortedOauthTokens.map((token) => this._renderTokenCard(token))}
+                  </div>
+                `
+              : ''}
+          </div>
+        </div>
+      </cc-block>
+    `;
+  }
+
+  /**
+   * @param {OauthTokenState} token
+   */
+  _renderTokenCard({ type, id, consumerName, imageUrl, lastUsedDate, creationDate, expirationDate }) {
+    const hasExpirationWarning = isExpirationClose({ creationDate, expirationDate });
+    const isRevoking = type === 'revoking';
+
+    return html`
+      <div class="oauth-token-card ${classMap({ 'is-revoking': isRevoking })}">
+        <div class="oauth-token-card__header">
+          <div class="oauth-token-card__header__logo-name">
+            <cc-img src="${imageUrl}"></cc-img>
+            <span>${consumerName}</span>
+          </div>
+          ${hasExpirationWarning
+            ? html` <cc-badge intent="warning">${i18n('cc-token-oauth-list.card.expires-soon')}</cc-badge> `
+            : ''}
+        </div>
+        <dl class="oauth-token-card__info-list">
+          <div class="oauth-token-card__info-list__item oauth-token-card__info-list__item--italic">
+            <dt>
+              <cc-icon .icon=${iconLastUsed}></cc-icon>
+              <span>${i18n('cc-token-oauth-list.card.label.last-used')}</span>
+            </dt>
+            <dd>${i18n('cc-token-oauth-list.card.human-friendly-date', { date: lastUsedDate })}</dd>
+          </div>
+          <div class="oauth-token-card__info-list__item">
+            <dt>
+              <cc-icon .icon=${iconCreation}></cc-icon>
+              <span>${i18n('cc-token-oauth-list.card.label.creation')}</span>
+            </dt>
+            <dd>${i18n('cc-token-oauth-list.card.human-friendly-date', { date: creationDate })}</dd>
+          </div>
+          <div class="oauth-token-card__info-list__item oauth-token-card__info-list__item--bold">
+            <dt>
+              <cc-icon .icon=${iconExpiration}></cc-icon>
+              <span>${i18n('cc-token-oauth-list.card.label.expiration')}</span>
+            </dt>
+            <dd>
+              <span>${i18n('cc-token-oauth-list.card.human-friendly-date', { date: expirationDate })}</span>
+            </dd>
+          </div>
+        </dl>
+        <cc-button
+          class="oauth-token-card__action-revoke"
+          danger
+          outlined
+          hide-text
+          .icon=${iconDelete}
+          circle
+          ?waiting=${type === 'revoking'}
+          @cc-click=${() => this._onRevokeToken(id)}
+        >
+          ${i18n('cc-token-oauth-list.revoke-token', { consumerName })}
+        </cc-button>
+      </div>
+    `;
+  }
+
+  static get styles() {
+    return css`
+      :host {
+        display: block;
+      }
+
+      /* Reset default margins and paddings */
+      dl,
+      dd,
+      dt {
+        margin: 0;
+        padding: 0;
+      }
+
+      p {
+        margin: 0;
+      }
+
+      .is-revoking > :not(cc-button) {
+        opacity: var(--cc-opacity-when-disabled, 0.65);
+      }
+
+      .empty {
+        border: 1px solid var(--cc-color-border-neutral-weak);
+        font-weight: bold;
+        padding: 1em;
+        text-align: center;
+      }
+
+      /* When all sessions are revoked, focus goes to the empty message container */
+      .empty:focus-visible {
+        outline: var(--cc-focus-outline);
+        outline-offset: var(--cc-focus-outline-offset, 2px);
+      }
+
+      .oauth-token-list-wrapper {
+        margin-top: 2.5em;
+      }
+
+      .oauth-token-list-wrapper__list {
+        display: grid;
+        gap: 1.5em;
+      }
+
+      @supports (grid-template-columns: subgrid) {
+        .oauth-token-list-wrapper__list {
+          grid-template-columns: [card-start info-start] max-content max-content 1fr [info-end actions-start] auto [actions-end card-end];
+        }
+
+        :host([w-lt-995]) .oauth-token-list-wrapper__list {
+          grid-template-columns: [card-start info-start] 1fr 1fr 1fr [info-end actions-start] auto [actions-end card-end];
+        }
+      }
+
+      .oauth-token-card {
+        align-items: center;
+        border: solid 1px var(--cc-color-border-neutral-weak, #e6e6e6);
+        border-radius: var(--cc-border-radius-default, 0.25em);
+        display: grid;
+        grid-template-columns: [card-start info-start] 1fr [info-end actions-start] auto [actions-end card-end];
+        padding: 1em;
+      }
+
+      :host([w-lt-730]) .oauth-token-card {
+        grid-template-columns: [card-start info-start] 1fr [info-end actions-start] max-content [actions-end card-end];
+      }
+
+      @supports (grid-template-columns: subgrid) {
+        .oauth-token-card {
+          display: grid;
+          grid-column: card-start / card-end;
+          grid-template-columns: subgrid;
+        }
+
+        :host([w-lt-730]) .oauth-token-card {
+          grid-template-columns: [card-start info-start] 1fr [info-end actions-start] auto [actions-end card-end];
+        }
+      }
+
+      .oauth-token-card__header {
+        --cc-icon-size: 1.2em;
+
+        align-items: center;
+        column-gap: 1em;
+        display: flex;
+        flex-wrap: wrap;
+        grid-column: info-start / info-end;
+        margin-bottom: 1em;
+        row-gap: 0.5em;
+      }
+
+      .oauth-token-card__header__logo-name {
+        align-items: center;
+        display: flex;
+        font-weight: bold;
+        gap: 0.5em;
+      }
+
+      .oauth-token-card__header__logo-name cc-img {
+        border-radius: var(--cc-border-radius-default, 0.25em);
+        height: 2em;
+        width: 2em;
+      }
+
+      .oauth-token-card__info-list {
+        display: flex;
+        gap: 1em;
+        grid-column: info-start / info-end;
+      }
+
+      :host([w-lt-730]) .oauth-token-card__info-list {
+        display: grid;
+        row-gap: 0.5em;
+      }
+
+      @supports (grid-template-columns: subgrid) {
+        .oauth-token-card__info-list {
+          display: grid;
+          grid-column: info-start / info-end;
+          grid-template-columns: subgrid;
+        }
+
+        :host([w-lt-730]) .oauth-token-card__info-list {
+          row-gap: 0.5em;
+        }
+      }
+
+      .oauth-token-card__info-list__item {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5em;
+      }
+
+      :host([w-lt-995]) .oauth-token-card__info-list__item {
+        display: grid;
+      }
+
+      @supports (grid-template-columns: subgrid) {
+        :host([w-lt-730]) .oauth-token-card__info-list__item {
+          display: flex;
+        }
+      }
+
+      .oauth-token-card__info-list__item--italic {
+        font-style: italic;
+      }
+
+      .oauth-token-card__info-list__item--bold {
+        font-weight: bold;
+      }
+
+      dt {
+        --line-height: 1.2em;
+        --cc-icon-size: var(--line-height);
+
+        align-items: center;
+        display: flex;
+        gap: 0.5em;
+        line-height: var(--line-height);
+      }
+
+      dd {
+        align-items: center;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5em;
+      }
+
+      .oauth-token-card cc-button {
+        align-self: start;
+        grid-column: actions-start / actions-end;
+        grid-row: 1 / -1;
+        justify-self: end;
+      }
+    `;
+  }
+}
+
+window.customElements.define('cc-token-oauth-list', CcTokenOauthList);

--- a/src/components/cc-token-oauth-list/cc-token-oauth-list.smart.js
+++ b/src/components/cc-token-oauth-list/cc-token-oauth-list.smart.js
@@ -1,0 +1,221 @@
+// prettier-ignore
+// @ts-expect-error FIXME: remove when clever-client exports types
+import { todo_listSelfTokens as getAllTokens,todo_revokeSelfToken as revokeToken } from '@clevercloud/client/esm/api/v2/user.js';
+import { notifyError, notifySuccess } from '../../lib/notifications.js';
+import { sendToApi } from '../../lib/send-to-api.js';
+import { defineSmartComponent } from '../../lib/smart/define-smart-component.js';
+import { i18n } from '../../translations/translation.js';
+import '../cc-smart-container/cc-smart-container.js';
+import './cc-token-oauth-list.js';
+
+/**
+ * @typedef {import('./cc-token-oauth-list.js').CcTokenOauthList} CcTokenOauthList
+ * @typedef {import('./cc-token-oauth-list.types.js').OauthTokenState} OauthTokenState
+ * @typedef {import('./cc-token-oauth-list.types.js').TokenOauthListStateLoaded} TokenOauthListStateLoaded
+ * @typedef {import('./cc-token-oauth-list.types.js').TokenOauthListStateRevokingAll} TokenOauthListStateRevokingAll
+ * @typedef {import('./cc-token-oauth-list.types.js').OauthToken} OauthToken
+ * @typedef {import('../cc-token-session-list/cc-token-session-list.types.js').RawTokenData} RawTokenData
+ * @typedef {import('../../lib/send-to-api.types.js').ApiConfig} ApiConfig
+ * @typedef {import('../../lib/smart/smart-component.types.js').OnContextUpdateArgs<CcTokenOauthList>} OnContextUpdateArgs
+ */
+
+defineSmartComponent({
+  selector: 'cc-token-oauth-list',
+  params: {
+    apiConfig: { type: Object },
+    authBridgeConsumerKey: { type: String },
+  },
+  /** @param {OnContextUpdateArgs} args */
+  onContextUpdate({ component, context, onEvent, updateComponent }) {
+    const { apiConfig, authBridgeConsumerKey } = context;
+    const api = new Api(apiConfig, authBridgeConsumerKey);
+
+    /**
+     * Updates a single OAuth token
+     *
+     * @param {string} tokenId The ID of the token to update
+     * @param {function(OauthTokenState): void} callback A callback function to execute with the updated token
+     */
+    function updateOneToken(tokenId, callback) {
+      updateComponent(
+        'state',
+        /** @param {TokenOauthListStateLoaded} state */
+        (state) => {
+          const oauthTokenToUpdate = state.oauthTokens.find((token) => token.id === tokenId);
+
+          if (oauthTokenToUpdate != null) {
+            callback(oauthTokenToUpdate);
+          }
+        },
+      );
+    }
+
+    updateComponent('state', { type: 'loading' });
+
+    api
+      .getOauthTokens()
+      .then((tokens) => {
+        const oauthTokens = tokens.map(
+          /** @return {OauthTokenState} */
+          (token) => ({
+            type: 'idle',
+            ...token,
+          }),
+        );
+        updateComponent('state', { type: 'loaded', oauthTokens });
+      })
+      .catch(() => {
+        updateComponent('state', { type: 'error' });
+      });
+
+    onEvent(
+      'cc-token-revoke',
+      /** @param {string} tokenId */
+      (tokenId) => {
+        updateOneToken(tokenId, (oauthTokenState) => {
+          oauthTokenState.type = 'revoking';
+        });
+
+        api
+          .revokeOauthToken(tokenId)
+          .then(() => {
+            updateComponent(
+              'state',
+              /** @param {TokenOauthListStateLoaded} state */
+              (state) => {
+                state.oauthTokens = state.oauthTokens.filter((token) => token.id !== tokenId);
+              },
+            );
+            notifySuccess(i18n('cc-token-oauth-list.revoke-token.success'));
+          })
+          .catch((error) => {
+            console.error(error);
+            updateOneToken(tokenId, (oauthTokenState) => {
+              oauthTokenState.type = 'idle';
+            });
+            notifyError(i18n('cc-token-oauth-list.revoke-token.error'));
+          });
+      },
+    );
+
+    onEvent('cc-tokens-revoke-all', () => {
+      updateComponent(
+        'state',
+        /** @param {TokenOauthListStateLoaded} state */
+        (state) =>
+          /** @type {TokenOauthListStateRevokingAll} */ ({
+            ...state,
+            type: 'revoking-all',
+            oauthTokens: state.oauthTokens.map((token) => ({ ...token, type: 'revoking' })),
+          }),
+      );
+
+      const tokens = /** @type {TokenOauthListStateLoaded} */ (component.state).oauthTokens;
+
+      api.revokeAllOauthTokens(tokens).then(({ remainingTokens, errors, revokedTokens }) => {
+        updateComponent('state', (state) => {
+          state.type = 'loaded';
+
+          /** @type {TokenOauthListStateLoaded} */
+          (state).oauthTokens = remainingTokens.map((token) => ({
+            ...token,
+            type: 'idle',
+          }));
+
+          return state;
+        });
+
+        if (errors.length === 0) {
+          notifySuccess(i18n('cc-token-oauth-list.revoke-all-tokens.success'));
+        } else if (revokedTokens.length > 0) {
+          notifyError(i18n('cc-token-oauth-list.revoke-all-tokens.partial-error'));
+        } else {
+          notifyError(i18n('cc-token-oauth-list.revoke-all-tokens.error'));
+        }
+      });
+    });
+  },
+});
+
+class Api {
+  /**
+   * @param {ApiConfig} apiConfig
+   * @param {string} authBridgeConsumerKey
+   */
+  constructor(apiConfig, authBridgeConsumerKey) {
+    this._apiConfig = apiConfig;
+    this._authBridgeConsumerKey = authBridgeConsumerKey;
+  }
+
+  /**
+   * Fetches and formats OAuth tokens
+   *
+   * @returns {Promise<OauthToken[]>} A promise that resolves to an array of formatted OAuth tokens
+   */
+  getOauthTokens() {
+    return getAllTokens()
+      .then(sendToApi({ apiConfig: this._apiConfig }))
+      .then(
+        /** @param {Array<RawTokenData>} tokens */
+        (tokens) => {
+          return tokens
+            .filter(
+              (token) =>
+                token.consumer.key !== this._apiConfig.OAUTH_CONSUMER_KEY &&
+                token.employeeId == null &&
+                token.consumer.key !== this._authBridgeConsumerKey,
+            )
+            .map(
+              /** @return {OauthToken} */
+              (token) => ({
+                id: token.token,
+                consumerName: token.consumer.name,
+                creationDate: new Date(token.creationDate),
+                expirationDate: new Date(token.expirationDate),
+                lastUsedDate: new Date(token.lastUtilisation),
+                imageUrl: token.consumer.picture,
+              }),
+            );
+        },
+      );
+  }
+
+  /**
+   * Revokes an OAuth token
+   *
+   * @param {string} tokenId - The ID of the token to revoke
+   * @returns {Promise<void>} A promise that resolves when the token is revoked
+   */
+  revokeOauthToken(tokenId) {
+    return revokeToken({ token: tokenId }).then(sendToApi({ apiConfig: this._apiConfig }));
+  }
+
+  /**
+   * Revokes all OAuth tokens
+   *
+   * @param {OauthTokenState[]} allTokens - An array of all OAuth tokens
+   * @returns {Promise<{ remainingTokens: OauthTokenState[], revokedTokens: string[], errors: any[] }>} A promise that resolves when all tokens are revoked
+   */
+  revokeAllOauthTokens(allTokens) {
+    let errors = [];
+    /** @type {string[]} */
+    let revokedTokens = [];
+
+    return Promise.allSettled(allTokens.map((token) => this.revokeOauthToken(token.id).then(() => token.id))).then(
+      /** @param {PromiseSettledResult<string>[]} results */
+      (results) => {
+        revokedTokens = results
+          .filter(
+            /** @returns {result is PromiseFulfilledResult<string>} */
+            (result) => result.status === 'fulfilled',
+          )
+          .map(({ value }) => value);
+        errors = results.filter((result) => result.status === 'rejected');
+
+        const remainingTokens = allTokens.filter((token) => !revokedTokens.includes(token.id));
+
+        return { remainingTokens, revokedTokens, errors };
+      },
+    );
+  }
+}

--- a/src/components/cc-token-oauth-list/cc-token-oauth-list.smart.md
+++ b/src/components/cc-token-oauth-list/cc-token-oauth-list.smart.md
@@ -1,0 +1,52 @@
+---
+kind: '🛠 Profile/<cc-token-oauth-list>'
+title: '💡 Smart'
+---
+
+# 💡 Smart `<cc-token-oauth-list>`
+
+## ℹ️ Details
+
+<table>
+  <tr><td><strong>Component    </strong> <td><a href="https://www.clever-cloud.com/doc/clever-components/?path=/docs/🛠-profile-cc-token-oauth-list--default-story"><code>&lt;cc-token-oauth-list&gt;</code></a>
+  <tr><td><strong>Selector     </strong> <td><code>cc-token-oauth-list</code>
+  <tr><td><strong>Requires auth</strong> <td>Yes
+</table>
+
+## ⚙️ Params
+
+| Name                    | Type        | Details                                                 | Default |
+|-------------------------|-------------|---------------------------------------------------------|---------|
+| `apiConfig`             | `ApiConfig` | Object with API configuration (target host, tokens...)  |         |
+| `authBridgeConsumerKey` | `string`    | The consumer key of the Auth Bridge                     |         |
+
+```ts
+interface ApiConfig {
+  API_HOST: string,
+  API_OAUTH_TOKEN: string,
+  API_OAUTH_TOKEN_SECRET: string,
+  OAUTH_CONSUMER_KEY: string,
+  OAUTH_CONSUMER_SECRET: string,
+}
+```
+
+## 🌐 API endpoints
+
+| Method   | Type                    | Cache?  |
+|----------|:------------------------|---------|
+| `GET`    | `/v2/self/tokens`       | Default |
+| `POST`   | `/v2/self/tokens/revoke`| Default |
+
+```html
+<cc-smart-container context='{
+    "apiConfig": {
+      API_HOST: "",
+      API_OAUTH_TOKEN: "",
+      API_OAUTH_TOKEN_SECRET: "",
+      OAUTH_CONSUMER_KEY: "",
+      OAUTH_CONSUMER_SECRET: "",
+    }
+}'>
+    <cc-token-oauth-list></cc-token-oauth-list>
+<cc-smart-container>
+```

--- a/src/components/cc-token-oauth-list/cc-token-oauth-list.stories.js
+++ b/src/components/cc-token-oauth-list/cc-token-oauth-list.stories.js
@@ -1,0 +1,250 @@
+import { shiftDateField } from '../../lib/date/date-utils.js';
+import { makeStory, storyWait } from '../../stories/lib/make-story.js';
+import './cc-token-oauth-list.js';
+
+export default {
+  tags: ['autodocs'],
+  title: '🛠 Profile/<cc-token-oauth-list>',
+  component: 'cc-token-oauth-list',
+};
+
+/**
+ * @typedef {import('./cc-token-oauth-list.js').CcTokenOauthList} CcTokenOauthList
+ * @typedef {import('./cc-token-oauth-list.types.js').OauthTokenState} OauthTokenState
+ */
+
+const conf = {
+  component: 'cc-token-oauth-list',
+};
+
+const NOW = new Date();
+
+/** @type {Array<OauthTokenState>} */
+const baseTokens = [
+  {
+    type: 'idle',
+    id: 'token-1',
+    consumerName: 'clever-tools',
+    creationDate: shiftDateField(NOW, 'D', -180),
+    expirationDate: shiftDateField(NOW, 'D', 32), // does not expire soon (32 days)
+    lastUsedDate: shiftDateField(NOW, 'D', -30),
+    imageUrl: 'https://assets.clever-cloud.com/logos/clever-tools.svg',
+  },
+  {
+    type: 'idle',
+    id: 'token-2',
+    consumerName: 'Matomo',
+    creationDate: shiftDateField(NOW, 'D', -90),
+    expirationDate: shiftDateField(NOW, 'D', 45), // does not expire soon (45 days)
+    lastUsedDate: shiftDateField(NOW, 'D', -7),
+    imageUrl: 'https://assets.clever-cloud.com/logos/matomo.svg',
+  },
+  {
+    type: 'idle',
+    id: 'token-3',
+    consumerName: 'Grafana',
+    creationDate: shiftDateField(NOW, 'D', -240),
+    expirationDate: shiftDateField(NOW, 'D', 6), // expires soon (6 days)
+    lastUsedDate: shiftDateField(NOW, 'D', -10),
+    imageUrl: 'https://assets.clever-cloud.com/logos/grafana.svg',
+  },
+  {
+    type: 'idle',
+    id: 'token-4',
+    consumerName: 'clever-tools',
+    creationDate: shiftDateField(NOW, 'D', -30),
+    expirationDate: shiftDateField(NOW, 'D', 2), // expires soon (2 days)
+    lastUsedDate: shiftDateField(NOW, 'D', -2),
+    imageUrl: 'https://assets.clever-cloud.com/logos/clever-tools.svg',
+  },
+];
+
+export const defaultStory = makeStory(conf, {
+  /** @type {Partial<CcTokenOauthList>[]} */
+  items: [
+    {
+      state: {
+        type: 'loaded',
+        oauthTokens: baseTokens,
+      },
+    },
+  ],
+});
+
+export const loading = makeStory(conf, {
+  /** @type {Partial<CcTokenOauthList>[]} */
+  items: [
+    {
+      state: { type: 'loading' },
+    },
+  ],
+});
+
+export const error = makeStory(conf, {
+  /** @type {Partial<CcTokenOauthList>[]} */
+  items: [
+    {
+      state: { type: 'error' },
+    },
+  ],
+});
+
+export const empty = makeStory(conf, {
+  /** @type {Partial<CcTokenOauthList>[]} */
+  items: [
+    {
+      state: {
+        type: 'loaded',
+        oauthTokens: [],
+      },
+    },
+  ],
+});
+
+export const waitingWithRevokingOneToken = makeStory(conf, {
+  /** @type {Partial<CcTokenOauthList>[]} */
+  items: [
+    {
+      state: {
+        type: 'loaded',
+        oauthTokens: baseTokens.map((token, index) => {
+          if (index === 2) {
+            return {
+              ...token,
+              type: 'revoking',
+            };
+          }
+
+          return token;
+        }),
+      },
+    },
+  ],
+});
+
+export const waitingWithRevokingAllTokens = makeStory(conf, {
+  /** @type {Partial<CcTokenOauthList>[]} */
+  items: [
+    {
+      state: {
+        type: 'revoking-all',
+        oauthTokens: baseTokens.map((token) => ({
+          ...token,
+          type: 'revoking',
+        })),
+      },
+    },
+  ],
+});
+
+export const simulationsWithLoadingSuccess = makeStory(conf, {
+  /** @type {Partial<CcTokenOauthList>[]} */
+  items: [{ state: { type: 'loading' } }],
+  simulations: [
+    storyWait(
+      2000,
+      /** @param {CcTokenOauthList[]} components */
+      ([component]) => {
+        component.state = {
+          type: 'loaded',
+          oauthTokens: baseTokens,
+        };
+      },
+    ),
+  ],
+});
+
+export const simulationsWithLoadingError = makeStory(conf, {
+  /** @type {Partial<CcTokenOauthList>[]} */
+  items: [{ state: { type: 'loading' } }],
+  simulations: [
+    storyWait(
+      2000,
+      /** @param {CcTokenOauthList[]} components */
+      ([component]) => {
+        component.state = {
+          type: 'error',
+        };
+      },
+    ),
+  ],
+});
+
+export const simulationsWithRevokingToken = makeStory(conf, {
+  /** @type {Partial<CcTokenOauthList>[]} */
+  items: [
+    {
+      state: {
+        type: 'loaded',
+        oauthTokens: baseTokens,
+      },
+    },
+  ],
+  simulations: [
+    storyWait(
+      1000,
+      /** @param {CcTokenOauthList[]} components */
+      ([component]) => {
+        component.state = {
+          type: 'loaded',
+          oauthTokens: baseTokens.map((token, index) => {
+            if (index === 1) {
+              return {
+                ...token,
+                type: 'revoking',
+              };
+            }
+            return token;
+          }),
+        };
+      },
+    ),
+    storyWait(
+      3000,
+      /** @param {CcTokenOauthList[]} components */
+      ([component]) => {
+        component.state = {
+          type: 'loaded',
+          oauthTokens: baseTokens.filter((_, index) => index !== 1),
+        };
+      },
+    ),
+  ],
+});
+
+export const simulationsWithRevokingAllTokens = makeStory(conf, {
+  /** @type {Partial<CcTokenOauthList>[]} */
+  items: [
+    {
+      state: {
+        type: 'loaded',
+        oauthTokens: baseTokens,
+      },
+    },
+  ],
+  simulations: [
+    storyWait(
+      1000,
+      /** @param {CcTokenOauthList[]} components */
+      ([component]) => {
+        component.state = {
+          type: 'revoking-all',
+          oauthTokens: baseTokens.map((token) => ({
+            ...token,
+            type: 'revoking',
+          })),
+        };
+      },
+    ),
+    storyWait(
+      3000,
+      /** @param {CcTokenOauthList[]} components */
+      ([component]) => {
+        component.state = {
+          type: 'loaded',
+          oauthTokens: [],
+        };
+      },
+    ),
+  ],
+});

--- a/src/components/cc-token-oauth-list/cc-token-oauth-list.types.d.ts
+++ b/src/components/cc-token-oauth-list/cc-token-oauth-list.types.d.ts
@@ -1,0 +1,42 @@
+export type TokenOauthListState =
+  | TokenOauthListStateLoaded
+  | TokenOauthListStateLoading
+  | TokenOauthListStateError
+  | TokenOauthListStateRevokingAll;
+
+export interface TokenOauthListStateLoaded {
+  type: 'loaded';
+  oauthTokens: Array<OauthTokenState>;
+}
+
+export interface TokenOauthListStateRevokingAll {
+  type: 'revoking-all';
+  oauthTokens: Array<OauthTokenStateRevoking>;
+}
+
+export interface TokenOauthListStateLoading {
+  type: 'loading';
+}
+
+export interface TokenOauthListStateError {
+  type: 'error';
+}
+
+export type OauthTokenState = OauthTokenStateIdle | OauthTokenStateRevoking;
+
+export interface OauthTokenStateIdle extends OauthToken {
+  type: 'idle';
+}
+
+export interface OauthTokenStateRevoking extends OauthToken {
+  type: 'revoking';
+}
+
+export interface OauthToken {
+  id: string;
+  consumerName: string;
+  creationDate: Date;
+  expirationDate: Date;
+  lastUsedDate: Date;
+  imageUrl: string;
+}

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -1509,6 +1509,28 @@ export const translations = {
   'cc-token-api-list.revoke-token.error': `Something went wrong while revoking the API token`,
   'cc-token-api-list.revoke-token.success': `The API token has been revoked successfully`,
   //#endregion
+  //#region cc-token-oauth-list
+  'cc-token-oauth-list.card.expires-soon': `Expires soon`,
+  'cc-token-oauth-list.card.human-friendly-date': /** @param {{ date: Date }} _ */ ({ date }) => formatDatetime(date),
+  'cc-token-oauth-list.card.label.creation': `Creation: `,
+  'cc-token-oauth-list.card.label.expiration': `Expiration: `,
+  'cc-token-oauth-list.card.label.last-used': `Last used: `,
+  'cc-token-oauth-list.empty': `You do not have any third-party applications linked to your account`,
+  'cc-token-oauth-list.error': `Something went wrong while loading OAuth tokens`,
+  'cc-token-oauth-list.intro': () =>
+    sanitize`Below is the list of third-party applications linked to your account and their associated information. You may revoke these <a href="https://www.clever-cloud.com/developers/api/howto/#oauth1" title="OAuth tokens - Documentation - new window">OAuth tokens</a> as needed.`,
+  'cc-token-oauth-list.main-heading': `OAuth tokens`,
+  'cc-token-oauth-list.revoke-all-tokens': `Revoke all OAuth tokens`,
+  'cc-token-oauth-list.revoke-all-tokens.error': () =>
+    sanitize`Something went wrong while revoking all OAuth tokens.<br>None of your OAuth tokens have been revoked`,
+  'cc-token-oauth-list.revoke-all-tokens.partial-error': () =>
+    sanitize`Something went wrong while revoking all OAuth tokens.<br>Only some OAuth tokens have been revoked successfully`,
+  'cc-token-oauth-list.revoke-all-tokens.success': `All OAuth tokens have been revoked successfully`,
+  'cc-token-oauth-list.revoke-token': /** @param {{ consumerName: string}} _ */ ({ consumerName }) =>
+    `Revoke OAuth token for ${consumerName}`,
+  'cc-token-oauth-list.revoke-token.error': `Something went wrong while revoking the OAuth token`,
+  'cc-token-oauth-list.revoke-token.success': `The OAuth token has been revoked successfully`,
+  //#endregion
   //#region cc-token-session-list
   'cc-token-session-list.card.clever-team': `Clever Cloud Team`,
   'cc-token-session-list.card.current-session': `Current session`,

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -1535,6 +1535,29 @@ export const translations = {
   'cc-token-api-list.revoke-token.error': `Une erreur est survenue pendant la révocation du token d'API`,
   'cc-token-api-list.revoke-token.success': `Le token d'API a été révoqué avec succès`,
   //#endregion
+  //#region cc-token-oauth-list
+  'cc-token-oauth-list.card.expires-soon': `Expire bientôt`,
+  'cc-token-oauth-list.card.human-friendly-date': /** @param {{ date: string|number }} _ */ ({ date }) =>
+    formatDatetime(date),
+  'cc-token-oauth-list.card.label.creation': () => sanitize`Création&nbsp;: `,
+  'cc-token-oauth-list.card.label.expiration': () => sanitize`Expiration&nbsp;: `,
+  'cc-token-oauth-list.card.label.last-used': () => sanitize`Dernière utilisation&nbsp;: `,
+  'cc-token-oauth-list.empty': `Aucune application tierce n'est liée à votre compte`,
+  'cc-token-oauth-list.error': `Une erreur est survenue pendant le chargement des tokens OAuth`,
+  'cc-token-oauth-list.intro': () =>
+    sanitize`Ci-dessous la liste des applications tierces liées à votre compte et leurs informations. Vous pouvez révoquer leurs <a href="https://www.clever-cloud.com/developers/api/howto/#oauth1" title="tokens OAuth - Documentation - nouvelle fenêtre">tokens OAuth</a> si vous le souhaitez.`,
+  'cc-token-oauth-list.main-heading': `Tokens OAuth`,
+  'cc-token-oauth-list.revoke-all-tokens': `Révoquer tous les tokens OAuth`,
+  'cc-token-oauth-list.revoke-all-tokens.error': () =>
+    sanitize`Une erreur est survenue pendant la révocation des tokens OAuth.<br>Aucun token OAuth n'a été révoqué`,
+  'cc-token-oauth-list.revoke-all-tokens.partial-error': () =>
+    sanitize`Une erreur est survenue pendant la révocation des tokens OAuth.<br>Seuls certains tokens OAuth ont été révoqués avec succès`,
+  'cc-token-oauth-list.revoke-all-tokens.success': `Tous les tokens OAuth ont été révoqués avec succès`,
+  'cc-token-oauth-list.revoke-token': /** @param {{ consumerName: string}} _ */ ({ consumerName }) =>
+    `Révoquer le token OAuth pour ${consumerName}`,
+  'cc-token-oauth-list.revoke-token.error': `Une erreur est survenue pendant la révocation du token OAuth`,
+  'cc-token-oauth-list.revoke-token.success': `Le token OAuth a été révoqué avec succès`,
+  //#endregion
   //#region cc-token-session-list
   'cc-token-session-list.card.clever-team': `Équipe Clever Cloud`,
   'cc-token-session-list.card.current-session': `Session actuelle`,


### PR DESCRIPTION
Fixes #1369 

## What does this PR do?

- Adds a `cc-token-oauth-list` component


## How to review?

> [!IMPORTANT]
>  - The component doesn't handle expired tokens because the API is only supposed to provide alive OAuth tokens,
>  - There is no sandbox / demo-smart because only almighty consumers may list tokens.
>  - You can probably skip the CSS code review since it's almost exactly the same as the session token component (I'll try to refactor all of this in a flexible `cc-token-card` component afterwards).

- check all the stories within the [preview](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-session-tokens/init/index.html?path=/story/%F0%9F%9B%A0-profile-cc-token-oauth-list--default-story),
- proceed with the QA in the usual google drive :wink: 
 