### PR TITLE
fix(cc-block-details): improve responsive

### DIFF
--- a/src/components/cc-block-details/cc-block-details.js
+++ b/src/components/cc-block-details/cc-block-details.js
@@ -55,14 +55,26 @@ export class CcBlockDetails extends LitElement {
       // language=CSS
       css`
         :host {
+          container-type: inline-size;
           display: block;
         }
 
         .wrapper {
+          align-items: center;
           display: grid;
           grid-template-areas: 'button links' 'content content';
           grid-template-columns: 1fr auto;
           justify-items: start;
+        }
+
+        @container (max-width: 34em) {
+          .wrapper {
+            grid-template-areas:
+              'button'
+              'content'
+              'links';
+            grid-template-columns: 1fr;
+          }
         }
 
         .button {
@@ -127,6 +139,13 @@ export class CcBlockDetails extends LitElement {
           gap: 0.5em;
           grid-area: links;
           justify-self: end;
+        }
+
+        @container (max-width: 34em) {
+          .links {
+            justify-self: unset;
+            margin-block-start: 0.5em;
+          }
         }
 
         ::slotted([slot='link']) {

--- a/stylelint.config.js
+++ b/stylelint.config.js
@@ -37,6 +37,7 @@ export default {
           'multicolumn',
           'css-clip-path',
           'css-masks',
+          'css-container-queries',
         ],
       },
     ],


### PR DESCRIPTION
Fixes #1450

## What does this PR do?

- Improves the responsive aspect of `cc-block-details` by using container queries.

## How to review?

- Check the commit,
- Check the preview vs prod.

## TODO

- [x] Merge #1510 before (or at least make sure both these PRs are part of the same release) to allow using container queries