### PR TITLE
cem: adapt plugin to use latest version of TS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -115,7 +115,7 @@
         "text-table": "^0.2.0",
         "tinyglobby": "^0.2.10",
         "ts-lit-plugin": "^2.0.2",
-        "typescript": "~5.4.2",
+        "typescript": "^5.8.3",
         "unified": "^9.2.1",
         "vite": "^6.3.5"
       }
@@ -2742,6 +2742,19 @@
       "bin": {
         "cem": "cem.js",
         "custom-elements-manifest": "cem.js"
+      }
+    },
+    "node_modules/@custom-elements-manifest/analyzer/node_modules/typescript": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/@custom-elements-manifest/find-dependencies": {
@@ -14781,19 +14794,6 @@
         "postcss": "^8.4.21"
       }
     },
-    "node_modules/postcss-styled-syntax/node_modules/typescript": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
-      "dev": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
@@ -17692,9 +17692,9 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -21038,6 +21038,14 @@
         "debounce": "1.2.1",
         "globby": "11.0.4",
         "typescript": "~5.4.2"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "5.4.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+          "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+          "dev": true
+        }
       }
     },
     "@custom-elements-manifest/find-dependencies": {
@@ -30152,14 +30160,6 @@
       "dev": true,
       "requires": {
         "typescript": "^5.6.3"
-      },
-      "dependencies": {
-        "typescript": {
-          "version": "5.6.3",
-          "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
-          "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
-          "dev": true
-        }
       }
     },
     "postcss-value-parser": {
@@ -32422,9 +32422,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true
     },
     "typical": {

--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "text-table": "^0.2.0",
     "tinyglobby": "^0.2.10",
     "ts-lit-plugin": "^2.0.2",
-    "typescript": "~5.4.2",
+    "typescript": "^5.8.3",
     "unified": "^9.2.1",
     "vite": "^6.3.5"
   },

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -129,7 +129,7 @@ export function asyncMap(array, asyncCallback) {
  * Returns the currency symbol corresponding to the given currency.
  *
  * @param {string} currency - the currency to get the symbol for
- * @param {string} [currencyDisplay] - the currency formatting dysplay (defaults to "narrowSymbol")
+ * @param{Intl.NumberFormatOptions['currencyDisplay']} [currencyDisplay] - the currency formatting dysplay (defaults to "narrowSymbol")
  * @returns {string} the formatted currency symbol
  */
 export function getCurrencySymbol(currency, currencyDisplay = 'narrowSymbol') {


### PR DESCRIPTION
## What does this PR do?

* This PR makes use of the latest TS version for our typedef plugin
indtead of the one provided by CEM.

## How to review?

* Check the commits
* Run `npm components:docs` or check the preview
* In storybook you should still see the types in the docs section of the components.
 