### PR TITLE
refactor(translations): remove trailing dots and "please" inside error messages

### DIFF
--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -118,14 +118,14 @@ export const translations = {
   'cc-addon-backups.restore.btn': `restore...`,
   'cc-addon-backups.restore.manual.description.es-addon': () =>
     sanitize`You can restore this backup using <a href="https://curl.se/docs/">cURL</a> by executing this command:`,
-  'cc-addon-backups.restore.manual.description.jenkins': `Restoring a Jenkins backup must be done by our support team. Please open a support ticket containing the add-on ID and the backup to restore and we will do it for you.`,
+  'cc-addon-backups.restore.manual.description.jenkins': `Restoring a Jenkins backup must be done by our support team. Open a support ticket containing the add-on ID and the backup to restore and we will do it for you.`,
   'cc-addon-backups.restore.manual.description.mongodb-addon': () =>
     sanitize`You can restore this backup using the <a href="https://docs.mongodb.com/v4.0/reference/program/mongorestore/">mongorestore</a> tool by executing this command:`,
   'cc-addon-backups.restore.manual.description.mysql-addon': () =>
     sanitize`You can restore this backup using the <a href="https://dev.mysql.com/doc/refman/8.0/en/mysql.html">mysql</a> CLI by executing this command:`,
   'cc-addon-backups.restore.manual.description.postgresql-addon': () =>
     sanitize`You can restore this backup using the <a href="https://www.postgresql.org/docs/current/app-pgrestore.html">pg_restore</a> tool by executing this command:`,
-  'cc-addon-backups.restore.manual.description.redis-addon': `Restoring a Redis backup must be done by our support team. Please open a support ticket containing the add-on ID and the backup to restore and we will do it for you.`,
+  'cc-addon-backups.restore.manual.description.redis-addon': `Restoring a Redis backup must be done by our support team. Open a support ticket containing the add-on ID and the backup to restore and we will do it for you.`,
   'cc-addon-backups.restore.manual.title': `Restore manually`,
   'cc-addon-backups.restore.with-service.description.es-addon': /** @param {{href: string}} _ */ ({ href }) =>
     sanitize`You can restore this backup using Kibana by going to the <a href="${href}">backup repository</a>.`,
@@ -325,7 +325,7 @@ export const translations = {
   'cc-domain-management.list.empty': `No domain associated to this application`,
   'cc-domain-management.list.error-not-found.heading': `Domain not found`,
   'cc-domain-management.list.error-not-found.text': /** @param {{domain: string}} _ */ ({ domain }) =>
-    sanitize`<p>"${domain}" may have been removed by someone else after loading the list of domains.<p><p>Please <strong>refresh your page</strong> to get the updated list of domains.</p>`,
+    sanitize`<p>"${domain}" may have been removed by someone else after loading the list of domains.<p><p><strong>Refresh your page</strong> to get the updated list of domains.</p>`,
   'cc-domain-management.list.heading': `Domain names linked to this application`,
   'cc-domain-management.list.http-only.notice': () =>
     sanitize`Only direct domains of <code>cleverapps.io</code> are secured with SSL certificates, not <code>xx.yy.cleverapps.io</code> domains.`,
@@ -592,7 +592,7 @@ export const translations = {
   //#endregion
   //#region cc-input-date
   'cc-input-date.error.bad-input': `You must enter a date.`,
-  'cc-input-date.error.empty': `You must enter a value.`,
+  'cc-input-date.error.empty': `You must enter a value`,
   'cc-input-date.error.range-overflow': /** @param {{max: string}} _ */ ({ max }) =>
     `You must enter a date lower that ${max}.`,
   'cc-input-date.error.range-underflow': /** @param {{min: string}} _ */ ({ min }) =>
@@ -603,7 +603,7 @@ export const translations = {
   //#region cc-input-number
   'cc-input-number.decrease': `decrease`,
   'cc-input-number.error.bad-type': `You must enter a number.`,
-  'cc-input-number.error.empty': `You must enter a value.`,
+  'cc-input-number.error.empty': `You must enter a value`,
   'cc-input-number.error.range-overflow': /** @param {{max: number}} _ */ ({ max }) =>
     `You must enter a number lower that ${max}.`,
   'cc-input-number.error.range-underflow': /** @param {{min: number}} _ */ ({ min }) =>
@@ -614,8 +614,8 @@ export const translations = {
   //#region cc-input-text
   'cc-input-text.clipboard': `Copy to clipboard`,
   'cc-input-text.error.bad-email': () => sanitize`Invalid email address format.<br>Example: john.doe@example.com.`,
-  'cc-input-text.error.empty': `You must enter a value.`,
-  'cc-input-text.error.empty.email': `Please enter an email address.`,
+  'cc-input-text.error.empty': `You must enter a value`,
+  'cc-input-text.error.empty.email': `Enter an email address`,
   'cc-input-text.required': `required`,
   'cc-input-text.secret.hide': `Hide secret`,
   'cc-input-text.secret.show': `Show secret`,
@@ -1086,7 +1086,7 @@ export const translations = {
   'cc-orga-member-card.btn.validate.visible-text': `Validate`,
   'cc-orga-member-card.current-user': `Your account`,
   'cc-orga-member-card.error.last-admin.heading': `You are the last admin of the organisation`,
-  'cc-orga-member-card.error.last-admin.text': `Please add a new admin before you can edit your role or leave the organisation.`,
+  'cc-orga-member-card.error.last-admin.text': `Add a new admin before you can edit your role or leave the organisation`,
   'cc-orga-member-card.mfa-disabled': `2FA disabled`,
   'cc-orga-member-card.mfa-enabled': `2FA enabled`,
   'cc-orga-member-card.role.accounting': `Accountant`,
@@ -1108,7 +1108,7 @@ export const translations = {
   'cc-orga-member-list.error': `Something went wrong while loading the organisation member list.`,
   'cc-orga-member-list.error-member-not-found.heading': `Member not found`,
   'cc-orga-member-list.error-member-not-found.text': () =>
-    sanitize`<p>The member has left the organisation or has been removed by someone else after loading the list of members.<p><p>Please <strong>refresh your page</strong> to get the updated list of members.</p>`,
+    sanitize`<p>The member has left the organisation or has been removed by someone else after loading the list of members.<p><p><strong>Refresh your page</strong> to get the updated list of members.</p>`,
   'cc-orga-member-list.error.unauthorised.heading': `Unauthorised action`,
   'cc-orga-member-list.error.unauthorised.text': `Only admins may invite, edit or remove other admins.`,
   'cc-orga-member-list.filter.mfa': `Accounts not secured with 2FA`,
@@ -1134,7 +1134,7 @@ export const translations = {
   'cc-orga-member-list.leave.btn': `Leave the organisation`,
   'cc-orga-member-list.leave.error': `Something went wrong when trying to leave the organisation.`,
   'cc-orga-member-list.leave.error-last-admin.heading': `You are the last admin of your organisation`,
-  'cc-orga-member-list.leave.error-last-admin.text': `Please add a new admin before you can edit your role or leave the organisation.`,
+  'cc-orga-member-list.leave.error-last-admin.text': `Add a new admin before you can edit your role or leave the organisation`,
   'cc-orga-member-list.leave.heading': `Danger zone`,
   'cc-orga-member-list.leave.success': `You have left the organisation.`,
   'cc-orga-member-list.leave.text': () => sanitize`
@@ -1162,11 +1162,11 @@ export const translations = {
     return `To avoid any suspension of your services and deletion of your data, please check the billing info related to the following ${organisation}:`;
   },
   'cc-payment-warning.home.title': `Beware! Something is wrong with your payment methods.`,
-  'cc-payment-warning.orga.default-payment-method-is-expired': `To avoid any suspension of your services and deletion of your data, please add a valid payment method and set it as default.`,
+  'cc-payment-warning.orga.default-payment-method-is-expired': `To avoid any suspension of your services and deletion of your data, add a valid payment method and set it as default.`,
   'cc-payment-warning.orga.default-payment-method-is-expired.title': `Beware! Your default payment method has expired`,
-  'cc-payment-warning.orga.no-default-payment-method': `To avoid any suspension of your services and deletion of your data, please set one of them as default.`,
+  'cc-payment-warning.orga.no-default-payment-method': `To avoid any suspension of your services and deletion of your data, set one of them as default.`,
   'cc-payment-warning.orga.no-default-payment-method.title': `Beware! You have registered payment methods but none of them are set as default`,
-  'cc-payment-warning.orga.no-payment-method': `To avoid any suspension of your services and deletion of your data, please add a valid payment method and set it as default.`,
+  'cc-payment-warning.orga.no-payment-method': `To avoid any suspension of your services and deletion of your data, add a valid payment method and set it as default.`,
   'cc-payment-warning.orga.no-payment-method.title': `Beware! You don't have any registered payment method`,
   //#endregion
   //#region cc-plan-picker
@@ -1354,7 +1354,7 @@ export const translations = {
   'cc-product-list.search-label': `Search for a product`,
   //#endregion
   //#region cc-select
-  'cc-select.error.empty': `You must select a value.`,
+  'cc-select.error.empty': `You must select a value`,
   'cc-select.required': `required`,
   //#endregion
   //#region cc-ssh-key-list
@@ -1373,8 +1373,8 @@ export const translations = {
     `An error occurred while importing your GitHub key "${name}".`,
   'cc-ssh-key-list.error.loading': `An error occurred while loading your keys.`,
   'cc-ssh-key-list.error.private-key': `Invalid format: did you enter your private key instead of your public key?`,
-  'cc-ssh-key-list.error.required.name': `Please enter a name for your SSH key`,
-  'cc-ssh-key-list.error.required.public-key': `Please enter the public key value`,
+  'cc-ssh-key-list.error.required.name': `Enter a name for your SSH key`,
+  'cc-ssh-key-list.error.required.public-key': `Enter the public key value`,
   'cc-ssh-key-list.github.empty': `There are no SSH keys available for import from your GitHub account.`,
   'cc-ssh-key-list.github.import': `Import`,
   'cc-ssh-key-list.github.import.a11y': /** @param {{name: string}} _ */ ({ name }) =>

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -129,14 +129,14 @@ export const translations = {
   'cc-addon-backups.restore.btn': `restaurer...`,
   'cc-addon-backups.restore.manual.description.es-addon': () =>
     sanitize`Vous pouvez restaurer cette sauvegarde manuellement grâce à l'outil <a href="https://curl.se/docs/">cURL</a> en exécutant cette commande :`,
-  'cc-addon-backups.restore.manual.description.jenkins': `La restauration de backups Jenkins doit passer par notre support. Veuillez créer un ticket en indiquant l'ID de votre add-on ainsi que la date du backup à restaurer et nous le ferons pour vous.`,
+  'cc-addon-backups.restore.manual.description.jenkins': `La restauration de backups Jenkins doit passer par notre support. Créez un ticket en indiquant l'ID de votre add-on ainsi que la date du backup à restaurer et nous le ferons pour vous.`,
   'cc-addon-backups.restore.manual.description.mongodb-addon': () =>
     sanitize`Vous pouvez restaurer cette sauvegarde manuellement grâce à l'outil <a href="https://docs.mongodb.com/v4.0/reference/program/mongorestore/">mongorestore</a> en exécutant cette commande :`,
   'cc-addon-backups.restore.manual.description.mysql-addon': () =>
     sanitize`Vous pouvez restaurer cette sauvegarde manuellement grâce à la CLI <a href="https://dev.mysql.com/doc/refman/8.0/en/mysql.html">mysql</a> en exécutant cette commande :`,
   'cc-addon-backups.restore.manual.description.postgresql-addon': () =>
     sanitize`Vous pouvez restaurer cette sauvegarde manuellement grâce à l'outil <a href="https://www.postgresql.org/docs/current/app-pgrestore.html">pg_restore</a> en exécutant cette commande :`,
-  'cc-addon-backups.restore.manual.description.redis-addon': `La restauration de backups Redis doit passer par notre support. Veuillez créer un ticket en indiquant l'ID de votre add-on ainsi que la date du backup à restaurer et nous le ferons pour vous.`,
+  'cc-addon-backups.restore.manual.description.redis-addon': `La restauration de backups Redis doit passer par notre support. Créez un ticket en indiquant l'ID de votre add-on ainsi que la date du backup à restaurer et nous le ferons pour vous`,
   'cc-addon-backups.restore.manual.title': `Restauration manuelle`,
   'cc-addon-backups.restore.with-service.description.es-addon': /** @param {{href: string}} _ */ ({ href }) =>
     sanitize`Vous pouvez restaurer cette sauvegarde avec Kibana en vous rendant sur le <a href="${href}">dépôt de sauvegardes</a>.`,
@@ -603,31 +603,31 @@ export const translations = {
   'cc-heptapod-info.storage-description': `Stockage utilisé`,
   //#endregion
   //#region cc-input-date
-  'cc-input-date.error.bad-input': `Veuillez saisir une date.`,
-  'cc-input-date.error.empty': `Veuillez saisir une valeur.`,
+  'cc-input-date.error.bad-input': `Saisir une date`,
+  'cc-input-date.error.empty': `Saisissez une valeur`,
   'cc-input-date.error.range-overflow': /** @param {{max: string}} _ */ ({ max }) =>
-    `Veuillez saisir une date inférieure à ${max}.`,
+    `Saisissez une date inférieure à ${max}`,
   'cc-input-date.error.range-underflow': /** @param {{min: string}} _ */ ({ min }) =>
-    `Veuillez saisir une date supérieure à ${min}.`,
+    `Saisissez une date supérieure à ${min}`,
   'cc-input-date.keyboard-hint': `Vous pouvez utiliser les touches flèche haut et flèche bas pour modifier des parties de la date.`,
   'cc-input-date.required': `obligatoire`,
   //#endregion
   //#region cc-input-number
   'cc-input-number.decrease': `décrémenter`,
-  'cc-input-number.error.bad-type': `Veuillez saisir un nombre.`,
-  'cc-input-number.error.empty': `Veuillez saisir une valeur.`,
+  'cc-input-number.error.bad-type': `Saisissez un nombre`,
+  'cc-input-number.error.empty': `Saisissez une valeur`,
   'cc-input-number.error.range-overflow': /** @param {{max: string}} _ */ ({ max }) =>
-    `Veuillez saisir un nombre supérieur à ${max}.`,
+    `Saisissez un nombre supérieur à ${max}`,
   'cc-input-number.error.range-underflow': /** @param {{min: string}} _ */ ({ min }) =>
-    `Veuillez saisir un nombre inférieur à ${min}.`,
+    `Saisissez un nombre inférieur à ${min}`,
   'cc-input-number.increase': `incrémenter`,
   'cc-input-number.required': `obligatoire`,
   //#endregion
   //#region cc-input-text
   'cc-input-text.clipboard': `Copier dans le presse-papier`,
   'cc-input-text.error.bad-email': () => sanitize`Format d'adresse e-mail invalide.<br>Exemple: john.doe@example.com.`,
-  'cc-input-text.error.empty': `Veuillez saisir une valeur.`,
-  'cc-input-text.error.empty.email': `Veuillez saisir une adresse e-mail.`,
+  'cc-input-text.error.empty': `Saisissez une valeur`,
+  'cc-input-text.error.empty.email': `Saisissez une adresse e-mail`,
   'cc-input-text.required': `obligatoire`,
   'cc-input-text.secret.hide': `Cacher le secret`,
   'cc-input-text.secret.show': `Afficher le secret`,
@@ -1098,7 +1098,7 @@ export const translations = {
   'cc-orga-member-card.btn.validate.visible-text': `Valider`,
   'cc-orga-member-card.current-user': `Votre compte`,
   'cc-orga-member-card.error.last-admin.heading': `Vous êtes le dernier admin de l'organisation`,
-  'cc-orga-member-card.error.last-admin.text': `Veuillez désigner un nouvel admin avant de pouvoir modifier votre rôle ou quitter l'organisation.`,
+  'cc-orga-member-card.error.last-admin.text': `Désignez un nouvel admin avant de pouvoir modifier votre rôle ou quitter l'organisation`,
   'cc-orga-member-card.mfa-disabled': `2FA désactivée`,
   'cc-orga-member-card.mfa-enabled': `2FA activée`,
   'cc-orga-member-card.role.accounting': `Comptable`,
@@ -1120,7 +1120,7 @@ export const translations = {
   'cc-orga-member-list.error': `Une erreur est survenue pendant le chargement de la liste des membres.`,
   'cc-orga-member-list.error-member-not-found.heading': `Membre introuvable`,
   'cc-orga-member-list.error-member-not-found.text': () =>
-    sanitize`<p>Le membre a probablement quitté l'organisation ou a été supprimé par quelqu'un d'autre pendant que vous consultiez la liste.<p><p>Veuillez <strong>rafraîchir votre page</strong> pour récupérer la liste des membres à jour.</p>`,
+    sanitize`<p>Le membre a probablement quitté l'organisation ou a été supprimé par quelqu'un d'autre pendant que vous consultiez la liste.<p><p><strong>Rafraîchissez votre page</strong> pour récupérer la liste des membres à jour.</p>`,
   'cc-orga-member-list.error.unauthorised.heading': `Vous n'avez pas les droits nécessaires`,
   'cc-orga-member-list.error.unauthorised.text': `Seul un admin peut inviter, éditer ou supprimer un autre admin.`,
   'cc-orga-member-list.filter.mfa': `Comptes non sécurisés par 2FA`,
@@ -1146,7 +1146,7 @@ export const translations = {
   'cc-orga-member-list.leave.btn': `Quitter l'organisation`,
   'cc-orga-member-list.leave.error': `Une erreur est survenue lorsque vous avez tenté de quitter l'organisation.`,
   'cc-orga-member-list.leave.error-last-admin.heading': `Vous êtes le dernier admin de l'organisation`,
-  'cc-orga-member-list.leave.error-last-admin.text': `Veuillez désigner un nouvel admin avant de pouvoir quitter l'organisation.`,
+  'cc-orga-member-list.leave.error-last-admin.text': `Désignez un nouvel admin avant de pouvoir quitter l'organisation`,
   'cc-orga-member-list.leave.heading': `Zone de danger`,
   'cc-orga-member-list.leave.success': `Vous avez quitté l'organisation.`,
   'cc-orga-member-list.leave.text': () => sanitize`
@@ -1377,7 +1377,7 @@ export const translations = {
   'cc-product-list.search-label': `Chercher un produit`,
   //#endregion
   //#region cc-select
-  'cc-select.error.empty': `Veuillez sélectionner une valeur.`,
+  'cc-select.error.empty': `Sélectionnez une valeur`,
   'cc-select.required': `obligatoire`,
   //#endregion
   //#region cc-ssh-key-list
@@ -1397,8 +1397,8 @@ export const translations = {
   'cc-ssh-key-list.error.loading': `Une erreur est survenue pendant le chargement de vos clés.`,
   'cc-ssh-key-list.error.private-key': () =>
     sanitize`Format incorrect&nbsp;: avez-vous saisi votre clé privée au lieu de votre clé publique&nbsp;?`,
-  'cc-ssh-key-list.error.required.name': `Veuillez saisir un nom pour votre clé SSH`,
-  'cc-ssh-key-list.error.required.public-key': `Veuillez saisir la valeur de votre clé publique`,
+  'cc-ssh-key-list.error.required.name': `Saisissez un nom pour votre clé SSH`,
+  'cc-ssh-key-list.error.required.public-key': `Saisissez la valeur de votre clé publique`,
   'cc-ssh-key-list.github.empty': `Il n'y a aucune clé SSH disponible à l'import depuis votre compte GitHub.`,
   'cc-ssh-key-list.github.import': `Importer`,
   'cc-ssh-key-list.github.import.a11y': /** @param {{name: string}} _ */ ({ name }) =>


### PR DESCRIPTION
Fixes #1037
Fixes #1038

## What does this PR do?

- Removes trailing `.` at the end of error messages,
- Removes "Please" / "Veuillez" inside error messages.

## How to review?

- Check the commit,
- You could also check the preview if you want but I feel like it's overkill for this one?
- 1 reviewer is enough.