### PR TITLE
feat(cc-token-oauth-list): add doc link to `cc-block` footer

### DIFF
--- a/src/components/cc-token-oauth-list/cc-token-oauth-list.js
+++ b/src/components/cc-token-oauth-list/cc-token-oauth-list.js
@@ -5,6 +5,7 @@ import {
   iconRemixCalendar_2Fill as iconCreation,
   iconRemixDeleteBinLine as iconDelete,
   iconRemixInformationLine as iconExpiration,
+  iconRemixLogoutBoxRLine as iconExternalLink,
   iconRemixHistoryLine as iconLastUsed,
 } from '../../assets/cc-remix.icons.js';
 import { LostFocusController } from '../../controllers/lost-focus-controller.js';
@@ -124,6 +125,12 @@ export class CcTokenOauthList extends LitElement {
               : ''}
           </div>
         </div>
+        <div slot="footer-right">
+          <a slot="link" href="https://www.clever-cloud.com/developers/api/howto/#oauth1" target="_blank">
+            <span class="cc-link">${i18n('cc-token-oauth-list.link.doc')}</span>
+            <cc-icon .icon=${iconExternalLink}></cc-icon>
+          </a>
+        </div>
       </cc-block>
     `;
   }
@@ -193,6 +200,14 @@ export class CcTokenOauthList extends LitElement {
       css`
         :host {
           display: block;
+        }
+
+        [slot='link'] {
+          align-items: center;
+          color: var(--cc-color-text-primary-highlight, blue);
+          display: flex;
+          flex-direction: row;
+          gap: 0.5em;
         }
 
         /* Reset default margins and paddings */

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -1596,6 +1596,7 @@ export const translations = {
   'cc-token-oauth-list.error': `Something went wrong while loading OAuth tokens`,
   'cc-token-oauth-list.intro': () =>
     sanitize`Below is the list of third-party applications linked to your account and their associated information. You may revoke these <a href="https://www.clever-cloud.com/developers/api/howto/#oauth1" title="OAuth tokens - Documentation - new window">OAuth tokens</a> as needed.`,
+  'cc-token-oauth-list.link.doc': `OAuth tokens - Documentation`,
   'cc-token-oauth-list.main-heading': `OAuth tokens`,
   'cc-token-oauth-list.revoke-all-tokens': `Revoke all OAuth tokens`,
   'cc-token-oauth-list.revoke-all-tokens.error': () =>

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -1624,6 +1624,7 @@ export const translations = {
   'cc-token-oauth-list.error': `Une erreur est survenue pendant le chargement des tokens OAuth`,
   'cc-token-oauth-list.intro': () =>
     sanitize`Ci-dessous la liste des applications tierces liées à votre compte et leurs informations. Vous pouvez révoquer leurs <a href="https://www.clever-cloud.com/developers/api/howto/#oauth1" title="tokens OAuth - Documentation - nouvelle fenêtre">tokens OAuth</a> si vous le souhaitez.`,
+  'cc-token-oauth-list.link.doc': `Tokens OAuth - Documentation`,
   'cc-token-oauth-list.main-heading': `Tokens OAuth`,
   'cc-token-oauth-list.revoke-all-tokens': `Révoquer tous les tokens OAuth`,
   'cc-token-oauth-list.revoke-all-tokens.error': () =>


### PR DESCRIPTION
Fixes #1416

## What does this PR do?

- Adds a doc link to the `cc-block` footer in the `cc-token-oauth-list` component.

## How to review?

Note that the fact we have to add CSS to `[slot="link"]` is not ideal because it should probably be done by the `cc-block` component but this will be solved with the `cc-link` component anyway.

- Check the commit,
- Check the [preview](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-token-oauth-list/add-doc-link-to-cc-block-footer/index.html?path=/story/%F0%9F%9B%A0-profile-cc-token-oauth-list--default-story),
- 1 reviewer is enough.