### PR TITLE
Fix/opacity when disabled var

### DIFF
--- a/src/components/cc-button/cc-button.js
+++ b/src/components/cc-button/cc-button.js
@@ -438,7 +438,7 @@ export class CcButton extends LitElement {
 
         button[aria-disabled='true'] {
           cursor: inherit;
-          opacity: 0.5;
+          opacity: var(--cc-opacity-when-disabled);
         }
 
         .skeleton {

--- a/src/components/cc-input-number/cc-input-number.js
+++ b/src/components/cc-input-number/cc-input-number.js
@@ -483,7 +483,7 @@ export class CcInputNumber extends CcFormControlElement {
         }
 
         button[disabled] {
-          opacity: 0.5;
+          opacity: var(--cc-opacity-when-disabled);
           pointer-events: none;
         }
 

--- a/src/components/cc-toggle/cc-toggle.js
+++ b/src/components/cc-toggle/cc-toggle.js
@@ -314,7 +314,7 @@ export class CcToggle extends LitElement {
         /* DISABLED */
 
         .toggle-group.disabled {
-          opacity: 0.5;
+          opacity: var(--cc-opacity-when-disabled);
         }
 
         .disabled label {


### PR DESCRIPTION
Fixes #617 

# What does this PR do?

- Changes `opacity: 0.5` to `opacity: --cc-opacity-when-disabled`  in waiting or disabled mode.

# How to review?

- Check the commits,
- Check the preview,
- 1 reviewer should be enough for this one.
