### PR TITLE
chore(prettier): bump prettier to 3.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -89,7 +89,7 @@
         "mime-types": "^2.1.30",
         "mocha": "^10.0.0",
         "postcss-styled-syntax": "^0.7.0",
-        "prettier": "^3.2.5",
+        "prettier": "^3.6.0",
         "prettier-plugin-organize-imports": "^4.0.0",
         "remark-frontmatter": "^3.0.0",
         "remark-gfm": "^1.0.0",
@@ -14506,9 +14506,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
-      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.0.tgz",
+      "integrity": "sha512-ujSB9uXHJKzM/2GBuE0hBOUgC77CN3Bnpqa+g80bkv3T3A93wL/xlzDATHhnhkzifz/UE2SNOvmbTz5hSkDlHw==",
       "dev": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
@@ -29633,9 +29633,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
-      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.0.tgz",
+      "integrity": "sha512-ujSB9uXHJKzM/2GBuE0hBOUgC77CN3Bnpqa+g80bkv3T3A93wL/xlzDATHhnhkzifz/UE2SNOvmbTz5hSkDlHw==",
       "dev": true
     },
     "prettier-plugin-organize-imports": {

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "mime-types": "^2.1.30",
     "mocha": "^10.0.0",
     "postcss-styled-syntax": "^0.7.0",
-    "prettier": "^3.2.5",
+    "prettier": "^3.6.0",
     "prettier-plugin-organize-imports": "^4.0.0",
     "remark-frontmatter": "^3.0.0",
     "remark-gfm": "^1.0.0",

--- a/src/components/cc-input-date/cc-input-date.js
+++ b/src/components/cc-input-date/cc-input-date.js
@@ -312,7 +312,7 @@ export class CcInputDate extends CcFormControlElement {
    * @return {Date|null} The current value as Date or null if the value is not a valid date.
    */
   get valueAsDate() {
-    return this._valueState.type === 'valid' ? this._valueState.date ?? null : null;
+    return this._valueState.type === 'valid' ? (this._valueState.date ?? null) : null;
   }
 
   /* endregion */

--- a/src/styles/shoelace.js
+++ b/src/styles/shoelace.js
@@ -102,8 +102,9 @@ export const shoelaceStyles = css`
     --sl-transition-fast: 150ms;
     --sl-transition-x-fast: 50ms;
     --sl-font-mono: SFMono-Regular, Consolas, 'Liberation Mono', Menlo, monospace;
-    --sl-font-sans: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif,
-      'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
+    --sl-font-sans:
+      -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif, 'Apple Color Emoji',
+      'Segoe UI Emoji', 'Segoe UI Symbol';
     --sl-font-serif: Georgia, 'Times New Roman', serif;
     --sl-font-size-xx-small: 0.625em;
     --sl-font-size-x-small: 0.75em;


### PR DESCRIPTION
## What does this PR do?

* This PR bumps the prettier version to 3.6.0
* This version supposedly introduces a (experimental) new and faster CLI
	* Though we can't use it yet as it only supports string plugins

## How to review?

* Check the commits
* Let the ci do its job
 * You can run `npm run format:check` anyway if you want to test it
* One reviewer is enough  	