### PR TITLE
`cc-token-api-creation-form`: init

### DIFF
--- a/demo-smart/index.html
+++ b/demo-smart/index.html
@@ -91,6 +91,11 @@
       <li>
         <a class="definition-link" href="?definition=cc-token-api-list.smart">cc-token-api-list.smart</a>
       </li>
+      <li>
+        <a class="definition-link" href="?definition=cc-token-api-creation-form.smart">
+          cc-token-api-creation-form.smart
+        </a>
+      </li>
       <!--  <li>-->
       <!--    <a class="definition-link" href="?definition=cc-pricing-page.smart">cc-pricing-page.smart</a>-->
       <!--  </li>-->

--- a/src/components/cc-token-api-creation-form/cc-token-api-creation-form.events.js
+++ b/src/components/cc-token-api-creation-form/cc-token-api-creation-form.events.js
@@ -1,0 +1,18 @@
+import { CcEvent } from '../../lib/events.js';
+
+/**
+ * @typedef {import('./cc-token-api-creation-form.types.js').NewToken} NewToken
+ */
+
+/**
+ * Dispatched when a token creation is requested.
+ * @extends {CcEvent<NewToken>}
+ */
+export class CcTokenCreateEvent extends CcEvent {
+  static TYPE = 'cc-token-create';
+
+  /** @param {NewToken} detail */
+  constructor(detail) {
+    super(CcTokenCreateEvent.TYPE, detail);
+  }
+}

--- a/src/components/cc-token-api-creation-form/cc-token-api-creation-form.js
+++ b/src/components/cc-token-api-creation-form/cc-token-api-creation-form.js
@@ -1,0 +1,925 @@
+import { LitElement, css, html } from 'lit';
+import { classMap } from 'lit/directives/class-map.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { createRef, ref } from 'lit/directives/ref.js';
+import {
+  iconRemixArrowRightCircleLine as iconActiveStep,
+  iconRemixCheckboxCircleLine as iconDoneStep,
+  iconRemixLogoutBoxRLine as iconExternalLink,
+  iconRemixArrowLeftLine as iconGoBack,
+} from '../../assets/cc-remix.icons.js';
+import { DateFormatter } from '../../lib/date/date-formatter.js';
+import { getRelativeDateFromNow, shiftDateField } from '../../lib/date/date-utils.js';
+import { FormErrorFocusController } from '../../lib/form/form-error-focus-controller.js';
+import { formSubmit } from '../../lib/form/form-submit-directive.js';
+import { cliCommandsStyles } from '../../styles/cli-commands.js';
+import { linkStyles } from '../../templates/cc-link/cc-link.js';
+import { i18n } from '../../translations/translation.js';
+import '../cc-block-details/cc-block-details.js';
+import '../cc-block/cc-block.js';
+import '../cc-input-date/cc-input-date.js';
+import '../cc-input-text/cc-input-text.js';
+import '../cc-loader/cc-loader.js';
+import '../cc-notice/cc-notice.js';
+import '../cc-select/cc-select.js';
+import { CcTokenCreateEvent } from './cc-token-api-creation-form.events.js';
+
+const DEFAULT_EXPIRATION_DURATION = 'one-year';
+const DATE_FORMATTER_SHORT = new DateFormatter('datetime-short', 'local');
+const DATE_FORMATTER_ISO = new DateFormatter('datetime-iso', 'UTC');
+
+/** @type {Map<ExpirationPreset['preset'], number>} */
+const DURATION_TO_NB_OF_DAYS_MAP = new Map([
+  ['seven-days', 7],
+  ['thirty-days', 30],
+  ['sixty-days', 60],
+  ['ninety-days', 90],
+  ['one-year', 365],
+]);
+
+/**
+ * @typedef {import('./cc-token-api-creation-form.types.js').TokenApiCreationFormState} TokenApiCreationFormState
+ * @typedef {import('./cc-token-api-creation-form.types.js').TokenApiCreationFormStateLoaded} TokenApiCreationFormStateLoaded
+ * @typedef {import('./cc-token-api-creation-form.types.js').TokenApiCreationFormStateLoadedValidation} TokenApiCreationFormStateLoadedValidation
+ * @typedef {import('./cc-token-api-creation-form.types.js').Expiration} Expiration
+ * @typedef {import('./cc-token-api-creation-form.types.js').ExpirationPreset} ExpirationPreset
+ * @typedef {import('./cc-token-api-creation-form.types.js').ExpirationDurationOptions} ExpirationDurationOptions
+ * @typedef {import('./cc-token-api-creation-form.types.js').FormValues} FormValues
+ * @typedef {import('../cc-input-text/cc-input-text.js').CcInputText} CcInputText
+ * @typedef {import('../cc-input-date/cc-input-date.js').CcInputDate} CcInputDate
+ * @typedef {import('../../lib/events.types.js').EventWithTarget<CcInputText | CcInputDate>} EventWithCcFormControlTarget
+ * @typedef {import('lit').PropertyValues<CcTokenApiCreationForm>} CcTokenApiCreationFormPropertyValues
+ * @typedef {import('lit/directives/ref.js').Ref<HTMLFormElement>} HTMLFormElementRef
+ * @typedef {import('lit/directives/ref.js').Ref<CcInputDate>} CcInputDateRef
+ */
+
+/**
+ * A component that provides a multi-step form to create API tokens.
+ *
+ * This component guides users through a three-step process:
+ *
+ * 1. Configuration - Set token name, description (optional), and expiration date (or compute the expiration date based on the expiration duration preset),
+ * 2. Validation - Authenticate with password and MFA (if enabled),
+ * 3. Copy - View and copy the newly created token.
+ *
+ * The component manages state transitions, form validation, and visual feedback throughout the token creation process.
+ */
+export class CcTokenApiCreationForm extends LitElement {
+  static get properties() {
+    return {
+      apiTokenListHref: { type: String, attribute: 'api-token-list-href' },
+      state: { type: Object },
+    };
+  }
+
+  static get DEFAULT_FORM_VALUES() {
+    return /** @type {const} */ ({
+      name: '',
+      description: '',
+      expiration: {
+        type: 'preset',
+        preset: DEFAULT_EXPIRATION_DURATION,
+      },
+      password: '',
+      mfaCode: '',
+    });
+  }
+
+  /**
+   * @param {ExpirationPreset['preset']} durationPreset
+   * @returns {string} computed expiration date (ISO format)
+   */
+  static computeExpirationDate(durationPreset) {
+    const expirationDate = getRelativeDateFromNow('D', DURATION_TO_NB_OF_DAYS_MAP.get(durationPreset));
+    return DATE_FORMATTER_ISO.format(expirationDate);
+  }
+
+  constructor() {
+    super();
+
+    /** @type {string} URL for the API token list screen */
+    this.apiTokenListHref = '';
+
+    /** @type {TokenApiCreationFormState} Sets the state of the component */
+    this.state = { type: 'loading' };
+
+    /** @type {HTMLFormElementRef} */
+    this._configurationFormRef = createRef();
+
+    /** @type {CcInputDateRef} */
+    this._expirationDateInputRef = createRef();
+
+    this._expirationDateErrorMessages = {
+      badInput: () =>
+        i18n('cc-token-api-creation-form.configuration-step.form.expiration-date.error.invalid', {
+          date: DATE_FORMATTER_SHORT.format(shiftDateField(new Date(), 'Y', 1)),
+        }),
+      rangeUnderflow: () =>
+        i18n('cc-token-api-creation-form.configuration-step.form.expiration-date.error.range-underflow', {
+          date: DATE_FORMATTER_SHORT.format(shiftDateField(new Date(), 'm', 30)),
+        }),
+      rangeOverflow: () =>
+        i18n('cc-token-api-creation-form.configuration-step.form.expiration-date.error.range-overflow', {
+          date: DATE_FORMATTER_SHORT.format(shiftDateField(new Date(), 'Y', 1)),
+        }),
+    };
+
+    /** @type {HTMLFormElementRef} */
+    this._validationFormRef = createRef();
+
+    new FormErrorFocusController(this, this._validationFormRef, () =>
+      this.state.type === 'loaded' && this.state.activeStep === 'validation' ? this.state.credentialsError : null,
+    );
+  }
+
+  /**
+   * @param {TokenApiCreationFormStateLoaded['activeStep']} activeStep
+   * @returns {string}
+   */
+  _getMainHeading(activeStep) {
+    switch (activeStep) {
+      case 'configuration':
+        return i18n('cc-token-api-creation-form.configuration-step.main-heading');
+      case 'validation':
+        return i18n('cc-token-api-creation-form.validation-step.main-heading');
+      case 'copy':
+        return i18n('cc-token-api-creation-form.copy-step.main-heading');
+    }
+  }
+
+  /** @returns {Array<{ label: string, value: ExpirationDurationOptions}>} */
+  _getExpirationDurationOptions() {
+    return [
+      {
+        label: i18n('cc-token-api-creation-form.configuration-step.form.expiration-duration.option-label.seven-days'),
+        value: 'seven-days',
+      },
+      {
+        label: i18n('cc-token-api-creation-form.configuration-step.form.expiration-duration.option-label.thirty-days'),
+        value: 'thirty-days',
+      },
+      {
+        label: i18n('cc-token-api-creation-form.configuration-step.form.expiration-duration.option-label.sixty-days'),
+        value: 'sixty-days',
+      },
+      {
+        label: i18n('cc-token-api-creation-form.configuration-step.form.expiration-duration.option-label.ninety-days'),
+        value: 'ninety-days',
+      },
+      {
+        label: i18n('cc-token-api-creation-form.configuration-step.form.expiration-duration.option-label.one-year'),
+        value: 'one-year',
+      },
+      {
+        label: i18n('cc-token-api-creation-form.configuration-step.form.expiration-duration.option-label.custom'),
+        value: 'custom',
+      },
+    ];
+  }
+
+  /** @param {Event} event */
+  _onConfigLinkClick(event) {
+    event.preventDefault();
+    // to make sure the console router doesn't pick this event as a navigation
+    event.stopPropagation();
+    this.state = /** @type {TokenApiCreationFormStateLoaded} */ ({
+      ...this.state,
+      activeStep: 'configuration',
+    });
+  }
+
+  _onConfigFormSubmit() {
+    this.state = {
+      ...this.state,
+      activeStep: 'validation',
+    };
+  }
+
+  /**
+   * @param {Expiration} expiration
+   * @returns {ExpirationPreset['preset']|null}
+   */
+  _getCurrentExpirationPreset(expiration) {
+    return expiration.type === 'preset' ? expiration.preset : null;
+  }
+
+  /**
+   * @param {Expiration} expiration
+   * @returns {string} the expiration date (ISO format)
+   */
+  _getExpirationDate(expiration) {
+    if (expiration.type === 'custom') {
+      return expiration.date;
+    }
+
+    return CcTokenApiCreationForm.computeExpirationDate(expiration.preset);
+  }
+
+  _onValidationFormSubmit() {
+    if (this.state.type !== 'loaded' || this.state.activeStep !== 'validation') {
+      return;
+    }
+
+    // clean up potential error messages related to credentials
+    this.state = {
+      ...this.state,
+      credentialsError: null,
+    };
+
+    const newToken = {
+      name: this.state.values.name,
+      description: this.state.values.description,
+      expirationDate: this._getExpirationDate(this.state.values.expiration),
+      password: this.state.values.password,
+      mfaCode: this.state.values.mfaCode,
+      isMfaEnabled: this.state.isMfaEnabled,
+    };
+
+    this.dispatchEvent(new CcTokenCreateEvent(newToken));
+  }
+
+  /** @param {CcTokenApiCreationFormPropertyValues} changedProperties */
+  willUpdate(changedProperties) {
+    if (
+      changedProperties.has('state') &&
+      this.state.type === 'loaded' &&
+      this.state.values.expiration.type === 'preset'
+    ) {
+      // clear potential error messages that are no longer relevant since the input becomes readonly
+      this.updateComplete.then(() => {
+        this._expirationDateInputRef.value.reportInlineValidity();
+      });
+    }
+  }
+
+  /** @param {CcTokenApiCreationFormPropertyValues} changedProperties */
+  updated(changedProperties) {
+    if (changedProperties.has('state') && this.state.type === 'loaded') {
+      // Handle focus in case `prefers-reduced-motion: reduce` is active because `transitionend` event is not triggered
+      if (window.matchMedia('(prefers-reduced-motion: no-preference)').matches) {
+        return;
+      }
+
+      const activeElement = this.shadowRoot.activeElement;
+      const activeStepElement = this.shadowRoot.querySelector('.steps-content__step-item--active');
+      if (!activeStepElement.contains(activeElement)) {
+        /** @type {CcInputText} */
+        const firstActiveCcInputText = activeStepElement.querySelector('cc-input-text');
+        firstActiveCcInputText.focus();
+      }
+    }
+  }
+
+  /** @param {EventWithCcFormControlTarget & { detail: string }} event */
+  _onInput(event) {
+    if (this.state.type !== 'loaded' || this.state.activeStep === 'copy') {
+      return;
+    }
+
+    if (event.target.name === 'expirationDate') {
+      this.state = {
+        ...this.state,
+        values: {
+          ...this.state.values,
+          expiration: {
+            type: 'custom',
+            date: event.detail,
+          },
+        },
+      };
+    } else {
+      this.state = {
+        ...this.state,
+        values: {
+          ...this.state.values,
+          [event.target.name]: event.detail,
+        },
+      };
+    }
+  }
+
+  /** @param {CcSelectEvent<ExpirationDurationOptions>} detail */
+  _onSelect({ detail: value }) {
+    if (this.state.type !== 'loaded' || this.state.activeStep === 'copy') {
+      return;
+    }
+
+    const currentExpirationPreset = this._getCurrentExpirationPreset(this.state.values.expiration);
+
+    this.state = {
+      ...this.state,
+      values: {
+        ...this.state.values,
+        expiration:
+          value === 'custom'
+            ? {
+                type: 'custom',
+                date: CcTokenApiCreationForm.computeExpirationDate(currentExpirationPreset),
+              }
+            : {
+                type: 'preset',
+                preset: value,
+              },
+      },
+    };
+  }
+
+  /**
+   * Handle focus after transition (will only be triggered if `prefers-reduced-motion: no-preference`)
+   * It is important to only move focus after the transition is complete because moving focus before that makes the transition fail
+   *
+   * @param {TransitionEvent & { currentTarget: HTMLDivElement }} event
+   */
+  _onTransitionEnd(event) {
+    if (event.propertyName === 'visibility') {
+      /** @type {CcInputText} */
+      const firstActiveCcInputText = event.currentTarget.querySelector(
+        '.steps-content__step-item--active cc-input-text',
+      );
+      firstActiveCcInputText.focus();
+    }
+  }
+
+  render() {
+    const activeStep =
+      this.state.type === 'loaded' || this.state.type === 'creating' ? this.state.activeStep : 'configuration';
+    const isMfaEnabled =
+      this.state.type === 'loaded' || this.state.type === 'creating' ? this.state.isMfaEnabled : true;
+    const credentialsError =
+      this.state.type === 'loaded' && this.state.activeStep === 'validation' ? this.state.credentialsError : null;
+    const token = this.state.type === 'loaded' && this.state.activeStep === 'copy' ? this.state.token : '';
+    const formValues =
+      this.state.type === 'loaded' || this.state.type === 'creating'
+        ? this.state.values
+        : CcTokenApiCreationForm.DEFAULT_FORM_VALUES;
+
+    return html`
+      <cc-block>
+        <div slot="header-title">${this._getMainHeading(activeStep)}</div>
+        <div slot="content">
+          ${this._renderStepsNav(activeStep, this.state.type)}
+          ${this.state.type === 'error'
+            ? html`<cc-notice intent="warning" message="${i18n('cc-token-api-creation-form.error')}"></cc-notice>`
+            : ''}
+          ${this.state.type !== 'error'
+            ? this._renderMainContent({
+                skeleton: this.state.type === 'loading',
+                activeStep,
+                isMfaEnabled,
+                isWaiting: this.state.type === 'creating',
+                credentialsError,
+                token,
+                formValues,
+              })
+            : ''}
+        </div>
+        <cc-block-details slot="footer-left">
+          <div slot="button-text">${i18n('cc-block-details.cli.text')}</div>
+          <a slot="link" href="https://www.clever-cloud.com/developers/api/howto/#request-the-api" target="_blank">
+            <span class="cc-link">${i18n('cc-token-api-creation-form.link.doc')}</span>
+            <cc-icon .icon=${iconExternalLink}></cc-icon>
+          </a>
+          <div slot="content">${i18n('cc-token-api-creation-form.cli.content')}</div>
+        </cc-block-details>
+      </cc-block>
+    `;
+  }
+
+  /**
+   * @param {TokenApiCreationFormStateLoaded['activeStep']} activeStep
+   * @param {TokenApiCreationFormState['type']} stateType
+   */
+  _renderStepsNav(activeStep, stateType) {
+    const steps = /** @type {const} */ ([
+      {
+        name: 'configuration',
+        text: i18n('cc-token-api-creation-form.configuration-step.nav.label'),
+        isLoading: stateType === 'loading',
+        isActive: activeStep === 'configuration',
+        isClickable: activeStep === 'validation',
+        isDone: activeStep !== 'configuration',
+      },
+      {
+        name: 'validation',
+        text: i18n('cc-token-api-creation-form.validation-step.nav.label'),
+        isLoading: stateType === 'creating',
+        isActive: activeStep === 'validation',
+        isClickable: false,
+        isDone: activeStep === 'copy',
+      },
+      {
+        name: 'copy',
+        text: i18n('cc-token-api-creation-form.copy-step.nav.label'),
+        isLoading: false,
+        isActive: activeStep === 'copy',
+        isClickable: false,
+        isDone: false,
+      },
+    ]);
+
+    return html`
+      <nav role="navigation" aria-label="${i18n('cc-token-api-creation-form.nav.aria-label')}">
+        <ol class="creation-steps-nav">
+          ${steps.map(
+            (step) => html`
+              <li
+                class="creation-steps-nav__step-item ${classMap({
+                  'creation-steps-nav__step-item--active': step.isActive,
+                  'creation-steps-nav__step-item--done': step.isDone,
+                })}"
+                aria-current="${ifDefined(step.isActive ? 'step' : null)}"
+              >
+                ${step.isLoading ? html`<cc-loader class="creation-steps-nav__step-item__loader"></cc-loader>` : ''}
+                ${step.isActive && !step.isLoading ? html`<cc-icon .icon=${iconActiveStep} size="lg"></cc-icon>` : ''}
+                ${step.isDone ? html`<cc-icon .icon=${iconDoneStep} size="lg"></cc-icon>` : ''}
+                ${step.isClickable ? html`<a @click="${this._onConfigLinkClick}" href="#">${step.text}</a>` : ''}
+                ${!step.isClickable ? html`<span>${step.text}</span>` : ''}
+              </li>
+            `,
+          )}
+        </ol>
+      </nav>
+    `;
+  }
+
+  /**
+   * @param {object} _
+   * @param {boolean} _.skeleton
+   * @param {TokenApiCreationFormStateLoaded['activeStep']} _.activeStep
+   * @param {boolean} _.isMfaEnabled
+   * @param {boolean} _.isWaiting
+   * @param {TokenApiCreationFormStateLoadedValidation['credentialsError']} _.credentialsError
+   * @param {string} _.token
+   * @param {FormValues} _.formValues
+   */
+  _renderMainContent({ skeleton, activeStep, isMfaEnabled, isWaiting, credentialsError, token, formValues }) {
+    /**
+     * Note: Every step is rendered at the same time, even though only one step is displayed.
+     * This is essential to allow transitions / animations between steps.
+     * We may be able to remove this behavior once `viewTransition` is supported (at least newly available).
+     * The `steps-content__step-item--active` class is not used for CSS but in JS to make it easier to focus
+     * the first input after changing the active step.
+     */
+    return html`
+      <!-- FIXME: replace cc-expand with interpolate-size (CSS) once it's newly available -->
+      <cc-expand>
+        <div class="steps-content" @transitionend="${this._onTransitionEnd}">
+          <div
+            class="steps-content__step-item ${classMap({
+              'steps-content__step-item--active': activeStep === 'configuration',
+              'steps-content__step-item--out-left': activeStep !== 'configuration',
+            })}"
+          >
+            ${this._renderConfigurationForm({
+              name: formValues.name,
+              description: formValues.description,
+              expiration: formValues.expiration,
+              skeleton,
+            })}
+          </div>
+          <div
+            class="steps-content__step-item ${classMap({
+              'steps-content__step-item--active': activeStep === 'validation',
+              'steps-content__step-item--out-right': activeStep === 'configuration',
+              'steps-content__step-item--out-left': activeStep === 'copy',
+            })}"
+          >
+            ${this._renderValidationForm({
+              password: formValues.password,
+              mfaCode: formValues.mfaCode,
+              isMfaEnabled,
+              isWaiting,
+              credentialsError: credentialsError,
+            })}
+          </div>
+          <div
+            class="steps-content__step-item ${classMap({
+              'steps-content__step-item--active': activeStep === 'copy',
+              'steps-content__step-item--out-right': activeStep !== 'copy',
+            })}"
+          >
+            ${this._renderCopyStep(token)}
+          </div>
+        </div>
+      </cc-expand>
+    `;
+  }
+
+  /**
+   *
+   * @param {object} _
+   * @param {string} _.name
+   * @param {string} _.description
+   * @param {Expiration} _.expiration
+   * @param {boolean} _.skeleton
+   */
+  _renderConfigurationForm({ name, description, expiration, skeleton }) {
+    const isExpirationDurationCustom = expiration.type === 'custom';
+    const expirationDuration = expiration.type === 'preset' ? expiration.preset : expiration.type;
+    const expirationDate = this._getExpirationDate(expiration);
+
+    return html`
+      <form
+        name="configuration-form"
+        class="form"
+        ${formSubmit(this._onConfigFormSubmit.bind(this))}
+        ${ref(this._configurationFormRef)}
+        @cc-input="${this._onInput}"
+        @cc-select="${this._onSelect}"
+      >
+        <cc-input-text
+          label="${i18n('cc-token-api-creation-form.configuration-step.form.name.label')}"
+          required
+          ?skeleton=${skeleton}
+          name="name"
+          value=${name}
+        ></cc-input-text>
+        <cc-input-text
+          label="${i18n('cc-token-api-creation-form.configuration-step.form.desc.label')}"
+          ?skeleton=${skeleton}
+          name="description"
+          value=${description}
+        ></cc-input-text>
+        <div class="form__expiration">
+          <cc-select
+            label="${i18n('cc-token-api-creation-form.configuration-step.form.expiration-duration.label')}"
+            name="expirationDuration"
+            .options=${this._getExpirationDurationOptions()}
+            value="${expirationDuration}"
+            ?disabled=${skeleton}
+          >
+            ${isExpirationDurationCustom
+              ? html`<p slot="help">
+                  ${i18n('cc-token-api-creation-form.configuration-step.form.expiration-duration.help.custom')}
+                </p>`
+              : ''}
+          </cc-select>
+          <cc-input-date
+            label="${i18n('cc-token-api-creation-form.configuration-step.form.expiration-date.label')}"
+            name="expirationDate"
+            ?required="${isExpirationDurationCustom}"
+            ?readonly="${!isExpirationDurationCustom}"
+            .value="${expirationDate}"
+            .min="${shiftDateField(new Date(), 'm', 15)}"
+            .max="${shiftDateField(new Date(), 'Y', 1)}"
+            .customErrorMessages="${this._expirationDateErrorMessages}"
+            timezone="local"
+            ?skeleton="${skeleton}"
+            ${ref(this._expirationDateInputRef)}
+          >
+            ${isExpirationDurationCustom
+              ? html`
+                  <p slot="help">
+                    ${i18n('cc-token-api-creation-form.configuration-step.form.expiration-date.help.min-max')}
+                  </p>
+                `
+              : ''}
+            <p slot="help">${i18n('cc-token-api-creation-form.configuration-step.form.expiration-date.help.format')}</p>
+          </cc-input-date>
+        </div>
+        <div class="form__actions">
+          <div class="form__actions__link-container">
+            <a href="${this.apiTokenListHref}" class="form__actions__link-container__link">
+              <cc-icon .icon=${iconGoBack}></cc-icon>
+              <span>${i18n('cc-token-api-creation-form.configuration-step.form.link.back-to-list')}</span>
+            </a>
+          </div>
+          <cc-button class="form__actions__submit-button" primary type="submit" ?disabled=${skeleton}>
+            ${i18n('cc-token-api-creation-form.configuration-step.form.submit-button.label')}
+          </cc-button>
+        </div>
+      </form>
+    `;
+  }
+
+  /**
+   * @param {object} _
+   * @param {string} _.password
+   * @param {string} _.mfaCode
+   * @param {boolean} _.isMfaEnabled
+   * @param {boolean} _.isWaiting
+   * @param {TokenApiCreationFormStateLoadedValidation['credentialsError']} _.credentialsError
+   */
+  _renderValidationForm({ password, mfaCode, isMfaEnabled, isWaiting, credentialsError }) {
+    const passwordErrorMessage =
+      credentialsError === 'password' ? i18n('cc-token-api-creation-form.validation-step.form.password.error') : null;
+    const mfaErrorMessage =
+      credentialsError === 'mfaCode' ? i18n('cc-token-api-creation-form.validation-step.form.mfa-code.error') : null;
+
+    return html`
+      <form
+        name="validation-form"
+        class="form"
+        @cc-input="${this._onInput}"
+        @cc-select="${this._onInput}"
+        ${formSubmit(this._onValidationFormSubmit.bind(this))}
+        ${ref(this._validationFormRef)}
+      >
+        <cc-input-text
+          label="${i18n('cc-token-api-creation-form.validation-step.form.password.label')}"
+          name="password"
+          ?readonly=${isWaiting}
+          required
+          secret
+          .errorMessage=${passwordErrorMessage}
+          .value="${password}"
+        ></cc-input-text>
+        ${isMfaEnabled
+          ? html`
+              <cc-input-text
+                label="${i18n('cc-token-api-creation-form.validation-step.form.mfa-code.label')}"
+                name="mfaCode"
+                ?readonly=${isWaiting}
+                required
+                .errorMessage=${mfaErrorMessage}
+                .value="${mfaCode}"
+              ></cc-input-text>
+            `
+          : ''}
+
+        <div class="form__actions">
+          <div class="form__actions__link-container">
+            ${isWaiting
+              ? html`
+                  <div class="form__actions__link-container__link">
+                    <cc-icon .icon=${iconGoBack}></cc-icon>
+                    <span>${i18n('cc-token-api-creation-form.validation-step.form.link.back-to-configuration')}</span>
+                  </div>
+                `
+              : ''}
+            ${!isWaiting
+              ? html`
+                  <a class="form__actions__link-container__link" @click="${this._onConfigLinkClick}" href="#">
+                    <cc-icon .icon=${iconGoBack}></cc-icon>
+                    <span>${i18n('cc-token-api-creation-form.validation-step.form.link.back-to-configuration')}</span>
+                  </a>
+                `
+              : ''}
+          </div>
+          <cc-button class="form__actions__submit-button" primary type="submit" ?waiting=${isWaiting}>
+            ${i18n('cc-token-api-creation-form.validation-step.form.submit-button.label')}
+          </cc-button>
+        </div>
+      </form>
+    `;
+  }
+
+  /** @param {string} token */
+  _renderCopyStep(token) {
+    return html`
+      <div class="copy-step-wrapper">
+        <cc-notice intent="warning" .message=${i18n('cc-token-api-creation-form.copy-step.notice.message')}></cc-notice>
+        <cc-input-text
+          label="${i18n('cc-token-api-creation-form.copy-step.form.token.label')}"
+          name="token"
+          readonly
+          secret
+          clipboard
+          value=${token}
+        ></cc-input-text>
+        <a class="token-list-link-cta" href="${this.apiTokenListHref}">
+          <span>${i18n('cc-token-api-creation-form.copy-step.link.back-to-list')}</span>
+        </a>
+      </div>
+    `;
+  }
+
+  static get styles() {
+    return [
+      linkStyles,
+      cliCommandsStyles,
+      css`
+        :host {
+          display: block;
+
+          --transition-duration: 300ms;
+        }
+
+        @media (prefers-reduced-motion) {
+          :host {
+            --transition-duration: 0ms;
+          }
+        }
+
+        /* FIXME: not great when viewport is reduced + should be handled by the cc-block component itself */
+        cc-block {
+          padding-top: 2em;
+        }
+
+        /* FIXME: not great when viewport is reduced + should be handled by the cc-block component itself */
+        cc-block > [slot='content'] {
+          padding-bottom: 2em;
+          padding-inline: 3em;
+        }
+
+        /* FIXME: not great when viewport is reduced + should be handled by the cc-block component itself */
+        [slot='header-title'] {
+          padding-inline: 1.5em;
+        }
+
+        [slot='link'] {
+          --cc-icon-color: var(--cc-color-text-primary-highlight);
+
+          text-decoration: none;
+        }
+
+        .cc-link {
+          text-decoration: underline;
+        }
+
+        .block-intro {
+          margin: 0;
+        }
+
+        .creation-steps-nav {
+          column-gap: 2em;
+          display: flex;
+          flex-wrap: wrap;
+          list-style: none;
+          margin: 0;
+          margin-block: 2em;
+          padding: 0;
+          row-gap: 1em;
+        }
+
+        .creation-steps-nav__step-item {
+          --cc-icon-size: 1.3em;
+
+          align-items: center;
+          border-top: 3px solid currentcolor;
+          color: var(--cc-color-text-weak);
+          display: flex;
+          flex: 1 1 10em;
+          gap: 0.5em;
+          line-height: 1.3em;
+          padding-block: 1em;
+          position: relative;
+          transition: all var(--transition-duration) ease-in-out;
+        }
+
+        .creation-steps-nav__step-item a {
+          color: inherit;
+          text-decoration: none;
+        }
+
+        .creation-steps-nav__step-item--active {
+          color: var(--cc-color-text-primary);
+          transition: all var(--transition-duration) ease-in-out;
+        }
+
+        .creation-steps-nav__step-item--done {
+          color: var(--cc-color-text-success);
+          transition: all var(--transition-duration) ease-in-out;
+        }
+
+        .creation-steps-nav__step-item__loader {
+          height: 1.3em;
+          width: 1.3em;
+        }
+
+        .steps-content {
+          display: grid;
+          grid-template-areas: 'step';
+        }
+
+        cc-expand {
+          margin-inline: -1em;
+          padding: 1em;
+          transition: all var(--transition-duration) ease-in-out;
+        }
+
+        .steps-content__step-item {
+          display: block;
+          grid-area: step;
+          height: auto;
+          opacity: 1;
+          transform: translateX(0);
+          transition:
+            transform var(--transition-duration) ease-in-out,
+            opacity var(--transition-duration) ease-in-out;
+          visibility: visible;
+        }
+
+        .steps-content__step-item--out-left {
+          height: 0;
+          opacity: 0;
+          transform: translateX(-110%);
+          transition:
+            transform var(--transition-duration) ease-in-out,
+            opacity var(--transition-duration) ease-in-out,
+            visibility var(--transition-duration) ease-in-out var(--transition-duration);
+          visibility: hidden;
+        }
+
+        .steps-content__step-item--out-right {
+          height: 0;
+          opacity: 0;
+          transform: translateX(110%);
+          transition:
+            transform var(--transition-duration) ease-in-out,
+            opacity var(--transition-duration) ease-in-out,
+            visibility var(--transition-duration) ease-in-out var(--transition-duration);
+          visibility: hidden;
+        }
+
+        .form {
+          display: grid;
+          gap: 1.5em;
+        }
+
+        .form__expiration {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 1.5em;
+        }
+
+        .form__expiration cc-input-date,
+        .form__expiration cc-select {
+          flex: 1 1 18em;
+        }
+
+        .form__actions {
+          align-items: center;
+          display: flex;
+          flex-wrap: wrap;
+          gap: 1.5em;
+          justify-content: flex-end;
+          margin-top: 2em;
+        }
+
+        .form__actions__submit-button {
+          flex: 1 0 min(100%, 12.5em);
+        }
+
+        .copy-step-wrapper {
+          display: grid;
+          gap: 1.5em;
+        }
+
+        .copy-step-wrapper cc-input-text {
+          order: -1;
+        }
+
+        .token-list-link-cta {
+          align-items: center;
+          background-color: var(--cc-color-bg-primary, #fff);
+          border: 1px solid var(--cc-color-bg-primary);
+          border-radius: var(--cc-button-border-radius, 0.15em);
+          box-sizing: border-box;
+          color: var(--cc-color-text-inverted, #fff);
+          cursor: pointer;
+          display: flex;
+          font-weight: var(--cc-button-font-weight, bold);
+          justify-self: flex-end;
+          min-height: 2em;
+          padding: 0 0.5em;
+          text-decoration: none;
+          text-transform: var(--cc-button-text-transform, uppercase);
+          user-select: none;
+        }
+
+        .token-list-link-cta:focus-visible {
+          outline: var(--cc-focus-outline);
+          outline-offset: var(--cc-focus-outline-offset, 2px);
+        }
+
+        .token-list-link-cta span {
+          font-size: 0.85em;
+        }
+
+        .form__actions__link-container {
+          display: grid;
+          flex: 100 1 auto;
+          justify-content: flex-end;
+        }
+
+        .form__actions__link-container__link {
+          align-items: center;
+          color: var(--cc-color-text-weak);
+          cursor: pointer;
+          display: flex;
+          gap: 0.5em;
+          padding: 0.25em 0.5em;
+          text-decoration: none;
+        }
+
+        .form__actions__link-container__link:visited,
+        .form__actions__link-container__link:active {
+          color: var(--cc-color-text-weak);
+        }
+
+        .form__actions__link-container__link:focus-visible {
+          border-radius: var(--cc-border-radius-default, 0.25em);
+          outline: var(--cc-focus-outline);
+          outline-offset: var(--cc-focus-outline-offset, 2px);
+        }
+
+        .form__actions__link-container__link cc-icon {
+          flex: 0 0 auto;
+        }
+      `,
+    ];
+  }
+}
+
+window.customElements.define('cc-token-api-creation-form', CcTokenApiCreationForm);

--- a/src/components/cc-token-api-creation-form/cc-token-api-creation-form.smart.js
+++ b/src/components/cc-token-api-creation-form/cc-token-api-creation-form.smart.js
@@ -1,0 +1,166 @@
+// @ts-expect-error FIXME: remove when clever-client exports types
+import { get as getSelf } from '@clevercloud/client/esm/api/v2/organisation.js';
+import { notifyError } from '../../lib/notifications.js';
+import { sendToApi } from '../../lib/send-to-api.js';
+import { sendToAuthBridge } from '../../lib/send-to-auth-bridge.js';
+import { defineSmartComponent } from '../../lib/smart/define-smart-component.js';
+import { i18n } from '../../translations/translation.js';
+import '../cc-smart-container/cc-smart-container.js';
+import { CcTokenApiCreationForm } from './cc-token-api-creation-form.js';
+
+/**
+ * @typedef {import('./cc-token-api-creation-form.types.js').TokenApiCreationFormStateLoadedConfiguration} TokenApiCreationFormStateLoadedConfiguration
+ * @typedef {import('./cc-token-api-creation-form.types.js').TokenApiCreationFormStateLoadedValidation} TokenApiCreationFormStateLoadedValidation
+ * @typedef {import('./cc-token-api-creation-form.types.js').TokenApiCreationFormStateLoadedCopy} TokenApiCreationFormStateLoadedCopy
+ * @typedef {import('./cc-token-api-creation-form.types.js').TokenApiCreationFormStateCreating} TokenApiCreationFormStateCreating
+ * @typedef {import('../../lib/send-to-api.types.js').ApiConfig} ApiConfig
+ * @typedef {import('../../lib/send-to-api.types.js').AuthBridgeConfig} AuthBridgeConfig
+ * @typedef {import('../../lib/smart/smart-component.types.js').OnContextUpdateArgs<CcTokenApiCreationForm>} OnContextUpdateArgs
+ */
+
+defineSmartComponent({
+  selector: 'cc-token-api-creation-form',
+  params: {
+    apiConfig: { type: Object },
+  },
+  /** @param {OnContextUpdateArgs} args */
+  onContextUpdate({ component, context, onEvent, updateComponent }) {
+    const { apiConfig } = context;
+    const api = new Api(apiConfig);
+
+    updateComponent('state', { type: 'loading' });
+
+    api
+      .getUserInfo()
+      .then(({ isMfaEnabled }) => {
+        /** @type {TokenApiCreationFormStateLoadedConfiguration} */
+        const newState = {
+          type: 'loaded',
+          activeStep: 'configuration',
+          isMfaEnabled,
+          values: CcTokenApiCreationForm.DEFAULT_FORM_VALUES,
+        };
+        updateComponent('state', newState);
+      })
+      .catch((error) => {
+        console.error(error);
+        updateComponent('state', { type: 'error' });
+      });
+
+    onEvent('cc-token-create', ({ name, description, expirationDate, password, mfaCode }) => {
+      updateComponent('state', (state) => {
+        state.type = 'creating';
+      });
+      const componentState = /** @type {TokenApiCreationFormStateCreating} */ (component.state);
+
+      api
+        .createApiToken({ name, description, expirationDate, password, mfaCode })
+        .then((token) => {
+          /** @type {TokenApiCreationFormStateLoadedCopy} */
+          const newState = {
+            ...componentState,
+            type: 'loaded',
+            activeStep: 'copy',
+            token,
+          };
+
+          updateComponent('state', newState);
+        })
+        .catch(
+          /** @param {Error} error */
+          (error) => {
+            const errorCode =
+              'responseBody' in error && typeof error.responseBody === 'object' && 'code' in error.responseBody
+                ? error.responseBody.code
+                : null;
+            /** @type {TokenApiCreationFormStateLoadedValidation['credentialsError']} */
+            let credentialsError;
+
+            if (errorCode === 'invalid-credential') {
+              credentialsError = 'password';
+            }
+
+            if (errorCode === 'invalid-mfa-code') {
+              credentialsError = 'mfaCode';
+            }
+
+            /** @type {TokenApiCreationFormStateLoadedValidation} */
+            const newState = {
+              ...componentState,
+              type: 'loaded',
+              credentialsError,
+            };
+
+            updateComponent('state', newState);
+
+            if (credentialsError == null) {
+              notifyError(i18n('cc-token-api-creation-form.validation-step.error.generic'));
+            }
+          },
+        );
+    });
+  },
+});
+
+class Api {
+  /** @param {ApiConfig & AuthBridgeConfig} apiConfig */
+  constructor(apiConfig) {
+    this._authAndApiConfig = apiConfig;
+
+    /** @type {string|null} */
+    this._userEmail = null;
+  }
+
+  /**
+   * @param {object} options
+   * @param {string} options.name
+   * @param {string} options.description
+   * @param {string} options.expirationDate
+   * @param {string} options.password
+   * @param {string} options.mfaCode
+   */
+  _prepareCreateApiTokenRequest({ name, description, expirationDate, password, mfaCode }) {
+    return Promise.resolve({
+      method: 'post',
+      url: '/api-tokens',
+      headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+      body: { email: this._userEmail, password, mfaCode, name, description, expirationDate },
+    });
+  }
+
+  /**
+   * @param {object} options
+   * @param {string} options.name
+   * @param {string} options.description
+   * @param {string} options.expirationDate
+   * @param {string} options.password
+   * @param {string} options.mfaCode
+   */
+  createApiToken({ name, description, expirationDate, password, mfaCode }) {
+    return this._prepareCreateApiTokenRequest({
+      password,
+      mfaCode,
+      name,
+      description,
+      expirationDate: expirationDate,
+    })
+      .then(sendToAuthBridge({ authBridgeConfig: this._authAndApiConfig }))
+      .then(({ apiToken }) => apiToken);
+  }
+
+  /** @returns {Promise<{ isMfaEnabled: boolean }>} */
+  getUserInfo() {
+    return getSelf({})
+      .then(sendToApi({ apiConfig: this._authAndApiConfig }))
+      .then(
+        /**
+         * @param {{ email: string, preferredMFA: 'TOTP' | null }} user
+         * @returns {{ isMfaEnabled: boolean }}
+         */
+        (user) => {
+          this._userEmail = user.email;
+          return { isMfaEnabled: user.preferredMFA === 'TOTP' };
+        },
+      );
+  }
+}

--- a/src/components/cc-token-api-creation-form/cc-token-api-creation-form.smart.md
+++ b/src/components/cc-token-api-creation-form/cc-token-api-creation-form.smart.md
@@ -1,0 +1,53 @@
+---
+kind: '🛠 Profile/<cc-token-api-creation-form>'
+title: '💡 Smart'
+---
+
+# 💡 Smart `<cc-token-api-creation-form>`
+
+## ℹ️ Details
+
+<table>
+  <tr><td><strong>Component    </strong> <td><a href="https://www.clever-cloud.com/doc/clever-components/?path=/docs/🛠-profile-cc-token-api-creation-form--default-story"><code>&lt;cc-token-api-creation-form&gt;</code></a>
+  <tr><td><strong>Selector     </strong> <td><code>cc-token-api-creation-form</code>
+  <tr><td><strong>Requires auth</strong> <td>Yes
+</table>
+
+## ⚙️ Params
+
+| Name        | Type        | Details                                                 | Default |
+|-------------|-------------|---------------------------------------------------------|---------|
+| `apiConfig` | `ApiConfig` | Object with API configuration (target host, tokens...)  |         |
+
+```ts
+interface ApiConfig {
+  API_HOST: string,
+  API_OAUTH_TOKEN: string,
+  API_OAUTH_TOKEN_SECRET: string,
+  OAUTH_CONSUMER_KEY: string,
+  OAUTH_CONSUMER_SECRET: string,
+  AUTH_BRIDGE_HOST: string,
+}
+```
+
+## 🌐 API endpoints
+
+| Method   | Type                    | Cache?  |
+|----------|:------------------------|---------|
+| `GET`    | `/v2/self`              | Default |
+| `POST`   | `/api-tokens`           | N/A     |
+
+```html
+<cc-smart-container context='{
+    "apiConfig": {
+      API_HOST: "",
+      API_OAUTH_TOKEN: "",
+      API_OAUTH_TOKEN_SECRET: "",
+      OAUTH_CONSUMER_KEY: "",
+      OAUTH_CONSUMER_SECRET: "",
+      AUTH_BRIDGE_HOST: "",
+    }
+}'>
+    <cc-token-api-creation-form></cc-token-api-creation-form>
+<cc-smart-container>
+```

--- a/src/components/cc-token-api-creation-form/cc-token-api-creation-form.stories.js
+++ b/src/components/cc-token-api-creation-form/cc-token-api-creation-form.stories.js
@@ -1,0 +1,791 @@
+import { DateFormatter } from '../../lib/date/date-formatter.js';
+import { shiftDateField } from '../../lib/date/date-utils.js';
+import { makeStory, storyWait } from '../../stories/lib/make-story.js';
+import { CcTokenApiCreationForm } from './cc-token-api-creation-form.js';
+
+const DATE_FORMATTER_ISO = new DateFormatter('datetime-iso', 'local');
+
+/**
+ * @param {CcTokenApiCreationForm} component
+ * @param {'configuration-form'|'validation-form'} formName
+ * @returns {HTMLFormElement}
+ */
+const getForm = function (component, formName) {
+  return component.shadowRoot.querySelector(`form[name=${formName}]`);
+};
+
+export default {
+  tags: ['autodocs'],
+  title: '🛠 Profile/<cc-token-api-creation-form>',
+  component: 'cc-token-api-creation-form',
+};
+
+/**
+ * @typedef {import('./cc-token-api-creation-form.types.js').TokenApiCreationFormStateLoaded} TokenApiCreationFormStateLoaded
+ * @typedef {import('./cc-token-api-creation-form.types.js').TokenApiCreationFormStateCreating} TokenApiCreationFormStateCreating
+ */
+
+const conf = {
+  component: 'cc-token-api-creation-form',
+};
+
+export const defaultStory = makeStory(conf, {
+  /** @type {Partial<CcTokenApiCreationForm>[]} */
+  items: [
+    {
+      state: {
+        type: 'loaded',
+        activeStep: 'configuration',
+        isMfaEnabled: true,
+        values: CcTokenApiCreationForm.DEFAULT_FORM_VALUES,
+      },
+    },
+  ],
+});
+
+export const loading = makeStory(conf, {
+  /** @type {Partial<CcTokenApiCreationForm>[]} */
+  items: [
+    {
+      state: {
+        type: 'loading',
+      },
+    },
+  ],
+});
+
+export const dataLoadedWithConfigurationStep = makeStory(conf, {
+  /** @type {Partial<CcTokenApiCreationForm>[]} */
+  items: [
+    {
+      state: {
+        type: 'loaded',
+        activeStep: 'configuration',
+        isMfaEnabled: true,
+        values: CcTokenApiCreationForm.DEFAULT_FORM_VALUES,
+      },
+    },
+  ],
+});
+
+export const dataLoadedWithValidationStep = makeStory(conf, {
+  /** @type {Partial<CcTokenApiCreationForm>[]} */
+  items: [
+    {
+      state: {
+        type: 'loaded',
+        activeStep: 'validation',
+        isMfaEnabled: true,
+        values: CcTokenApiCreationForm.DEFAULT_FORM_VALUES,
+      },
+    },
+  ],
+});
+
+export const dataLoadedWithApiTokenCreated = makeStory(conf, {
+  /** @type {Partial<CcTokenApiCreationForm>[]} */
+  items: [
+    {
+      state: {
+        type: 'loaded',
+        activeStep: 'copy',
+        token: 'this-is-my-super-secret-token-that-should-be-copied',
+        isMfaEnabled: true,
+        values: CcTokenApiCreationForm.DEFAULT_FORM_VALUES,
+      },
+    },
+  ],
+});
+
+export const waitingWithCreatingToken = makeStory(conf, {
+  /** @type {Partial<CcTokenApiCreationForm>[]} */
+  items: [
+    {
+      state: {
+        type: 'creating',
+        activeStep: 'validation',
+        values: {
+          ...CcTokenApiCreationForm.DEFAULT_FORM_VALUES,
+          password: 'my-fake-secret-password',
+          mfaCode: '293381',
+        },
+        isMfaEnabled: true,
+      },
+    },
+  ],
+});
+
+export const errorWithLoading = makeStory(conf, {
+  /** @type {Partial<CcTokenApiCreationForm>[]} */
+  items: [
+    {
+      state: {
+        type: 'error',
+      },
+    },
+  ],
+});
+
+export const errorWithConfigStepEmptyFormControls = makeStory(conf, {
+  /** @type {Partial<CcTokenApiCreationForm>[]} */
+  items: [
+    {
+      state: {
+        type: 'loaded',
+        activeStep: 'configuration',
+        values: {
+          ...CcTokenApiCreationForm.DEFAULT_FORM_VALUES,
+          expiration: {
+            type: 'custom',
+            date: null,
+          },
+        },
+        isMfaEnabled: true,
+      },
+    },
+  ],
+  /** @param {CcTokenApiCreationForm} component */
+  onUpdateComplete: (component) => {
+    getForm(component, 'configuration-form').requestSubmit();
+  },
+});
+
+export const errorWithConfigStepInvalidDateFormat = makeStory(conf, {
+  /** @type {Partial<CcTokenApiCreationForm>[]} */
+  items: [
+    {
+      state: {
+        type: 'loaded',
+        activeStep: 'configuration',
+        values: {
+          ...CcTokenApiCreationForm.DEFAULT_FORM_VALUES,
+          name: 'My API token name',
+          expiration: {
+            type: 'custom',
+            date: 'invalid format',
+          },
+        },
+        isMfaEnabled: true,
+      },
+    },
+  ],
+  /** @param {CcTokenApiCreationForm} component */
+  onUpdateComplete: (component) => {
+    getForm(component, 'configuration-form').requestSubmit();
+  },
+});
+
+export const errorWithConfigStepDateMin = makeStory(conf, {
+  /** @type {Partial<CcTokenApiCreationForm>[]} */
+  items: [
+    {
+      state: {
+        type: 'loaded',
+        activeStep: 'configuration',
+        values: {
+          ...CcTokenApiCreationForm.DEFAULT_FORM_VALUES,
+          name: 'My API token name',
+          expiration: {
+            type: 'custom',
+            date: DATE_FORMATTER_ISO.format(shiftDateField(new Date(), 'Y', -1)),
+          },
+        },
+        isMfaEnabled: true,
+      },
+    },
+  ],
+  /** @param {CcTokenApiCreationForm} component */
+  onUpdateComplete: (component) => {
+    getForm(component, 'configuration-form').requestSubmit();
+  },
+});
+
+export const errorWithConfigStepDateMax = makeStory(conf, {
+  /** @type {Partial<CcTokenApiCreationForm>[]} */
+  items: [
+    {
+      state: {
+        type: 'loaded',
+        activeStep: 'configuration',
+        values: {
+          ...CcTokenApiCreationForm.DEFAULT_FORM_VALUES,
+          name: 'My API token name',
+          expiration: {
+            type: 'custom',
+            date: DATE_FORMATTER_ISO.format(shiftDateField(new Date(), 'Y', 2)),
+          },
+        },
+        isMfaEnabled: true,
+      },
+    },
+  ],
+  /** @param {CcTokenApiCreationForm} component */
+  onUpdateComplete: (component) => {
+    getForm(component, 'configuration-form').requestSubmit();
+  },
+});
+
+export const errorWithValidationStepEmptyFormControls = makeStory(conf, {
+  /** @type {Partial<CcTokenApiCreationForm>[]} */
+  items: [
+    {
+      state: {
+        type: 'loaded',
+        activeStep: 'validation',
+        isMfaEnabled: true,
+        values: CcTokenApiCreationForm.DEFAULT_FORM_VALUES,
+      },
+    },
+  ],
+  /** @param {CcTokenApiCreationForm} component */
+  onUpdateComplete: (component) => {
+    getForm(component, 'validation-form').requestSubmit();
+  },
+});
+
+export const errorWithValidationStepEmptyFormControlsAndMfaDisabled = makeStory(conf, {
+  /** @type {Partial<CcTokenApiCreationForm>[]} */
+  items: [
+    {
+      state: {
+        type: 'loaded',
+        activeStep: 'validation',
+        isMfaEnabled: false,
+        values: CcTokenApiCreationForm.DEFAULT_FORM_VALUES,
+      },
+    },
+  ],
+  /** @param {CcTokenApiCreationForm} component */
+  onUpdateComplete: (component) => {
+    getForm(component, 'validation-form').requestSubmit();
+  },
+});
+
+export const errorWithValidationStepInvalidPassword = makeStory(conf, {
+  /** @type {Partial<CcTokenApiCreationForm>[]} */
+  items: [
+    {
+      state: {
+        type: 'loaded',
+        activeStep: 'validation',
+        isMfaEnabled: true,
+        values: {
+          ...CcTokenApiCreationForm.DEFAULT_FORM_VALUES,
+          password: 'my-fake-secret-password',
+          mfaCode: 'AAAAAA',
+        },
+        credentialsError: 'password',
+      },
+    },
+  ],
+});
+
+export const errorWithValidationStepInvalid2faCode = makeStory(conf, {
+  /** @type {Partial<CcTokenApiCreationForm>[]} */
+  items: [
+    {
+      state: {
+        type: 'loaded',
+        activeStep: 'validation',
+        isMfaEnabled: true,
+        values: {
+          ...CcTokenApiCreationForm.DEFAULT_FORM_VALUES,
+          password: 'my-fake-secret-password',
+          mfaCode: 'AAAAAA',
+        },
+        credentialsError: 'mfaCode',
+      },
+    },
+  ],
+});
+
+export const simulationLoadingSuccess = makeStory(conf, {
+  /** @type {Partial<CcTokenApiCreationForm>[]} */
+  items: [{ state: { type: 'loading' } }],
+  simulations: [
+    storyWait(
+      1500,
+      /** @param {CcTokenApiCreationForm[]} components */
+      ([component]) => {
+        component.state = {
+          type: 'loaded',
+          activeStep: 'configuration',
+          isMfaEnabled: true,
+          values: CcTokenApiCreationForm.DEFAULT_FORM_VALUES,
+        };
+      },
+    ),
+  ],
+});
+
+export const simulationLoadingError = makeStory(conf, {
+  /** @type {Partial<CcTokenApiCreationForm>[]} */
+  items: [{ state: { type: 'loading' } }],
+  simulations: [
+    storyWait(
+      1500,
+      /** @param {CcTokenApiCreationForm[]} components */
+      ([component]) => {
+        component.state = {
+          type: 'error',
+        };
+      },
+    ),
+  ],
+});
+
+export const simulationsCreatingWithSuccess = makeStory(conf, {
+  /** @type {Partial<CcTokenApiCreationForm>[]} */
+  items: [
+    {
+      state: {
+        type: 'loaded',
+        activeStep: 'configuration',
+        isMfaEnabled: true,
+        values: CcTokenApiCreationForm.DEFAULT_FORM_VALUES,
+      },
+    },
+  ],
+  simulations: [
+    // Fill token name
+    storyWait(
+      2000,
+      /** @param {(CcTokenApiCreationForm & { state: TokenApiCreationFormStateLoaded })[]} components */
+      ([component]) => {
+        component.state = {
+          type: 'loaded',
+          activeStep: 'configuration',
+          isMfaEnabled: true,
+          values: {
+            ...component.state.values,
+            name: 'My Token',
+          },
+        };
+      },
+    ),
+    // Fill token description
+    storyWait(
+      2000,
+      /** @param {(CcTokenApiCreationForm & { state: TokenApiCreationFormStateLoaded })[]} components */
+      ([component]) => {
+        component.state = {
+          type: 'loaded',
+          activeStep: 'configuration',
+          isMfaEnabled: true,
+          values: {
+            ...component.state.values,
+            description: 'My Token Description',
+          },
+        };
+      },
+    ),
+    // Select expiration duration
+    storyWait(
+      2000,
+      /** @param {(CcTokenApiCreationForm & { state: TokenApiCreationFormStateLoaded })[]} components */
+      ([component]) => {
+        component.state = {
+          type: 'loaded',
+          activeStep: 'configuration',
+          isMfaEnabled: true,
+          values: {
+            ...component.state.values,
+            expiration: {
+              type: 'preset',
+              preset: 'seven-days',
+            },
+          },
+        };
+      },
+    ),
+    // Move to validation step
+    storyWait(
+      2000,
+      /** @param {(CcTokenApiCreationForm & { state: TokenApiCreationFormStateLoaded })[]} components */
+      ([component]) => {
+        component.state = {
+          type: 'loaded',
+          activeStep: 'validation',
+          isMfaEnabled: true,
+          values: component.state.values,
+        };
+      },
+    ),
+    // Fill password
+    storyWait(
+      2000,
+      /** @param {(CcTokenApiCreationForm & { state: TokenApiCreationFormStateLoaded })[]} components */
+      ([component]) => {
+        component.state = {
+          type: 'loaded',
+          activeStep: 'validation',
+          isMfaEnabled: true,
+          values: {
+            ...component.state.values,
+            password: 'my-secret-password',
+          },
+        };
+      },
+    ),
+    // Fill MFA code
+    storyWait(
+      2000,
+      /** @param {(CcTokenApiCreationForm & { state: TokenApiCreationFormStateLoaded })[]} components */
+      ([component]) => {
+        component.state = {
+          type: 'loaded',
+          activeStep: 'validation',
+          isMfaEnabled: true,
+          values: {
+            ...component.state.values,
+            mfaCode: '259384',
+          },
+        };
+      },
+    ),
+    // Submit validation form and transition to creating state
+    storyWait(
+      2000,
+      /** @param {(CcTokenApiCreationForm & { state: TokenApiCreationFormStateLoaded | TokenApiCreationFormStateCreating })[]} components */
+      ([component]) => {
+        getForm(component, 'validation-form').requestSubmit();
+        component.state = {
+          type: 'creating',
+          activeStep: 'validation',
+          values: component.state.values,
+          isMfaEnabled: true,
+        };
+      },
+    ),
+    // Transition to created state with token
+    storyWait(
+      2000,
+      /** @param {(CcTokenApiCreationForm & { state: TokenApiCreationFormStateLoaded | TokenApiCreationFormStateCreating })[]} components */
+      ([component]) => {
+        component.state = {
+          type: 'loaded',
+          activeStep: 'copy',
+          isMfaEnabled: true,
+          token: 'my-fake-secret-token',
+          values: component.state.values,
+        };
+      },
+    ),
+  ],
+});
+
+export const simulationWithAllPossibleFormErrors = makeStory(conf, {
+  /** @type {Partial<CcTokenApiCreationForm>[]} */
+  items: [
+    {
+      state: {
+        type: 'loaded',
+        activeStep: 'configuration',
+        isMfaEnabled: true,
+        values: CcTokenApiCreationForm.DEFAULT_FORM_VALUES,
+      },
+    },
+  ],
+  simulations: [
+    // Select custom expiration
+    storyWait(
+      2000,
+      /** @param {(CcTokenApiCreationForm & { state: TokenApiCreationFormStateLoaded })[]} components */
+      ([component]) => {
+        const currentExpirationPreset =
+          component.state.values.expiration.type === 'preset' ? component.state.values.expiration.preset : null;
+        component.state = {
+          type: 'loaded',
+          activeStep: 'configuration',
+          values: {
+            ...component.state.values,
+            expiration: {
+              type: 'custom',
+              date: CcTokenApiCreationForm.computeExpirationDate(currentExpirationPreset),
+            },
+          },
+          isMfaEnabled: true,
+        };
+      },
+    ),
+    // Erase the expiration date value so that it's empty
+    storyWait(
+      2000,
+      /** @param {(CcTokenApiCreationForm & { state: TokenApiCreationFormStateLoaded })[]} components */
+      ([component]) => {
+        component.state = {
+          type: 'loaded',
+          activeStep: 'configuration',
+          values: {
+            ...component.state.values,
+            expiration: {
+              type: 'custom',
+              date: null,
+            },
+          },
+          isMfaEnabled: true,
+        };
+      },
+    ),
+    // Submit configuration form (expect empty name and empty date errors)
+    storyWait(
+      2000,
+      /** @param {CcTokenApiCreationForm[]} components */
+      ([component]) => {
+        getForm(component, 'configuration-form').requestSubmit();
+      },
+    ),
+    // Set invalid expiration date format
+    storyWait(
+      2000,
+      /** @param {(CcTokenApiCreationForm & { state: TokenApiCreationFormStateLoaded })[]} components */
+      ([component]) => {
+        component.state = {
+          type: 'loaded',
+          activeStep: 'configuration',
+          values: {
+            ...CcTokenApiCreationForm.DEFAULT_FORM_VALUES,
+            name: 'My API token name',
+            expiration: {
+              type: 'custom',
+              date: 'invalid format',
+            },
+          },
+          isMfaEnabled: true,
+        };
+      },
+    ),
+    // Submit configuration form (expect date format error)
+    storyWait(
+      2000,
+      /** @param {CcTokenApiCreationForm[]} components */
+      ([component]) => {
+        getForm(component, 'configuration-form').requestSubmit();
+      },
+    ),
+    // Set past expiration date
+    storyWait(
+      2000,
+      /** @param {(CcTokenApiCreationForm & { state: TokenApiCreationFormStateLoaded })[]} components */
+      ([component]) => {
+        component.state = {
+          type: 'loaded',
+          activeStep: 'configuration',
+          values: {
+            ...component.state.values,
+            name: 'My API token name',
+            expiration: {
+              type: 'custom',
+              date: DATE_FORMATTER_ISO.format(shiftDateField(new Date(), 'Y', -1)),
+            },
+          },
+          isMfaEnabled: true,
+        };
+      },
+    ),
+    // Submit configuration form (expect date min error)
+    storyWait(
+      2000,
+      /** @param {CcTokenApiCreationForm[]} components */
+      ([component]) => {
+        getForm(component, 'configuration-form').requestSubmit();
+      },
+    ),
+    // Set future expiration date (too far)
+    storyWait(
+      2000,
+      /** @param {(CcTokenApiCreationForm & { state: TokenApiCreationFormStateLoaded })[]} components */
+      ([component]) => {
+        component.state = {
+          type: 'loaded',
+          activeStep: 'configuration',
+          values: {
+            ...component.state.values,
+            name: 'My API token name',
+            expiration: {
+              type: 'custom',
+              date: DATE_FORMATTER_ISO.format(shiftDateField(new Date(), 'Y', 2)),
+            },
+          },
+          isMfaEnabled: true,
+        };
+      },
+    ),
+    // Submit configuration form (expect date max error)
+    storyWait(
+      2000,
+      /** @param {CcTokenApiCreationForm[]} components */
+      ([component]) => {
+        getForm(component, 'configuration-form').requestSubmit();
+      },
+    ),
+    // Set valid expiration duration (one year)
+    storyWait(
+      2000,
+      /** @param {(CcTokenApiCreationForm & { state: TokenApiCreationFormStateLoaded })[]} components */
+      ([component]) => {
+        component.state = {
+          type: 'loaded',
+          activeStep: 'configuration',
+          values: {
+            ...component.state.values,
+            name: 'My API token name',
+            expiration: {
+              type: 'preset',
+              preset: 'one-year',
+            },
+          },
+          isMfaEnabled: true,
+        };
+      },
+    ),
+    // Submit configuration form and move to validation step
+    storyWait(
+      2000,
+      /** @param {(CcTokenApiCreationForm & { state: TokenApiCreationFormStateLoaded })[]} components */
+      ([component]) => {
+        getForm(component, 'configuration-form').requestSubmit();
+        component.state = {
+          type: 'loaded',
+          activeStep: 'validation',
+          values: component.state.values,
+          isMfaEnabled: true,
+        };
+      },
+    ),
+    // Submit validation form with empty password & 2FA code
+    storyWait(
+      2000,
+      /** @param {CcTokenApiCreationForm[]} components */
+      ([component]) => {
+        getForm(component, 'validation-form').requestSubmit();
+      },
+    ),
+    // Fill invalid password and MFA code
+    storyWait(
+      2000,
+      /** @param {(CcTokenApiCreationForm & { state: TokenApiCreationFormStateLoaded })[]} components */
+      ([component]) => {
+        component.state = {
+          type: 'loaded',
+          activeStep: 'validation',
+          values: {
+            ...component.state.values,
+            password: 'my-fake-secret-password',
+            mfaCode: 'AAAAAAA',
+          },
+          isMfaEnabled: true,
+        };
+      },
+    ),
+    // Submit validation form, transition to creating (simulating API call)
+    storyWait(
+      2000,
+      /** @param {(CcTokenApiCreationForm & { state: TokenApiCreationFormStateLoaded | TokenApiCreationFormStateCreating })[]} components */
+      ([component]) => {
+        getForm(component, 'validation-form').requestSubmit();
+        component.state = {
+          type: 'creating',
+          activeStep: 'validation',
+          values: component.state.values,
+          isMfaEnabled: true,
+        };
+      },
+    ),
+    // Transition back to loaded state with password error
+    storyWait(
+      2000,
+      /** @param {(CcTokenApiCreationForm & { state: TokenApiCreationFormStateLoaded | TokenApiCreationFormStateCreating })[]} components */
+      ([component]) => {
+        component.state = {
+          type: 'loaded',
+          activeStep: 'validation',
+          values: component.state.values,
+          credentialsError: 'password',
+          isMfaEnabled: true,
+        };
+      },
+    ),
+    // Correct password, submit again (expect MFA code error), transition to creating
+    storyWait(
+      2000,
+      /** @param {(CcTokenApiCreationForm & { state: TokenApiCreationFormStateLoaded | TokenApiCreationFormStateCreating })[]} components */
+      ([component]) => {
+        // clears the invalid format error message
+        getForm(component, 'validation-form').requestSubmit();
+        component.state = {
+          type: 'creating',
+          activeStep: 'validation',
+          values: {
+            ...component.state.values,
+            password: 'my-fake-secret-password-corrected',
+          },
+          isMfaEnabled: true,
+        };
+      },
+    ),
+    // Transition back to loaded state with MFA code error
+    storyWait(
+      2000,
+      /** @param {(CcTokenApiCreationForm & { state: TokenApiCreationFormStateLoaded | TokenApiCreationFormStateCreating })[]} components */
+      ([component]) => {
+        component.state = {
+          type: 'loaded',
+          activeStep: 'validation',
+          values: component.state.values,
+          isMfaEnabled: true,
+          credentialsError: 'mfaCode',
+        };
+      },
+    ),
+    // Correct MFA code (still show error state briefly before submitting)
+    storyWait(
+      2000,
+      /** @param {(CcTokenApiCreationForm & { state: TokenApiCreationFormStateLoaded | TokenApiCreationFormStateCreating })[]} components */
+      ([component]) => {
+        component.state = {
+          type: 'loaded',
+          activeStep: 'validation',
+          values: {
+            ...component.state.values,
+            mfaCode: '293832',
+          },
+          isMfaEnabled: true,
+          credentialsError: 'mfaCode',
+        };
+      },
+    ),
+    // Submit validation form with correct credentials, transition to creating
+    storyWait(
+      2000,
+      /** @param {(CcTokenApiCreationForm & { state: TokenApiCreationFormStateLoaded | TokenApiCreationFormStateCreating })[]} components */
+      ([component]) => {
+        // clears the invalid format error message
+        getForm(component, 'validation-form').requestSubmit();
+        component.state = {
+          type: 'creating',
+          activeStep: 'validation',
+          values: {
+            ...component.state.values,
+            mfaCode: '293832',
+          },
+          isMfaEnabled: true,
+        };
+      },
+    ),
+    // Transition to created state with token
+    storyWait(
+      2000,
+      /** @param {(CcTokenApiCreationForm & { state: TokenApiCreationFormStateLoaded | TokenApiCreationFormStateCreating })[]} components */
+      ([component]) => {
+        component.state = {
+          type: 'loaded',
+          activeStep: 'copy',
+          isMfaEnabled: true,
+          token: 'my-fake-secret-token',
+          values: component.state.values,
+        };
+      },
+    ),
+  ],
+});

--- a/src/components/cc-token-api-creation-form/cc-token-api-creation-form.types.d.ts
+++ b/src/components/cc-token-api-creation-form/cc-token-api-creation-form.types.d.ts
@@ -1,0 +1,83 @@
+export type TokenApiCreationFormState =
+  | TokenApiCreationFormStateLoaded
+  | TokenApiCreationFormStateCreating
+  | TokenApiCreationFormStateLoading
+  | TokenApiCreationFormStateError;
+
+export type TokenApiCreationFormStateLoaded =
+  | TokenApiCreationFormStateLoadedConfiguration
+  | TokenApiCreationFormStateLoadedValidation
+  | TokenApiCreationFormStateLoadedCopy;
+
+export interface TokenApiCreationFormStateLoadedConfiguration extends FormValuesAndMfaStatus {
+  type: 'loaded';
+  activeStep: 'configuration';
+}
+
+export interface TokenApiCreationFormStateLoadedValidation extends FormValuesAndMfaStatus {
+  type: 'loaded';
+  activeStep: 'validation';
+  credentialsError?: 'password' | 'mfaCode' | null;
+}
+
+export interface TokenApiCreationFormStateCreating extends FormValuesAndMfaStatus {
+  type: 'creating';
+  activeStep: 'validation';
+  credentialsError?: null;
+}
+
+/*
+ * MFA status must be provided because the validation form is still visible during the transition from the 'validation' to 'copy' step
+ * We don't want the form to go from password only to password + 2FA code or vice-versa
+ * Form values must be provided because they are visible during the transition from the 'validation' to 'copy' step
+ */
+export interface TokenApiCreationFormStateLoadedCopy extends FormValuesAndMfaStatus {
+  type: 'loaded';
+  activeStep: 'copy';
+  token: string;
+}
+
+export interface TokenApiCreationFormStateLoading {
+  type: 'loading';
+}
+
+export interface TokenApiCreationFormStateError {
+  type: 'error';
+}
+
+export type Expiration = ExpirationPreset | ExpirationCustom;
+
+export interface ExpirationPreset {
+  type: 'preset';
+  preset: 'seven-days' | 'thirty-days' | 'sixty-days' | 'ninety-days' | 'one-year';
+}
+
+export interface ExpirationCustom {
+  type: 'custom';
+  /** ISO format */
+  date: string;
+}
+
+interface FormValuesAndMfaStatus {
+  values: FormValues;
+  isMfaEnabled: boolean;
+}
+
+export interface FormValues {
+  name: string;
+  description: string;
+  expiration: Expiration;
+  password: string;
+  mfaCode: string;
+}
+
+export interface NewToken {
+  name: string;
+  description: string;
+  /** ISO format */
+  expirationDate: string;
+  password: string;
+  mfaCode: string;
+}
+
+type ExpirationDurationOptions = ExpirationPreset['preset'] | ExpirationCustom['type'];

--- a/src/components/cc-token-api-list/cc-token-api-list.smart.js
+++ b/src/components/cc-token-api-list/cc-token-api-list.smart.js
@@ -14,6 +14,7 @@ import './cc-token-api-list.js';
  * @typedef {import('./cc-token-api-list.types.js').RawApiToken} RawApiToken
  * @typedef {import('../../lib/smart/smart-component.types.js').OnContextUpdateArgs<CcTokenApiList>} OnContextUpdateArgs
  * @typedef {import('../../lib/send-to-api.types.js').ApiConfig} ApiConfig
+ * @typedef {import('../../lib/send-to-api.types.js').AuthBridgeConfig} AuthBridgeConfig
  */
 
 defineSmartComponent({
@@ -93,9 +94,9 @@ defineSmartComponent({
 });
 
 class Api {
-  /** @param {ApiConfig} apiConfig */
+  /** @param {AuthBridgeConfig} apiConfig */
   constructor(apiConfig) {
-    this._apiConfig = apiConfig;
+    this._authBridgeConfig = apiConfig;
   }
 
   _listApiTokens() {
@@ -118,7 +119,7 @@ class Api {
   /** @returns {Promise<ApiToken[]>} */
   getApiTokens() {
     return this._listApiTokens()
-      .then(sendToAuthBridge({ apiConfig: this._apiConfig }))
+      .then(sendToAuthBridge({ authBridgeConfig: this._authBridgeConfig }))
       .then(
         /** @param {RawApiToken[]} tokens */
         (tokens) =>
@@ -141,6 +142,6 @@ class Api {
    * @returns {Promise<void>}
    */
   revokeApiToken(apiTokenId) {
-    return this._deleteApiToken(apiTokenId).then(sendToAuthBridge({ apiConfig: this._apiConfig }));
+    return this._deleteApiToken(apiTokenId).then(sendToAuthBridge({ authBridgeConfig: this._authBridgeConfig }));
   }
 }

--- a/src/components/cc-token-api-list/cc-token-api-list.smart.md
+++ b/src/components/cc-token-api-list/cc-token-api-list.smart.md
@@ -21,7 +21,6 @@ title: '💡 Smart'
 
 ```ts
 interface ApiConfig {
-  API_HOST: string,
   API_OAUTH_TOKEN: string,
   API_OAUTH_TOKEN_SECRET: string,
   OAUTH_CONSUMER_KEY: string,
@@ -35,7 +34,7 @@ interface ApiConfig {
 | Method   | Type                    | Cache?  |
 |----------|:------------------------|---------|
 | `GET`    | `/api-tokens`           | Default |
-| `DELETE` | `/api-tokens/{tokenId}` | Default |
+| `DELETE` | `/api-tokens/{tokenId}` | N/A     |
 
 ```html
 <cc-smart-container context='{

--- a/src/lib/date/date-utils.js
+++ b/src/lib/date/date-utils.js
@@ -2,6 +2,7 @@ import { clampNumber } from '../utils.js';
 
 /**
  * @typedef {import('./date.types.js').Timezone} Timezone
+ * @typedef {import('./date.types.js').DateField} DateField
  * @typedef {(date: Date, offset: number) => Date} DateShiftFunction
  */
 
@@ -48,6 +49,16 @@ export function clampDate(date, min, max) {
  */
 export function getNumberOfDaysInMonth(year, month) {
   return new Date(year, month + 1, 0).getDate();
+}
+
+/**
+ * @param {DateField} field
+ * @param {number} offset
+ * @returns {Date}
+ */
+export function getRelativeDateFromNow(field, offset) {
+  const now = new Date();
+  return shiftDateField(now, field, offset);
 }
 
 // region Date shift
@@ -120,7 +131,7 @@ const DATE_SHIFTER = {
  * The given date is not mutated.
  *
  * @param {Date} date
- * @param {'Y'|'M'|'D'|'H'|'m'|'s'|'S'} field the date field to shift
+ * @param {DateField} field the date field to shift
  * @param {number} offset the shifting offset
  * @return {Date}
  */

--- a/src/lib/date/date.types.d.ts
+++ b/src/lib/date/date.types.d.ts
@@ -24,3 +24,5 @@ export interface DateParts {
 }
 
 export type DatePart = keyof DateParts;
+
+export type DateField = 'Y' | 'M' | 'D' | 'H' | 'm' | 's' | 'S';

--- a/src/lib/events-map.types.d.ts
+++ b/src/lib/events-map.types.d.ts
@@ -122,6 +122,7 @@ import {
   CcTcpRedirectionDeleteEvent,
 } from '../components/cc-tcp-redirection/cc-tcp-redirection.events.js';
 import { CcToastDismissEvent } from '../components/cc-toast/cc-toast.events.js';
+import { CcTokenCreateEvent } from '../components/cc-token-api-creation-form/cc-token-api-creation-form.events.js';
 import {
   CcClickEvent,
   CcRequestSubmitEvent,
@@ -245,6 +246,7 @@ declare global {
     'cc-tcp-redirection-delete': CcTcpRedirectionDeleteEvent;
     'cc-toast-dismiss': CcToastDismissEvent;
     'cc-toggle': CcToggleEvent;
+    'cc-token-create': CcTokenCreateEvent;
     'cc-token-revoke': CcTokenRevokeEvent;
     'cc-tokens-revoke-all': CcTokensRevokeAllEvent;
   }

--- a/src/lib/send-to-api.types.d.ts
+++ b/src/lib/send-to-api.types.d.ts
@@ -13,3 +13,11 @@ export interface Warp10ApiConfig {
   OAUTH_CONSUMER_KEY: string;
   OAUTH_CONSUMER_SECRET: string;
 }
+
+export interface AuthBridgeConfig {
+  AUTH_BRIDGE_HOST: string;
+  API_OAUTH_TOKEN: string;
+  API_OAUTH_TOKEN_SECRET: string;
+  OAUTH_CONSUMER_KEY: string;
+  OAUTH_CONSUMER_SECRET: string;
+}

--- a/src/lib/send-to-auth-bridge.js
+++ b/src/lib/send-to-auth-bridge.js
@@ -8,25 +8,25 @@ import { withCache } from '@clevercloud/client/esm/with-cache.js';
 import { withOptions } from '@clevercloud/client/esm/with-options.js';
 
 /**
- * @typedef {import('./send-to-api.types.js').ApiConfig} ApiConfig
+ * @typedef {import('./send-to-api.types.js').AuthBridgeConfig} AuthBridgeConfig
  */
 
 /**
  *
  * @param {object} params
- * @param {ApiConfig} params.apiConfig
+ * @param {AuthBridgeConfig} params.authBridgeConfig
  * @param {AbortSignal} [params.signal]
  * @param {number} [params.cacheDelay]
  * @param {number} [params.timeout]
  * @returns {(requestParams: any) => Promise<any>}
  */
-export function sendToAuthBridge({ apiConfig, signal, cacheDelay, timeout }) {
+export function sendToAuthBridge({ authBridgeConfig, signal, cacheDelay, timeout }) {
   return (requestParams) => {
-    const cacheParams = { ...apiConfig, ...requestParams };
+    const cacheParams = { ...authBridgeConfig, ...requestParams };
     return withCache(cacheParams, cacheDelay, () => {
-      const { API_HOST, ...tokens } = apiConfig;
+      const { AUTH_BRIDGE_HOST = 'https://api-bridge.clever-cloud.com', ...tokens } = authBridgeConfig;
       return Promise.resolve(requestParams)
-        .then(prefixUrl('https://api-bridge.clever-cloud.com'))
+        .then(prefixUrl(AUTH_BRIDGE_HOST))
         .then(addOauthHeaderPlaintext(tokens))
         .then(withOptions({ signal, timeout }))
         .then(request);
@@ -35,7 +35,7 @@ export function sendToAuthBridge({ apiConfig, signal, cacheDelay, timeout }) {
 }
 
 /**
- * @param {Omit<ApiConfig, 'API_HOST'>} tokens
+ * @param {Omit<AuthBridgeConfig, 'AUTH_BRIDGE_HOST'>} tokens
  * @returns {(requestParams: any) => any}
  */
 export function addOauthHeaderPlaintext(tokens) {

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -1636,7 +1636,7 @@ export const translations = {
   'cc-token-api-list.empty': `You have not created any token yet or you don't have any active token. Go ahead and create a new API token`,
   'cc-token-api-list.error': `Something went wrong while loading API tokens`,
   'cc-token-api-list.intro': () =>
-    sanitize`Below is the list of <a href="https://www.clever-cloud.com/developers/api/howto/#api-tokens" title="API Tokens - Documentation - new window">API tokens</a> linked to your account and their associated information. You may revoke them as needed.`,
+    sanitize`Below is the list of <a href="https://www.clever-cloud.com/developers/api/howto/#request-the-api" title="API Tokens - Documentation - new window">API tokens</a> linked to your account and their associated information. You may revoke them as needed.`,
   'cc-token-api-list.link.doc': `API tokens - Documentation`,
   'cc-token-api-list.main-heading': `API tokens`,
   'cc-token-api-list.revoke-token': /** @param {{ name: string}} _ */ ({ name }) => `Revoke API token - ${name}`,

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -1548,6 +1548,66 @@ export const translations = {
   'cc-toast.icon-alt.success': `Success`,
   'cc-toast.icon-alt.warning': `Warning`,
   //#endregion
+  //#region cc-token-api-creation-form
+  'cc-token-api-creation-form.cli.content': () => sanitize`
+    <p>
+      Manage your API tokens from a terminal using the commands below.
+      To install Clever Tools CLI, follow the instructions from the <a href="https://www.clever-cloud.com/developers/doc/cli/install/" title="documentation - Install Clever Tools - new window">documentation</a>.
+    </p>
+    <dl>
+      <dt>Create a token:</dt>
+      <dd><code>clever tokens create "&lt;your token name&gt;"</code></dd>
+      <dt>Revoke a token:</dt>
+      <dd><code>clever tokens revoke &lt;api_token_id&gt;</code></dd>
+      <dt>List tokens:</dt>
+      <dd><code>clever tokens list</code></dd>
+      <dt>Use your API token&nbsp;:</dt>
+      <dd><code>curl -H "Authorization: Bearer &lt;your_token&gt;" https://api-bridge.clever-cloud.com/v2/self</code></dd>
+    </dl>
+  `,
+  'cc-token-api-creation-form.configuration-step.form.desc.label': `Description`,
+  'cc-token-api-creation-form.configuration-step.form.expiration-date.error.invalid':
+    /** @param {{ date: string }} _ */ ({ date }) => sanitize`Enter a valid date and time.<br>For instance: ${date}`,
+  'cc-token-api-creation-form.configuration-step.form.expiration-date.error.range-overflow':
+    /** @param {{ date: string }} _ */ ({ date }) =>
+      sanitize`The expiration date must be less than 1 year from now<br>For instance: ${date}`,
+  'cc-token-api-creation-form.configuration-step.form.expiration-date.error.range-underflow':
+    /** @param {{ date: string }} _ */ ({ date }) =>
+      sanitize`The expiration date must be at least 15 minutes from now<br>For instance: ${date}`,
+  'cc-token-api-creation-form.configuration-step.form.expiration-date.help.format': `Format: YYYY-MM-DD HH:MM:SS`,
+  'cc-token-api-creation-form.configuration-step.form.expiration-date.help.min-max': `Must be at least 15 minutes and up to 1 year from now`,
+  'cc-token-api-creation-form.configuration-step.form.expiration-date.label': `Expiration date`,
+  'cc-token-api-creation-form.configuration-step.form.expiration-duration.help.custom': `Specify the expiration date using the following field`,
+  'cc-token-api-creation-form.configuration-step.form.expiration-duration.label': `Time before expiration`,
+  'cc-token-api-creation-form.configuration-step.form.expiration-duration.option-label.custom': `Custom`,
+  'cc-token-api-creation-form.configuration-step.form.expiration-duration.option-label.ninety-days': `90 days`,
+  'cc-token-api-creation-form.configuration-step.form.expiration-duration.option-label.one-year': `1 year`,
+  'cc-token-api-creation-form.configuration-step.form.expiration-duration.option-label.seven-days': `7 days`,
+  'cc-token-api-creation-form.configuration-step.form.expiration-duration.option-label.sixty-days': `60 days`,
+  'cc-token-api-creation-form.configuration-step.form.expiration-duration.option-label.thirty-days': `30 days`,
+  'cc-token-api-creation-form.configuration-step.form.link.back-to-list': `Back to the API token list`,
+  'cc-token-api-creation-form.configuration-step.form.name.label': `Name`,
+  'cc-token-api-creation-form.configuration-step.form.submit-button.label': `Continue`,
+  'cc-token-api-creation-form.configuration-step.main-heading': `Create a new API token`,
+  'cc-token-api-creation-form.configuration-step.nav.label': `Configuration`,
+  'cc-token-api-creation-form.copy-step.form.token.label': `Your API token`,
+  'cc-token-api-creation-form.copy-step.link.back-to-list': `Go to the token list`,
+  'cc-token-api-creation-form.copy-step.main-heading': `Your API token is now created`,
+  'cc-token-api-creation-form.copy-step.nav.label': `Get API token`,
+  'cc-token-api-creation-form.copy-step.notice.message': `For security reasons, this API token will only be shown once. Make sure to copy and store it in a secure place. After creation, you will not be able to retrieve it ever again. If you lose this token, you will have to revoke it and create a new one.`,
+  'cc-token-api-creation-form.error': `Something went wrong while loading information about your account`,
+  'cc-token-api-creation-form.link.doc': `API tokens - Documentation`,
+  'cc-token-api-creation-form.nav.aria-label': `API token creation steps`,
+  'cc-token-api-creation-form.validation-step.error.generic': `Something went wrong while creating the API token`,
+  'cc-token-api-creation-form.validation-step.form.link.back-to-configuration': `Back to the configuration step`,
+  'cc-token-api-creation-form.validation-step.form.mfa-code.error': `Invalid 2FA code`,
+  'cc-token-api-creation-form.validation-step.form.mfa-code.label': `Two-factor authentication code (2FA)`,
+  'cc-token-api-creation-form.validation-step.form.password.error': `Invalid password`,
+  'cc-token-api-creation-form.validation-step.form.password.label': `Password`,
+  'cc-token-api-creation-form.validation-step.form.submit-button.label': `Create`,
+  'cc-token-api-creation-form.validation-step.main-heading': `Confirm your identity`,
+  'cc-token-api-creation-form.validation-step.nav.label': `Authentication`,
+  //#endregion
   //#region cc-token-api-list
   'cc-token-api-list.card.expired': `Expired`,
   'cc-token-api-list.card.expires-soon': `Expires soon`,
@@ -1560,10 +1620,7 @@ export const translations = {
         Manage your API tokens from a terminal using the commands below.
         To install Clever Tools CLI, follow the instructions from the <a href="https://www.clever-cloud.com/developers/doc/cli/install/" title="documentation - Install Clever Tools - new window">documentation</a>.
       </p>
-      <p>Note: These commands are experimental and need to be enabled in the CLI in order to be used.
       <dl>
-        <dt>Enable the API tokens feature:</dt>
-        <dd><code>clever features enable tokens</code></dd>
         <dt>Create a token:</dt>
         <dd><code>clever tokens create "&lt;your token name&gt;"</code></dd>
         <dt>Revoke a token:</dt>

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -1665,7 +1665,7 @@ export const translations = {
     sanitize`Vous n'avez aucun token d'API. Cliquez sur le bouton ci-dessous pour créer un nouveau token&nbsp;:`,
   'cc-token-api-list.error': `Une erreur est survenue pendant le chargement des tokens d'API`,
   'cc-token-api-list.intro': () =>
-    sanitize`Ci-dessous la liste des tokens d'API associés à votre compte <a href="https://www.clever-cloud.com/developers/api/howto/#api-tokens" title="Tokens d'API - Documentation - nouvelle fenêtre">tokens d'API</a> et leurs informations. Vous pouvez les révoquez si nécessaire.`,
+    sanitize`Ci-dessous la liste des tokens d'API associés à votre compte <a href="https://www.clever-cloud.com/developers/api/howto/#request-the-api" title="Tokens d'API - Documentation - nouvelle fenêtre">tokens d'API</a> et leurs informations. Vous pouvez les révoquez si nécessaire.`,
   'cc-token-api-list.link.doc': `Tokens d'API - Documentation`,
   'cc-token-api-list.main-heading': `Tokens d'API`,
   'cc-token-api-list.revoke-token': /** @param {{ name: string}} _ */ ({ name }) => `Révoquer le token d'API - ${name}`,

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -1572,6 +1572,68 @@ export const translations = {
   'cc-toast.icon-alt.success': `Succès`,
   'cc-toast.icon-alt.warning': `Avertissement`,
   //#endregion
+  //#region cc-token-api-creation-form
+  'cc-token-api-creation-form.cli.content': () => sanitize`
+    <p>
+      Gérez vos tokens d'API depuis un terminal à l'aide des commandes ci-dessous.
+      Pour installer les Clever Tools (CLI), suivez les instructions de la <a href="https://www.clever-cloud.com/developers/doc/cli/install/" title="documentation - Installer les Clever Tools - nouvelle fenêtre - en Anglais">documentation</a>.
+    </p>
+    <dl>
+      <dt>Créer un token d'API&nbsp;:</dt>
+      <dd><code>clever tokens create "&lt;votre nom de token&gt;"</code></dd>
+      <dt>Révoquer un token d'API&nbsp;:</dt>
+      <dd><code>clever tokens revoke &lt;api_token_id&gt;</code></dd>
+      <dt>Lister les tokens d'API&nbsp;:</dt>
+      <dd><code>clever tokens list</code></dd>
+      <dt>Utiliser votre token d'API&nbsp;:</dt>
+      <dd><code>curl -H "Authorization: Bearer &lt;votre_token&gt;" https://api-bridge.clever-cloud.com/v2/self</code></dd>
+    </dl>
+  `,
+  'cc-token-api-creation-form.configuration-step.form.desc.label': `Description`,
+  'cc-token-api-creation-form.configuration-step.form.expiration-date.error.invalid':
+    /** @param {{ date: string }} _ */ ({ date }) =>
+      sanitize`Saisissez une date et une heure valide.<br>Par exemple&nbsp;: ${date}`,
+  'cc-token-api-creation-form.configuration-step.form.expiration-date.error.range-overflow':
+    /** @param {{ date: string }} _ */ ({ date }) =>
+      sanitize`La date d'expiration doit être moins d'un an à partir de maintenant<br>Par exemple&nbsp;: ${date}`,
+  'cc-token-api-creation-form.configuration-step.form.expiration-date.error.range-underflow':
+    /** @param {{ date: string }} _ */ ({ date }) =>
+      sanitize`La date d'expiration doit être au moins 15 minutes à partir de maintenant<br>Par exemple&nbsp;: ${date}`,
+  'cc-token-api-creation-form.configuration-step.form.expiration-date.help.format': () =>
+    sanitize`Format&nbsp;: AAAA-MM-JJ HH:MM:SS`,
+  'cc-token-api-creation-form.configuration-step.form.expiration-date.help.min-max': `Au moins 15 minutes et jusqu'à 1 an à partir de maintenant`,
+  'cc-token-api-creation-form.configuration-step.form.expiration-date.label': `Date d'expiration`,
+  'cc-token-api-creation-form.configuration-step.form.expiration-duration.help.custom': `Spécifiez la date d'expiration à l'aide du champ ci-contre`,
+  'cc-token-api-creation-form.configuration-step.form.expiration-duration.label': `Durée avant expiration`,
+  'cc-token-api-creation-form.configuration-step.form.expiration-duration.option-label.custom': `Personnalisée`,
+  'cc-token-api-creation-form.configuration-step.form.expiration-duration.option-label.ninety-days': `90 jours`,
+  'cc-token-api-creation-form.configuration-step.form.expiration-duration.option-label.one-year': `1 an`,
+  'cc-token-api-creation-form.configuration-step.form.expiration-duration.option-label.seven-days': `7 jours`,
+  'cc-token-api-creation-form.configuration-step.form.expiration-duration.option-label.sixty-days': `60 jours`,
+  'cc-token-api-creation-form.configuration-step.form.expiration-duration.option-label.thirty-days': `30 jours`,
+  'cc-token-api-creation-form.configuration-step.form.link.back-to-list': `Retour à la liste des tokens d'API`,
+  'cc-token-api-creation-form.configuration-step.form.name.label': `Nom`,
+  'cc-token-api-creation-form.configuration-step.form.submit-button.label': `Continuer`,
+  'cc-token-api-creation-form.configuration-step.main-heading': `Créer un nouveau token d'API`,
+  'cc-token-api-creation-form.configuration-step.nav.label': `Configuration`,
+  'cc-token-api-creation-form.copy-step.form.token.label': `Votre token d'API`,
+  'cc-token-api-creation-form.copy-step.link.back-to-list': `Retour à la liste des tokens d'API`,
+  'cc-token-api-creation-form.copy-step.main-heading': `Votre token d'API est prêt`,
+  'cc-token-api-creation-form.copy-step.nav.label': `Récupération du token d'API`,
+  'cc-token-api-creation-form.copy-step.notice.message': `Pour des raisons de sécurité, ce token d'API ne sera affiché qu'une fois. Assurez-vous de le copier et de le stocker dans un endroit sécurisé. Si vous perdez ce token, vous devrez le révoquer et en créer un nouveau.`,
+  'cc-token-api-creation-form.error': `Une erreur est survenue lors du chargement des informations liées votre compte`,
+  'cc-token-api-creation-form.link.doc': `Tokens d'API - Documentation`,
+  'cc-token-api-creation-form.nav.aria-label': `Étapes de création de token d'API`,
+  'cc-token-api-creation-form.validation-step.error.generic': `Une erreur est survenue lors de la création du token d'API`,
+  'cc-token-api-creation-form.validation-step.form.link.back-to-configuration': `Retour à l'étape de configuration`,
+  'cc-token-api-creation-form.validation-step.form.mfa-code.error': `Code 2FA invalide`,
+  'cc-token-api-creation-form.validation-step.form.mfa-code.label': `Code de double authentification (2FA)`,
+  'cc-token-api-creation-form.validation-step.form.password.error': `Mot de passe invalide`,
+  'cc-token-api-creation-form.validation-step.form.password.label': `Mot de passe`,
+  'cc-token-api-creation-form.validation-step.form.submit-button.label': `Créer`,
+  'cc-token-api-creation-form.validation-step.main-heading': `Confirmer votre identité`,
+  'cc-token-api-creation-form.validation-step.nav.label': `Authentification`,
+  //#endregion
   //#region cc-token-api-list
   'cc-token-api-list.card.expired': `Expiré`,
   'cc-token-api-list.card.expires-soon': `Expire bientôt`,
@@ -1585,10 +1647,7 @@ export const translations = {
         Gérez vos tokens d'API depuis un terminal à l'aide des commandes ci-dessous.
         Pour installer les Clever Tools (CLI), suivez les instructions de la <a href="https://www.clever-cloud.com/developers/doc/cli/install/" title="documentation - Installer les Clever Tools - nouvelle fenêtre - en Anglais">documentation</a>.
       </p>
-      <p>Note&nbsp;: Ces commandes sont expérimentales et doivent être activées dans la CLI pour être utilisées.
       <dl>
-        <dt>Activer la fonctionnalité des tokens d'API&nbsp;:</dt>
-        <dd><code>clever features enable tokens</code></dd>
         <dt>Créer un token d'API&nbsp;:</dt>
         <dd><code>clever tokens create "&lt;votre nom de token&gt;"</code></dd>
         <dt>Révoquer un token d'API&nbsp;:</dt>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -95,7 +95,8 @@
           // https://developer.mozilla.org/en-US/docs/Web/API/Element/mouseenter_event
           "wheel",
           "copy",
-          "paste"
+          "paste",
+          "transitionend"
         ]
       }
     ]


### PR DESCRIPTION
Fixes #1395 

## What does this PR do?

- Adds a new `cc-token-api-creation-form` component that relies on 3 steps:
  - configuration form: the user provides info about the token they want to create (name, desc, duration or expiration date),
    - no API call on submit, only client-side validation,
  - validation form: the user provides the credentials required to validate the creation of the token,
    - client-side validation to prevent empty values + API call & validation about the credentials,
    - the user can go back to the config step if they want (by clicking the "configuration" step in the nav, or the link on the left of the submit button),
  - copy token: the created token is displayed in a cc-input-text with the `secret` option so the value is hidden by default,
  - the user cannot go back to previous steps because the token is now created,
  - the user can go back to the list of API tokens screen thanks to the CTA link.
- Note that this screen / component will be accessed from the `create token` link in the `cc-token-api-list` component but not from the console menu.

## How to review?

> [!IMPORTANT]
> I left a few notes as comments (on GitHub, below) about my hesitations and stuff that might look weird during your review. 
> They might seem obscure without context so my advice is: 
> - read briefly, 
> - go and do the code review, 
> - come back to these notes once the context is clearer if you still feel something is weird so we can discuss alternatives :sweat_smile: 

- Review the commit (only the last commit, the others will be removed when rebasing),
- Check the stories from the [preview](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-token-api-creation-form/init/index.html?path=/story/%F0%9F%9B%A0-profile-cc-token-api-creation-form--default-story),
- Check the docs,
- QA (Notion > CC Console Overview > QA (screen) > cc-token-api-creation-form).

## TODO Flo

- [x] Rebase & use new events
