### PR TITLE
fix(cc-input-text): align back button correctly on multi

### DIFF
--- a/src/components/cc-input-text/cc-input-text.js
+++ b/src/components/cc-input-text/cc-input-text.js
@@ -511,7 +511,6 @@ export class CcInputText extends CcFormControlElement {
         /* endregion */
 
         .meta-input {
-          align-items: center;
           box-sizing: border-box;
           display: inline-flex;
           grid-area: input;
@@ -700,6 +699,7 @@ export class CcInputText extends CcFormControlElement {
         .btn,
         .btn-copy {
           flex-shrink: 0;
+          margin: 0.2em 0.2em 0.2em 0;
           margin-right: 0.15em;
           z-index: 2;
         }
@@ -708,7 +708,6 @@ export class CcInputText extends CcFormControlElement {
           border-radius: var(--cc-border-radius-small, 0.15em);
           cursor: pointer;
           height: 1.6em;
-          margin: 0.2em 0.2em 0.2em 0;
           width: 1.6em;
         }
 


### PR DESCRIPTION
## What does this PR do?

* This PR reverts and set the initial margin for the buttons instead of doing `align-items: center` in the `cc-input-text`
* This caused the `cc-clipboard` to be aligned vertically in the center of the `cc-input-text` on mutli mode.
![image](https://github.com/user-attachments/assets/6d93ef67-f2d0-4d89-b42a-5d9be7b0b0f3)

## How to review?

* Check the commit
* Check the preview
* Two reviewers should be enough