### PR TITLE
fix(cc-invoice): fix invoice download URL

### DIFF
--- a/src/lib/api-helpers.js
+++ b/src/lib/api-helpers.js
@@ -106,9 +106,9 @@ function getDownloadUrl(apiConfig, ownerId, invoiceNumber) {
     .then(prefixUrl(apiConfig.API_HOST))
     .then(addOauthHeader(apiConfig))
     .then(
-      /** @param {{url: string, headers: {Authorization: string}}} requestParams */ (requestParams) => {
+      /** @param {{url: string, headers: {authorization: string}}} requestParams */ (requestParams) => {
         const url = new URL(requestParams.url);
-        url.searchParams.set('authorization', btoa(requestParams.headers.Authorization));
+        url.searchParams.set('authorization', btoa(requestParams.headers.authorization));
         return url.toString();
       },
     );


### PR DESCRIPTION
Regression introduced with the last version of the `clever-client.js` (`11.0.1`) which now stores, the authorization header in `authorization` instead of `Authorization`