### PR TITLE
fix(cc-link): make button mode closer to `cc-button`

### DIFF
--- a/src/components/cc-link/cc-link.js
+++ b/src/components/cc-link/cc-link.js
@@ -267,13 +267,19 @@ export class CcLink extends LitElement {
           text-decoration: none;
         }
 
+        :host([mode='button']) {
+          display: inline-block;
+        }
+
         :host([mode='button']) .cc-link {
           background-color: var(--cc-color-bg-primary, #3569aaff);
           border: 1px solid var(--cc-color-bg-primary, #3569aaff);
           border-radius: var(--cc-button-border-radius, 0.15em);
           box-sizing: border-box;
           cursor: pointer;
+          display: flex;
           font-weight: var(--cc-button-font-weight, bold);
+          justify-content: center;
           min-height: 2em;
           padding: 0 0.5em;
           text-transform: var(--cc-button-text-transform, uppercase);

--- a/src/components/cc-link/cc-link.stories.js
+++ b/src/components/cc-link/cc-link.stories.js
@@ -51,6 +51,23 @@ export const subtle = makeStory(conf, {
 });
 
 export const button = makeStory(conf, {
+  displayMode: 'flex-wrap',
+  items: [
+    {
+      mode: 'button',
+      href: 'https://clever-cloud.com',
+      innerHTML: 'edit the informations',
+    },
+    {
+      skeleton: true,
+      mode: 'button',
+      href: 'https://clever-cloud.com',
+      innerHTML: 'edit the informations',
+    },
+  ],
+});
+
+export const buttonWithFullWidth = makeStory(conf, {
   items: [
     {
       mode: 'button',


### PR DESCRIPTION
Fixes #1499

## What does this PR do?

- Makes the `cc-link` spread full width in `button` mode to match the behavior of `cc-button`,
- This fixes the case highlighted below:
<img width="390" height="152" alt="" src="https://github.com/user-attachments/assets/9fcd0162-7981-4e9e-b048-5e7b0d5f1d64" />
<img width="390" height="152" alt="image" src="https://github.com/user-attachments/assets/e25855da-6424-4b34-90c5-4916cb93a8d1" />

- Adds a separate story to show this case.


## How to review?

- Check the commit,
- Check the [preview](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-link/fix-width/index.html),
- 1 reviewer should be enough for this one.
