### PR TITLE
fix(cc-input-text): add the possibility to use command key on implicit submit

### DIFF
--- a/src/components/cc-input-text/cc-input-text.js
+++ b/src/components/cc-input-text/cc-input-text.js
@@ -309,7 +309,7 @@ export class CcInputText extends CcFormControlElement {
     }
     // Request implicit submit with keypress on enter key
     if (!this.readonly && e.type === 'keypress' && e.key === 'Enter') {
-      if (!this.multi || (this.multi && e.ctrlKey)) {
+      if (!this.multi || (this.multi && (e.ctrlKey || e.metaKey))) {
         this._internals.form?.requestSubmit();
         this.dispatchEvent(new CcRequestSubmitEvent());
       }


### PR DESCRIPTION
Fixes #1227

# What does this PR do?

- Add the possibility to use `cmd+Enter` on mac OS

# How to review?

- Check the commits,
- 1 reviewer should be enough for this one.
