### PR TITLE
feat(cc-addon-header): init component

### DIFF
--- a/demo-smart/index.html
+++ b/demo-smart/index.html
@@ -158,6 +158,11 @@
           >cc-oauth-consumer-form.smart-update</a
         >
       </li>
+      <li>
+        <a class="definition-link" href="?definition=cc-addon-header.smart-keycloak&smart-mode=keycloak"
+          >cc-addon-header.smart-keycloak</a
+        >
+      </li>
     </ul>
 
     <div class="context-buttons">
@@ -228,6 +233,11 @@
         data-context='{"ownerId":"orga_540caeb6-521c-4a19-a955-efe6da35d142", "key":"KpryQ9X1Snjrxa5ej2AOETa1dd0Auu"}'
       >
         oAuth Consumer
+      </button>
+      <button
+        data-context='{"ownerId":"orga_3547a882-d464-4c34-8168-add4b3e0c135", "addonId":"addon_b0156348-3825-4026-895a-bcaacafc4746", "logsUrlPattern":"/organisations/orga_3547a882-d464-4c34-8168-add4b3e0c135/applications/:id/logs"}'
+      >
+        addon-keycloak
       </button>
     </div>
 

--- a/src/components/cc-addon-header/cc-addon-header.events.js
+++ b/src/components/cc-addon-header/cc-addon-header.events.js
@@ -1,0 +1,25 @@
+import { CcEvent } from '../../lib/events.js';
+
+/**
+ * Dispatch when an addon restart is requested.
+ * @extends {CcEvent}
+ */
+export class CcAddonRestartEvent extends CcEvent {
+  static TYPE = 'cc-addon-restart';
+
+  constructor() {
+    super(CcAddonRestartEvent.TYPE);
+  }
+}
+
+/**
+ * Dispatch when an addon rebuild is requested.
+ * @extends {CcEvent}
+ */
+export class CcAddonRebuildEvent extends CcEvent {
+  static TYPE = 'cc-addon-rebuild';
+
+  constructor() {
+    super(CcAddonRebuildEvent.TYPE);
+  }
+}

--- a/src/components/cc-addon-header/cc-addon-header.js
+++ b/src/components/cc-addon-header/cc-addon-header.js
@@ -1,0 +1,380 @@
+import { LitElement, css, html } from 'lit';
+import { classMap } from 'lit/directives/class-map.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import {
+  iconCleverRunning as iconActive,
+  iconCleverRestarting as iconDeploying,
+  iconCleverRestartFailed as iconDeploymentFailed,
+} from '../../assets/cc-clever.icons.js';
+import { fakeString } from '../../lib/fake-strings.js';
+import { isStringEmpty } from '../../lib/utils.js';
+import { skeletonStyles } from '../../styles/skeleton.js';
+import { i18n } from '../../translations/translation.js';
+import '../cc-badge/cc-badge.js';
+import '../cc-block/cc-block.js';
+import '../cc-button/cc-button.js';
+import '../cc-clipboard/cc-clipboard.js';
+import '../cc-img/cc-img.js';
+import '../cc-link/cc-link.js';
+import '../cc-notice/cc-notice.js';
+import '../cc-zone/cc-zone.js';
+import { CcAddonRebuildEvent, CcAddonRestartEvent } from './cc-addon-header.events.js';
+
+/** @type {{ [Property in DeploymentStatus]: IconModel }} */
+const STATUS_ICON = {
+  deploying: iconDeploying,
+  active: iconActive,
+  failed: iconDeploymentFailed,
+};
+
+/** @type {Partial<CcAddonHeaderStateLoaded>} */
+const SKELETON_ADDON_INFO = {
+  providerName: fakeString(15),
+  providerLogoUrl: null,
+  name: fakeString(15),
+  id: fakeString(15),
+  zone: null,
+};
+
+/**
+ * @typedef {import('./cc-addon-header.types.js').CcAddonHeaderState} CcAddonHeaderState
+ * @typedef {import('./cc-addon-header.types.js').CcAddonHeaderStateLoaded} CcAddonHeaderStateLoaded
+ * @typedef {import('./cc-addon-header.types.js').DeploymentStatus} DeploymentStatus
+ * @typedef {import('../common.types.js').IconModel} IconModel
+ */
+
+/**
+ * A component to display various info about an add-on (name, plan, version...).
+ *
+ * @cssdisplay block
+ */
+export class CcAddonHeader extends LitElement {
+  static get properties() {
+    return {
+      state: { type: Object },
+    };
+  }
+
+  constructor() {
+    super();
+
+    /** @type {CcAddonHeaderState} Sets the state of the component. */
+    this.state = {
+      type: 'loading',
+      logsUrl: '',
+      openLinks: [],
+      actions: {
+        restart: false,
+        rebuildAndRestart: false,
+      },
+    };
+  }
+
+  /**
+   * @param {DeploymentStatus} deploymentStatus
+   * @returns {string}
+   * @private
+   */
+  _getStatusMsg(deploymentStatus) {
+    if (deploymentStatus === 'deploying') {
+      return i18n('cc-addon-header.state-msg.deployment-is-deploying');
+    }
+    if (deploymentStatus === 'active') {
+      return i18n('cc-addon-header.state-msg.deployment-is-active');
+    }
+    if (deploymentStatus === 'failed') {
+      return i18n('cc-addon-header.state-msg.deployment-failed');
+    }
+    return i18n('cc-addon-header.state-msg.unknown-state');
+  }
+
+  _onRestart() {
+    this.dispatchEvent(new CcAddonRestartEvent());
+  }
+
+  _onRebuild() {
+    this.dispatchEvent(new CcAddonRebuildEvent());
+  }
+
+  render() {
+    if (this.state.type === 'error') {
+      return html` <cc-notice slot="content" intent="warning" message=${i18n('cc-addon-header.error')}></cc-notice>`;
+    }
+
+    const skeleton = this.state.type === 'loading';
+    const addonInfo =
+      this.state.type === 'loaded' || this.state.type === 'restarting' || this.state.type === 'rebuilding'
+        ? this.state
+        : { ...SKELETON_ADDON_INFO, ...this.state };
+    const zoneState =
+      (this.state.type === 'loaded' || this.state.type === 'restarting' || this.state.type === 'rebuilding') &&
+      this.state.zone
+        ? { type: 'loaded', ...this.state.zone }
+        : { type: 'loading' };
+    const isRestarting = this.state.type === 'restarting';
+    const isRebuilding = this.state.type === 'rebuilding';
+    const deploymentStatus = this.state.deploymentStatus;
+
+    return html`
+      <cc-block>
+        <div slot="content" class="main">
+          <div class="addon-information">
+            <cc-img
+              class="logo"
+              ?skeleton=${skeleton}
+              src=${ifDefined(addonInfo.providerLogoUrl)}
+              a11y-name=${addonInfo.providerName}
+            ></cc-img>
+
+            <div class="details">
+              <div class="details__title">
+                <span class="details__name ${classMap({ skeleton })}">${addonInfo.name}</span>
+                ${!isStringEmpty(addonInfo.productStatus)
+                  ? html` <cc-badge ?skeleton=${skeleton}>${addonInfo.productStatus}</cc-badge> `
+                  : ''}
+              </div>
+              <div class="details__id">
+                <span class="${classMap({ skeleton })}">${addonInfo.id}</span>
+                ${this.state.type === 'loaded' || this.state.type === 'restarting' || this.state.type === 'rebuilding'
+                  ? html` <cc-clipboard value=${addonInfo.id}></cc-clipboard> `
+                  : ''}
+              </div>
+            </div>
+          </div>
+
+          <div class="actions">
+            ${addonInfo.openLinks?.map(
+              (link) => html`
+                <cc-link mode="button" href="${link.url}" ?skeleton=${skeleton}>
+                  ${i18n('cc-addon-header.action.open-addon', { linkName: link.name })}
+                </cc-link>
+              `,
+            )}
+            ${addonInfo.actions?.restart === true
+              ? html`
+                  <cc-button
+                    type="button"
+                    ?skeleton=${skeleton}
+                    ?waiting=${isRestarting}
+                    ?disabled=${isRebuilding}
+                    @cc-click=${this._onRestart}
+                  >
+                    ${i18n('cc-addon-header.action.restart')}
+                  </cc-button>
+                `
+              : ''}
+            ${addonInfo.actions?.rebuildAndRestart === true
+              ? html`
+                  <cc-button
+                    type="button"
+                    ?skeleton=${skeleton}
+                    ?waiting=${isRebuilding}
+                    ?disabled=${isRestarting}
+                    @cc-click=${this._onRebuild}
+                  >
+                    ${i18n('cc-addon-header.action.restart-rebuild')}
+                  </cc-button>
+                `
+              : ''}
+          </div>
+        </div>
+
+        <div slot="footer-left" class="footer messages">
+          ${!isStringEmpty(deploymentStatus)
+            ? html`
+                <cc-icon
+                  class="status-icon ${deploymentStatus}"
+                  size="lg"
+                  .icon=${STATUS_ICON[deploymentStatus]}
+                  ?skeleton=${skeleton}
+                ></cc-icon>
+                <span class=${classMap({ skeleton })}> ${this._getStatusMsg(deploymentStatus)} </span>
+              `
+            : ''}
+          ${!isStringEmpty(addonInfo.logsUrl)
+            ? html`
+                <cc-link
+                  href=${addonInfo.logsUrl}
+                  a11y-desc="${i18n('cc-addon-header.logs.link')}"
+                  ?skeleton=${skeleton}
+                >
+                  ${i18n('cc-addon-header.logs.link')}
+                </cc-link>
+              `
+            : ''}
+        </div>
+        <cc-zone slot="footer-right" .state=${zoneState} mode="small-infra"></cc-zone>
+      </cc-block>
+    `;
+  }
+
+  static get styles() {
+    return [
+      skeletonStyles,
+      // language=CSS
+      css`
+        :host {
+          container-type: inline-size;
+          display: block;
+        }
+
+        .main {
+          display: grid;
+          flex-wrap: wrap;
+          gap: 1em;
+          grid-auto-flow: column;
+          justify-content: space-between;
+          min-width: 0;
+        }
+
+        @container (max-width: 59em) {
+          .main {
+            grid-auto-flow: row;
+          }
+        }
+
+        .addon-information {
+          display: flex;
+          flex: 1 1 0;
+          gap: 1em;
+          min-width: 0;
+        }
+
+        .logo {
+          align-self: flex-start;
+          border-radius: var(--cc-border-radius-default, 0.25em);
+          height: 3.25em;
+          overflow: hidden;
+          width: 3.25em;
+        }
+
+        .details {
+          display: flex;
+          flex: 1;
+          flex-direction: column;
+          justify-content: space-around;
+          min-width: 0;
+        }
+
+        .details__title {
+          align-items: center;
+          display: flex;
+          flex-wrap: wrap;
+          gap: 0.5em 0.75em;
+        }
+
+        .details__name {
+          font-size: 1.1em;
+          font-weight: bold;
+        }
+
+        .details__id {
+          align-items: center;
+          display: flex;
+          gap: 0.5em;
+          min-width: 0;
+        }
+
+        .details__id span {
+          display: block;
+          font-family: var(--cc-ff-monospace);
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+
+        .actions {
+          align-items: center;
+          display: flex;
+          flex-wrap: wrap;
+          gap: 0.75em;
+        }
+
+        .actions cc-link,
+        .actions cc-button {
+          flex: 1 1 auto;
+        }
+
+        @container (max-width: 59em) {
+          .actions cc-link,
+          .actions cc-button {
+            flex: 0 0 auto;
+          }
+        }
+
+        @container (max-width: 34em) {
+          .actions {
+            display: flex;
+            flex: 1 1 auto;
+          }
+
+          .actions cc-link {
+            width: 100%;
+          }
+
+          .actions cc-button {
+            flex: 1 0 min(100%, 12.5em);
+          }
+        }
+
+        @container (max-width: 28em) {
+          .actions cc-link,
+          .actions cc-button {
+            flex: 1 0 min(100%, 12.5em);
+          }
+        }
+
+        .footer {
+          align-items: center;
+          display: flex;
+          flex-wrap: wrap;
+          font-size: 0.9em;
+          gap: 0.57em;
+        }
+
+        .messages {
+          align-items: center;
+          display: flex;
+          flex-wrap: wrap;
+          font-size: 0.9em;
+          font-style: italic;
+          gap: 0.57em;
+        }
+
+        .messages cc-link,
+        .messages cc-zone {
+          font-style: normal;
+        }
+
+        .status-icon.active {
+          --cc-icon-color: var(--color-legacy-green);
+          --cc-icon-size: 1.25em;
+        }
+
+        .status-icon.deploying {
+          --cc-icon-size: 1.25em;
+        }
+
+        .status-icon.failed {
+          --cc-icon-color: var(--color-legacy-red);
+          --cc-icon-size: 1.25em;
+        }
+
+        .status-icon.unknown {
+          --cc-icon-color: #ddd;
+        }
+
+        .footer__spacer {
+          flex: 1 1 0;
+        }
+
+        .skeleton {
+          background-color: #bbb;
+          border-color: #777;
+          color: transparent;
+        }
+      `,
+    ];
+  }
+}
+window.customElements.define('cc-addon-header', CcAddonHeader);

--- a/src/components/cc-addon-header/cc-addon-header.smart-keycloak.js
+++ b/src/components/cc-addon-header/cc-addon-header.smart-keycloak.js
@@ -1,0 +1,250 @@
+// @ts-expect-error FIXME: remove when clever-client exports types
+import { get as getAddon } from '@clevercloud/client/esm/api/v2/addon.js';
+// @ts-expect-error FIXME: remove when clever-client exports types
+import { getZone } from '@clevercloud/client/esm/api/v4/product.js';
+import { fakeString } from '../../lib/fake-strings.js';
+import { notify, notifyError } from '../../lib/notifications.js';
+import { sendToApi } from '../../lib/send-to-api.js';
+import { defineSmartComponent } from '../../lib/smart/define-smart-component.js';
+import { i18n } from '../../translations/translation.js';
+import '../cc-smart-container/cc-smart-container.js';
+import './cc-addon-header.js';
+
+/**
+ * @typedef {import('./cc-addon-header.types.js').RawAddon} RawAddon
+ * @typedef {import('./cc-addon-header.types.js').RawOperator} RawOperator
+ * @typedef {import('./cc-addon-header.js').CcAddonHeader} CcAddonHeader
+ * @typedef {import('../cc-zone/cc-zone.types.js').ZoneStateLoaded} ZoneStateLoaded
+ * @typedef {import('../../lib/send-to-api.types.js').ApiConfig} ApiConfig
+ * @typedef {import('../../lib/smart/smart-component.types.js').OnContextUpdateArgs<CcAddonHeader>} OnContextUpdateArgs
+ */
+
+defineSmartComponent({
+  selector: 'cc-addon-header[smart-mode=keycloak]',
+  params: {
+    apiConfig: { type: Object },
+    ownerId: { type: String },
+    addonId: { type: String },
+    logsUrlPattern: { type: String },
+    productStatus: { type: String, optional: true },
+  },
+
+  /** @param {OnContextUpdateArgs} args */
+  onContextUpdate({ context, updateComponent, onEvent, signal }) {
+    const { apiConfig, ownerId, addonId, productStatus } = context;
+    const api = new Api(apiConfig, ownerId, addonId, signal);
+    let logsUrl = '';
+
+    updateComponent('state', {
+      type: 'loading',
+      logsUrl: fakeString(15),
+      openLinks: [
+        {
+          url: fakeString(15),
+          name: fakeString(5),
+        },
+      ],
+      actions: {
+        restart: true,
+        rebuildAndRestart: true,
+      },
+      productStatus: fakeString(4),
+    });
+
+    api
+      .getAddonWithOperatorAndZone()
+      .then(({ rawAddon, operator, zone }) => {
+        const javaAppId = operator.resources.entrypoint;
+        logsUrl = context.logsUrlPattern.replace(':id', javaAppId);
+
+        updateComponent('state', {
+          type: 'loaded',
+          providerName: rawAddon.provider.name,
+          providerLogoUrl: rawAddon.provider.logoUrl,
+          name: rawAddon.name,
+          id: rawAddon.realId,
+          zone,
+          logsUrl,
+          openLinks: [
+            {
+              name: 'KEYCLOAK',
+              url: operator.accessUrl,
+            },
+          ],
+          actions: {
+            restart: true,
+            rebuildAndRestart: true,
+          },
+          productStatus,
+        });
+      })
+      .catch((error) => {
+        console.error(error);
+        updateComponent('state', {
+          type: 'error',
+        });
+      });
+
+    onEvent('cc-addon-restart', () => {
+      updateComponent('state', (state) => {
+        state.type = 'restarting';
+      });
+
+      api
+        .restartAddon()
+        .then(() => {
+          notify({
+            intent: 'success',
+            message: i18n('cc-addon-header.restart.success.message', { logsUrl }),
+            title: i18n('cc-addon-header.restart.success.title'),
+            options: {
+              timeout: 0,
+              closeable: true,
+            },
+          });
+        })
+        .catch((error) => {
+          console.error(error);
+          notifyError(i18n('cc-addon-header.restart.error'));
+        })
+        .finally(() => {
+          updateComponent('state', (state) => {
+            state.type = 'loaded';
+          });
+        });
+    });
+
+    onEvent('cc-addon-rebuild', () => {
+      updateComponent('state', (state) => {
+        state.type = 'rebuilding';
+      });
+
+      api
+        .rebuildAndRestartAddon()
+        .then(() => {
+          notify({
+            intent: 'success',
+            message: i18n('cc-addon-header.rebuild.success.message', { logsUrl }),
+            title: i18n('cc-addon-header.rebuild.success.title'),
+            options: {
+              timeout: 0,
+              closeable: true,
+            },
+          });
+        })
+        .catch((error) => {
+          console.error(error);
+          notifyError(i18n('cc-addon-header.rebuild.error'));
+        })
+        .finally(() => {
+          updateComponent('state', (state) => {
+            state.type = 'loaded';
+          });
+        });
+    });
+  },
+});
+
+class Api {
+  /**
+   * @param {ApiConfig} apiConfig
+   * @param {string} ownerId
+   * @param {string} addonId
+   * @param {AbortSignal} signal
+   */
+  constructor(apiConfig, ownerId, addonId, signal) {
+    this._apiConfig = apiConfig;
+    this._ownerId = ownerId;
+    this._addonId = addonId;
+    this._realId = null;
+    this._signal = signal;
+  }
+
+  /** @return {Promise<RawAddon>} */
+  getAddon() {
+    return getAddon({ id: this._ownerId, addonId: this._addonId }).then(
+      sendToApi({ apiConfig: this._apiConfig, signal: this._signal }),
+    );
+  }
+
+  /**
+   * @param {string} realId
+   * @return {Promise<RawOperator>}
+   */
+  getOperator(realId) {
+    return this._getOperator({ provider: 'keycloak', realId }).then(
+      sendToApi({ apiConfig: this._apiConfig, signal: this._signal }),
+    );
+  }
+
+  /**
+   * @param {string} zoneName
+   * @return {Promise<ZoneStateLoaded>}
+   */
+  getZone(zoneName) {
+    return getZone({ zoneName }).then(sendToApi({ apiConfig: this._apiConfig, signal: this._signal }));
+  }
+
+  /** @returns {Promise<{ rawAddon: RawAddon, operator: RawOperator, zone: ZoneStateLoaded }>} */
+  async getAddonWithOperatorAndZone() {
+    const rawAddon = await this.getAddon();
+    this._realId = rawAddon.realId;
+    const [operator, zone] = await Promise.all([this.getOperator(rawAddon.realId), this.getZone(rawAddon.region)]);
+
+    return { rawAddon, operator, zone };
+  }
+
+  /** @return {Promise<void>} */
+  async restartAddon() {
+    return rebootOperator({ provider: 'keycloak', realId: this._realId }).then(
+      sendToApi({ apiConfig: this._apiConfig }),
+    );
+  }
+
+  /** @return {Promise<void>} */
+  async rebuildAndRestartAddon() {
+    return rebuildOperator({ provider: 'keycloak', realId: this._realId }).then(
+      sendToApi({ apiConfig: this._apiConfig }),
+    );
+  }
+
+  /**
+   * @param {{ provider: string, realId: string }} params
+   * @returns {Promise<Object>}
+   */
+  _getOperator(params) {
+    return Promise.resolve({
+      method: 'get',
+      url: `/v4/addon-providers/addon-${params.provider}/addons/${params.realId}`,
+      headers: { Accept: 'application/json' },
+      // no queryParams
+      // no body
+    });
+  }
+}
+
+// FIXME: remove and use the clever-client call from the new clever-client
+/** @param {{ provider: string, realId: string }} params */
+export function rebootOperator(params) {
+  // no multipath for /self or /organisations/{id}
+  return Promise.resolve({
+    method: 'post',
+    url: `/v4/addon-providers/addon-${params.provider}/addons/${params.realId}/reboot`,
+    headers: { Accept: 'application/json' },
+    // no queryParams
+    // no body
+  });
+}
+
+// FIXME: remove and use the clever-client call from the new clever-client
+/** @param {{ provider: string, realId: string }} params */
+export function rebuildOperator(params) {
+  // no multipath for /self or /organisations/{id}
+  return Promise.resolve({
+    method: 'post',
+    url: `/v4/addon-providers/addon-${params.provider}/addons/${params.realId}/rebuild`,
+    headers: { Accept: 'application/json' },
+    // no queryParams
+    // no body
+  });
+}

--- a/src/components/cc-addon-header/cc-addon-header.smart-keycloak.md
+++ b/src/components/cc-addon-header/cc-addon-header.smart-keycloak.md
@@ -1,0 +1,65 @@
+---
+kind: '🛠 Addon/<cc-addon-header>'
+title: '💡 Smart (Keycloak)'
+---
+# 💡 Smart `<cc-addon-header smart-mode="keycloak">`
+
+## ℹ️ Details
+
+<table>
+<tr><td><strong>Component    </strong> <td><a href="🛠-addons-cc-addon-header--default-story"><code>&lt;cc-addon-header&gt;</code></a>
+<tr><td><strong>Selector     </strong> <td><code>cc-addon-header[smart-mode="keycloak"]</code>
+<tr><td><strong>Requires auth</strong> <td>Yes
+</table>
+
+## ⚙️ Params
+
+| Name             | Type        | Details                                                                                       | Default |
+|------------------|-------------|-----------------------------------------------------------------------------------------------|---------|
+| `apiConfig`      | `ApiConfig` | Object with API configuration (target host, tokens...)                                        |         |
+| `ownerId`        | `string`    | UUID prefixed with orga_                                                                      |         |
+| `addonId`        | `string`    | ID of the add-on                                                                              |         |
+| `logsUrlPattern` | `string`    | Pattern for the logs url (Example : `/organisations/${ownerId}/applications/${appId}/logs`)   |         |
+| `productStatus`  | `string`    | Maturity status of the product                                                                |         |
+
+
+  ```ts
+interface ApiConfig {
+  API_HOST: string,
+  API_OAUTH_TOKEN: string,
+  API_OAUTH_TOKEN_SECRET: string,
+  OAUTH_CONSUMER_KEY: string,
+  OAUTH_CONSUMER_SECRET: string,
+}
+```
+
+## 🌐 API endpoints
+
+| Method   | URL                                                            | Cache?  |
+|----------|----------------------------------------------------------------|---------|
+| `GET`    | `/v2/organisations/${ownerId}/addons/${addonId}`               | Default |
+| `GET`    | `/v4/products/zones?ownerId=${ownerId}`                        | Default |
+| `GET`    | `/v4/addon-providers/addon-keycloak/addons/${realId}`          | Default |
+| `POST`   | `/v4/addon-providers/addon-keycloak/addons/${realId}/reboot`   | Default |
+| `POST`   | `/v4/addon-providers/addon-keycloak/addons/${realId}/rebuild`  | Default |
+
+
+## ⬇️️ Examples
+
+  ```html
+<cc-smart-container context='{
+    "apiConfig": {
+      API_HOST: "",
+      API_OAUTH_TOKEN: "",
+      API_OAUTH_TOKEN_SECRET: "",
+      OAUTH_CONSUMER_KEY: "",
+      OAUTH_CONSUMER_SECRET: "",
+    },
+    "ownerId": "",
+    "addonId": "",
+    "logsUrlPattern": "",
+    "productStatus": "",
+}'>
+  <cc-addon-header smart-mode="keycloak"></cc-addon-header>
+</cc-smart-container>
+```

--- a/src/components/cc-addon-header/cc-addon-header.stories.js
+++ b/src/components/cc-addon-header/cc-addon-header.stories.js
@@ -1,0 +1,422 @@
+import { fakeString } from '../../lib/fake-strings.js';
+import {
+  configProviderData,
+  elasticData,
+  jenkinsData,
+  keycloakData,
+  materiaData,
+  matomoData,
+  pulsarData,
+  redisData,
+} from '../../stories/fixtures/addon.js';
+import { makeStory, storyWait } from '../../stories/lib/make-story.js';
+import './cc-addon-header.js';
+
+export default {
+  tags: ['autodocs'],
+  title: '🛠 Addon/<cc-addon-header>',
+  component: 'cc-addon-header',
+};
+
+const conf = {
+  component: 'cc-addon-header',
+};
+
+/**
+ * @typedef {import('./cc-addon-header.types.js').CcAddonHeaderStateLoaded} CcAddonHeaderStateLoaded
+ * @typedef {import('./cc-addon-header.types.js').CcAddonHeaderStateError} CcAddonHeaderStateError
+ * @typedef {import('./cc-addon-header.types.js').CcAddonHeaderStateLoading} CcAddonHeaderStateLoading
+ * @typedef {import('./cc-addon-header.types.js').CcAddonHeaderStateRestarting} CcAddonHeaderStateRestarting
+ * @typedef {import('./cc-addon-header.types.js').CcAddonHeaderStateRebuilding} CcAddonHeaderStateRebuilding
+ * @typedef {import('./cc-addon-header.js').CcAddonHeader} CcAddonHeader
+ */
+
+export const defaultStory = makeStory(conf, {
+  items: [
+    {
+      /** @type {CcAddonHeaderStateLoaded} */
+      state: {
+        type: 'loaded',
+        ...configProviderData,
+      },
+    },
+  ],
+});
+
+export const basicData = makeStory(conf, {
+  items: [
+    {
+      /** @type {CcAddonHeaderStateLoaded} */
+      state: {
+        type: 'loaded',
+        ...configProviderData,
+      },
+    },
+    {
+      /** @type {CcAddonHeaderStateLoading} */
+      state: {
+        type: 'loading',
+        logsUrl: '',
+        openLinks: [],
+        actions: {
+          restart: false,
+          rebuildAndRestart: false,
+        },
+        productStatus: '',
+      },
+    },
+  ],
+});
+
+export const withViewLogs = makeStory(conf, {
+  items: [
+    {
+      /** @type {CcAddonHeaderStateLoaded} */
+      state: {
+        type: 'loaded',
+        ...pulsarData,
+      },
+    },
+    {
+      /** @type {CcAddonHeaderStateLoading} */
+      state: {
+        type: 'loading',
+        logsUrl: 'https://example.com/logs',
+      },
+    },
+  ],
+});
+
+export const withOpenLink = makeStory(conf, {
+  items: [
+    {
+      /** @type {CcAddonHeaderStateLoaded} */
+      state: {
+        type: 'loaded',
+        ...jenkinsData,
+      },
+    },
+    {
+      /** @type {CcAddonHeaderStateLoading} */
+      state: {
+        type: 'loading',
+        logsUrl: fakeString(15),
+        openLinks: [
+          {
+            url: fakeString(15),
+            name: fakeString(5),
+          },
+        ],
+      },
+    },
+  ],
+});
+
+export const withOpenLinks = makeStory(conf, {
+  items: [
+    {
+      /** @type {CcAddonHeaderStateLoaded} */
+      state: {
+        type: 'loaded',
+        ...elasticData,
+      },
+    },
+    {
+      /** @type {CcAddonHeaderStateLoading} */
+      state: {
+        type: 'loading',
+        logsUrl: fakeString(15),
+        openLinks: [
+          {
+            url: fakeString(15),
+            name: fakeString(5),
+          },
+          {
+            url: fakeString(15),
+            name: fakeString(5),
+          },
+        ],
+      },
+    },
+  ],
+});
+
+export const withOpenLinkAndActions = makeStory(conf, {
+  items: [
+    {
+      /** @type {CcAddonHeaderStateLoaded} */
+      state: {
+        type: 'loaded',
+        ...matomoData,
+      },
+    },
+    {
+      /** @type {CcAddonHeaderStateLoading} */
+      state: {
+        type: 'loading',
+        logsUrl: fakeString(15),
+        openLinks: [
+          {
+            url: fakeString(15),
+            name: fakeString(5),
+          },
+        ],
+        actions: {
+          restart: true,
+          rebuildAndRestart: true,
+        },
+      },
+    },
+  ],
+});
+
+export const withProductStatus = makeStory(conf, {
+  items: [
+    {
+      /** @type {CcAddonHeaderStateLoaded} */
+      state: {
+        type: 'loaded',
+        ...materiaData,
+      },
+    },
+    {
+      /** @type {CcAddonHeaderStateLoading} */
+      state: {
+        type: 'loading',
+        logsUrl: fakeString(15),
+        openLinks: [
+          {
+            url: fakeString(15),
+            name: fakeString(5),
+          },
+        ],
+        actions: {
+          restart: true,
+          rebuildAndRestart: true,
+        },
+        productStatus: fakeString(5),
+      },
+    },
+  ],
+});
+
+export const withLongProductStatus = makeStory(conf, {
+  items: [
+    {
+      /** @type {CcAddonHeaderStateLoaded} */
+      state: {
+        type: 'loaded',
+        ...keycloakData,
+      },
+    },
+    {
+      /** @type {CcAddonHeaderStateLoading} */
+      state: {
+        type: 'loading',
+        logsUrl: fakeString(15),
+        openLinks: [
+          {
+            url: fakeString(15),
+            name: fakeString(5),
+          },
+        ],
+        actions: {
+          restart: true,
+          rebuildAndRestart: true,
+        },
+        productStatus: fakeString(10),
+      },
+    },
+  ],
+});
+
+export const withDeploymentStatusAndViewLogs = makeStory(conf, {
+  items: [
+    {
+      /** @type {CcAddonHeaderStateLoaded} */
+      state: {
+        type: 'loaded',
+        ...redisData,
+        deploymentStatus: 'active',
+      },
+    },
+    {
+      /** @type {CcAddonHeaderStateLoading} */
+      state: {
+        type: 'loading',
+        openLinks: [
+          {
+            url: fakeString(15),
+            name: fakeString(5),
+          },
+        ],
+        actions: {
+          restart: true,
+          rebuildAndRestart: true,
+        },
+        productStatus: fakeString(10),
+        deploymentStatus: 'deploying',
+      },
+    },
+  ],
+});
+
+export const waitingWithRestart = makeStory(conf, {
+  items: [
+    {
+      /** @type {CcAddonHeaderStateRestarting} */
+      state: {
+        type: 'restarting',
+        ...keycloakData,
+      },
+    },
+  ],
+});
+
+export const waitingWithRebuilding = makeStory(conf, {
+  items: [
+    {
+      /** @type {CcAddonHeaderStateRebuilding} */
+      state: {
+        type: 'rebuilding',
+        ...keycloakData,
+      },
+    },
+  ],
+});
+
+export const errorStory = makeStory(conf, {
+  items: [
+    {
+      /** @type {CcAddonHeaderStateError} */
+      state: {
+        type: 'error',
+      },
+    },
+  ],
+});
+
+export const simulationWithLoadingSuccess = makeStory(conf, {
+  /** @type {Partial<CcAddonHeader>[]} */
+  items: [
+    {
+      state: {
+        type: 'loading',
+        logsUrl: fakeString(15),
+        openLinks: [
+          {
+            url: fakeString(15),
+            name: fakeString(5),
+          },
+        ],
+        actions: {
+          restart: true,
+          rebuildAndRestart: true,
+        },
+        productStatus: fakeString(10),
+      },
+    },
+  ],
+  simulations: [
+    storyWait(
+      2000,
+      /** @param {CcAddonHeader[]} components */ ([component]) => {
+        component.state = {
+          type: 'loaded',
+          ...keycloakData,
+        };
+      },
+    ),
+  ],
+});
+
+export const simulationWithLoadingError = makeStory(conf, {
+  /** @type {Partial<CcAddonHeader>[]} */
+  items: [
+    {
+      state: {
+        type: 'loading',
+        logsUrl: fakeString(15),
+        openLinks: [
+          {
+            url: fakeString(15),
+            name: fakeString(5),
+          },
+        ],
+        actions: {
+          restart: true,
+          rebuildAndRestart: true,
+        },
+        productStatus: fakeString(10),
+      },
+    },
+  ],
+  simulations: [
+    storyWait(
+      2000,
+      /** @param {CcAddonHeader[]} components */ ([component]) => {
+        component.state = {
+          type: 'error',
+        };
+      },
+    ),
+  ],
+});
+
+export const simulationWithRestarting = makeStory(conf, {
+  /** @type {Partial<CcAddonHeader>[]} */
+  items: [
+    {
+      state: {
+        type: 'loaded',
+        ...keycloakData,
+      },
+    },
+  ],
+  simulations: [
+    storyWait(
+      2000,
+      /** @param {CcAddonHeader[]} components */ ([component]) => {
+        component.state = {
+          type: 'restarting',
+          ...keycloakData,
+        };
+      },
+    ),
+    storyWait(
+      5000,
+      /** @param {CcAddonHeader[]} components */ ([component]) => {
+        component.state = { type: 'loaded', ...keycloakData };
+      },
+    ),
+  ],
+});
+
+export const simulationWithRebuilding = makeStory(conf, {
+  /** @type {Partial<CcAddonHeader>[]} */
+  items: [
+    {
+      state: {
+        type: 'loaded',
+        ...keycloakData,
+      },
+    },
+  ],
+  simulations: [
+    storyWait(
+      2000,
+      /** @param {CcAddonHeader[]} components */ ([component]) => {
+        component.state = {
+          type: 'rebuilding',
+          ...keycloakData,
+        };
+      },
+    ),
+    storyWait(
+      5000,
+      /** @param {CcAddonHeader[]} components */ ([component]) => {
+        component.state = { type: 'loaded', ...keycloakData };
+      },
+    ),
+  ],
+});

--- a/src/components/cc-addon-header/cc-addon-header.types.d.ts
+++ b/src/components/cc-addon-header/cc-addon-header.types.d.ts
@@ -1,0 +1,90 @@
+import { ZoneStateLoaded } from '../cc-zone/cc-zone.types.js';
+import { AddonPlan, AddonProvider } from '../common.types.js';
+
+export type CcAddonHeaderState =
+  | CcAddonHeaderStateLoading
+  | CcAddonHeaderStateLoaded
+  | CcAddonHeaderStateError
+  | CcAddonHeaderStateRestarting
+  | CcAddonHeaderStateRebuilding;
+
+interface BaseProperties {
+  providerName: string;
+  providerLogoUrl: string;
+  name: string;
+  id: string;
+  zone: ZoneStateLoaded;
+}
+
+interface OptionalProperties {
+  logsUrl?: string;
+  openLinks?: Array<OpenLink>;
+  actions?: {
+    restart: boolean;
+    rebuildAndRestart: boolean;
+  };
+  productStatus?: string;
+  deploymentStatus?: DeploymentStatus;
+}
+
+interface OpenLink {
+  url: string;
+  name: string;
+}
+
+export type DeploymentStatus = 'deploying' | 'active' | 'failed';
+
+export interface CcAddonHeaderStateLoading extends OptionalProperties {
+  type: 'loading';
+}
+
+export interface CcAddonHeaderStateLoaded extends BaseProperties, OptionalProperties {
+  type: 'loaded';
+}
+
+export interface CcAddonHeaderStateError {
+  type: 'error';
+}
+
+export interface CcAddonHeaderStateRestarting extends BaseProperties, OptionalProperties {
+  type: 'restarting';
+}
+
+export interface CcAddonHeaderStateRebuilding extends BaseProperties, OptionalProperties {
+  type: 'rebuilding';
+}
+
+export interface RawAddon {
+  id: string;
+  name: string;
+  realId: string;
+  region: string;
+  zoneId: string;
+  provider: AddonProvider;
+  plan: AddonPlan;
+  creationDate: number;
+  configKeys: string[];
+}
+
+export interface RawOperator {
+  resourceId: string;
+  addonId: string;
+  name: string;
+  ownerId: string;
+  plan: string;
+  version: string;
+  javaVersion: string;
+  accessUrl: string;
+  availableVersions: string[];
+  resources: {
+    entrypoint: string;
+    fsbucketId: string;
+    pgsqlId: string;
+  };
+  features: {
+    networkGroup?: string;
+  };
+  envVars: Record<string, string>;
+}
+
+export type Addon = BaseProperties & OptionalProperties;

--- a/src/lib/events-map.types.d.ts
+++ b/src/lib/events-map.types.d.ts
@@ -4,6 +4,7 @@ import {
   CcAddonNameChangeEvent,
   CcAddonTagsChangeEvent,
 } from '../components/cc-addon-admin/cc-addon-admin.events.js';
+import { CcAddonRebuildEvent, CcAddonRestartEvent } from '../components/cc-addon-header/cc-addon-header.events.js';
 import { CcAddonOptionFormSubmitEvent } from '../components/cc-addon-option-form/cc-addon-option-form.events.js';
 import { CcAddonOptionChangeEvent } from '../components/cc-addon-option/cc-addon-option.events.js';
 import {
@@ -159,6 +160,8 @@ declare global {
     'cc-addon-name-change': CcAddonNameChangeEvent;
     'cc-addon-option-change': CcAddonOptionChangeEvent;
     'cc-addon-option-form-submit': CcAddonOptionFormSubmitEvent;
+    'cc-addon-rebuild': CcAddonRebuildEvent;
+    'cc-addon-restart': CcAddonRestartEvent;
     'cc-addon-tags-change': CcAddonTagsChangeEvent;
     'cc-api-error': CcApiErrorEvent;
     'cc-application-restart': CcApplicationRestartEvent;

--- a/src/stories/fixtures/addon.js
+++ b/src/stories/fixtures/addon.js
@@ -1,0 +1,167 @@
+import { ZONE } from "./zones.js";
+
+/**
+ * @typedef {import('../../components/cc-addon-header/cc-addon-header.types.js').Addon} Addon
+ */
+
+/** @type {Addon} */
+export const configProviderData = {
+  providerName: 'Configuration provider',
+  providerLogoUrl: 'https://assets.clever-cloud.com/logos/configprovider.svg',
+  name: 'my-config',
+  id: 'config_59xml9zd-f1rg-2jj2-z733-p564812374122',
+  zone: {
+    type: 'loaded',
+    ...ZONE,
+  },
+};
+
+/** @type {Addon} */
+export const pulsarData = {
+  providerName: 'Pulsar',
+  providerLogoUrl: 'https://assets.clever-cloud.com/logos/pulsar.svg',
+  name: 'my-pulsar',
+  id: 'pulsar_695g1427-sn3t-0200-36mw-h56983vb3653',
+  zone: {
+    type: 'loaded',
+    ...ZONE,
+  },
+  logsUrl: 'https://example.com/logs',
+};
+
+/** @type {Addon} */
+export const jenkinsData = {
+  providerName: 'Jenkins',
+  providerLogoUrl: 'https://assets.clever-cloud.com/logos/jenkins.svg',
+  name: 'my-jenkins',
+  id: 'jenkins_fgh7evv9-q21m-9129-mm3b-04f77lo56w36',
+  zone: {
+    type: 'loaded',
+    ...ZONE,
+  },
+  logsUrl: 'https://example.com/logs',
+  openLinks: [
+    {
+      url: 'https://example.com/logs',
+      name: 'Jenkins',
+    },
+  ],
+};
+
+/** @type {Addon} */
+export const elasticData = {
+  providerName: 'Elastic Stack',
+  providerLogoUrl: 'https://assets.clever-cloud.com/logos/elastic.svg',
+  name: 'my-elastic',
+  id: 'elasticsearch_23694507-44yt-023u-ib5o-6vc7d0mp99a2',
+  zone: {
+    type: 'loaded',
+    ...ZONE,
+  },
+  logsUrl: 'https://example.com/logs',
+  openLinks: [
+    {
+      url: 'https://example.com/logs',
+      name: 'APM',
+    },
+    {
+      url: 'https://example.com/logs',
+      name: 'Kibana',
+    },
+  ],
+};
+
+/** @type {Addon} */
+export const matomoData = {
+  providerName: 'Matomo Analytics',
+  providerLogoUrl: 'https://assets.clever-cloud.com/logos/matomo.svg',
+  name: 'my-matomo',
+  id: 'matomo_0985go7t-2kda-6dv2-x978-h63r45o11q6p',
+  zone: {
+    type: 'loaded',
+    ...ZONE,
+  },
+  logsUrl: 'https://example.com/logs',
+  openLinks: [
+    {
+      url: 'https://example.com/logs',
+      name: 'Matomo',
+    },
+  ],
+  actions: {
+    restart: true,
+    rebuildAndRestart: true,
+  },
+};
+
+/** @type {Addon} */
+export const keycloakData = {
+  providerName: 'Keycloak',
+  providerLogoUrl: 'https://cc-keycloak.cellar-c2.services.clever-cloud.com/keycloak_logo.svg',
+  name: 'my-keycloak',
+  id: 'keycloak_511f6k82-9r44-6w90-86s3-az6m5kvyy478',
+  zone: {
+    type: 'loaded',
+    ...ZONE,
+  },
+  logsUrl: 'https://example.com/logs',
+  openLinks: [
+    {
+      url: 'https://example.com/logs',
+      name: 'Keycloak',
+    },
+  ],
+  actions: {
+    restart: true,
+    rebuildAndRestart: true,
+  },
+  productStatus: 'Tech Preview',
+};
+
+/** @type {Addon} */
+export const materiaData = {
+  providerName: 'Materia',
+  providerLogoUrl: 'https://assets.clever-cloud.com/logos/materia-db-kv.png',
+  name: 'my-materia',
+  id: 'kv_54PE021ROIUTYZ8GH4DFGMB33Z',
+  zone: {
+    type: 'loaded',
+    ...ZONE,
+  },
+  logsUrl: 'https://example.com/logs',
+  openLinks: [
+    {
+      url: 'https://example.com/logs',
+      name: 'KV Explorer',
+    },
+  ],
+  actions: {
+    restart: false,
+    rebuildAndRestart: false,
+  },
+  productStatus: 'Alpha',
+};
+
+/** @type {Addon} */
+export const redisData = {
+  providerName: 'Redis',
+  providerLogoUrl: 'https://assets.clever-cloud.com/logos/redis.svg',
+  name: 'my-redis',
+  id: 'redis_236590c14-5119-4aca-9888-3b16523486b',
+  zone: {
+    type: 'loaded',
+    ...ZONE,
+  },
+  logsUrl: 'https://example.com/logs',
+  openLinks: [
+    {
+      url: 'https://example.com/logs',
+      name: 'KV Explorer',
+    },
+  ],
+  actions: {
+    restart: false,
+    rebuildAndRestart: false,
+  },
+  deploymentStatus: 'active'
+};

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -207,6 +207,25 @@ export const translations = {
   'cc-addon-features.loading-error': `Something went wrong while loading add-on features.`,
   'cc-addon-features.title': `Features`,
   //#endregion
+  //#region cc-addon-header
+  'cc-addon-header.action.open-addon': /** @param {{ linkName: string }} _ */ ({ linkName }) => `Open ${linkName}`,
+  'cc-addon-header.action.restart': `Restart`,
+  'cc-addon-header.action.restart-rebuild': `Re-build and restart`,
+  'cc-addon-header.error': `Something went wrong while loading add-on info.`,
+  'cc-addon-header.logs.link': `View logs`,
+  'cc-addon-header.rebuild.error': `Something went wrong while rebuilding the add-on.`,
+  'cc-addon-header.rebuild.success.message': /** @param {{logsUrl: string}} _*/ ({ logsUrl }) =>
+    sanitize`The process of rebuilding and restarting your add-on and its linked services is in progress. See the <cc-link href="${logsUrl}">logs</cc-link> or the <cc-link href="${generateDocsHref('/addons/keycloak/')}">documentation</cc-link> for more information.`,
+  'cc-addon-header.rebuild.success.title': `Re-build and restart in progress`,
+  'cc-addon-header.restart.error': `Something went wrong while restarting the add-on.`,
+  'cc-addon-header.restart.success.message': /** @param {{logsUrl: string}} _*/ ({ logsUrl }) =>
+    sanitize`The process of restarting your add-on and its linked services is in progress. See the <cc-link href="${logsUrl}">logs</cc-link> or the <cc-link href="${generateDocsHref('/addons/keycloak/')}">documentation</cc-link> for more information.`,
+  'cc-addon-header.restart.success.title': `Restart in progress`,
+  'cc-addon-header.state-msg.deployment-failed': `The deployement failed.`,
+  'cc-addon-header.state-msg.deployment-is-active': `Your add-on is active!`,
+  'cc-addon-header.state-msg.deployment-is-deploying': `Your add-on is deploying…`,
+  'cc-addon-header.state-msg.unknown-state': `Unknown state, try to restart the add-on or contact our support if you have additional questions.`,
+  //#endregion
   //#region cc-addon-jenkins-options
   'cc-addon-jenkins-options.description': `Choose the options you want for your Jenkins add-on.`,
   'cc-addon-jenkins-options.title': `Options for the Jenkins add-on`,

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -218,6 +218,25 @@ export const translations = {
   'cc-addon-features.loading-error': `Une erreur est survenue pendant le chargement des spécifications de l'add-on`,
   'cc-addon-features.title': `Spécifications`,
   //#endregion
+  //#region cc-addon-header
+  'cc-addon-header.action.open-addon': /** @param {{ linkName: string }} _ */ ({ linkName }) => `Ouvrir ${linkName}`,
+  'cc-addon-header.action.restart': `Redémarrer`,
+  'cc-addon-header.action.restart-rebuild': `Re-build et redémarrer`,
+  'cc-addon-header.error': `Une erreur est survenue pendant le chargement des informations de l'add-on.`,
+  'cc-addon-header.logs.link': `Voir les logs`,
+  'cc-addon-header.rebuild.error': `Une erreur est survenue pendant le re-build de l'add-on.`,
+  'cc-addon-header.rebuild.success.message': /** @param {{logsUrl: string}} _*/ ({ logsUrl }) =>
+    sanitize`Le processus de re-build et de redémarrage de votre add-on et de ses services associés est en cours.  Consultez les <cc-link href="${logsUrl}">logs</cc-link> ou la <cc-link href="${generateDocsHref('/addons/keycloak/')}">documentation</cc-link> pour plus d'informations.`,
+  'cc-addon-header.rebuild.success.title': `Re-build et redémarrage en cours`,
+  'cc-addon-header.restart.error': `Une erreur est survenue pendant le redémarrage de l'add-on.`,
+  'cc-addon-header.restart.success.message': /** @param {{logsUrl: string}} _*/ ({ logsUrl }) =>
+    sanitize`Le processus de redémarrage de votre add-on et de ses services associés est en cours. Consultez les <cc-link href="${logsUrl}">logs</cc-link> ou la <cc-link href="${generateDocsHref('/addons/keycloak/')}">documentation</cc-link> pour plus d'informations.`,
+  'cc-addon-header.restart.success.title': `Redémarrage en cours`,
+  'cc-addon-header.state-msg.deployment-failed': `Le déploiement de l'add-on a échoué.`,
+  'cc-addon-header.state-msg.deployment-is-active': `Votre add-on est disponible !`,
+  'cc-addon-header.state-msg.deployment-is-deploying': `L'add-on est en cours de déploiement…`,
+  'cc-addon-header.state-msg.unknown-state': `État inconnu, essayez de redémarrer l'add-on ou de contacter notre support si vous avez des questions.`,
+  //#endregion
   //#region cc-addon-jenkins-options
   'cc-addon-jenkins-options.description': `Sélectionnez les options que vous souhaitez pour votre add-on Jenkins.`,
   'cc-addon-jenkins-options.title': `Options pour l'add-on Jenkins`,


### PR DESCRIPTION
## What does this PR do?

- add a `cc-addon-header` component,
- add addon fixtures,
- add `cc-addon-header` to demo-smart.

## How to review?

- check the commits,
- check the stories in the [preview](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-addon-header/init/index.html?path=/docs/%F0%9F%9B%A0-addon-cc-addon-header--docs),
- QA is available on [Notion](https://www.notion.so/cc-header-addon-beta-23ffe1a33d3880c6b080deef2a09e6a3).

## TO DO

- [x]  Update notifications texts when validated,
- [x] Add Kubernetes.