### PR TITLE
Feat/cc block detail integration

### DIFF
--- a/src/components/cc-addon-backups/cc-addon-backups.js
+++ b/src/components/cc-addon-backups/cc-addon-backups.js
@@ -2,9 +2,11 @@ import { css, html, LitElement } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { iconRemixHistoryLine as iconBackup, iconRemixCloseLine as iconClose } from '../../assets/cc-remix.icons.js';
 import { fakeString } from '../../lib/fake-strings.js';
+import { cliCommandsStyles } from '../../styles/cli-commands.js';
 import { skeletonStyles } from '../../styles/skeleton.js';
 import { ccLink, linkStyles } from '../../templates/cc-link/cc-link.js';
 import { i18n } from '../../translations/translation.js';
+import '../cc-block-details/cc-block-details.js';
 import '../cc-block-section/cc-block-section.js';
 import '../cc-block/cc-block.js';
 import '../cc-button/cc-button.js';
@@ -49,6 +51,7 @@ const SKELETON_BACKUPS = {
 export class CcAddonBackups extends LitElement {
   static get properties() {
     return {
+      addonId: { type: String, attribute: 'addon-id' },
       state: { type: Object },
       _overlayType: { type: String, state: true },
       _selectedBackup: { type: Object, state: true },
@@ -57,6 +60,9 @@ export class CcAddonBackups extends LitElement {
 
   constructor() {
     super();
+
+    /** @type {string} Sets the addon id for documentation */
+    this.addonId = 'xxx_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
 
     /** @type {AddonBackupsState} Sets the state of the component. */
     this.state = {
@@ -265,6 +271,10 @@ export class CcAddonBackups extends LitElement {
           : ''}
         ${this.state.type === 'loading' ? this._renderLoading(this.state) : ''}
         ${this.state.type === 'loaded' ? this._renderLoaded(this.state) : ''}
+        <cc-block-details slot="footer-left">
+          <div slot="button-text">${i18n('cc-block-details.cli.text')}</div>
+          <div slot="content">${i18n('cc-addon-backups.cli.content', { addonId: this.addonId })}</div>
+        </cc-block-details>
       </cc-block>
     `;
   }
@@ -447,6 +457,7 @@ export class CcAddonBackups extends LitElement {
     return [
       skeletonStyles,
       linkStyles,
+      cliCommandsStyles,
       // language=CSS
       css`
         :host {

--- a/src/components/cc-addon-backups/cc-addon-backups.stories.js
+++ b/src/components/cc-addon-backups/cc-addon-backups.stories.js
@@ -30,6 +30,7 @@ const conf = {
 export const defaultStory = makeStory(conf, {
   items: [
     {
+      addonId: 'addon_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {AddonBackupsStateLoaded} */
       state: backupsNewElasticsearchState,
     },
@@ -39,6 +40,7 @@ export const defaultStory = makeStory(conf, {
 export const loading = makeStory(conf, {
   items: [
     {
+      addonId: 'addon_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {AddonBackupsStateLoading} */
       state: { type: 'loading' },
     },
@@ -48,6 +50,7 @@ export const loading = makeStory(conf, {
 export const error = makeStory(conf, {
   items: [
     {
+      addonId: 'addon_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {AddonBackupsStateError} */
       state: { type: 'error' },
     },
@@ -57,6 +60,7 @@ export const error = makeStory(conf, {
 export const empty = makeStory(conf, {
   items: [
     {
+      addonId: 'addon_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {AddonBackupsStateLoaded} */
       state: {
         ...backupsNewElasticsearchState,
@@ -69,6 +73,7 @@ export const empty = makeStory(conf, {
 export const dataLoadedWithNewElasticsearch = makeStory(conf, {
   items: [
     {
+      addonId: 'addon_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {AddonBackupsStateLoaded} */
       state: backupsNewElasticsearchState,
     },
@@ -78,6 +83,7 @@ export const dataLoadedWithNewElasticsearch = makeStory(conf, {
 export const dataLoadedWithNewElasticsearchAndSmallbackups = makeStory(conf, {
   items: [
     {
+      addonId: 'addon_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {AddonBackupsStateLoaded} */
       state: {
         ...backupsNewElasticsearchState,
@@ -90,6 +96,7 @@ export const dataLoadedWithNewElasticsearchAndSmallbackups = makeStory(conf, {
 export const dataLoadedWithOldElasticsearch = makeStory(conf, {
   items: [
     {
+      addonId: 'addon_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {AddonBackupsStateLoaded} */
       state: backupsOldElasticsearchState,
     },
@@ -99,6 +106,7 @@ export const dataLoadedWithOldElasticsearch = makeStory(conf, {
 export const dataLoadedWithOldElasticsearchAndBigbackups = makeStory(conf, {
   items: [
     {
+      addonId: 'addon_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {AddonBackupsStateLoaded} */
       state: {
         ...backupsOldElasticsearchState,
@@ -116,6 +124,7 @@ export const dataLoadedWithOldElasticsearchAndBigbackups = makeStory(conf, {
 export const dataLoadedWithPostgresql = makeStory(conf, {
   items: [
     {
+      addonId: 'addon_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {AddonBackupsStateLoaded} */
       state: backupsPostgresqlState,
     },
@@ -125,6 +134,7 @@ export const dataLoadedWithPostgresql = makeStory(conf, {
 export const dataLoadedWithPostgresqlAndBigbackups = makeStory(conf, {
   items: [
     {
+      addonId: 'addon_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {AddonBackupsStateLoaded} */
       state: {
         ...backupsPostgresqlState,
@@ -142,6 +152,7 @@ export const dataLoadedWithPostgresqlAndBigbackups = makeStory(conf, {
 export const dataLoadedWithMysql = makeStory(conf, {
   items: [
     {
+      addonId: 'addon_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {AddonBackupsStateLoaded} */
       state: backupsMysqlState,
     },
@@ -151,6 +162,7 @@ export const dataLoadedWithMysql = makeStory(conf, {
 export const dataLoadedWithMysqlAndBigbackups = makeStory(conf, {
   items: [
     {
+      addonId: 'addon_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {AddonBackupsStateLoaded} */
       state: {
         ...backupsMysqlState,
@@ -168,6 +180,7 @@ export const dataLoadedWithMysqlAndBigbackups = makeStory(conf, {
 export const dataLoadedWithMongodb = makeStory(conf, {
   items: [
     {
+      addonId: 'addon_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {AddonBackupsStateLoaded} */
       state: backupsMongodbState,
     },
@@ -177,6 +190,7 @@ export const dataLoadedWithMongodb = makeStory(conf, {
 export const dataLoadedWithMongodbAndBigbackups = makeStory(conf, {
   items: [
     {
+      addonId: 'addon_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {AddonBackupsStateLoaded} */
       state: {
         ...backupsMongodbState,
@@ -194,6 +208,7 @@ export const dataLoadedWithMongodbAndBigbackups = makeStory(conf, {
 export const dataLoadedWithRedis = makeStory(conf, {
   items: [
     {
+      addonId: 'addon_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {AddonBackupsStateLoaded} */
       state: backupsRedisState,
     },
@@ -203,6 +218,7 @@ export const dataLoadedWithRedis = makeStory(conf, {
 export const dataLoadedWithRedisAndBigbackups = makeStory(conf, {
   items: [
     {
+      addonId: 'addon_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {AddonBackupsStateLoaded} */
       state: {
         ...backupsRedisState,
@@ -220,6 +236,7 @@ export const dataLoadedWithRedisAndBigbackups = makeStory(conf, {
 export const dataLoadedWithJenkins = makeStory(conf, {
   items: [
     {
+      addonId: 'addon_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {AddonBackupsStateLoaded} */
       state: backupsJenkinsState,
     },
@@ -229,6 +246,7 @@ export const dataLoadedWithJenkins = makeStory(conf, {
 export const dataLoadedWithJenkinsAndBigbackups = makeStory(conf, {
   items: [
     {
+      addonId: 'addon_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {AddonBackupsStateLoaded} */
       state: {
         ...backupsJenkinsState,

--- a/src/components/cc-domain-management/cc-domain-management.js
+++ b/src/components/cc-domain-management/cc-domain-management.js
@@ -23,9 +23,11 @@ import {
 import { focusBySelector } from '../../lib/focus-helper.js';
 import { generateDocsHref } from '../../lib/utils.js';
 import { accessibilityStyles } from '../../styles/accessibility.js';
+import { cliCommandsStyles } from '../../styles/cli-commands.js';
 import { ccLink, linkStyles } from '../../templates/cc-link/cc-link.js';
 import { i18n } from '../../translations/translation.js';
 import '../cc-badge/cc-badge.js';
+import '../cc-block-details/cc-block-details.js';
 import '../cc-block-section/cc-block-section.js';
 import '../cc-block/cc-block.js';
 import '../cc-button/cc-button.js';
@@ -66,6 +68,7 @@ export class CcDomainManagement extends LitElement {
       dnsInfoState: { type: Object, attribute: 'dns-info-state' },
       domainFormState: { type: Object, attribute: 'domain-form-state' },
       domainListState: { type: Object, attribute: 'domain-list-state' },
+      resourceId: { type: String, attribute: 'resource-id' },
       _sortedDomains: { type: Array, state: true },
     };
   }
@@ -87,6 +90,9 @@ export class CcDomainManagement extends LitElement {
 
   constructor() {
     super();
+
+    /** @type {string} Sets the resource id for documentation */
+    this.resourceId = 'xxx_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
 
     /** @type {DomainManagementDnsInfoState} Sets the state of the DNS info section */
     this.dnsInfoState = { type: 'loading' };
@@ -350,12 +356,14 @@ export class CcDomainManagement extends LitElement {
             ${this.domainListState.type === 'loaded' ? this._renderDomains(this._sortedDomains) : ''}
           </cc-block-section>
 
-          <div slot="footer-right">
-            ${ccLink(
-              DOMAIN_NAMES_DOCUMENTATION,
-              html`<cc-icon .icon="${iconInfo}"></cc-icon> ${i18n('cc-domain-management.names.documentation.text')}`,
-            )}
-          </div>
+          <cc-block-details slot="footer-left">
+            <div slot="button-text">${i18n('cc-block-details.cli.text')}</div>
+            <div slot="link">
+              <cc-icon .icon="${iconInfo}"></cc-icon>
+              <a href="${DOMAIN_NAMES_DOCUMENTATION}">${i18n('cc-domain-management.names.documentation.text')}</a>
+            </div>
+            <div slot="content">${i18n('cc-domain-management.names.cli.content', { resourceId: this.resourceId })}</div>
+          </cc-block-details>
         </cc-block>
 
         <cc-block>
@@ -398,13 +406,14 @@ export class CcDomainManagement extends LitElement {
           ${this.dnsInfoState.type === 'loaded'
             ? this._renderDnsInfo(this.dnsInfoState.cnameRecord, this.dnsInfoState.aRecords)
             : ''}
-
-          <div slot="footer-right">
-            ${ccLink(
-              DNS_DOCUMENTATION,
-              html`<cc-icon .icon="${iconInfo}"></cc-icon> ${i18n('cc-domain-management.dns.documentation.text')}`,
-            )}
-          </div>
+          <cc-block-details slot="footer-left">
+            <div slot="button-text">${i18n('cc-block-details.cli.text')}</div>
+            <div slot="link">
+              <cc-icon .icon="${iconInfo}"></cc-icon>
+              <a href="${DNS_DOCUMENTATION}">${i18n('cc-domain-management.dns.documentation.text')}</a>
+            </div>
+            <div slot="content">${i18n('cc-domain-management.dns.cli.content', { resourceId: this.resourceId })}</div>
+          </cc-block-details>
         </cc-block>
       </div>
     `;
@@ -646,6 +655,7 @@ export class CcDomainManagement extends LitElement {
     return [
       accessibilityStyles,
       linkStyles,
+      cliCommandsStyles,
       css`
         :host {
           display: block;

--- a/src/components/cc-domain-management/cc-domain-management.stories.js
+++ b/src/components/cc-domain-management/cc-domain-management.stories.js
@@ -29,6 +29,7 @@ const conf = {
 export const defaultStory = makeStory(conf, {
   items: [
     {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {DomainManagementListStateLoaded} */
       domainListState: {
         type: 'loaded',
@@ -43,6 +44,7 @@ export const defaultStory = makeStory(conf, {
 export const dataLoadedWithMoreDomains = makeStory(conf, {
   items: [
     {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {DomainManagementListStateLoaded} */
       domainListState: {
         type: 'loaded',
@@ -57,6 +59,7 @@ export const dataLoadedWithMoreDomains = makeStory(conf, {
 export const dataLoadedWithHttpOnlyDomain = makeStory(conf, {
   items: [
     {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {DomainManagementListStateLoaded} */
       domainListState: {
         type: 'loaded',
@@ -71,6 +74,7 @@ export const dataLoadedWithHttpOnlyDomain = makeStory(conf, {
 export const dataLoadedWithLongDomains = makeStory(conf, {
   items: [
     {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {DomainManagementListStateLoaded} */
       domainListState: {
         type: 'loaded',
@@ -85,6 +89,7 @@ export const dataLoadedWithLongDomains = makeStory(conf, {
 export const empty = makeStory(conf, {
   items: [
     {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {DomainManagementListStateLoaded} */
       domainListState: {
         type: 'loaded',
@@ -99,6 +104,7 @@ export const empty = makeStory(conf, {
 export const loading = makeStory(conf, {
   items: [
     {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {DomainManagementListStateLoading} */
       domainListState: { type: 'loading' },
       /** @type {DomainManagementDnsInfoStateLoading} */
@@ -110,6 +116,7 @@ export const loading = makeStory(conf, {
 export const waitingWithAdding = makeStory(conf, {
   items: [
     {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {DomainManagementFormStateAdding} */
       domainFormState: {
         type: 'adding',
@@ -134,6 +141,7 @@ export const waitingWithAdding = makeStory(conf, {
 export const waitingWithDeleting = makeStory(conf, {
   items: [
     {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {DomainManagementListStateLoaded} */
       domainListState: {
         type: 'loaded',
@@ -158,6 +166,7 @@ export const waitingWithDeleting = makeStory(conf, {
 export const waitingWithMarkingAsPrimary = makeStory(conf, {
   items: [
     {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {DomainManagementListStateLoaded} */
       domainListState: {
         type: 'loaded',
@@ -182,6 +191,7 @@ export const waitingWithMarkingAsPrimary = makeStory(conf, {
 export const error = makeStory(conf, {
   items: [
     {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {DomainManagementListStateError} */
       domainListState: { type: 'error' },
       /** @type {DomainManagementDnsInfoStateError} */
@@ -193,6 +203,7 @@ export const error = makeStory(conf, {
 export const errorWithEmpty = makeStory(conf, {
   items: [
     {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {DomainManagementFormStateIdle} */
       domainFormState: {
         type: 'idle',
@@ -218,6 +229,7 @@ export const errorWithEmpty = makeStory(conf, {
 export const errorWithPathWithinDomain = makeStory(conf, {
   items: [
     {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {DomainManagementFormStateIdle} */
       domainFormState: {
         type: 'idle',
@@ -247,6 +259,7 @@ export const errorWithPathWithinDomain = makeStory(conf, {
 export const errorWithInvalidDomain = makeStory(conf, {
   items: [
     {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {DomainManagementFormStateIdle} */
       domainFormState: {
         type: 'idle',
@@ -272,6 +285,7 @@ export const errorWithInvalidDomain = makeStory(conf, {
 export const errorWithInvalidWildcard = makeStory(conf, {
   items: [
     {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {DomainManagementFormStateIdle} */
       domainFormState: {
         type: 'idle',

--- a/src/components/cc-env-var-form/cc-env-var-form.js
+++ b/src/components/cc-env-var-form/cc-env-var-form.js
@@ -1,8 +1,10 @@
 import { css, html, LitElement } from 'lit';
 import { iconRemixInformationFill as iconInfo } from '../../assets/cc-remix.icons.js';
 import { generateDocsHref } from '../../lib/utils.js';
-import { ccLink, linkStyles } from '../../templates/cc-link/cc-link.js';
+import { cliCommandsStyles } from '../../styles/cli-commands.js';
+import { linkStyles } from '../../templates/cc-link/cc-link.js';
 import { i18n } from '../../translations/translation.js';
+import '../cc-block-details/cc-block-details.js';
 import '../cc-block/cc-block.js';
 import '../cc-button/cc-button.js';
 import '../cc-env-var-editor-expert/cc-env-var-editor-expert.js';
@@ -46,6 +48,7 @@ export class CcEnvVarForm extends LitElement {
       context: { type: String, reflect: true },
       heading: { type: String, reflect: true },
       readonly: { type: Boolean, reflect: true },
+      resourceId: { type: String, attribute: 'resource-id' },
       restartApp: { type: Boolean, attribute: 'restart-app' },
       state: { type: Object },
       _editorsState: { type: Object, state: true },
@@ -59,6 +62,9 @@ export class CcEnvVarForm extends LitElement {
 
     /** @type {string} Defines add-on name used in some heading/description (depending on context). */
     this.addonName = '?';
+
+    /** @type {string} Sets the resource id for documentation */
+    this.resourceId = 'xxx_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
 
     /** @type {string} Defines application name used in some heading/description (depending on context). */
     this.appName = '?';
@@ -372,12 +378,14 @@ export class CcEnvVarForm extends LitElement {
             `
           : ''}
 
-        <div slot="footer-right">
-          ${ccLink(
-            `${ENV_VAR_DOCUMENTATION}`,
-            html`<cc-icon .icon="${iconInfo}"></cc-icon>${i18n('cc-env-var-form.documentation.text')}`,
-          )}
-        </div>
+        <cc-block-details slot="footer-left">
+          <div slot="button-text">${i18n('cc-block-details.cli.text')}</div>
+          <div slot="link">
+            <cc-icon .icon="${iconInfo}"></cc-icon>
+            <a href="${ENV_VAR_DOCUMENTATION}">${i18n('cc-env-var-form.documentation.text')}</a>
+          </div>
+          <div slot="content">${i18n('cc-env-var-form.cli.content', { resourceId: this.resourceId })}</div>
+        </cc-block-details>
       </cc-block>
     `;
   }
@@ -385,6 +393,7 @@ export class CcEnvVarForm extends LitElement {
   static get styles() {
     return [
       linkStyles,
+      cliCommandsStyles,
       // language=CSS
       css`
         :host {

--- a/src/components/cc-env-var-form/cc-env-var-form.stories.js
+++ b/src/components/cc-env-var-form/cc-env-var-form.stories.js
@@ -25,6 +25,7 @@ const conf = {
 export const defaultStory = makeStory(conf, {
   items: [
     {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       appName: 'Foobar backend python',
       context: 'env-var',
       state: { type: 'loaded', validationMode: 'simple', variables: VARIABLES_FULL },
@@ -33,16 +34,32 @@ export const defaultStory = makeStory(conf, {
 });
 
 export const loading = makeStory(conf, {
-  items: [{ appName: 'Foobar backend python', context: 'env-var', state: { type: 'loading' } }],
+  items: [
+    {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
+      appName: 'Foobar backend python',
+      context: 'env-var',
+      state: { type: 'loading' },
+    },
+  ],
 });
 
 export const loadingWithReadonly = makeStory(conf, {
-  items: [{ appName: 'Foobar backend python', context: 'env-var', readonly: true, state: { type: 'loading' } }],
+  items: [
+    {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
+      appName: 'Foobar backend python',
+      context: 'env-var',
+      readonly: true,
+      state: { type: 'loading' },
+    },
+  ],
 });
 
 export const empty = makeStory(conf, {
   items: [
     {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       appName: 'Foobar backend python',
       context: 'env-var',
       state: { type: 'loaded', validationMode: 'simple', variables: [] },
@@ -53,6 +70,7 @@ export const empty = makeStory(conf, {
 export const emptyWithReadonly = makeStory(conf, {
   items: [
     {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       appName: 'Foobar backend python',
       context: 'env-var',
       readonly: true,
@@ -62,22 +80,38 @@ export const emptyWithReadonly = makeStory(conf, {
 });
 
 export const dataLoadedWithNoContext = makeStory(conf, {
-  items: [{ state: { type: 'loaded', validationMode: 'simple', variables: VARIABLES_FULL } }],
+  items: [
+    {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
+      state: { type: 'loaded', validationMode: 'simple', variables: VARIABLES_FULL },
+    },
+  ],
 });
 
 export const dataLoadedWithContextEnvVarSimple = makeStory(conf, {
   items: [
-    { context: 'env-var-simple', state: { type: 'loaded', validationMode: 'simple', variables: VARIABLES_FULL } },
+    {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
+      context: 'env-var-simple',
+      state: { type: 'loaded', validationMode: 'simple', variables: VARIABLES_FULL },
+    },
   ],
 });
 
 export const dataLoadedWithContextEnvVarAddon = makeStory(conf, {
-  items: [{ context: 'env-var-addon', state: { type: 'loaded', validationMode: 'simple', variables: VARIABLES_FULL } }],
+  items: [
+    {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
+      context: 'env-var-addon',
+      state: { type: 'loaded', validationMode: 'simple', variables: VARIABLES_FULL },
+    },
+  ],
 });
 
 export const dataLoadedWithContextEnvVar = makeStory(conf, {
   items: [
     {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       appName: 'Foobar backend python',
       context: 'env-var',
       state: { type: 'loaded', validationMode: 'simple', variables: VARIABLES_FULL },
@@ -88,6 +122,7 @@ export const dataLoadedWithContextEnvVar = makeStory(conf, {
 export const dataLoadedWithContextExposedConfig = makeStory(conf, {
   items: [
     {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       appName: 'Foobar backend python',
       context: 'exposed-config',
       state: { type: 'loaded', validationMode: 'simple', variables: VARIABLES_FULL },
@@ -98,6 +133,7 @@ export const dataLoadedWithContextExposedConfig = makeStory(conf, {
 export const dataLoadedWithContextConfigProvider = makeStory(conf, {
   items: [
     {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       addonName: 'My shared config',
       context: 'config-provider',
       state: { type: 'loaded', validationMode: 'simple', variables: VARIABLES_FULL },
@@ -108,6 +144,7 @@ export const dataLoadedWithContextConfigProvider = makeStory(conf, {
 export const dataLoadedWithRestartButton = makeStory(conf, {
   items: [
     {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       appName: 'Foobar backend python',
       context: 'env-var',
       state: { type: 'loaded', validationMode: 'simple', variables: VARIABLES_FULL },
@@ -119,6 +156,7 @@ export const dataLoadedWithRestartButton = makeStory(conf, {
 export const dataLoadedWithCustomHeadingAndReadonly = makeStory(conf, {
   items: [
     {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       heading: 'Add-on: Awesome PG database',
       state: { type: 'loaded', validationMode: 'simple', variables: VARIABLES_FULL },
       readonly: true,
@@ -129,6 +167,7 @@ export const dataLoadedWithCustomHeadingAndReadonly = makeStory(conf, {
 export const dataLoadedWithCustomHeadingAndDescription = makeStory(conf, {
   items: [
     {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       state: { type: 'loaded', validationMode: 'simple', variables: VARIABLES_FULL },
       heading: 'Custom heading title',
       innerHTML: `
@@ -141,6 +180,7 @@ export const dataLoadedWithCustomHeadingAndDescription = makeStory(conf, {
 export const dataLoadedWithStrictMode = makeStory(conf, {
   items: [
     {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       appName: 'Foobar backend python (strict validation mode)',
       context: 'env-var',
       state: { type: 'loaded', validationMode: 'strict', variables: VARIABLES_FULL },
@@ -151,6 +191,7 @@ export const dataLoadedWithStrictMode = makeStory(conf, {
 export const saving = makeStory(conf, {
   items: [
     {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       appName: 'Foobar backend python',
       context: 'env-var',
       state: { type: 'loaded', validationMode: 'simple', variables: VARIABLES_FULL },
@@ -163,7 +204,14 @@ export const saving = makeStory(conf, {
 });
 
 export const errorWithLoading = makeStory(conf, {
-  items: [{ appName: 'Foobar backend python', context: 'env-var', state: { type: 'error' } }],
+  items: [
+    {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
+      appName: 'Foobar backend python',
+      context: 'env-var',
+      state: { type: 'error' },
+    },
+  ],
 });
 
 export const simulations = makeStory(conf, {

--- a/src/components/cc-tcp-redirection-form/cc-tcp-redirection-form.js
+++ b/src/components/cc-tcp-redirection-form/cc-tcp-redirection-form.js
@@ -1,9 +1,11 @@
 import { css, html, LitElement } from 'lit';
 import { iconRemixInformationFill as iconInfo } from '../../assets/cc-remix.icons.js';
 import { generateDocsHref } from '../../lib/utils.js';
-import { ccLink, linkStyles } from '../../templates/cc-link/cc-link.js';
+import { cliCommandsStyles } from '../../styles/cli-commands.js';
+import { linkStyles } from '../../templates/cc-link/cc-link.js';
 import { i18n } from '../../translations/translation.js';
 import '../cc-badge/cc-badge.js';
+import '../cc-block-details/cc-block-details.js';
 import '../cc-block/cc-block.js';
 import '../cc-notice/cc-notice.js';
 import '../cc-tcp-redirection/cc-tcp-redirection.js';
@@ -31,12 +33,16 @@ export class CcTcpRedirectionForm extends LitElement {
   static get properties() {
     return {
       context: { type: String },
+      resourceId: { type: String, attribute: 'resource-id' },
       state: { type: Object },
     };
   }
 
   constructor() {
     super();
+
+    /** @type {string} Sets the resource id for documentation */
+    this.resourceId = 'xxx_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
 
     /** @type {TcpRedirectionFormContextType} Defines in which context the form is used so it can show the appropriate description or lack thereof (defaults to user). */
     this.context = 'user';
@@ -80,12 +86,14 @@ export class CcTcpRedirectionForm extends LitElement {
             : ''}
         </div>
 
-        <div slot="footer-right">
-          ${ccLink(
-            `${TCP_REDIRECTION_DOCUMENTATION}`,
-            html`<cc-icon .icon="${iconInfo}"></cc-icon> ${i18n('cc-tcp-redirection-form.documentation.text')}`,
-          )}
-        </div>
+        <cc-block-details slot="footer-left">
+          <div slot="button-text">${i18n('cc-block-details.cli.text')}</div>
+          <div slot="link">
+            <cc-icon .icon="${iconInfo}"></cc-icon>
+            <a href="${TCP_REDIRECTION_DOCUMENTATION}">${i18n('cc-tcp-redirection-form.documentation.text')}</a>
+          </div>
+          <div slot="content">${i18n('cc-tcp-redirection-form.cli.content', { resourceId: this.resourceId })}</div>
+        </cc-block-details>
       </cc-block>
     `;
   }
@@ -104,6 +112,7 @@ export class CcTcpRedirectionForm extends LitElement {
   static get styles() {
     return [
       linkStyles,
+      cliCommandsStyles,
       // language=CSS
       css`
         :host {

--- a/src/components/cc-tcp-redirection-form/cc-tcp-redirection-form.stories.js
+++ b/src/components/cc-tcp-redirection-form/cc-tcp-redirection-form.stories.js
@@ -22,6 +22,7 @@ const conf = {
 export const defaultStory = makeStory(conf, {
   items: [
     {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {TcpRedirectionFormStateLoaded} */
       state: {
         type: 'loaded',
@@ -37,6 +38,7 @@ export const defaultStory = makeStory(conf, {
 export const empty = makeStory(conf, {
   items: [
     {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {TcpRedirectionFormStateLoaded} **/
       state: {
         type: 'loaded',
@@ -49,6 +51,7 @@ export const empty = makeStory(conf, {
 export const loading = makeStory(conf, {
   items: [
     {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {TcpRedirectionFormStateLoading} **/
       state: {
         type: 'loading',
@@ -60,6 +63,7 @@ export const loading = makeStory(conf, {
 export const errorWithLoading = makeStory(conf, {
   items: [
     {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {TcpRedirectionFormStateError} **/
       state: {
         type: 'error',
@@ -71,6 +75,7 @@ export const errorWithLoading = makeStory(conf, {
 export const dataLoaded = makeStory(conf, {
   items: [
     {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {TcpRedirectionFormStateLoaded} **/
       state: {
         type: 'loaded',
@@ -88,6 +93,7 @@ export const dataLoadedWithContextAdmin = makeStory(conf, {
   docs: 'When `context="admin"` is used, the component description is hidden, the block is collapsed and a redirection counter bubble is be displayed.',
   items: [
     {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {TcpRedirectionFormStateLoaded} **/
       state: {
         type: 'loaded',
@@ -106,6 +112,7 @@ export const dataLoadedWithContextAdminAndNoRedirections = makeStory(conf, {
   docs: 'When `context="admin"` is used, the counter bubble is not displayed if there is no redirection.',
   items: [
     {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {TcpRedirectionFormStateLoaded} **/
       state: {
         type: 'loaded',
@@ -124,6 +131,7 @@ export const dataLoadedWithContextAdminAndNoRedirections = makeStory(conf, {
 export const dataLoadedWithCreatingRedirection = makeStory(conf, {
   items: [
     {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {TcpRedirectionFormStateLoaded} **/
       state: {
         type: 'loaded',
@@ -140,6 +148,7 @@ export const dataLoadedWithCreatingRedirection = makeStory(conf, {
 export const dataLoadedWithDeletingRedirection = makeStory(conf, {
   items: [
     {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {TcpRedirectionFormStateLoaded} **/
       state: {
         type: 'loaded',
@@ -156,6 +165,7 @@ export const dataLoadedWithDeletingRedirection = makeStory(conf, {
 export const dataLoadedWithManyNamespaces = makeStory(conf, {
   items: [
     {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       /** @type {TcpRedirectionFormStateLoaded} **/
       state: {
         type: 'loaded',

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -470,6 +470,21 @@ export const translations = {
   'cc-env-var-editor-simple.empty-data': `There are no variables.`,
   //#endregion
   //#region cc-env-var-form
+  'cc-env-var-form.cli.content': /** @param {{resourceId: string}} _ */ ({ resourceId }) =>
+    sanitize`
+      <p class="text">
+        You can manage environment variables directly from your terminal using the commands below.
+        To install Clever Tools CLI, follow the instructions from the <a href="${generateDocsHref('/cli/install/')}" title="documentation - Install Clever Tools - new window">documentation</a>.
+      </p>
+      <dl>
+        <dt>List environment variables:</dt>
+        <dd><code>clever env --app ${resourceId}</code></dd>
+        <dt>Get a sourceable env file:</dt>
+        <dd><code>clever env --app ${resourceId} -F shell</code></dd>
+        <dt>Add or update an environment variable:</dt>
+        <dd><code>clever env set VAR_NAME VAR_VALUE --app ${resourceId}</code></dd>
+      </dl>
+    `,
   'cc-env-var-form.description.config-provider': /** @param {{addonName: string}} _ */ ({ addonName }) =>
     sanitize`Configuration exposed to dependent applications. <a href="${generateDocsHref('/deploy/addon/config-provider/')}">Learn more</a><br>These variables will be injected as environment variables in applications that have the add-on <strong>${addonName}</strong> in their service dependencies.<br>Every time you update your changes, all the dependent applications will be automatically restarted.`,
   'cc-env-var-form.description.env-var': /** @param {{appName: string}} _ */ ({ appName }) =>

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -272,6 +272,16 @@ export const translations = {
     sanitize`<p>If you choose to use <code>A</code> records, for instance with a root domain (APEX), you'll need to update them yourself. Follow our <a href="${generateDevHubHref('/changelog')}">changelog</a> or check our <a href="${generateDevHubHref('/api/v4/#load-balancers')}">v4 API documentation</a> for this.</p>`,
   'cc-domain-management.dns.a.heading': `A records`,
   'cc-domain-management.dns.a.label': `A Record values`,
+  'cc-domain-management.dns.cli.content': /** @param {{resourceId: string}} _ */ ({ resourceId }) =>
+    sanitize`
+      <p>
+        To install Clever Tools CLI, follow the instructions from the <a href="${generateDocsHref('/cli/install/')}" title="documentation - Install Clever Tools - new window">documentation</a>.
+      </p>
+      <dl>
+        <dt>Diagnose the current configuration:</dt>
+        <dd><code>clever diag --app ${resourceId}</code></dd>
+      </dl>
+    `,
   'cc-domain-management.dns.cname.desc': () =>
     sanitize`<p>Using a <code>CNAME</code> record is recommended. This keeps your configuration up to date.</p>`,
   'cc-domain-management.dns.cname.heading': `CNAME record`,
@@ -338,6 +348,21 @@ export const translations = {
   'cc-domain-management.list.primary.success': /** @param {{domain: string}} _ */ ({ domain }) =>
     `"${domain}" has been successfully marked as primary domain`,
   'cc-domain-management.main-heading': `Manage your domain names`,
+  'cc-domain-management.names.cli.content': /** @param {{resourceId: string}} _ */ ({ resourceId }) =>
+    sanitize`
+      <p class="text">
+        You can manage domains directly from your terminal using the commands below. 
+        To install Clever Tools CLI, follow the instructions from the <a href="${generateDocsHref('/cli/install/')}" title="documentation - Install Clever Tools - new window">documentation</a>.
+      </p>
+      <dl>
+        <dt>List domains:</dt>
+        <dd><code>clever domain --app ${resourceId}</code></dd>
+        <dt>Diagnose DNS records:</dt>
+        <dd><code>clever domain diag --app ${resourceId}</code></dd>
+        <dt>Add a domain:</dt>
+        <dd><code>clever domain add myapp.example.com --app ${resourceId}</code></dd>
+      </dl>
+    `,
   'cc-domain-management.names.documentation.text': `Domain names - Documentation`,
   'cc-domain-management.new-window': `New Window`,
   'cc-domain-management.tls.certificates.documentation.text': `TLS certificates - Documentation`,

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -1458,6 +1458,21 @@ export const translations = {
     sanitize`You can create a redirection in the <strong>${namespace}</strong> namespace.`,
   //#endregion
   //#region cc-tcp-redirection-form
+  'cc-tcp-redirection-form.cli.content': /** @param {{resourceId: string}} _ */ ({ resourceId }) =>
+    sanitize`
+      <p class="text">
+        You can manage TCP redirections directly from your terminal using the commands below.
+        To install Clever Tools CLI, follow the instructions from the <a href="${generateDocsHref('/cli/install/')}" title="documentation - Install Clever Tools - new window">documentation</a>.
+      </p>
+      <dl>
+        <dt>List TCP redirections:</dt>
+        <dd><code>clever tcp-redirs --app ${resourceId}</code></dd>
+        <dt>Add a TCP redirection:</dt>
+        <dd><code>clever tcp-redirs add --namespace my-namespace --app ${resourceId}</code></dd>
+        <dt>Remove a TCP redirection:</dt>
+        <dd><code>clever tcp-redirs remove --namespace my-namespace {portNumber} --app ${resourceId}</code></dd>
+      </dl>
+    `,
   'cc-tcp-redirection-form.create.error': /** @param {{namespace: string}} _ */ ({ namespace }) => {
     return sanitize`Something went wrong while creating a TCP redirection in the <strong>${namespace}</strong> namespace.`;
   },

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -84,6 +84,19 @@ export const translations = {
   'cc-addon-admin.update': `Update name`,
   //#endregion
   //#region cc-addon-backups
+  'cc-addon-backups.cli.content': /** @param {{addonId: string}} _ */ ({ addonId }) =>
+    sanitize`
+      <p>
+        You can manage backups directly from your terminal using the commands below. 
+        To install Clever Tools CLI, follow the instructions from the <a href="${generateDocsHref('/cli/install/')}" title="documentation - Install Clever Tools - new window">documentation</a>.
+      </p>
+      <dl>
+        <dt>List available database backups:</dt>
+        <dd><code>clever database backups ${addonId}</code></dd>
+        <dt>Download a database backup:</dt>
+        <dd><code>clever database backups download ${addonId} BACKUP_ID</code></dd>
+      </dl>
+    `,
   'cc-addon-backups.close-btn': `Close this panel`,
   'cc-addon-backups.command-password': `This command will ask for your password, here it is:`,
   'cc-addon-backups.delete': /** @param {{createdAt: string|number}} _ */ ({ createdAt }) =>

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -283,6 +283,16 @@ export const translations = {
     sanitize`<p>Si vous choisissez d'utiliser des enregistrements de type <code>A</code>, par exemple pour un domaine racine (APEX), vous devrez vous-même assurer leur mise à jour. Pensez à suivre notre <a href="${generateDevHubHref('/changelog')}" lang="en">changelog</a> ou à lire la documentation de notre <a href="${generateDevHubHref('/api/v4/#load-balancers')}" lang="en">API v4</a> pour cela.</p>`,
   'cc-domain-management.dns.a.heading': `Enregistrements A`,
   'cc-domain-management.dns.a.label': `Valeurs d'enregistrement A`,
+  'cc-domain-management.dns.cli.content': /** @param {{resourceId: string}} _ */ ({ resourceId }) =>
+    sanitize`
+      <p>
+      Pour installer les Clever Tools (CLI), suivez les instructions de la <a href="${generateDocsHref('/cli/install/')}" title="documentation - Installer les Clever Tools - nouvelle fenêtre - en Anglais">documentation</a>.
+      </p>
+      <dl>
+        <dt>Commande pour diagnostiquer l'installation actuelle :</dt>
+        <dd><code>clever diag --app ${resourceId}</code></dd>
+      </dl>
+    `,
   'cc-domain-management.dns.cname.desc': () =>
     sanitize`<p>Utiliser un enregistrement <code>CNAME</code> est fortement recommandé. Ainsi, votre configuration est automatiquement maintenue à jour.`,
   'cc-domain-management.dns.cname.heading': `Enregistrement CNAME`,
@@ -348,6 +358,21 @@ export const translations = {
   'cc-domain-management.list.primary.success': /** @param {{domain: string}} _ */ ({ domain }) =>
     `"${domain}" a bien été défini comme nom de domaine principal`,
   'cc-domain-management.main-heading': `Gérez vos noms de domaine`,
+  'cc-domain-management.names.cli.content': /** @param {{resourceId: string}} _ */ ({ resourceId }) =>
+    sanitize`
+      <p>
+      Vous pouvez gérer les domaines directement depuis votre terminal grâce aux commandes ci-dessous.
+      Pour installer les Clever Tools (CLI), suivez les instructions de la <a href="${generateDocsHref('/cli/install/')}" title="documentation - Installer les Clever Tools - nouvelle fenêtre - en Anglais">documentation</a>.
+      </p>
+      <dl>
+        <dt>Lister les domaines :</dt>
+        <dd><code>clever domain --app ${resourceId}</code></dd>
+        <dt>Diagnostiquer les enregistrements DNS :</dt>
+        <dd><code>clever domain diag --app ${resourceId}</code></dd>
+        <dt>Ajouter un domaine :</dt>
+        <dd><code>clever domain add myapp.example.com --app ${resourceId}</code></dd>
+      </dl>
+      `,
   'cc-domain-management.names.documentation.text': `Noms de domaine - Documentation`,
   'cc-domain-management.new-window': `Nouvelle fenêtre`,
   'cc-domain-management.tls.certificates.documentation.text': `Certificats TLS - Documentation`,

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -479,6 +479,21 @@ export const translations = {
   'cc-env-var-editor-simple.empty-data': `Il n'y a pas de variable.`,
   //#endregion
   //#region cc-env-var-form
+  'cc-env-var-form.cli.content': /** @param {{resourceId: string}} _ */ ({ resourceId }) =>
+    sanitize`
+      <p class="text">
+        Vous pouvez gérer les variables d'environnement directement depuis votre terminal en utilisant les commandes ci-dessous.
+        Pour installer les Clever Tools (CLI), suivez les instructions de la <a href="${generateDocsHref('/cli/install/')}" title="documentation - Installer les Clever Tools - nouvelle fenêtre - en Anglais">documentation</a>.
+      </p>
+      <dl>
+        <dt>Lister les variables d'environnement :</dt>
+        <dd><code>clever env --app ${resourceId}</code></dd>
+        <dt>Récupérer un fichier de variables d'environnement exécutable :</dt>
+        <dd><code>clever env --app ${resourceId} -F shell</code></dd>
+        <dt>Ajouter ou modifier une variable d'environnement :</dt>
+        <dd><code>clever env set VAR_NAME VAR_VALUE --app ${resourceId}</code></dd>
+      </dl>
+    `,
   'cc-env-var-form.description.config-provider': /** @param {{addonName: string}} _ */ ({ addonName }) =>
     sanitize`Configuration publiée pour les applications dépendantes. <a href="${generateDocsHref('/deploy/addon/config-provider/')}">En savoir plus</a><br>Ces seront injectées en tant que variables d'environnement dans les applications qui ont l'add-on <strong>${addonName}</strong> dans leurs services liés.<br>À chaque fois que vous mettez à jour les changements, toutes les applications dépendantes seront redémarrées automatiquement.`,
   'cc-env-var-form.description.env-var': /** @param {{appName: string}} _ */ ({ appName }) =>

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -1495,6 +1495,20 @@ export const translations = {
     sanitize`Vous pouvez créer une redirection dans l'espace de nommage <strong>${namespace}</strong>.`,
   //#endregion
   //#region cc-tcp-redirection-form
+  'cc-tcp-redirection-form.cli.content': /** @param {{resourceId: string}} _ */ ({ resourceId }) =>
+    sanitize`
+      <p class="text">
+        Vous pouvez gérer les redirections TCP directement depuis votre terminal grâce aux commandes ci-dessous.
+        Pour installer les Clever Tools (CLI), suivez les instructions de la <a href="${generateDocsHref('/cli/install/')}" title="documentation - Installer les Clever Tools - nouvelle fenêtre - en Anglais">documentation</a>.      </p>
+      <dl>
+        <dt>Lister les redirections TCP :</dt>
+        <dd><code>clever tcp-redirs --app ${resourceId}</code></dd>
+        <dt>Ajouter une redirection TCP :</dt>
+        <dd><code>clever tcp-redirs add --namespace my-namespace --app ${resourceId}</code></dd>
+        <dt>Supprimer une redirection TCP :</dt>
+        <dd><code>clever tcp-redirs remove --namespace my-namespace {portNumber} --app ${resourceId}</code></dd>
+      </dl>
+    `,
   'cc-tcp-redirection-form.create.error': /** @param {{namespace: string}} _ */ ({ namespace }) => {
     return sanitize`Une erreur est survenue pendant la création d'une redirection TCP dans l'espace de nommage <strong>${namespace}</strong>.`;
   },

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -95,6 +95,19 @@ export const translations = {
   'cc-addon-admin.update': `Mettre à jour le nom`,
   //#endregion
   //#region cc-addon-backups
+  'cc-addon-backups.cli.content': /** @param {{addonId: string}} _ */ ({ addonId }) =>
+    sanitize`
+      <p>
+        Vous pouvez gérer les sauvegardes directement depuis votre terminal en utilisant les commandes ci-dessous. 
+        Pour installer les Clever Tools (CLI), suivez les instructions de la <a href="${generateDocsHref('/cli/install/')}" title="documentation - Installer les Clever Tools - nouvelle fenêtre - en Anglais">documentation</a>.
+      </p>
+      <dl>
+        <dt>Lister les sauvegardes de bases de données disponibles :</dt>
+        <dd><code>clever database backups ${addonId}</code></dd>
+        <dt>Télécharger une sauvegarde de la base de données :</dt>
+        <dd><code>clever database backups download ${addonId} BACKUP_ID</code></dd>
+      </dl>
+    `,
   'cc-addon-backups.close-btn': `Fermer ce panneau`,
   'cc-addon-backups.command-password': `Cette commande vous demandera votre mot de passe, le voici :`,
   'cc-addon-backups.delete': /** @param {{createdAt: string|number}} _ */ ({ createdAt }) =>


### PR DESCRIPTION
## What does this PR do?

- Integrates the cc-block-details component into other components.

## How to review?

- Check the default component story, where the cc-block-details component is integrated, within the [preview](https://clever-components-preview.cellar-c2.services.clever-cloud.com/feat/cc-block-detail-integration/index.html?path=/story/%F0%9F%9B%A0-domains-cc-domain-management--default-story),

## Component list

- [x] cc-domain-management
- [x] cc-env-var-form
- [x] cc-tcp-redirection-form
- [x] cc-addon-backups