### PR TITLE
fix(cc-env-var-form.smart-env-var-app): support restart app and dispatch event

### DIFF
--- a/demo-smart/index.html
+++ b/demo-smart/index.html
@@ -162,12 +162,12 @@
         grafana-info
       </button>
       <button
-        data-context='{"ownerId":"orga_3547a882-d464-4c34-8168-add4b3e0c135","appId":"app_7c6f466c-3314-4753-9e06-f87912f6b856","consoleGrafanaLink":"https://console.clever-cloud.com","grafanaBaseLink":"https://grafana.services.clever-cloud.com/"}'
+        data-context='{"ownerId":"orga_3547a882-d464-4c34-8168-add4b3e0c135","appId":"app_7c6f466c-3314-4753-9e06-f87912f6b856","consoleGrafanaLink":"https://console.clever-cloud.com","grafanaBaseLink":"https://grafana.services.clever-cloud.com/", "logsUrlPattern":"/organisations/orga_3547a882-d464-4c34-8168-add4b3e0c135/applications/:id/logs"}'
       >
         app-node
       </button>
       <button
-        data-context='{"ownerId":"orga_3547a882-d464-4c34-8168-add4b3e0c135","appId":"app_e048c5ba-dc84-4f01-a750-d053706805fd","consoleGrafanaLink":"https://console.clever-cloud.com","grafanaBaseLink":"https://grafana.services.clever-cloud.com/"}'
+        data-context='{"ownerId":"orga_3547a882-d464-4c34-8168-add4b3e0c135","appId":"app_e048c5ba-dc84-4f01-a750-d053706805fd","consoleGrafanaLink":"https://console.clever-cloud.com","grafanaBaseLink":"https://grafana.services.clever-cloud.com/", "logsUrlPattern":"/organisations/orga_3547a882-d464-4c34-8168-add4b3e0c135/applications/:id/logs"}'
       >
         app-play
       </button>

--- a/src/components/cc-env-var-form/cc-env-var-form.events.js
+++ b/src/components/cc-env-var-form/cc-env-var-form.events.js
@@ -33,3 +33,18 @@ export class CcEnvChangeEvent extends CcEvent {
     super(CcEnvChangeEvent.TYPE, detail);
   }
 }
+
+/**
+ * Dispatched when env vars have been updated successfully.
+ * @extends {CcEvent<Array<EnvVar>>}
+ */
+export class CcEnvVarsWasUpdatedEvent extends CcEvent {
+  static TYPE = 'cc-env-vars-was-updated';
+
+  /**
+   * @param {Array<EnvVar>} detail
+   */
+  constructor(detail) {
+    super(CcEnvVarsWasUpdatedEvent.TYPE, detail);
+  }
+}

--- a/src/components/cc-env-var-form/cc-env-var-form.smart-env-var-app.md
+++ b/src/components/cc-env-var-form/cc-env-var-form.smart-env-var-app.md
@@ -2,7 +2,7 @@
 kind: '🛠 Environment variables/<cc-env-var-form>'
 title: '💡 Smart (env-var-app)'
 ---
-# 💡 Smart `<cc-env-var-form>` for application environment variables
+# 💡 Smart `<cc-env-var-form context="env-var-app">` for application environment variables
 
 ## ℹ️ Details
 
@@ -15,10 +15,11 @@ title: '💡 Smart (env-var-app)'
 ## ⚙️ Params
 
 <table>
-  <tr><th>Name                   <th>Type                   <th>Details                                                     <th>Default
-  <tr><td><code>apiConfig</code> <td><code>ApiConfig</code> <td>Object with API configuration (target host, tokens...)      <td>
-  <tr><td><code>ownerId</code>   <td><code>String</code>    <td>UUID prefixed with <code>user_</code> or <code>orga_</code> <td>
-  <tr><td><code>appId</code>   <td><code>String</code>    <td>UUID prefixed with <code>app_</code>                      <td>
+  <tr><th>Name                          <th>Type                       <th>Details                                                     <th>Default
+  <tr><td><code>apiConfig</code>        <td><code>ApiConfig</code>     <td>Object with API configuration (target host, tokens...)      <td>
+  <tr><td><code>ownerId</code>          <td><code>String</code>        <td>UUID prefixed with <code>user_</code> or <code>orga_</code> <td>
+  <tr><td><code>appId</code>            <td><code>String</code>        <td>UUID prefixed with <code>app_</code>                        <td>
+  <tr><td><code>logsUrlPattern</code>   <td><code>String</code>        <td>Pattern for the logs url                                    <td>
 </table>
 
 ```ts
@@ -33,11 +34,10 @@ interface ApiConfig {
 
 ## 🌐 API endpoints
 
-<!-- List API endpoints used by the component here with the details. -->
-
 <table>
-  <tr><th>Method <th>URL                                                      <th>Cache?
-  <tr><td>GET    <td><code>/v2/organisations/{id}/applications/{appId}/env</code> <td>Default
+  <tr><th>Method  <th>URL                                                                        <th>Cache?
+  <tr><td>GET     <td><code>/v2/organisations/{ownerId}/applications/{appId}/env</code>          <td>Default
+  <tr><td>POST    <td><code>/v2$/organisations/{ownerId}/applications/${appId}/instances`</code> <td>Default
 </table>
 
 ## ⬇️️ Examples
@@ -53,6 +53,7 @@ interface ApiConfig {
   },
   "ownerId": "",
   "appId": "",
+  "logsUrlPattern": "",
 }'>
   <cc-env-var-form context="env-var-app"></cc-env-var-form>
 </cc-smart-container>

--- a/src/lib/events-map.types.d.ts
+++ b/src/lib/events-map.types.d.ts
@@ -19,7 +19,11 @@ import {
   CcEmailSendConfirmationEvent,
 } from '../components/cc-email-list/cc-email-list.events.js';
 import { CcEnvVarCreateEvent } from '../components/cc-env-var-create/cc-env-var-create.events.js';
-import { CcEnvChangeEvent, CcEnvVarFormSubmitEvent } from '../components/cc-env-var-form/cc-env-var-form.events.js';
+import {
+  CcEnvChangeEvent,
+  CcEnvVarFormSubmitEvent,
+  CcEnvVarsWasUpdatedEvent,
+} from '../components/cc-env-var-form/cc-env-var-form.events.js';
 import {
   CcEnvVarChangeEvent,
   CcEnvVarDeleteEvent,
@@ -176,6 +180,7 @@ declare global {
     'cc-env-var-delete': CcEnvVarDeleteEvent;
     'cc-env-var-form-submit': CcEnvVarFormSubmitEvent;
     'cc-env-var-keep': CcEnvVarKeepEvent;
+    'cc-env-vars-was-updated': CcEnvVarsWasUpdatedEvent;
     'cc-error-message-change': CcErrorMessageChangeEvent;
     'cc-form-invalid': CcFormInvalidEvent;
     'cc-form-valid': CcFormValidEvent;

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -489,6 +489,11 @@ export const translations = {
   'cc-env-var-form.heading.exposed-config': `Exposed configuration`,
   'cc-env-var-form.mode.expert': `Expert`,
   'cc-env-var-form.mode.simple': `Simple`,
+  'cc-env-var-form.redeploy.error': `Something went wrong while trying to restart your application`,
+  'cc-env-var-form.redeploy.error.app-stopped': `The app has never been deployed so it cannot be redeployed. Push a commit to start a deployment.`,
+  'cc-env-var-form.redeploy.success.heading': `Restart in progress`,
+  'cc-env-var-form.redeploy.success.text': /** @param {{ logsUrl: string }} _ */ ({ logsUrl }) =>
+    sanitize`The process of restarting your application is in progress. See the <cc-link href="${logsUrl}">logs</cc-link>.`,
   'cc-env-var-form.reset': `Reset changes`,
   'cc-env-var-form.restart-app': `Restart the app to apply changes`,
   'cc-env-var-form.update': `Update changes`,

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -503,6 +503,11 @@ export const translations = {
   'cc-env-var-form.heading.exposed-config': `Configuration publiée`,
   'cc-env-var-form.mode.expert': `Expert`,
   'cc-env-var-form.mode.simple': `Simple`,
+  'cc-env-var-form.redeploy.error': `Une erreur est survenue lors du redémarrage de votre application`,
+  'cc-env-var-form.redeploy.error.app-stopped': `L'application n'a jamais été déployée donc elle ne peut pas être redéployée. Poussez un commit pour lancer un déploiement.`,
+  'cc-env-var-form.redeploy.success.heading': `Redémarrage en cours`,
+  'cc-env-var-form.redeploy.success.text': /** @param {{ logsUrl: string }} _ */ ({ logsUrl }) =>
+    sanitize`Le processus de redémarrage de votre application est en cours. Consultez les <cc-link href="${logsUrl}">logs</cc-link>`,
   'cc-env-var-form.reset': `Annuler les changements`,
   'cc-env-var-form.restart-app': `Redémarrer l'app pour appliquer les changements`,
   'cc-env-var-form.update': `Mettre à jour les changements`,


### PR DESCRIPTION
## What does this PR do?

- Adds missing support for the restart app feature to the `cc-env-var-form.smart-env-var-app` component,
- Dispatch an event when env vars have been successfully updated to let the console update the EOL variables list.

## How to review?

- Check the commit,
- Run locally and check the http://localhost:6006/demo-smart/?definition=cc-env-var-form.smart-env-var-app&context=env-var-app : 
  - Test updating variables,
  - After an update, you should see the `restart` button next to the submit button,
  - Try restarting the app => you should see a success toast.
  - Block the request when trying to update your env variables,
  - Block the request when trying to restart the app using the button.