### PR TITLE
fix(cc-addon-backups): allow using the delete feature in french

### DIFF
--- a/demo-smart/index.html
+++ b/demo-smart/index.html
@@ -190,7 +190,7 @@
         ACME FOO
       </button>
       <button
-        data-context='{"ownerId":"orga_3547a882-d464-4c34-8168-add4b3e0c135","addonId":"addon_53167b5a-3290-430d-912a-a084b6e905e7"}'
+        data-context='{"ownerId":"orga_3547a882-d464-4c34-8168-add4b3e0c135","addonId":"addon_e41d1602-9ec0-43ce-811a-1f47efc2c962"}'
       >
         addon-elastic
       </button>

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -115,8 +115,8 @@ export const translations = {
   'cc-addon-backups.delete': /** @param {{createdAt: string|number}} _ */ ({ createdAt }) =>
     sanitize`Supprimer la sauvegarde du <strong title="${formatDate(createdAt)}">${formatDatetime(createdAt)}</strong>`,
   'cc-addon-backups.delete.btn': `supprimer…`,
-  'cc-addon-backups.delete.manual.description.es-addon': /** @param {{href: string}} _ */ ({ href }) =>
-    sanitize`Vous pouvez supprimer cette sauvegarde manuellement grâce à l'outil <cc-link href="${href}">cURL</cc-link> en exécutant cette commande\u00A0:`,
+  'cc-addon-backups.delete.manual.description.es-addon': () =>
+    sanitize`Vous pouvez supprimer cette sauvegarde manuellement grâce à l'outil <cc-link href="https://curl.se/docs/">cURL</cc-link> en exécutant cette commande\u00A0:`,
   'cc-addon-backups.delete.manual.title': `Suppression manuelle`,
   'cc-addon-backups.delete.with-service.description.es-addon': /** @param {{href: string}} _ */ ({ href }) =>
     sanitize`Vous pouvez supprimer cette sauvegarde avec Kibana en vous rendant sur le <cc-link href="${href}">dépôt de sauvegardes</cc-link>.`,


### PR DESCRIPTION
Fixes #1508

## What does this PR do?

- Fixes the delete feature (ES Add-on) in French for the `cc-addon-backups` component (this bug is actually very old, it hasn't been working since 2021 :see_no_evil:)

## How to review?

- Check the commit,
- Check the [`cc-addon-backups` - Data Loaded (new elasticsearch) in prod](https://www.clever.cloud/developers/clever-components/?path=/story/%F0%9F%9B%A0-addon-cc-addon-backups--data-loaded-with-new-elasticsearch&globals=locale:fr) vs [`cc-addon-backups` - Data Loaded (new elasticsearch) in preview](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-addon-backups/fix-deletion-feature/index.html?path=/story/%F0%9F%9B%A0-addon-cc-addon-backups--data-loaded-with-new-elasticsearch&globals=locale:fr).