### PR TITLE
feat(cc-zone): use diplayName when it's defined

### DIFF
--- a/src/components/cc-zone/cc-zone.js
+++ b/src/components/cc-zone/cc-zone.js
@@ -17,8 +17,6 @@ const SKELETON_ZONE = {
   tags: ['????????', '????????????'],
 };
 
-const PRIVATE_ZONE = 'scope:private';
-
 /**
  * @typedef {import('./cc-zone.types.js').ZoneState} ZoneState
  * @typedef {import('./cc-zone.types.js').ZoneStateLoaded} ZoneStateLoaded
@@ -32,7 +30,7 @@ const PRIVATE_ZONE = 'scope:private';
  * ## Details
  *
  * * When a tag prefixed with `infra:` is used, the corresponding logo is displayed.
- * * When the `scope:private` tag is used, the optional `displayName` of the zone will be used instead of the City + Country.
+ * * When it's defined, the `displayName` of the zone will be used instead of the City + Country.
  * * If the browser supports it, the `countryCode` will be used to display a translated version of the country's name.
  *
  * @cssdisplay flex
@@ -82,15 +80,20 @@ export class CcZone extends LitElement {
    * @private
    */
   static _getTextParts(zone) {
-    if (zone.tags.includes(PRIVATE_ZONE) && zone.displayName != null) {
-      return { title: zone.displayName };
-    }
+    const title = zone.displayName ?? zone.city;
+    const subtitle =
+      zone.displayName == null
+        ? i18n('cc-zone.country', {
+            code: zone.countryCode,
+            name: zone.country,
+          })
+        : null;
 
     const infraTag = zone.tags.find((t) => t.startsWith('infra:'));
     const infraSlug = infraTag?.split(':')[1] ?? null;
     return {
-      title: zone.city,
-      subtitle: i18n('cc-zone.country', { code: zone.countryCode, name: zone.country }),
+      title,
+      subtitle,
       infra: infraSlug,
     };
   }

--- a/src/components/cc-zone/cc-zone.stories.js
+++ b/src/components/cc-zone/cc-zone.stories.js
@@ -9,6 +9,12 @@ export default {
 
 const conf = {
   component: 'cc-zone',
+  // language=CSS
+  css: `
+    cc-zone {
+      align-self: start;
+    }
+  `,
 };
 
 /**
@@ -43,7 +49,7 @@ const zoneWithInfra = {
 };
 
 /** @type {ZoneStateLoaded} */
-const zonePrivate = {
+const zoneWithDisplayName = {
   type: 'loaded',
   name: 'acme-corp',
   displayName: 'ACME Corp',
@@ -52,7 +58,7 @@ const zonePrivate = {
   city: 'Berlin',
   lat: 52.52,
   lon: 13.39,
-  tags: ['region:eu', 'scope:private'],
+  tags: ['region:eu', 'infra:clever-cloud'],
 };
 
 /** @type {ZoneStateLoaded} */
@@ -90,15 +96,15 @@ const zoneWithManyTags = {
 
 export const defaultStory = makeStory(conf, {
   /** @type {{ state: ZoneStateLoaded, mode?: ZoneModeType }[]} */
-  items: [{ state: zoneDefault }, { state: zoneDefault, mode: 'small' }, { state: zoneDefault, mode: 'small-infra' }],
+  items: [{ state: zoneDefault }, { state: zoneDefault, mode: 'small-infra' }, { state: zoneDefault, mode: 'small' }],
 });
 
 export const loading = makeStory(conf, {
   /** @type {{ state: ZoneStateLoading, mode?: ZoneModeType }[]} */
   items: [
     { state: { type: 'loading' } },
-    { state: { type: 'loading' }, mode: 'small' },
     { state: { type: 'loading' }, mode: 'small-infra' },
+    { state: { type: 'loading' }, mode: 'small' },
   ],
 });
 
@@ -108,22 +114,26 @@ export const dataLoadedWithInfra = makeStory(conf, {
   /** @type {{ state: ZoneStateLoaded, mode?: ZoneModeType }[]} */
   items: [
     { state: zoneWithInfra },
-    { state: zoneWithInfra, mode: 'small' },
     { state: zoneWithInfra, mode: 'small-infra' },
+    { state: zoneWithInfra, mode: 'small' },
   ],
 });
 
-export const dataLoadedWithPrivate = makeStory(conf, {
+export const dataLoadedWithDisplayName = makeStory(conf, {
   /** @type {{ state: ZoneStateLoaded, mode?: ZoneModeType }[]} */
-  items: [{ state: zonePrivate }, { state: zonePrivate, mode: 'small' }, { state: zonePrivate, mode: 'small-infra' }],
+  items: [
+    { state: zoneWithDisplayName },
+    { state: zoneWithDisplayName, mode: 'small-infra' },
+    { state: zoneWithDisplayName, mode: 'small' },
+  ],
 });
 
 export const dataLoadedWithNoTags = makeStory(conf, {
   /** @type {{ state: ZoneStateLoaded, mode?: ZoneModeType }[]} */
   items: [
     { state: zoneWithoutTags },
-    { state: zoneWithoutTags, mode: 'small' },
     { state: zoneWithoutTags, mode: 'small-infra' },
+    { state: zoneWithoutTags, mode: 'small' },
   ],
 });
 
@@ -131,8 +141,8 @@ export const dataLoadedWithManyTags = makeStory(conf, {
   /** @type {{ state: ZoneStateLoaded, mode?: ZoneModeType }[]} */
   items: [
     { state: zoneWithManyTags },
-    { state: zoneWithManyTags, mode: 'small' },
     { state: zoneWithManyTags, mode: 'small-infra' },
+    { state: zoneWithManyTags, mode: 'small' },
   ],
 });
 


### PR DESCRIPTION
## What does this PR do?

- Show the `displayName` of a zone when it's defined (even if it does not have a `scope:private` tag)
- Rework the stories to reflect better this modified behavior
- Rework the stories to reflect better the inline display of the cc-zone in headers

## How to review?

- look at the cc-zone stories
- look at the cc-zone-input stories

The zone with a `displayName` should show this instead of "City, Country".