### PR TITLE
fix(cc-notice): align icon to top when no heading is present

### DIFF
--- a/src/components/cc-notice/cc-notice.js
+++ b/src/components/cc-notice/cc-notice.js
@@ -135,7 +135,7 @@ export class CcNotice extends LitElement {
         }
 
         .wrapper {
-          align-items: center;
+          align-items: start;
           border-radius: var(--cc-border-radius-default, 0.25em);
           display: grid;
           gap: 0.5em;
@@ -200,6 +200,7 @@ export class CcNotice extends LitElement {
         }
 
         .heading {
+          align-self: center;
           font-weight: bold;
           grid-area: heading;
         }
@@ -213,6 +214,7 @@ export class CcNotice extends LitElement {
         }
 
         .notice-icon {
+          align-self: start;
           grid-area: icon;
           height: 1.5em;
           width: 1.5em;


### PR DESCRIPTION
Fixes #828

# What to review

Icon alignment when there are no heading.

# How to review

Compare the `With long text and no heading` story in both [production](https://www.clever-cloud.com/doc/clever-components/?path=/story/%F0%9F%A7%AC-atoms-cc-notice--with-long-text-and-no-heading) & preview Storybook .

# How many reviewers

One should be enough.