### PR TITLE
refactor(cem/sort-items): sort modules to make diffing easier

### DIFF
--- a/cem/sort-items.js
+++ b/cem/sort-items.js
@@ -26,6 +26,8 @@ export default function sortItems() {
           }
         }
       }
+
+      customElementsManifest.modules.sort(sortBy('path'));
     },
   };
 }


### PR DESCRIPTION
Fixes #1025

## What does this PR do?

- Sorts CEM modules so we can diff manifests easily.
  - Without this change, only properties inside each modules are sorted so when you generate a manifest, you sometimes end up with `cc-addon-admin` being the first module and sometimes `cc-addon-elasticsearch-options` instead.

## How to review?

- Run `npm run components:docs`,
- Copy the result `dist/custom-elements.json` to somewhere outside `dist` so it doesn't get erased,
- Run `npm run components:docs` again,
- Copy the result again,
- Diff the two files: `diff custom-elements-1.json custom-elements-2.json` => there should be no changes,
- 1 reviewer (@Galimede) should be enough for this one!