### PR TITLE
refactor(cc-input-date): improve format displayed

### DIFF
--- a/src/components/cc-input-date/cc-input-date.js
+++ b/src/components/cc-input-date/cc-input-date.js
@@ -538,6 +538,7 @@ export class CcInputDate extends CcFormControlElement {
 
       <div class="help-container" id="help">
         <slot name="help"></slot>
+        <p class="help-message">${i18n('cc-input-date.help')}</p>
       </div>
 
       ${hasErrorMessage
@@ -692,6 +693,12 @@ export class CcInputDate extends CcFormControlElement {
           line-height: 2em;
           overflow: hidden;
           z-index: 2;
+        }
+
+        .help-message {
+          color: var(--cc-color-text-weak, #333);
+          font-size: 0.9em;
+          margin: 0.3em 0 0;
         }
 
         /* STATES */

--- a/src/components/cc-input-date/cc-input-date.js
+++ b/src/components/cc-input-date/cc-input-date.js
@@ -215,8 +215,10 @@ export class CcInputDate extends CcFormControlElement {
         i18n('cc-input-date.error.bad-input', {
           date: DATE_FORMATTER_SHORT.format(shiftDateField(NOW, 'D', 1)),
         }),
-      rangeUnderflow: () => i18n('cc-input-date.error.range-underflow', { min: this.min }),
-      rangeOverflow: () => i18n('cc-input-date.error.range-overflow', { max: this.max }),
+      rangeUnderflow: () =>
+        i18n('cc-input-date.error.range-underflow', { min: DATE_FORMATTER_SHORT.format(new Date(this.min)) }),
+      rangeOverflow: () =>
+        i18n('cc-input-date.error.range-overflow', { max: DATE_FORMATTER_SHORT.format(new Date(this.max)) }),
     };
   }
 

--- a/src/components/cc-input-date/cc-input-date.stories.js
+++ b/src/components/cc-input-date/cc-input-date.stories.js
@@ -124,6 +124,29 @@ export const errorMessageInvalidFormat = makeStory(conf, {
   },
 });
 
+export const errorMessageInvalidRangeOverflowAndUnderflow = makeStory(conf, {
+  items: [
+    {
+      ...baseItems[0],
+      value: '2023-07-23T00:00:00.000Z',
+      min: '2023-07-23T00:00:00.000Z',
+      max: '2023-05-22T00:00:00.000Z',
+      label: 'Since',
+    },
+    {
+      ...baseItems[0],
+      value: '2023-05-22T00:00:00.000Z',
+      min: '2023-07-23T00:00:00.000Z',
+      max: '2023-09-23T00:00:00.000Z',
+      label: 'Until',
+    },
+  ],
+  /** @param {CcInputDate} component */
+  onUpdateComplete: (component) => {
+    component.reportInlineValidity();
+  },
+});
+
 export const inline = makeStory(conf, {
   items: baseItems.map((p) => ({
     ...p,

--- a/src/components/cc-input-date/cc-input-date.stories.js
+++ b/src/components/cc-input-date/cc-input-date.stories.js
@@ -89,11 +89,11 @@ export const required = makeStory(conf, {
   items: baseItems.map((p) => ({ ...p, required: true })),
 });
 
-export const helpMessage = makeStory(conf, {
+export const helpMessageSlotted = makeStory(conf, {
   items: baseItems.map((p) => ({
     ...p,
     required: true,
-    innerHTML: '<p slot="help">Format: YYYY-MM-DD HH:MM:SS</p>',
+    innerHTML: '<p slot="help">Specify the date using this field</p>',
   })),
 });
 
@@ -124,22 +124,6 @@ export const errorMessageInvalidFormat = makeStory(conf, {
   },
 });
 
-export const errorMessageWithHelpMessage = makeStory(conf, {
-  items: [
-    {
-      ...baseItems[0],
-      required: true,
-      innerHTML: `
-      <p slot="help">Format: YYYY-MM-DD HH:MM:SS</p>
-    `,
-    },
-  ],
-  /** @param {CcInputDate} component */
-  onUpdateComplete: (component) => {
-    component.reportInlineValidity();
-  },
-});
-
 export const inline = makeStory(conf, {
   items: baseItems.map((p) => ({
     ...p,
@@ -161,9 +145,6 @@ export const inlineWithErrorAndHelpMessages = makeStory(conf, {
       ...baseItems[0],
       inline: true,
       required: true,
-      innerHTML: `
-      <p slot="help">Format: YYYY-MM-DD HH:MM:SS</p>
-    `,
     },
   ],
   /** @param {CcInputDate} component */
@@ -231,23 +212,12 @@ export const customLabelStyle = makeStory(
       ...customBaseItems,
       ...customBaseItems.map((item) => ({
         ...item,
-        innerHTML: `<p slot="help">Format: YYYY-MM-DD HH:MM:SS</p>`,
       })),
       ...customBaseItems.map((item) => ({
         ...item,
       })),
       ...customBaseItems.map((item) => ({
         ...item,
-        innerHTML: `<p slot="help">Format: YYYY-MM-DD HH:MM:SS</p>`,
-      })),
-      ...customBaseItems.map((item) => ({
-        ...item,
-        inline: true,
-      })),
-      ...customBaseItems.map((item) => ({
-        ...item,
-        inline: true,
-        innerHTML: `<p slot="help">Format: YYYY-MM-DD HH:MM:SS</p>`,
       })),
       ...customBaseItems.map((item) => ({
         ...item,
@@ -256,7 +226,14 @@ export const customLabelStyle = makeStory(
       ...customBaseItems.map((item) => ({
         ...item,
         inline: true,
-        innerHTML: `<p slot="help">Format: YYYY-MM-DD HH:MM:SS</p>`,
+      })),
+      ...customBaseItems.map((item) => ({
+        ...item,
+        inline: true,
+      })),
+      ...customBaseItems.map((item) => ({
+        ...item,
+        inline: true,
       })),
     ],
     onUpdateComplete: () => {

--- a/src/components/cc-logs-date-range-selector/cc-logs-date-range-selector.js
+++ b/src/components/cc-logs-date-range-selector/cc-logs-date-range-selector.js
@@ -447,6 +447,7 @@ export class CcLogsDateRangeSelector extends LitElement {
         .options-popover-content--left {
           display: flex;
           flex-direction: column;
+          justify-content: space-evenly;
         }
 
         .options-popover-content--right {

--- a/src/components/cc-token-api-creation-form/cc-token-api-creation-form.js
+++ b/src/components/cc-token-api-creation-form/cc-token-api-creation-form.js
@@ -577,7 +577,6 @@ export class CcTokenApiCreationForm extends LitElement {
                   </p>
                 `
               : ''}
-            <p slot="help">${i18n('cc-token-api-creation-form.configuration-step.form.expiration-date.help.format')}</p>
           </cc-input-date>
         </div>
         <div class="form__actions">

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -649,9 +649,9 @@ export const translations = {
     sanitize`You must enter a date. <br> For instance: ${date}.`,
   'cc-input-date.error.empty': `You must enter a value`,
   'cc-input-date.error.range-overflow': /** @param {{max: string}} _ */ ({ max }) =>
-    `You must enter a date lower that ${max}.`,
+    `You must enter a date lower than ${max}.`,
   'cc-input-date.error.range-underflow': /** @param {{min: string}} _ */ ({ min }) =>
-    `You must enter a date higher that ${min}.`,
+    `You must enter a date higher than ${min}.`,
   'cc-input-date.help': `Format: YYYY-MM-DD HH:MM:SS`,
   'cc-input-date.keyboard-hint': `You can use up or down arrow keys to modify parts of the date.`,
   'cc-input-date.required': `required`,

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -1649,7 +1649,6 @@ export const translations = {
   'cc-token-api-creation-form.configuration-step.form.expiration-date.error.range-underflow':
     /** @param {{ date: string }} _ */ ({ date }) =>
       sanitize`The expiration date must be at least 15 minutes from now<br>For instance: ${date}`,
-  'cc-token-api-creation-form.configuration-step.form.expiration-date.help.format': `Format: YYYY-MM-DD HH:MM:SS`,
   'cc-token-api-creation-form.configuration-step.form.expiration-date.help.min-max': `Must be at least 15 minutes and up to 1 year from now`,
   'cc-token-api-creation-form.configuration-step.form.expiration-date.label': `Expiration date`,
   'cc-token-api-creation-form.configuration-step.form.expiration-duration.help.custom': `Specify the expiration date using the following field`,

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -652,6 +652,7 @@ export const translations = {
     `You must enter a date lower that ${max}.`,
   'cc-input-date.error.range-underflow': /** @param {{min: string}} _ */ ({ min }) =>
     `You must enter a date higher that ${min}.`,
+  'cc-input-date.help': `Format: YYYY-MM-DD HH:MM:SS`,
   'cc-input-date.keyboard-hint': `You can use up or down arrow keys to modify parts of the date.`,
   'cc-input-date.required': `required`,
   //#endregion

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -1673,8 +1673,6 @@ export const translations = {
   'cc-token-api-creation-form.configuration-step.form.expiration-date.error.range-underflow':
     /** @param {{ date: string }} _ */ ({ date }) =>
       sanitize`La date d'expiration doit être au moins 15 minutes à partir de maintenant<br>Par exemple&nbsp;: ${date}`,
-  'cc-token-api-creation-form.configuration-step.form.expiration-date.help.format': () =>
-    sanitize`Format&nbsp;: AAAA-MM-JJ HH:MM:SS`,
   'cc-token-api-creation-form.configuration-step.form.expiration-date.help.min-max': `Au moins 15 minutes et jusqu'à 1 an à partir de maintenant`,
   'cc-token-api-creation-form.configuration-step.form.expiration-date.label': `Date d'expiration`,
   'cc-token-api-creation-form.configuration-step.form.expiration-duration.help.custom': `Spécifiez la date d'expiration à l'aide du champ ci-contre`,

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -664,6 +664,7 @@ export const translations = {
     `Saisissez une date inférieure à ${max}`,
   'cc-input-date.error.range-underflow': /** @param {{min: string}} _ */ ({ min }) =>
     `Saisissez une date supérieure à ${min}`,
+  'cc-input-date.help': `Format : AAAA-MM-JJ HH:MM:SS`,
   'cc-input-date.keyboard-hint': `Vous pouvez utiliser les touches flèche haut et flèche bas pour modifier des parties de la date.`,
   'cc-input-date.required': `obligatoire`,
   //#endregion


### PR DESCRIPTION
Fixes #1455
Fixes #1456

## What does this PR do?
- Refactors the `cc-input-date` render to always display the help message,
- Removes the unnecessary `helpMessage` and `errorMessageWithHelpMessage` stories,
- Formats the underflow and overflow date ranges,
- Adds a `errorMessageInvalidRangeOverflowAndUnderflow`.

## How to review?
- Check the commits,
- Check the [preview](https://clever-components-preview.cellar-c2.services.clever-cloud.com/refactor/cc-input-date-improve-format-displayed/index.html?path=/docs/%F0%9F%A7%AC-atoms-cc-input-date--docs) and compare with [prod](https://www.clever-cloud.com/doc/clever-components/?path=/story/%F0%9F%A7%AC-atoms-cc-input-date--default-story),
- Look for any visual regression on different screen sizes, especially on impacted components (`cc-logs-date-range-selector` and `cc-token-api-creation-form`),
- 2 reviewers should be enough.