### PR TITLE
fix(form elements): use reportInlineValidity in error stories

### DIFF
--- a/src/components/cc-input-number/cc-input-number.stories.js
+++ b/src/components/cc-input-number/cc-input-number.stories.js
@@ -2,6 +2,10 @@ import { allFormControlsStory } from '../../stories/all-form-controls.js';
 import { makeStory, storyWait } from '../../stories/lib/make-story.js';
 import './cc-input-number.js';
 
+/**
+ * @typedef {import('./cc-input-number.js').CcInputNumber} CcInputNumber
+ */
+
 const baseItems = [
   { label: 'The Label' },
   { label: 'The Label', value: 100 },
@@ -50,22 +54,46 @@ export const helpMessage = makeStory(conf, {
 });
 
 export const errorMessage = makeStory(conf, {
-  items: baseItems.map((p) => ({
-    ...p,
-    required: true,
-    errorMessage: 'You must enter a value',
-  })),
+  items: [
+    {
+      ...baseItems[0],
+      required: true,
+    },
+  ],
+  /** @param {CcInputNumber} component */
+  onUpdateComplete: (component) => {
+    component.reportInlineValidity();
+  },
 });
 
 export const errorMessageWithHelpMessage = makeStory(conf, {
-  items: baseItems.map((p) => ({
-    ...p,
-    required: true,
-    errorMessage: 'You must enter a value',
-    innerHTML: `
-      <p slot="help">Must be an integer</p>
-    `,
-  })),
+  items: [
+    {
+      ...baseItems[0],
+      required: true,
+      innerHTML: `
+   <p slot="help">Must be an integer</p>
+   `,
+    },
+  ],
+  /** @param {CcInputNumber} component */
+  onUpdateComplete: (component) => {
+    component.reportInlineValidity();
+  },
+});
+
+export const errorMessageWithInvalidTypeFormat = makeStory(conf, {
+  items: [
+    {
+      ...baseItems[0],
+      required: true,
+      value: 'Invalid Type Format',
+    },
+  ],
+  /** @param {CcInputNumber} component */
+  onUpdateComplete: (component) => {
+    component.reportInlineValidity();
+  },
 });
 
 export const inline = makeStory(conf, {
@@ -84,15 +112,20 @@ export const inlineWithRequired = makeStory(conf, {
 });
 
 export const inlineWithErrorAndHelpMessages = makeStory(conf, {
-  items: baseItems.map((p) => ({
-    ...p,
-    inline: true,
-    required: true,
-    errorMessage: 'You must enter a value',
-    innerHTML: `
-      <p slot="help">Must be an integer</p>
-    `,
-  })),
+  items: [
+    {
+      ...baseItems[0],
+      required: true,
+      inline: true,
+      innerHTML: `
+   <p slot="help">Must be an integer</p>
+   `,
+    },
+  ],
+  /** @param {CcInputNumber} component */
+  onUpdateComplete: (component) => {
+    component.reportInlineValidity();
+  },
 });
 
 export const controls = makeStory(conf, {
@@ -171,6 +204,8 @@ const customBaseItems = [
   { label: 'The label', value: 100, required: true },
   { label: 'The label', value: 100, controls: true },
   { label: 'The label', value: 100, required: true, controls: true },
+  { label: 'The label', required: true },
+  { label: 'The label', required: true, controls: true },
 ];
 
 export const customLabelStyle = makeStory(
@@ -201,11 +236,9 @@ export const customLabelStyle = makeStory(
       })),
       ...customBaseItems.map((item) => ({
         ...item,
-        errorMessage: 'You must enter a value',
       })),
       ...customBaseItems.map((item) => ({
         ...item,
-        errorMessage: 'You must enter a value',
         innerHTML: `<p slot="help">Must be an integer</p>`,
       })),
       ...customBaseItems.map((item) => ({
@@ -220,47 +253,78 @@ export const customLabelStyle = makeStory(
       ...customBaseItems.map((item) => ({
         ...item,
         inline: true,
-        errorMessage: 'You must enter a value',
       })),
       ...customBaseItems.map((item) => ({
         ...item,
         inline: true,
-        errorMessage: 'You must enter a value',
         innerHTML: `<p slot="help">Must be an integer</p>`,
       })),
     ],
+    onUpdateComplete: () => {
+      /** @type {HTMLElement} */
+      const container = document.querySelector('.story-shadow-container');
+      /** @type {NodeListOf<CcInputNumber>} */
+      const allComponents = container.shadowRoot.querySelectorAll('cc-input-number');
+      allComponents.forEach((component) => {
+        component.reportInlineValidity();
+      });
+    },
   },
 );
 
 export const allFormControls = allFormControlsStory;
 
 export const simulation = makeStory(conf, {
-  items: [{}],
+  items: [{ label: 'The Label', required: true }],
   simulations: [
-    storyWait(0, ([component]) => {
-      component.innerHTML = `
+    storyWait(
+      0,
+      /**
+       * @param {Array<CcInputNumber>} args
+       */
+      ([component]) => {
+        component.innerHTML = `
         <p slot="help">No error, no focus</p>
       `;
-    }),
-    storyWait(2000, ([component]) => {
-      component.errorMessage = 'This is an error message';
-      component.innerHTML = `
+      },
+    ),
+    storyWait(
+      2000,
+      /**
+       * @param {Array<CcInputNumber>} args
+       */
+      ([component]) => {
+        component.reportInlineValidity();
+        component.innerHTML = `
         <p slot="help">With error, no focus</p>
       `;
-    }),
-    storyWait(2000, ([component]) => {
-      component.errorMessage = 'This is an error message';
-      component.innerHTML = `
+      },
+    ),
+    storyWait(
+      2000,
+      /**
+       * @param {Array<CcInputNumber>} args
+       */
+      ([component]) => {
+        component.reportInlineValidity();
+        component.innerHTML = `
         <p slot="help">With error, with focus</p>
       `;
-      component.focus();
-    }),
-    storyWait(2000, ([component]) => {
-      component.errorMessage = null;
-      component.innerHTML = `
+        component.focus();
+      },
+    ),
+    storyWait(
+      2000,
+      /**
+       * @param {Array<CcInputNumber>} args
+       */
+      ([component]) => {
+        component.errorMessage = null;
+        component.innerHTML = `
         <p slot="help">No error, with focus</p>
       `;
-      component.focus();
-    }),
+        component.focus();
+      },
+    ),
   ],
 });

--- a/src/components/cc-input-text/cc-input-text.stories.js
+++ b/src/components/cc-input-text/cc-input-text.stories.js
@@ -2,6 +2,10 @@ import { allFormControlsStory } from '../../stories/all-form-controls.js';
 import { makeStory, storyWait } from '../../stories/lib/make-story.js';
 import './cc-input-text.js';
 
+/**
+ * @typedef {import('./cc-input-text.js').CcInputText} CcInputText
+ */
+
 function widthContent(chars) {
   const rawContents = `_chars`;
   return String(chars) + String(rawContents).padStart(chars - 2, '_');
@@ -119,22 +123,47 @@ export const helpMessage = makeStory(conf, {
 });
 
 export const errorMessage = makeStory(conf, {
-  items: baseItems.map((p) => ({
-    ...p,
-    required: true,
-    errorMessage: 'You must enter a value',
-  })),
+  items: [
+    {
+      ...baseItems[0],
+      required: true,
+    },
+  ],
+  /** @param {CcInputText} component */
+  onUpdateComplete: (component) => {
+    component.reportInlineValidity();
+  },
 });
 
 export const errorMessageWithHelpMessage = makeStory(conf, {
-  items: baseItems.map((p) => ({
-    ...p,
-    required: true,
-    errorMessage: 'You must enter a value',
-    innerHTML: `
+  items: [
+    {
+      ...baseItems[0],
+      required: true,
+      innerHTML: `
       <p slot="help">Must be at least 7 characters long</p>
-    `,
-  })),
+     `,
+    },
+  ],
+  /** @param {CcInputText} component */
+  onUpdateComplete: (component) => {
+    component.reportInlineValidity();
+  },
+});
+
+export const errorMessageWithInvalidEmailFormat = makeStory(conf, {
+  items: [
+    {
+      ...baseItems[0],
+      required: true,
+      type: 'email',
+      value: 'Invalid Email Format',
+    },
+  ],
+  /** @param {CcInputText} component */
+  onUpdateComplete: (component) => {
+    component.reportInlineValidity();
+  },
 });
 
 export const inline = makeStory(conf, {
@@ -153,15 +182,20 @@ export const inlineWithRequired = makeStory(conf, {
 });
 
 export const inlineWithErrorAndHelpMessages = makeStory(conf, {
-  items: baseItems.map((p) => ({
-    ...p,
-    inline: true,
-    required: true,
-    errorMessage: 'You must enter a value',
-    innerHTML: `
+  items: [
+    {
+      ...baseItems[0],
+      required: true,
+      inline: true,
+      innerHTML: `
       <p slot="help">Must be at least 7 characters long</p>
-    `,
-  })),
+     `,
+    },
+  ],
+  /** @param {CcInputText} component */
+  onUpdateComplete: (component) => {
+    component.reportInlineValidity();
+  },
 });
 
 export const clipboard = makeStory(conf, {
@@ -239,7 +273,7 @@ const customBaseItems = [
     placeholder: 'No value yet...',
     multi: true,
     required: true,
-    value: 'Simple value\nOther lines...',
+    value: '',
   },
 ];
 
@@ -272,11 +306,9 @@ export const customLabelStyle = makeStory(conf, {
     })),
     ...customBaseItems.map((item) => ({
       ...item,
-      errorMessage: 'You must enter a value',
     })),
     ...customBaseItems.map((item) => ({
       ...item,
-      errorMessage: 'You must enter a value',
       innerHTML: `<p slot="help">Must be at least 7 characters long</p>`,
     })),
     ...customBaseItems.map((item) => ({
@@ -291,46 +323,78 @@ export const customLabelStyle = makeStory(conf, {
     ...customBaseItems.map((item) => ({
       ...item,
       inline: true,
-      errorMessage: 'You must enter a value',
     })),
     ...customBaseItems.map((item) => ({
       ...item,
       inline: true,
-      errorMessage: 'You must enter a value',
       innerHTML: `<p slot="help">Must be at least 7 characters long</p>`,
     })),
   ],
+
+  onUpdateComplete: () => {
+    /** @type {HTMLElement} */
+    const container = document.querySelector('.story-shadow-container');
+    /** @type {NodeListOf<CcInputText>} */
+    const allComponents = container.shadowRoot.querySelectorAll('cc-input-text');
+    allComponents.forEach((component) => {
+      component.reportInlineValidity();
+    });
+  },
 });
 
 export const allFormControls = allFormControlsStory;
 
 export const simulation = makeStory(conf, {
-  items: [{}],
+  items: [{ label: 'The Label', required: true }],
   simulations: [
-    storyWait(0, ([component]) => {
-      component.innerHTML = `
+    storyWait(
+      0,
+      /**
+       * @param {Array<CcInputText>} args
+       */
+      ([component]) => {
+        component.innerHTML = `
         <p slot="help">No error, no focus</p>
       `;
-    }),
-    storyWait(2000, ([component]) => {
-      component.errorMessage = 'This is an error message';
-      component.innerHTML = `
+      },
+    ),
+    storyWait(
+      2000,
+      /**
+       * @param {Array<CcInputText>} args
+       */
+      ([component]) => {
+        component.reportInlineValidity();
+        component.innerHTML = `
         <p slot="help">With error, no focus</p>
       `;
-    }),
-    storyWait(2000, ([component]) => {
-      component.errorMessage = 'This is an error message';
-      component.innerHTML = `
+      },
+    ),
+    storyWait(
+      2000,
+      /**
+       * @param {Array<CcInputText>} args
+       */
+      ([component]) => {
+        component.reportInlineValidity();
+        component.innerHTML = `
         <p slot="help">With error, with focus</p>
       `;
-      component.focus();
-    }),
-    storyWait(2000, ([component]) => {
-      component.errorMessage = null;
-      component.innerHTML = `
+        component.focus();
+      },
+    ),
+    storyWait(
+      2000,
+      /**
+       * @param {Array<CcInputText>} args
+       */
+      ([component]) => {
+        component.errorMessage = null;
+        component.innerHTML = `
         <p slot="help">No error, with focus</p>
       `;
-      component.focus();
-    }),
+        component.focus();
+      },
+    ),
   ],
 });

--- a/src/components/cc-select/cc-select.stories.js
+++ b/src/components/cc-select/cc-select.stories.js
@@ -75,7 +75,7 @@ export const helpMessage = makeStory(conf, {
       required: true,
       value: '',
       options: baseOptions,
-      innerHTML: '<p slot="help">There can be only one.</p>',
+      innerHTML: '<p slot="help">There can be only one</p>',
     },
   ],
 });
@@ -88,9 +88,12 @@ export const errorMessage = makeStory(conf, {
       required: true,
       value: '',
       options: baseOptions,
-      errorMessage: 'A value must be selected.',
     },
   ],
+  /** @param {CcSelect} component */
+  onUpdateComplete: (component) => {
+    component.reportInlineValidity();
+  },
 });
 
 export const errorMessageWithHelpMessage = makeStory(conf, {
@@ -101,12 +104,15 @@ export const errorMessageWithHelpMessage = makeStory(conf, {
       required: true,
       value: '',
       options: baseOptions,
-      errorMessage: 'A value must be selected.',
       innerHTML: `
-        <p slot="help">There can be only one.</p>
+        <p slot="help">There can be only one</p>
       `,
     },
   ],
+  /** @param {CcSelect} component */
+  onUpdateComplete: (component) => {
+    component.reportInlineValidity();
+  },
 });
 
 export const inline = makeStory(conf, {
@@ -154,10 +160,8 @@ export const inlineWithErrorAndHelpMessages = makeStory(conf, {
       inline: true,
       required: true,
       options: baseOptions,
-      value: 'LENNON',
-      errorMessage: 'A value must be selected.',
       innerHTML: `
-        <p slot="help">There can be only one.</p>
+        <p slot="help">There can be only one</p>
       `,
     },
     {
@@ -167,12 +171,20 @@ export const inlineWithErrorAndHelpMessages = makeStory(conf, {
       required: true,
       value: '',
       options: baseOptions,
-      errorMessage: 'A value must be selected.',
       innerHTML: `
-        <p slot="help">There can be only one.</p>
+        <p slot="help">There can be only one</p>
       `,
     },
   ],
+  onUpdateComplete: () => {
+    /** @type {HTMLElement} */
+    const container = document.querySelector('.story-shadow-container');
+    /** @type {NodeListOf<CcSelect>} */
+    const allComponents = container.shadowRoot.querySelectorAll('cc-select');
+    allComponents.forEach((component) => {
+      component.reportInlineValidity();
+    });
+  },
 });
 
 export const disabled = makeStory(conf, {
@@ -211,6 +223,7 @@ export const longContentWihFixedWidth = makeStory(
 const customBaseItems = [
   { label: 'Favourite artist', value: 'LENNON', options: baseOptions },
   { label: 'Favourite artist', value: 'LENNON', options: baseOptions, required: true },
+  { label: 'Favourite artist', required: true, options: baseOptions },
 ];
 
 export const customLabelStyle = makeStory(
@@ -237,16 +250,14 @@ export const customLabelStyle = makeStory(
       ...customBaseItems,
       ...customBaseItems.map((item) => ({
         ...item,
-        innerHTML: `<p slot="help">There can be only one.</p>`,
+        innerHTML: `<p slot="help">There can be only one</p>`,
       })),
       ...customBaseItems.map((item) => ({
         ...item,
-        errorMessage: 'A value must be selected.',
       })),
       ...customBaseItems.map((item) => ({
         ...item,
-        errorMessage: 'A value must be selected.',
-        innerHTML: `<p slot="help">There can be only one.</p>`,
+        innerHTML: `<p slot="help">There can be only one</p>`,
       })),
       ...customBaseItems.map((item) => ({
         ...item,
@@ -255,34 +266,34 @@ export const customLabelStyle = makeStory(
       ...customBaseItems.map((item) => ({
         ...item,
         inline: true,
-        innerHTML: `<p slot="help">There can be only one.</p>`,
+        innerHTML: `<p slot="help">There can be only one</p>`,
       })),
       ...customBaseItems.map((item) => ({
         ...item,
         inline: true,
-        errorMessage: 'A value must be selected.',
       })),
       ...customBaseItems.map((item) => ({
         ...item,
         inline: true,
-        errorMessage: 'A value must be selected.',
-        innerHTML: `<p slot="help">There can be only one.</p>`,
+        innerHTML: `<p slot="help">There can be only one</p>`,
       })),
     ],
+    onUpdateComplete: () => {
+      /** @type {HTMLElement} */
+      const container = document.querySelector('.story-shadow-container');
+      /** @type {NodeListOf<CcSelect>} */
+      const allComponents = container.shadowRoot.querySelectorAll('cc-select');
+      allComponents.forEach((component) => {
+        component.reportInlineValidity();
+      });
+    },
   },
 );
 
 export const allFormControls = allFormControlsStory;
 
 export const simulation = makeStory(conf, {
-  items: [
-    {
-      label: 'Favourite artist',
-      placeholder: '-- Select an artist --',
-      value: '',
-      options: baseOptions,
-    },
-  ],
+  items: [{ label: 'The Label', required: true }],
   simulations: [
     storyWait(
       0,
@@ -301,7 +312,7 @@ export const simulation = makeStory(conf, {
        * @param {Array<CcSelect>} args
        */
       ([component]) => {
-        component.errorMessage = 'This is an error message';
+        component.reportInlineValidity();
         component.innerHTML = `
         <p slot="help">With error, no focus</p>
       `;
@@ -313,7 +324,7 @@ export const simulation = makeStory(conf, {
        * @param {Array<CcSelect>} args
        */
       ([component]) => {
-        component.errorMessage = 'This is an error message';
+        component.reportInlineValidity();
         component.innerHTML = `
         <p slot="help">With error, with focus</p>
       `;

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -657,7 +657,7 @@ export const translations = {
   //#endregion
   //#region cc-input-number
   'cc-input-number.decrease': `decrease`,
-  'cc-input-number.error.bad-type': `You must enter a number.`,
+  'cc-input-number.error.bad-type': `You must enter a number`,
   'cc-input-number.error.empty': `You must enter a value`,
   'cc-input-number.error.range-overflow': /** @param {{max: number}} _ */ ({ max }) =>
     `You must enter a number lower that ${max}.`,


### PR DESCRIPTION
Fixes #1447

## What does this PR do?

- Reworks error stories of form elements to use `reportInlineValidity` on inputs,
- Simplifies the error stories to only display one case,
- Adds error stories with invalid format,
- Removes impossible states (ex : required inputs with a valid value and empty error message),
- Removes "." at the end of simple sentence.

## How to review ?

- Check to commits,
- Check the preview stories and compare with prod.

## Questions / Reflexions

- On the `cc-input-text`, I figured out that a component with `multi` prop can not be visually seen with expended input and an error message (as the input expends regarding the text added inside and the empty error message is triggered on empty input). I have left the example of a `cc-input-text` multilines on the `customLabelStyle` story, but we can not see it anymore on error mode as it is in prod.
