### PR TITLE
feat(cc-token-api-list): handle users with no password set

### DIFF
--- a/src/components/cc-token-api-list/cc-token-api-list.smart.md
+++ b/src/components/cc-token-api-list/cc-token-api-list.smart.md
@@ -21,6 +21,7 @@ title: '💡 Smart'
 
 ```ts
 interface ApiConfig {
+  API_HOST: string,
   API_OAUTH_TOKEN: string,
   API_OAUTH_TOKEN_SECRET: string,
   OAUTH_CONSUMER_KEY: string,
@@ -33,6 +34,7 @@ interface ApiConfig {
 
 | Method   | Type                    | Cache?  |
 |----------|:------------------------|---------|
+| `GET`    | `/v2/self`              | Default |
 | `GET`    | `/api-tokens`           | Default |
 | `DELETE` | `/api-tokens/{tokenId}` | N/A     |
 

--- a/src/components/cc-token-api-list/cc-token-api-list.stories.js
+++ b/src/components/cc-token-api-list/cc-token-api-list.stories.js
@@ -93,6 +93,31 @@ export const defaultStory = makeStory(conf, {
   ],
 });
 
+export const dataLoaded = makeStory(conf, {
+  /** @type {Partial<CcTokenApiList>[]} */
+  items: [
+    {
+      apiTokenUpdateHref,
+      state: {
+        type: 'loaded',
+        apiTokens: baseTokens,
+      },
+    },
+  ],
+});
+
+export const dataLoadedWithNoPassword = makeStory(conf, {
+  /** @type {Partial<CcTokenApiList>[]} */
+  items: [
+    {
+      apiTokenUpdateHref,
+      state: {
+        type: 'no-password',
+      },
+    },
+  ],
+});
+
 export const loading = makeStory(conf, {
   /** @type {Partial<CcTokenApiList>[]} */
   items: [
@@ -181,6 +206,18 @@ export const waitingWithDeletingExpiredToken = makeStory(conf, {
   ],
 });
 
+export const waitingWithResettingPassword = makeStory(conf, {
+  /** @type {Partial<CcTokenApiList>[]} */
+  items: [
+    {
+      apiTokenUpdateHref,
+      state: {
+        type: 'resetting-password',
+      },
+    },
+  ],
+});
+
 export const simulationsWithLoadingSuccess = makeStory(conf, {
   /** @type {Partial<CcTokenApiList>[]} */
   items: [
@@ -261,6 +298,27 @@ export const simulationsWithRevokingToken = makeStory(conf, {
         component.state = {
           type: 'loaded',
           apiTokens: baseTokens.filter((_, index) => index !== 1),
+        };
+      },
+    ),
+  ],
+});
+
+export const simulationsWithNoPassword = makeStory(conf, {
+  /** @type {Partial<CcTokenApiList>[]} */
+  items: [
+    {
+      apiTokenUpdateHref,
+      state: { type: 'loading' },
+    },
+  ],
+  simulations: [
+    storyWait(
+      2000,
+      /** @param {CcTokenApiList[]} components */
+      ([component]) => {
+        component.state = {
+          type: 'no-password',
         };
       },
     ),

--- a/src/components/cc-token-api-list/cc-token-api-list.types.d.ts
+++ b/src/components/cc-token-api-list/cc-token-api-list.types.d.ts
@@ -1,4 +1,9 @@
-export type TokenApiListState = TokenApiListStateLoading | TokenApiListStateError | TokenApiListStateLoaded;
+export type TokenApiListState =
+  | TokenApiListStateLoading
+  | TokenApiListStateError
+  | TokenApiListStateLoaded
+  | TokenApiListStateNoPassword
+  | TokenApiListStateResettingPassword;
 
 export interface TokenApiListStateLoading {
   type: 'loading';
@@ -11,6 +16,14 @@ export interface TokenApiListStateError {
 export interface TokenApiListStateLoaded {
   type: 'loaded';
   apiTokens: ApiTokenState[];
+}
+
+export interface TokenApiListStateNoPassword {
+  type: 'no-password';
+}
+
+export interface TokenApiListStateResettingPassword {
+  type: 'resetting-password';
 }
 
 export type ApiTokenState = ApiTokenStateIdle | ApiTokenStateRevoking;

--- a/src/components/common.events.js
+++ b/src/components/common.events.js
@@ -113,3 +113,15 @@ export class CcTokenRevokeEvent extends CcEvent {
     super(CcTokenRevokeEvent.TYPE, detail);
   }
 }
+
+/**
+ * Dispatched when a password reset is requested.
+ * @extends {CcEvent}
+ */
+export class CcPasswordResetEvent extends CcEvent {
+  static TYPE = 'cc-password-reset';
+
+  constructor() {
+    super(CcPasswordResetEvent.TYPE);
+  }
+}

--- a/src/lib/events-map.types.d.ts
+++ b/src/lib/events-map.types.d.ts
@@ -129,6 +129,7 @@ import {
 } from '../components/cc-token-api-update-form/cc-token-api-update-form.events.js';
 import {
   CcClickEvent,
+  CcPasswordResetEvent,
   CcRequestSubmitEvent,
   CcToggleEvent,
   CcTokenRevokeEvent,
@@ -233,6 +234,7 @@ declare global {
     'cc-orga-member-leave': CcOrgaMemberLeaveEvent;
     'cc-orga-member-left': CcOrgaMemberLeftEvent;
     'cc-orga-member-update': CcOrgaMemberUpdateEvent;
+    'cc-password-reset': CcPasswordResetEvent;
     'cc-pricing-currency-change': CcPricingCurrencyChangeEvent;
     'cc-pricing-plan-add': CcPricingPlanAddEvent;
     'cc-pricing-plan-delete': CcPricingPlanDeleteEvent;

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -1633,12 +1633,18 @@ export const translations = {
     `,
   'cc-token-api-list.create-token': `Create new token`,
   'cc-token-api-list.delete-token': /** @param {{ name: string}} _ */ ({ name }) => `Delete API token - ${name}`,
-  'cc-token-api-list.empty': `You have not created any token yet or you don't have any active token. Go ahead and create a new API token`,
+  'cc-token-api-list.empty': `You haven't created any API tokens yet, or none of them are active. Let's create a new one:`,
   'cc-token-api-list.error': `Something went wrong while loading API tokens`,
   'cc-token-api-list.intro': () =>
     sanitize`Below is the list of <a href="https://www.clever-cloud.com/developers/api/howto/#request-the-api" title="API Tokens - Documentation - new window">API tokens</a> linked to your account and their associated information. You may revoke them as needed.`,
   'cc-token-api-list.link.doc': `API tokens - Documentation`,
   'cc-token-api-list.main-heading': `API tokens`,
+  'cc-token-api-list.no-password.create-password-btn': `Add a password`,
+  'cc-token-api-list.no-password.message': () =>
+    sanitize`Your Clever Cloud account is linked via GitHub and has no password. <strong>Setting one is required to create API tokens</strong>. Click the following button to <strong>add a password to your account</strong>, we’ll  send you an email to confirm your identity.`,
+  'cc-token-api-list.no-password.reset-password-error': `Something went wrong while trying to send your password creation request`,
+  'cc-token-api-list.no-password.reset-password-successful': /** @param {{ email: string }} _ */ ({ email }) =>
+    `The email has been sent to ${email}, reload this page once the password is added to your account`,
   'cc-token-api-list.revoke-token': /** @param {{ name: string}} _ */ ({ name }) => `Revoke API token - ${name}`,
   'cc-token-api-list.revoke-token.error': `Something went wrong while revoking the API token`,
   'cc-token-api-list.revoke-token.success': `The API token has been revoked successfully`,

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -1665,7 +1665,7 @@ export const translations = {
     sanitize`Vous n'avez aucun token d'API, ou aucun d'eux n'est actif. Créez un nouveau token&nbsp;:`,
   'cc-token-api-list.error': `Une erreur est survenue pendant le chargement des tokens d'API`,
   'cc-token-api-list.intro': () =>
-    sanitize`Ci-dessous la liste des tokens d'API associés à votre compte <a href="https://www.clever-cloud.com/developers/api/howto/#request-the-api" title="Tokens d'API - Documentation - nouvelle fenêtre">tokens d'API</a> et leurs informations. Vous pouvez les révoquez si nécessaire.`,
+    sanitize`Ci-dessous la liste des <a href="https://www.clever-cloud.com/developers/api/howto/#request-the-api" title="Tokens d'API - Documentation - nouvelle fenêtre">tokens d'API</a> associés à votre compte et leurs informations. Vous pouvez les révoquer si nécessaire.`,
   'cc-token-api-list.link.doc': `Tokens d'API - Documentation`,
   'cc-token-api-list.main-heading': `Tokens d'API`,
   'cc-token-api-list.no-password.create-password-btn': `Ajouter un mot de passe`,

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -1662,12 +1662,18 @@ export const translations = {
   'cc-token-api-list.delete-token': /** @param {{ name: string}} _ */ ({ name }) =>
     `Supprimer le token d'API - ${name}`,
   'cc-token-api-list.empty': () =>
-    sanitize`Vous n'avez aucun token d'API. Cliquez sur le bouton ci-dessous pour créer un nouveau token&nbsp;:`,
+    sanitize`Vous n'avez aucun token d'API, ou aucun d'eux n'est actif. Créez un nouveau token&nbsp;:`,
   'cc-token-api-list.error': `Une erreur est survenue pendant le chargement des tokens d'API`,
   'cc-token-api-list.intro': () =>
     sanitize`Ci-dessous la liste des tokens d'API associés à votre compte <a href="https://www.clever-cloud.com/developers/api/howto/#request-the-api" title="Tokens d'API - Documentation - nouvelle fenêtre">tokens d'API</a> et leurs informations. Vous pouvez les révoquez si nécessaire.`,
   'cc-token-api-list.link.doc': `Tokens d'API - Documentation`,
   'cc-token-api-list.main-heading': `Tokens d'API`,
+  'cc-token-api-list.no-password.create-password-btn': `Ajouter un mot de passe`,
+  'cc-token-api-list.no-password.message': () =>
+    sanitize`Votre compte Clever Cloud est lié via GitHub et ne possède pas de mot de passe. <strong>L'ajout d'un mot de passe est nécessaire pour créer des tokens d'API</strong>. Cliquez sur le bouton ci-contre pour <strong>ajouter un mot de passe à votre compte</strong>, nous vous enverrons un e-mail pour confirmer votre identité.`,
+  'cc-token-api-list.no-password.reset-password-error': `Une erreur est survenue lors de la demande de création de mot de passe`,
+  'cc-token-api-list.no-password.reset-password-successful': /** @param {{ email: string }} _ */ ({ email }) =>
+    `L'e-mail a été envoyé à ${email}, rechargez cette page une fois le mot de passe ajouté à votre compte`,
   'cc-token-api-list.revoke-token': /** @param {{ name: string}} _ */ ({ name }) => `Révoquer le token d'API - ${name}`,
   'cc-token-api-list.revoke-token.error': `Une erreur est survenue pendant la révocation du token d'API`,
   'cc-token-api-list.revoke-token.success': `Le token d'API a été révoqué avec succès`,


### PR DESCRIPTION
Fixes #1431

## What does this PR do?

- Handles cases where the user has no password set (account created through GitHub),
  - Replaces the "Create new token" button with a notice inviting the user to add a password to their account,
  - Adds a "Add a password" button that sends a password request to the user email when clicking on the button.

## How to review?

- Check the code,
- Check the new stories,
- Check the demo-smart if you want (you'll need an account with no password or you'll need to override the call through the network tab - ping me if you need help)