### PR TITLE
feat(cc-logs-*): set a longer timeout when waiting first log in cold mode

### DIFF
--- a/test/logs/logs-stream.test.js
+++ b/test/logs/logs-stream.test.js
@@ -13,7 +13,7 @@ class FakeLogsStream extends LogsStream {
    * @param {number} [waitingTimeout]
    */
   constructor(waitingTimeout) {
-    super(100, { waitingTimeout });
+    super(100, { waitingTimeout: { live: waitingTimeout, cold: waitingTimeout } });
     this._spies = {
       createStream: hanbi.spy(),
       updateStreamState: hanbi.spy(),


### PR DESCRIPTION
# What this PR do?

When connecting to a log stream, we create a timer that waits for the first log to come. When the first log comes before the timeout, everything is fine. If the timeout elapses with no log, we do the following:
- in live mode, we display a waiting message and let the stream open.
- in cold mode, we consider that there is no log in the selected time range and we stop the SSE.

The actual timeout is set to 2 seconds.

In fact, when using cold mode, it can happen that the first log comes way after those two seconds.
So we need to wait a bit more time in cold mode before considering that there are no logs in the selected time range.

* This PR allows to use a different timeout when in cold or live mode.
* It keeps the 2 seconds timeout for live mode
* It uses an 8 seconds timeout for cold mode

# How to review

* Check the code
* Use my logs test app and, within the sandbox, play with the date range. Sometime it takes more than 2 seconds to see the first log.