### PR TITLE
feat(cc-addon-info): init component with keycloak smart 

### DIFF
--- a/demo-smart/index.html
+++ b/demo-smart/index.html
@@ -167,9 +167,16 @@
         <a class="definition-link" href="?definition=cc-addon-header.smart-keycloak&smart-mode=keycloak"
           >cc-addon-header.smart-keycloak</a
         >
+      </li>
+      <li>
         <a class="definition-link" href="?definition=cc-addon-credentials-beta.smart-keycloak&smart-mode=keycloak">
           cc-addon-credentials-beta.smart-keycloak
         </a>
+      </li>
+      <li>
+        <a class="definition-link" href="?definition=cc-addon-info.smart-keycloak&smart-mode=keycloak"
+          >cc-addon-info.smart-keycloak</a
+        >
       </li>
     </ul>
 
@@ -243,7 +250,18 @@
         oAuth Consumer
       </button>
       <button
-        data-context='{"ownerId":"orga_3547a882-d464-4c34-8168-add4b3e0c135", "addonId":"addon_b0156348-3825-4026-895a-bcaacafc4746", "logsUrlPattern":"/organisations/orga_3547a882-d464-4c34-8168-add4b3e0c135/applications/:id/logs"}'
+        data-context='{
+          "ownerId":"orga_3547a882-d464-4c34-8168-add4b3e0c135",
+          "addonId":"addon_b0156348-3825-4026-895a-bcaacafc4746",
+          "logsUrlPattern":"/organisations/orga_3547a882-d464-4c34-8168-add4b3e0c135/applications/:id/logs",
+          "grafanaLink": {
+            "base": "https://grafana.services.clever-cloud.com",
+            "console": "https://console.clever-cloud.com"
+          },
+          "appOverviewUrlPattern": "/organisations/orga_3547a882-d464-4c34-8168-add4b3e0c135/applications/:id",
+          "addonDashboardUrlPattern": "/organisations/orga_3547a882-d464-4c34-8168-addons/:id",
+          "scalabilityUrlPattern": "/organisations/orga_3547a882-d464-4c34-8168-add4b3e0c135/applications/:id/settings"
+        }'
       >
         addon-keycloak
       </button>

--- a/src/components/cc-addon-info/cc-addon-info.events.js
+++ b/src/components/cc-addon-info/cc-addon-info.events.js
@@ -1,0 +1,14 @@
+import { CcEvent } from '../../lib/events.js';
+
+/**
+ * Dispatched when an add-on version update was requested.
+ * @extends {CcEvent<string>}
+ */
+export class CcAddonVersionChangeEvent extends CcEvent {
+  static TYPE = 'cc-addon-version-change';
+
+  /** @param {string} targetVersion */
+  constructor(targetVersion) {
+    super(CcAddonVersionChangeEvent.TYPE, targetVersion);
+  }
+}

--- a/src/components/cc-addon-info/cc-addon-info.js
+++ b/src/components/cc-addon-info/cc-addon-info.js
@@ -1,0 +1,645 @@
+import { css, html, LitElement } from 'lit';
+import { classMap } from 'lit/directives/class-map.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
+import { createRef, ref } from 'lit/directives/ref.js';
+import {
+  iconRemixCloseLine as iconClose,
+  iconRemixInformationFill as iconInfo,
+  iconRemixSettings_3Line as iconUpdate,
+} from '../../assets/cc-remix.icons.js';
+import { LostFocusController } from '../../controllers/lost-focus-controller.js';
+import { hasSlottedChildren } from '../../directives/has-slotted-children.js';
+import { getAssetUrl } from '../../lib/assets-url.js';
+import { fakeString } from '../../lib/fake-strings.js';
+import { formSubmit } from '../../lib/form/form-submit-directive.js';
+import { accessibilityStyles } from '../../styles/accessibility.js';
+import { skeletonStyles } from '../../styles/skeleton.js';
+import { i18n } from '../../translations/translation.js';
+import '../cc-block/cc-block.js';
+import '../cc-link/cc-link.js';
+import '../cc-notice/cc-notice.js';
+import '../cc-select/cc-select.js';
+import { CcAddonVersionChangeEvent } from './cc-addon-info.events.js';
+
+/** @type {Record<FormattedFeature['code'], () => string>} */
+const FEATURES_I18N = {
+  'connection-limit': () => i18n('cc-addon-info.feature.connection-limit'),
+  cpu: () => i18n('cc-addon-info.feature.cpu'),
+  databases: () => i18n('cc-addon-info.feature.databases'),
+  dedicated: () => i18n('cc-addon-info.feature.dedicated'),
+  'disk-size': () => i18n('cc-addon-info.feature.disk-size'),
+  gpu: () => i18n('cc-addon-info.feature.gpu'),
+  'has-logs': () => i18n('cc-addon-info.feature.has-logs'),
+  'has-metrics': () => i18n('cc-addon-info.feature.has-metrics'),
+  'is-migratable': () => i18n('cc-addon-info.feature.is-migratable'),
+  'max-db-size': () => i18n('cc-addon-info.feature.max-db-size'),
+  memory: () => i18n('cc-addon-info.feature.memory'),
+  version: () => i18n('cc-addon-info.feature.version'),
+  'encryption-at-rest': () => i18n('cc-addon-info.feature.encryption-at-rest'),
+  users: () => i18n('cc-addon-info.feature.users'),
+  'data-exploration': () => i18n('cc-addon-info.feature.data-exploration'),
+  'db-analysis': () => i18n('cc-addon-info.feature.db-analysis'),
+};
+
+const GRAFANA_LOGO_URL = getAssetUrl('/logos/grafana.svg');
+
+/**
+ * @typedef {import('./cc-addon-info.types.js').AddonInfoState} AddonInfoState
+ * @typedef {import('./cc-addon-info.types.js').AddonVersionStateUpdateAvailable} AddonVersionStateUpdateAvailable
+ * @typedef {import('./cc-addon-info.types.js').AddonVersionStateRequestingUpdate} AddonVersionStateRequestingUpdate
+ * @typedef {import('./cc-addon-info.types.js').LinkedService} LinkedService
+ * @typedef {import('../cc-select/cc-select.types.js').Option} Option
+ * @typedef {import('../common.types.js').FormattedFeature} FormattedFeature
+ * @typedef {import('lit/directives/ref.js').Ref<HTMLDialogElement>} HTMLDialogElementRef
+ * @typedef {import('lit/directives/ref.js').Ref<HTMLElement>} HTMLElementRef
+ * @typedef {import('lit/directives/ref.js').Ref<HTMLFormElement>} HTMLFormElementRef
+ * @typedef {import('lit').PropertyValues<CcAddonInfo>} CcAddonInfoPropertyValues
+ */
+
+/**
+ * A component to display detailed info about an add-on.
+ *
+ * @cssdisplay block
+ *
+ * @slot billing - A customised text regarding the billing.
+ * @slot linked-services - A customised text regarding the linked services.
+ */
+export class CcAddonInfo extends LitElement {
+  static get properties() {
+    return {
+      docLink: { type: Object, attribute: 'doc-link' },
+      state: { type: Object },
+    };
+  }
+
+  constructor() {
+    super();
+
+    /** @type {{ text: string; href: string; }} */
+    this.docLink = null;
+
+    /** @type {AddonInfoState} Sets the state of the component*/
+    this.state = { type: 'loading', creationDate: '2025-08-04 15:03:02' };
+
+    /** @type {HTMLDialogElementRef} */
+    this._versionDialogRef = createRef();
+
+    /** @type {HTMLElementRef} */
+    this._versionTextRef = createRef();
+
+    /** @type {HTMLFormElementRef} */
+    this._versionFormRef = createRef();
+
+    new LostFocusController(this, 'dialog', () => {
+      this._versionTextRef.value?.focus();
+    });
+  }
+
+  /**
+   * Returns the formatted value corresponding to a feature
+   *
+   * @param {FormattedFeature} feature - the feature to get the formatted value from
+   * @return {string|Node|void} the formatted value for the given feature or the feature value itself if it does not require any formatting
+   */
+  _getFeatureValue(feature) {
+    if (feature == null) {
+      return '';
+    }
+
+    switch (feature.type) {
+      case 'boolean':
+        return i18n('cc-addon-info.type.boolean', { boolean: feature.value === 'true' });
+      case 'boolean-shared':
+        return i18n('cc-addon-info.type.boolean-shared', { shared: feature.value === 'shared' });
+      case 'bytes':
+        return feature.code === 'memory' && feature.value === '0'
+          ? i18n('cc-addon-info.type.boolean-shared', { shared: true })
+          : i18n('cc-addon-info.type.bytes', { bytes: Number(feature.value) });
+      case 'number':
+        return feature.code === 'cpu' && feature.value === '0'
+          ? i18n('cc-addon-info.type.boolean-shared', { shared: true })
+          : i18n('cc-addon-info.type.number', { number: Number(feature.value) });
+      case 'number-cpu-runtime':
+        return i18n('cc-addon-info.type.number-cpu-runtime', {
+          /**
+           * Narrowing the type would make the code less readable for no gain, improving the type to separate
+           * `number-cpu-runtime` from other types makes the code a lot more complex for almost no type safety gain
+           */
+          // @ts-ignore
+          cpu: feature.value.cpu,
+          // @ts-ignore
+          shared: feature.value.shared,
+        });
+      case 'string':
+        return feature.value.toString();
+    }
+  }
+
+  /**
+   * Returns the complete linked service name with the 'app' or 'addon' mention
+   *
+   * @param {LinkedService} service
+   * @param {boolean} skeleton
+   * @return {string|Node}
+   * @private
+   */
+  _getServiceType(service, skeleton) {
+    if (skeleton) {
+      return fakeString(15);
+    }
+
+    switch (service.type) {
+      case 'app':
+        return i18n('cc-addon-info.service.name.app', { name: service.name });
+      case 'addon':
+        return i18n('cc-addon-info.service.name.addon', { name: service.name });
+      default:
+        return fakeString(15);
+    }
+  }
+
+  /** @param {{ version: string }} formData */
+  _onUpdateVersionRequested({ version }) {
+    this.dispatchEvent(new CcAddonVersionChangeEvent(version));
+  }
+
+  _onVersionDialogOpen() {
+    this._versionDialogRef.value.showModal();
+  }
+
+  _onVersionDialogClose() {
+    this._versionDialogRef.value.close();
+  }
+
+  /** @param {CcAddonInfoPropertyValues} changedProperties */
+  updated(changedProperties) {
+    // when a version has been updated, we need to close the dialog & reset the form
+    const previousState = changedProperties.get('state');
+    const wasRequestingUpdate =
+      previousState?.type === 'loaded' && previousState?.version.stateType === 'requesting-update';
+    const isNotRequestingUpdate = this.state.type === 'loaded' && this.state.version.stateType !== 'requesting-update';
+    if (wasRequestingUpdate && isNotRequestingUpdate) {
+      this._versionDialogRef.value?.close();
+      this._versionFormRef.value?.reset();
+    }
+  }
+
+  render() {
+    if (this.state.type === 'error') {
+      return html`<cc-notice intent="warning" message="${i18n('cc-addon-info.error')}"></cc-notice>`;
+    }
+
+    const skeleton = this.state.type === 'loading';
+
+    return html`
+      <cc-block>
+        <div slot="header-title">${i18n('cc-addon-info.heading')}</div>
+        <div slot="content" class="main">
+          ${this.state.version != null
+            ? html`
+                <div class="section" tabindex="-1" ${ref(this._versionTextRef)}>
+                  <strong class="heading">${i18n('cc-addon-info.version.heading')}</strong>
+                  <div class="value version__content">
+                    <p class="version__content__version ${classMap({ skeleton })}">${this.state.version.installed}</p>
+                    ${this.state.version.stateType !== 'up-to-date'
+                      ? html`
+                          <cc-button
+                            primary
+                            outlined
+                            ?waiting="${this.state.version.stateType === 'requesting-update'}"
+                            @cc-click="${this._onVersionDialogOpen}"
+                            .icon="${iconUpdate}"
+                          >
+                            ${i18n('cc-addon-info.version.btn')}
+                          </cc-button>
+                          ${this._renderVersionDialog(this.state.version)}
+                        `
+                      : ''}
+                  </div>
+                </div>
+              `
+            : ''}
+          ${this.state.plan != null
+            ? html`
+                <div class="section">
+                  <strong class="heading">${i18n('cc-addon-info.plan.heading')}</strong>
+                  <div class="value">
+                    <p class="data-decoration ${classMap({ skeleton })}">${this.state.plan}</p>
+                  </div>
+                </div>
+              `
+            : ''}
+          ${this.state.features != null && this.state.features.length > 0
+            ? html`
+                <div class="section">
+                  <strong class="heading">${i18n('cc-addon-info.feature.heading')}</strong>
+                  <dl class="value features__content">
+                    ${this.state.features.map((feature) => this._renderFeature(feature, skeleton))}
+                  </dl>
+                </div>
+              `
+            : ''}
+
+          <div class="section">
+            <strong class="heading">${i18n('cc-addon-info.creation-date.heading')}</strong>
+            <div class="value">
+              <p class="${classMap({ skeleton })}">
+                ${i18n('cc-addon-info.creation-date.human-friendly-date', { date: this.state.creationDate })}
+              </p>
+            </div>
+          </div>
+
+          ${this.state.role != null
+            ? html`
+                <div class="section">
+                  <strong class="heading">${i18n('cc-addon-info.role.heading')}</strong>
+                  <div class="value">
+                    <p class="${classMap({ skeleton })}">${this.state.role}</p>
+                  </div>
+                </div>
+              `
+            : ''}
+          ${this.state.openGrafanaLink != null
+            ? html`
+                <div class="section">
+                  <strong class="heading">Grafana</strong>
+                  <cc-link
+                    class="value"
+                    href="${this.state.openGrafanaLink}"
+                    image="${GRAFANA_LOGO_URL}"
+                    ?skeleton=${skeleton}
+                    >${i18n('cc-addon-info.grafana.link')}
+                  </cc-link>
+                </div>
+              `
+            : ''}
+          ${this.state.openScalabilityLink != null
+            ? html`
+                <div class="section">
+                  <strong class="heading">${i18n('cc-addon-info.scalability-link.heading')}</strong>
+                  <cc-link
+                    class="value"
+                    href="${this.state.openScalabilityLink}"
+                    .icon="${iconUpdate}"
+                    ?skeleton=${skeleton}
+                    >${i18n('cc-addon-info.scalability.link')}
+                  </cc-link>
+                </div>
+              `
+            : ''}
+
+          <div class="section section--billing" ${hasSlottedChildren()}>
+            <strong class="heading">${i18n('cc-addon-info.billing.heading')}</strong>
+            <div class="value">
+              <slot name="billing"></slot>
+            </div>
+          </div>
+
+          ${this.state.linkedServices != null && this.state.linkedServices.length > 0
+            ? html`
+                <div class="section">
+                  <strong class="heading">${i18n('cc-addon-info.linked-services.heading')}</strong>
+                  <div class="value linked-services__content">
+                    <ul>
+                      ${this.state.linkedServices.map((service) => {
+                        return html`
+                          <li class="linked-service__li">
+                            <cc-img
+                              src="${ifDefined(skeleton ? undefined : service.logoUrl)}"
+                              ?skeleton=${skeleton}
+                            ></cc-img>
+                            <cc-link href="${service.link}" ?skeleton=${skeleton}
+                              >${this._getServiceType(service, skeleton)}
+                            </cc-link>
+                          </li>
+                        `;
+                      })}
+                    </ul>
+                    <slot name="linked-services"></slot>
+                  </div>
+                </div>
+              `
+            : ''}
+        </div>
+        ${this.docLink != null
+          ? html`
+              <div slot="footer-right">
+                <cc-link href="${this.docLink.href}" .icon="${iconInfo}">${this.docLink.text}</cc-link>
+              </div>
+            `
+          : ''}
+      </cc-block>
+    `;
+  }
+
+  /** @param {AddonVersionStateUpdateAvailable | AddonVersionStateRequestingUpdate} addonVersionState */
+  _renderVersionDialog({ stateType, available, installed, changelogLink, latest }) {
+    /** @type {Option[]} */
+    const selectOptions = available.map((availableVersion) => ({
+      label: availableVersion,
+      value: availableVersion,
+    }));
+
+    return html`
+      <dialog aria-labelledby="dialog-heading" closedby="any" ${ref(this._versionDialogRef)}>
+        <button
+          class="dialog-close"
+          @click=${this._onVersionDialogClose}
+          ?disabled="${stateType === 'requesting-update'}"
+        >
+          <span class="visually-hidden">${i18n('cc-addon-info.version.dialog.close')}</span>
+          <cc-icon .icon="${iconClose}"></cc-icon>
+        </button>
+        <div class="dialog-heading" id="dialog-heading">${i18n('cc-addon-info.version.dialog.heading')}</div>
+        <div class="dialog-desc">${i18n('cc-addon-info.version.dialog.desc', { url: changelogLink })}</div>
+        <form ${formSubmit(this._onUpdateVersionRequested.bind(this))} ${ref(this._versionFormRef)}>
+          <div class="dialog-form">
+            <p class="dialog-form__version-from">
+              <strong>${i18n('cc-addon-info.version.dialog.select.desc')}</strong>
+              <span>${installed}</span>
+            </p>
+            <cc-select
+              class="dialog-form__select"
+              .options="${selectOptions}"
+              .label="${i18n('cc-addon-info.version.dialog.select.label')}"
+              .value="${latest}"
+              .resetValue="${latest}"
+              name="version"
+              inline
+            >
+              <p slot="help" class="visually-hidden">
+                ${i18n('cc-addon-info.version.dialog.select.help', { currentVersion: installed })}
+              </p>
+            </cc-select>
+          </div>
+          <div class="dialog-form__actions">
+            <cc-button
+              primary
+              outlined
+              type="reset"
+              @cc-click="${this._onVersionDialogClose}"
+              ?disabled="${stateType === 'requesting-update'}"
+              >${i18n('cc-addon-info.version.dialog.btn.cancel')}</cc-button
+            >
+            <cc-button primary type="submit" ?waiting="${stateType === 'requesting-update'}"
+              >${i18n('cc-addon-info.version.dialog.btn.submit')}</cc-button
+            >
+          </div>
+        </form>
+      </dialog>
+    `;
+  }
+
+  /**
+   * @param {FormattedFeature} param
+   * @param {boolean} skeleton
+   **/
+  _renderFeature({ code, type, value }, skeleton) {
+    return html`
+      <div class="features__content__item">
+        <dt class="features__content__item__label ${classMap({ skeleton })}">${FEATURES_I18N[code]()}</dt>
+        <dd class="features__content__item__value data-decoration ${classMap({ skeleton })}">
+          ${this._getFeatureValue({ code, type, value })}
+        </dd>
+      </div>
+    `;
+  }
+
+  static get styles() {
+    return [
+      accessibilityStyles,
+      skeletonStyles,
+      css`
+        :host {
+          display: block;
+        }
+
+        .main {
+          display: flex;
+          flex-direction: column;
+        }
+
+        p,
+        dl,
+        dt,
+        dd {
+          margin: 0;
+        }
+
+        .section {
+          align-items: flex-start;
+          display: flex;
+          flex-wrap: wrap;
+          gap: 0.5em;
+          padding-block: 1em;
+        }
+
+        .section:focus-visible {
+          outline: var(--cc-focus-outline);
+          outline-offset: var(--cc-focus-outline-offset, 2px);
+        }
+
+        .section:not(:first-child) {
+          border-top: solid 1px var(--cc-color-border-neutral-weak);
+        }
+
+        .section.section--billing:not([billing-is-slotted]) {
+          display: none;
+        }
+
+        .heading {
+          flex: 1 1 33%;
+          font-weight: bold;
+          max-width: 21em;
+        }
+
+        .value {
+          align-items: center;
+          display: flex;
+          flex: 1 1 21em;
+          flex-wrap: wrap;
+          gap: 0.5em;
+        }
+
+        .version__content {
+          align-items: center;
+          display: flex;
+          gap: 1em;
+        }
+
+        .version__content__version {
+          display: inline;
+        }
+
+        .data-decoration {
+          border: solid 1px var(--cc-color-border-neutral, #bfbfbf);
+          border-radius: var(--cc-border-radius-default, 0.25em);
+          font-weight: bold;
+          padding: 0.12em 0.4em;
+        }
+
+        .billing__container {
+          display: none;
+        }
+
+        slot[name='linked-services'] {
+          font-size: 0.9em;
+        }
+
+        ::slotted(p) {
+          margin: 0;
+        }
+
+        .linked-services__content {
+          gap: 0.75em;
+        }
+
+        .linked-services__content ul {
+          column-gap: 1.5em;
+          display: flex;
+          flex-wrap: wrap;
+          list-style: none;
+          margin: 0;
+          padding: 0;
+          row-gap: 0.5em;
+        }
+
+        .linked-service__li {
+          align-items: center;
+          display: flex;
+          gap: 0.5em;
+        }
+
+        .linked-service__li cc-img {
+          border-radius: 0.19em;
+          height: 1.5em;
+          width: 1.5em;
+        }
+
+        .features__content {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 0.75em 1.5em;
+        }
+
+        .features__content__item {
+          align-items: center;
+          display: flex;
+          flex-wrap: wrap;
+          gap: 0.5em;
+        }
+
+        dialog {
+          border: none;
+          border-radius: var(--cc-border-radius-default, 0.25em);
+          box-shadow: 2px 4px 8px 0 rgb(0 0 0 / 12%);
+          box-sizing: border-box;
+          padding: 4em;
+          width: min(38em, 80%);
+        }
+
+        /* stylelint-disable-next-line media-feature-range-notation */
+        @media screen and (max-width: 38em) {
+          dialog {
+            padding: 1em;
+          }
+        }
+
+        ::backdrop {
+          background: rgb(30 30 30 / 55%);
+        }
+
+        @supports (backdrop-filter: blur(5px)) {
+          ::backdrop {
+            backdrop-filter: blur(5px);
+            background: rgb(30 30 30 / 35%);
+          }
+        }
+
+        .dialog-close {
+          background: none;
+          border: none;
+          border-radius: var(--cc-border-radius-default, 0.25em);
+          color: var(--cc-color-text-weak);
+          cursor: pointer;
+          padding: 0.5em;
+          position: absolute;
+          right: 1.5em;
+          top: 1.5em;
+
+          --cc-icon-size: 1.4em;
+        }
+
+        /* stylelint-disable-next-line media-feature-range-notation */
+        @media screen and (max-width: 38em) {
+          .dialog-close {
+            right: 0.5em;
+            top: 0.5em;
+          }
+        }
+
+        .dialog-close:disabled {
+          opacity: var(--cc-opacity-when-disabled);
+        }
+
+        .dialog-close:focus-visible {
+          outline: var(--cc-focus-outline);
+          outline-offset: var(--cc-focus-outline-offset, 2px);
+        }
+
+        .dialog-heading {
+          border-bottom: solid 1px var(--cc-color-border-neutral-weak);
+          color: var(--cc-color-text-primary-strongest);
+          font-weight: bold;
+          margin-bottom: 1.25em;
+          padding-bottom: 1.25em;
+        }
+
+        .dialog-desc {
+          margin-bottom: 1.25em;
+        }
+
+        .dialog-form {
+          align-items: baseline;
+          display: flex;
+          flex-wrap: wrap;
+          gap: 0.5em 1em;
+        }
+
+        .dialog-form__version-from {
+          display: flex;
+          gap: 1em;
+        }
+
+        .dialog-form__actions {
+          display: flex;
+          flex-wrap: wrap;
+          gap: 1em;
+          justify-content: end;
+          margin-top: 3.75em;
+        }
+
+        /* stylelint-disable-next-line media-feature-range-notation */
+        @media screen and (max-width: 38em) {
+          .dialog-form__actions {
+            display: grid;
+            justify-content: stretch;
+            margin-top: 2em;
+          }
+        }
+
+        .dialog-form cc-select {
+          column-gap: 1em;
+          flex: 1 1 auto;
+        }
+
+        .skeleton {
+          background-color: #bbb;
+          color: transparent;
+        }
+      `,
+    ];
+  }
+}
+
+customElements.define('cc-addon-info', CcAddonInfo);

--- a/src/components/cc-addon-info/cc-addon-info.smart-keycloak.js
+++ b/src/components/cc-addon-info/cc-addon-info.smart-keycloak.js
@@ -1,0 +1,355 @@
+import { defineSmartComponent } from '../../lib/smart/define-smart-component.js';
+// @ts-expect-error FIXME: remove when clever-client exports types
+import { get as getAddon } from '@clevercloud/client/esm/api/v2/addon.js';
+// @ts-expect-error FIXME: remove when clever-client exports types
+import { getGrafanaOrganisation } from '@clevercloud/client/esm/api/v4/saas.js';
+import { getAssetUrl } from '../../lib/assets-url.js';
+import { notifyError, notifySuccess } from '../../lib/notifications.js';
+import { sendToApi } from '../../lib/send-to-api.js';
+import { generateDevHubHref, generateDocsHref } from '../../lib/utils.js';
+import { i18n } from '../../translations/translation.js';
+import '../cc-smart-container/cc-smart-container.js';
+import './cc-addon-info.js';
+
+/**
+ * @typedef {import('./cc-addon-info.js').CcAddonInfo} CcAddonInfo
+ * @typedef {import('./cc-addon-info.types.js').AddonInfoStateLoaded} AddonInfoStateLoaded
+ * @typedef {import('./cc-addon-info.types.js').AddonInfoStateLoading} AddonInfoStateLoading
+ * @typedef {import('./cc-addon-info.types.js').AddonVersionStateUpdateAvailable} AddonVersionStateUpdateAvailable
+ * @typedef {import('./cc-addon-info.types.js').AddonVersionStateUpToDate} AddonVersionStateUpToDate
+ * @typedef {import('./cc-addon-info.types.js').AddonVersionStateRequestingUpdate} AddonVersionStateRequestingUpdate
+ * @typedef {import('./cc-addon-info.types.js').AddonInfoStateBaseProperties} AddonInfoStateBaseProperties
+ * @typedef {import('./cc-addon-info.types.js').RawAddon} RawAddon
+ * @typedef {import('./cc-addon-info.types.js').KeycloakOperatorInfo} KeycloakOperatorInfo
+ * @typedef {import('./cc-addon-info.types.js').OperatorVersionInfo} OperatorVersionInfo
+ * @typedef {import('../../lib/smart/smart-component.types.js').OnContextUpdateArgs<CcAddonInfo>} OnContextUpdateArgs
+ * @typedef {import('../../lib/send-to-api.types.js').ApiConfig} ApiConfig
+ * @typedef {import('../../lib/send-to-api.types.js').AuthBridgeConfig} AuthBridgeConfig
+ */
+
+defineSmartComponent({
+  selector: 'cc-addon-info[smart-mode="keycloak"]',
+  params: {
+    apiConfig: { type: Object },
+    ownerId: { type: String },
+    addonId: { type: String },
+    appOverviewUrlPattern: { type: String },
+    addonDashboardUrlPattern: { type: String },
+    scalabilityUrlPattern: { type: String },
+    grafanaLink: { type: Object, optional: true },
+    logsUrlPattern: { type: String },
+  },
+  /** @param {OnContextUpdateArgs} _ */
+  onContextUpdate({ context, onEvent, updateComponent, signal }) {
+    const {
+      apiConfig,
+      ownerId,
+      addonId,
+      appOverviewUrlPattern,
+      addonDashboardUrlPattern,
+      scalabilityUrlPattern,
+      grafanaLink,
+    } = context;
+    let logsUrl = '';
+
+    const api = new Api({ apiConfig, ownerId, addonId, grafanaLink, signal });
+
+    /** @type {AddonInfoStateLoading} */
+    const LOADING_STATE = {
+      type: 'loading',
+      version: {
+        stateType: 'up-to-date',
+        installed: '0.0.0',
+        latest: '0.0.0',
+      },
+      creationDate: '2025-08-06 15:03:00',
+      // if Grafana is totally disabled within the console, do not display a skeleton for grafana link
+      openGrafanaLink: grafanaLink != null ? 'https://example.com' : null,
+      openScalabilityLink: '/placeholder',
+      linkedServices: [
+        {
+          type: 'app',
+          name: 'Java',
+          logoUrl: null,
+          link: 'https://example.com',
+        },
+        {
+          type: 'addon',
+          name: 'PostgreSQL',
+          logoUrl: null,
+          link: 'https://example.com',
+        },
+        {
+          type: 'addon',
+          name: 'FS Bucket',
+          logoUrl: null,
+          link: 'https://example.com',
+        },
+      ],
+    };
+
+    updateComponent('state', LOADING_STATE);
+    updateComponent('docLink', {
+      text: i18n('cc-addon-info.doc-link.keycloak'),
+      href: generateDocsHref('/addons/keycloak'),
+    });
+
+    api
+      .getAddonInfo()
+      .then(({ operatorVersionInfo, addonInfo, grafanaAppLink, operator }) => {
+        const javaAppId = operator.resources.entrypoint;
+        logsUrl = context.logsUrlPattern.replace(':id', javaAppId);
+
+        updateComponent('state', {
+          type: 'loaded',
+          version: formatVersionState(operatorVersionInfo),
+          creationDate: addonInfo.creationDate,
+          openGrafanaLink: grafanaAppLink,
+          openScalabilityLink: scalabilityUrlPattern.replace(':id', javaAppId),
+          linkedServices: [
+            {
+              type: 'app',
+              name: 'Java',
+              logoUrl: getAssetUrl('/logos/java-jar.svg'),
+              link: appOverviewUrlPattern.replace(':id', javaAppId),
+            },
+            {
+              type: 'addon',
+              name: 'PostgreSQL',
+              logoUrl: getAssetUrl('/logos/pgsql.svg'),
+              link: addonDashboardUrlPattern.replace(':id', operator.resources.pgsqlId),
+            },
+            {
+              type: 'addon',
+              name: 'FS Bucket',
+              logoUrl: getAssetUrl('/logos/fsbucket.svg'),
+              link: addonDashboardUrlPattern.replace(':id', operator.resources.fsbucketId),
+            },
+          ],
+        });
+      })
+      .catch((error) => {
+        console.error(error);
+        updateComponent('state', { type: 'error' });
+      });
+
+    onEvent('cc-addon-version-change', (targetVersion) => {
+      updateComponent(
+        'state',
+        /** @param {AddonInfoStateLoaded & { version: AddonVersionStateUpdateAvailable | AddonVersionStateRequestingUpdate }} state */
+        (state) => {
+          state.version = {
+            ...state.version,
+            stateType: 'requesting-update',
+          };
+        },
+      );
+
+      api
+        .updateOperatorVersion(targetVersion)
+        .then(({ availableVersions }) => {
+          notifySuccess(
+            i18n('cc-addon-info.version.update.success.content', { logsUrl }),
+            i18n('cc-addon-info.version.update.success.heading', { version: targetVersion }),
+          );
+
+          updateComponent(
+            'state',
+            /** @param {AddonInfoStateLoaded} state */
+            (state) => {
+              const needUpdate = targetVersion !== state.version.latest;
+              state.version = formatVersionState({
+                installed: targetVersion,
+                available: availableVersions,
+                latest: state.version.latest,
+                needUpdate,
+              });
+            },
+          );
+        })
+        .catch((error) => {
+          updateComponent(
+            'state',
+            /** @param {AddonInfoStateLoaded & { version: AddonVersionStateUpdateAvailable | AddonVersionStateRequestingUpdate }} state */
+            (state) => {
+              state.version = {
+                ...state.version,
+                stateType: 'update-available',
+              };
+            },
+          );
+          notifyError(i18n('cc-addon-info.version.update.error'));
+          console.error(error);
+        });
+    });
+  },
+});
+
+class Api {
+  /**
+   * @param {Object} config - Configuration object
+   * @param {ApiConfig} config.apiConfig - API configuration
+   * @param {string} config.ownerId - Owner identifier
+   * @param {string} config.addonId - Addon identifier
+   * @param {{ base: string, console: string }} [config.grafanaLink] - Base url to build a grafana link to the app
+   * @param {AbortSignal} config.signal - Signal to abort calls
+   */
+  constructor({ apiConfig, ownerId, addonId, grafanaLink, signal }) {
+    this._apiConfig = apiConfig;
+    this._ownerId = ownerId;
+    this._addonId = addonId;
+    this._grafanaLink = grafanaLink;
+    this._realId = null;
+    this._signal = signal;
+  }
+
+  /** @return {Promise<RawAddon>} */
+  _getAddon() {
+    return getAddon({ id: this._ownerId, addonId: this._addonId }).then(
+      sendToApi({ apiConfig: this._apiConfig, signal: this._signal }),
+    );
+  }
+
+  /**
+   * @param {string} providerId
+   * @param {string} realId
+   * @returns {Promise<KeycloakOperatorInfo>}
+   */
+  _getOperator(providerId, realId) {
+    return getOperator({ providerId, realId }).then(sendToApi({ apiConfig: this._apiConfig, signal: this._signal }));
+  }
+
+  /** @returns {Promise<OperatorVersionInfo>} */
+  getOperatorVersionInfo() {
+    return checkOperatorVersion({ providerId: this._providerId, realId: this._realId }).then(
+      sendToApi({ apiConfig: this._apiConfig, signal: this._signal }),
+    );
+  }
+
+  /**
+   * @param {Object} parameters
+   * @param {string} parameters.appId
+   * @param {AbortSignal} parameters.signal
+   * @returns {Promise<string>}
+   */
+  _getGrafanaAppLink({ appId, signal }) {
+    return getGrafanaOrganisation({ id: this._ownerId })
+      .then(sendToApi({ apiConfig: this._apiConfig, signal }))
+      .then(
+        /** @param {{id: string}} grafanaOrg*/
+        (grafanaOrg) => {
+          const grafanaLink = new URL('/d/runtime/application-runtime', this._grafanaLink.base);
+          grafanaLink.searchParams.set('orgId', grafanaOrg.id);
+          grafanaLink.searchParams.set('var-SELECT_APP', appId);
+          return grafanaLink.toString();
+        },
+      )
+      .catch(
+        /** @param {Error & { response?: { status?: number }}} error */
+        (error) => {
+          if (error.response?.status === 404) {
+            return this._grafanaLink.console;
+          }
+          return error;
+        },
+      );
+  }
+
+  /**
+   * @param {string} targetVersion
+   * @returns {Promise<KeycloakOperatorInfo>}
+   **/
+  updateOperatorVersion(targetVersion) {
+    return updateOperatorVersion({ providerId: this._providerId, realId: this._realId }, { targetVersion }).then(
+      sendToApi({ apiConfig: this._apiConfig }),
+    );
+  }
+
+  /**
+   * @return {Promise<{addonInfo: RawAddon, operator: KeycloakOperatorInfo, operatorVersionInfo: OperatorVersionInfo, grafanaAppLink: string}>}
+   */
+  async getAddonInfo() {
+    // Fetch addon to get realId,
+    const rawAddon = await this._getAddon();
+    this._realId = rawAddon.realId;
+    this._providerId = /** @type {import('../common.types.js').RawAddonProvider} */ rawAddon.provider.id;
+    // Fetch operator with realId,
+    const [operator, operatorVersionInfo] = await Promise.all([
+      this._getOperator(this._providerId, this._realId),
+      this.getOperatorVersionInfo(),
+    ]);
+    const grafanaAppLink =
+      this._grafanaLink != null
+        ? await this._getGrafanaAppLink({ appId: operator.resources.entrypoint, signal: this._signal })
+        : null;
+
+    return { addonInfo: rawAddon, operator, operatorVersionInfo, grafanaAppLink };
+  }
+}
+
+/**
+ * @param {{ providerId: string, realId: string }} params
+ */
+function getOperator(params) {
+  // no multipath for /self or /organisations/{id}
+  return Promise.resolve({
+    method: 'get',
+    url: `/v4/addon-providers/addon-${params.providerId}/addons/${params.realId}`,
+    headers: { Accept: 'application/json' },
+    // no queryParams
+    // no body
+  });
+}
+
+/**
+ * @param {{ providerId: string, realId: string }} params
+ */
+function checkOperatorVersion(params) {
+  // no multipath for /self or /organisations/{id}
+  return Promise.resolve({
+    method: 'get',
+    url: `/v4/addon-providers/addon-${params.providerId}/addons/${params.realId}/version/check`,
+    headers: { Accept: 'application/json' },
+    // no queryParams
+    // no body
+  });
+}
+
+/**
+ * @param {object} params
+ * @param {string} params.providerId
+ * @param {string} params.realId
+ * @param {object} body
+ */
+export function updateOperatorVersion(params, body) {
+  // no multipath for /self or /organisations/{id}
+  return Promise.resolve({
+    method: 'post',
+    url: `/v4/addon-providers/addon-${params.providerId}/addons/${params.realId}/version/update`,
+    headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+    // no queryParams
+    body,
+  });
+}
+
+/**
+ * @param {OperatorVersionInfo} operatorVersionInfo
+ * @returns {AddonInfoStateLoaded['version']}
+ **/
+function formatVersionState(operatorVersionInfo) {
+  if (operatorVersionInfo.needUpdate) {
+    return {
+      stateType: 'update-available',
+      installed: operatorVersionInfo.installed,
+      available: operatorVersionInfo.available.filter((version) => version !== operatorVersionInfo.installed),
+      latest: operatorVersionInfo.latest,
+      changelogLink: `${generateDevHubHref('/changelog')}`,
+    };
+  }
+
+  return {
+    stateType: 'up-to-date',
+    installed: operatorVersionInfo.installed,
+    latest: operatorVersionInfo.latest,
+  };
+}

--- a/src/components/cc-addon-info/cc-addon-info.smart-keycloak.md
+++ b/src/components/cc-addon-info/cc-addon-info.smart-keycloak.md
@@ -1,0 +1,79 @@
+---
+kind: '🛠 Addon/<cc-addon-info>'
+title: '💡 Smart (Keycloak)'
+---
+# 💡 Smart `<cc-addon-info smart-mode="keycloak">`
+
+## ℹ️ Details
+
+<table>
+<tr><td><strong>Component    </strong> <td><a href="🛠-addons-cc-addon-info--default-story"><code>cc-addon-info</code></a>
+<tr><td><strong>Selector     </strong> <td><code>cc-addon-info[smart-mode="keycloak"]</code>
+<tr><td><strong>Requires auth</strong> <td>Yes
+</table>
+
+## ⚙️ Params
+
+| Name                          | Type          | Details                                                                                         | Default   |
+| ----------------------------- | ------------- | ----------------------------------------------------------------------------------------------- | --------- |
+| `apiConfig`                   | `ApiConfig`   | Object with API configuration (target host, tokens...)                                          |           |
+| `ownerId`                     | `string`      | UUID prefixed with orga_                                                                        |           |
+| `addonId`                     | `string`      | ID of the add-on                                                                                |           |
+| `appOverviewUrlPattern`       | `string`      | Pattern for the application overview url                                                        |           |
+| `addonDashboardUrlPattern`    | `string`      | Pattern for the addon dashboard url                                                             |           |
+| `scalabilityUrlPattern`       | `string`      | Pattern for the scalability url                                                                 |           |
+| `grafanaLink`                 | `GrafanaLink` | Grafana configuration object (may be disabled in some environments)                             | Optional  |
+| `logsUrlPattern`              | `string`      | Pattern for the logs url (Example : `/organisations/${ownerId}/applications/${appId}/logs`)     |           |
+
+```ts
+interface ApiConfig {
+  API_HOST: string;
+  API_OAUTH_TOKEN: string;
+  API_OAUTH_TOKEN_SECRET: string;
+  OAUTH_CONSUMER_KEY: string;
+  OAUTH_CONSUMER_SECRET: string;
+}
+
+interface GrafanaLink {
+  // Base used to build the URL leading to Grafana services, usually the Grafana host name
+  base: string;
+  // Console route leading to the Grafana org page where users may enable / disable Grafana
+  console: string;
+}
+```
+
+## 🌐 API endpoints
+
+| Method   | URL                                                                       | Cache?  |
+|----------|---------------------------------------------------------------------------|---------|
+| `GET`    | `/v2/organisations/${ownerId}/addons/${addonId}`                          | Default |
+| `GET`    | `/v4/addon-providers/addon-keycloak/addons/${realId}`                     | Default |
+| `GET`    | `/v4/addon-providers/addon-keycloak/addons/${realId}/version/check`       | Default |
+| `GET`    | `/v2/organisations/${ownerId}/grafana`                                    | Default |
+| `POST`   | `/v4/addon-providers/addon-${providerId}/addons/${realId}/version/update` | Default |
+
+## ⬇️️ Examples
+
+```html
+<cc-smart-container context='{
+    "apiConfig": {
+      "API_HOST": "",
+      "API_OAUTH_TOKEN": "",
+      "API_OAUTH_TOKEN_SECRET": "",
+      "OAUTH_CONSUMER_KEY": "",
+      "OAUTH_CONSUMER_SECRET": ""
+    },
+    "ownerId": "orga_XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
+    "addonId": "addon_XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX",
+    "appOverviewUrlPattern": "/organisations/orga_XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX/applications/:id",
+    "addonDashboardUrlPattern": "/organisations/orga_3547a882-d464-4c34-8168-addons/:id", 
+    "scalabilityUrlPattern": "/organisations/orga_XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX/applications/:id/settings",
+    "grafanaLink": {
+      "base": "https://grafana.services.example.com",
+      "console": "https://console.example.com/organisations/orga_XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX/grafana"
+    },
+    "logsUrlPattern": "/organisations/orga_XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX/applications/:id/logs"
+}'>
+  <cc-addon-info smart-mode="keycloak"></cc-addon-info>
+</cc-smart-container>
+```

--- a/src/components/cc-addon-info/cc-addon-info.stories.js
+++ b/src/components/cc-addon-info/cc-addon-info.stories.js
@@ -1,0 +1,544 @@
+import { generateDocsHref } from '../../lib/utils.js';
+import {
+  azimuttInfo,
+  configInfo,
+  elasticInfo,
+  jenkinsInfo,
+  keycloakInfo,
+  kubernetesInfo,
+  mailpaceInfo,
+  materiaInfo,
+  matomoInfo,
+  metabaseInfo,
+  mongodbInfo,
+  mysqlInfo,
+  otoroshiInfo,
+  postgresqlInfo,
+  pulsarInfo,
+  redisInfo,
+} from '../../stories/fixtures/addon-info.js';
+import { makeStory } from '../../stories/lib/make-story.js';
+import './cc-addon-info.js';
+
+export default {
+  tags: ['autodocs'],
+  title: '🛠 Addon/<cc-addon-info>',
+  component: 'cc-addon-info',
+};
+
+/**
+ * @typedef {import('./cc-addon-info.js').CcAddonInfo} CcAddonInfo
+ * @typedef {import('./cc-addon-info.types.js').AddonInfoStateLoaded} AddonInfoStateLoaded
+ * @typedef {import('./cc-addon-info.types.js').AddonInfoStateLoading} AddonInfoStateLoading
+ * @typedef {import('./cc-addon-info.types.js').AddonInfoStateError} AddonInfoStateError
+ */
+
+const conf = {
+  component: 'cc-addon-info',
+};
+
+export const defaultStory = makeStory(conf, {
+  /** @type {Partial<CcAddonInfo>[]} */
+  items: [
+    {
+      /** @type {AddonInfoStateLoaded} */ /** @type {AddonInfoStateLoaded} */
+      state: {
+        type: 'loaded',
+        ...matomoInfo,
+      },
+      innerHTML: `
+        <p slot="billing"><strong>This add-on is free but its dependencies, mentioned above, are billed based on their consumptions,</strong> just like other applications and add-ons.</p>
+        <p slot="linked-services"><em>The Matomo add-on is a meta add-on. It provides you with a PHP application, a MySQL add-on and a Redis add-on. They appear in your organisation just like your other applications and add-ons. You can still configure them as you like. For example, you may want to change the PHP application's domain or migrate the MySQL add-on to a bigger plan.</em></p>
+`,
+    },
+  ],
+});
+
+export const error = makeStory(conf, {
+  items: [
+    {
+      /** @type {AddonInfoStateError} */
+      state: { type: 'error' },
+    },
+  ],
+});
+
+export const waitingWithRequestingUpdate = makeStory(conf, {
+  items: [
+    {
+      /** @type {AddonInfoStateLoaded} */
+      state: {
+        type: 'loaded',
+        version: {
+          latest: '1.3.0',
+          installed: '1.2.3',
+          stateType: 'requesting-update',
+          available: ['1.2.4', '1.3.0'],
+          changelogLink: 'https://example.com/changelog',
+        },
+        plan: 'DEV',
+        features: [
+          {
+            code: 'cpu',
+            type: 'number',
+            value: '1',
+          },
+          {
+            code: 'memory',
+            type: 'bytes',
+            value: '17179869184',
+          },
+          {
+            code: 'disk-size',
+            type: 'bytes',
+            value: '483183820800',
+          },
+          {
+            code: 'connection-limit',
+            type: 'number',
+            value: '15',
+          },
+        ],
+        creationDate: '2023-01-15T10:30:00Z',
+        openGrafanaLink: 'https://grafana.example.com',
+        openScalabilityLink: 'https://scalability.example.com',
+      },
+      innerHTML: `
+        <p slot="billing"><strong>This add-on is free but its dependencies, mentioned above, are billed based on their consumptions,</strong> just like other applications and add-ons.</p>`,
+    },
+  ],
+});
+
+export const matomo = makeStory(conf, {
+  /** @type {Partial<CcAddonInfo>[]} */
+  items: [
+    {
+      /** @type {AddonInfoStateLoaded} */
+      state: {
+        type: 'loaded',
+        ...matomoInfo,
+      },
+      innerHTML: `
+        <p slot="billing"><strong>This add-on is free but its dependencies, mentioned above, are billed based on their consumptions,</strong> just like other applications and add-ons.</p>
+        <p slot="linked-services"><em>The Matomo add-on is a meta add-on. It provides you with a PHP application, a MySQL add-on and a Redis add-on. They appear in your organisation just like your other applications and add-ons. You can still configure them as you like. For example, you may want to change the PHP application's domain or migrate the MySQL add-on to a bigger plan.</em></p>
+`,
+    },
+    {
+      /** @type {AddonInfoStateLoading} */
+      state: {
+        type: 'loading',
+        ...matomoInfo,
+      },
+      innerHTML: `
+        <p slot="billing"><strong>This add-on is free but its dependencies, mentioned above, are billed based on their consumptions,</strong> just like other applications and add-ons.</p>
+        <p slot="linked-services"><em>The Matomo add-on is a meta add-on. It provides you with a PHP application, a MySQL add-on and a Redis add-on. They appear in your organisation just like your other applications and add-ons. You can still configure them as you like. For example, you may want to change the PHP application's domain or migrate the MySQL add-on to a bigger plan.</em></p>
+`,
+    },
+  ],
+});
+
+export const metabase = makeStory(conf, {
+  /** @type {Partial<CcAddonInfo>[]} */
+  items: [
+    {
+      /** @type {AddonInfoStateLoaded} */
+      state: {
+        type: 'loaded',
+        ...metabaseInfo,
+      },
+      innerHTML: `
+        <p slot="billing">Discover Metabase at no extra cost. Services and management fees are added to the price of these resources. <strong>During the discovery phase, these fees are offered free of charge.</strong></p>
+        <p slot="linked-services"><em>Metabase, easy to configure and hosted on our services, is now generally available. It deploys a Java application and a PostgreSQL add-on. You can scale them as you grow.</em></p>
+`,
+    },
+    {
+      /** @type {AddonInfoStateLoading} */
+      state: {
+        type: 'loading',
+        ...metabaseInfo,
+      },
+      innerHTML: `
+        <p slot="billing">Discover Metabase at no extra cost. Services and management fees are added to the price of these resources. <strong>During the discovery phase, these fees are offered free of charge.</strong></p>
+        <p slot="linked-services"><em>Metabase, easy to configure and hosted on our services, is now generally available. It deploys a Java application and a PostgreSQL add-on. You can scale them as you grow.</em></p>
+`,
+    },
+  ],
+});
+
+export const keycloak = makeStory(conf, {
+  /** @type {Partial<CcAddonInfo>[]} */
+  items: [
+    {
+      /** @type {AddonInfoStateLoaded} */
+      state: {
+        type: 'loaded',
+        ...keycloakInfo,
+      },
+      innerHTML: `
+        <p slot="billing">Services and management fees are added to the price of these resources.<strong>During the discovery phase, these fees are offered free of charge</strong>.</p>
+        <p slot="linked-services"><em>Keycloak, built with <a href="https://please-open.it/">Please Open It</a> and hosted on our services, is now generally available. It deploys a Java application, a PostgreSQL add-on and a FS Bucket. You can scale them as you grow.</em></p>
+`,
+    },
+    {
+      /** @type {AddonInfoStateLoading} */
+      state: {
+        type: 'loading',
+        ...keycloakInfo,
+      },
+      innerHTML: `
+        <p slot="billing">Services and management fees are added to the price of these resources.<strong>During the discovery phase, these fees are offered free of charge</strong>.</p>
+        <p slot="linked-services"><em>Keycloak, built with <a href="https://please-open.it/">Please Open It</a> and hosted on our services, is now generally available. It deploys a Java application, a PostgreSQL add-on and a FS Bucket. You can scale them as you grow.</em></p>
+`,
+    },
+  ],
+});
+
+export const otoroshi = makeStory(conf, {
+  /** @type {Partial<CcAddonInfo>[]} */
+  items: [
+    {
+      /** @type {AddonInfoStateLoaded} */
+      state: {
+        type: 'loaded',
+        ...otoroshiInfo,
+      },
+      innerHTML: `
+        <p slot="billing">Services and management fees are added to the price of these resources. <strong>During the discovery phase, these fees are offered free of charge</strong>.</p>
+        <p slot="linked-services"><em>Otoroshi, easy to configure and hosted on our services, is now generally available. It deploys a Java application and a Redis add-on. You can scale them as you grow.</em></p>
+`,
+    },
+    {
+      /** @type {AddonInfoStateLoading} */
+      state: {
+        type: 'loading',
+        ...otoroshiInfo,
+      },
+      innerHTML: `
+        <p slot="billing">Services and management fees are added to the price of these resources. <strong>During the discovery phase, these fees are offered free of charge</strong>.</p>
+        <p slot="linked-services"><em>Otoroshi, easy to configure and hosted on our services, is now generally available. It deploys a Java application and a Redis add-on. You can scale them as you grow.</em></p>
+`,
+    },
+  ],
+});
+
+export const materia = makeStory(conf, {
+  /** @type {Partial<CcAddonInfo>[]} */
+  items: [
+    {
+      /** @type {AddonInfoStateLoaded} */
+      state: {
+        type: 'loaded',
+        ...materiaInfo,
+      },
+      innerHTML: `
+        <p slot="billing">Materia KV uses our next generation of serverless distributed database, synchronously-replicated. Free of charge during testing phases, it will be available on a pay-as-you-go flexible pricing. Develop with ease, it's compatible with third-party protocols, such as Redis: <a href="${generateDocsHref('/doc/addons/materia-kv/')}">learn more.</a></p>
+`,
+    },
+    {
+      /** @type {AddonInfoStateLoading} */
+      state: {
+        type: 'loading',
+        ...materiaInfo,
+      },
+      innerHTML: `
+        <p slot="billing">Materia KV uses our next generation of serverless distributed database, synchronously-replicated. Free of charge during testing phases, it will be available on a pay-as-you-go flexible pricing. Develop with ease, it's compatible with third-party protocols, such as Redis: <a href="${generateDocsHref('/doc/addons/materia-kv/')}">learn more.</a></p>
+`,
+    },
+  ],
+});
+
+export const jenkins = makeStory(conf, {
+  /** @type {Partial<CcAddonInfo>[]} */
+  items: [
+    {
+      /** @type {AddonInfoStateLoaded} */
+      state: {
+        type: 'loaded',
+        ...jenkinsInfo,
+      },
+    },
+    {
+      /** @type {AddonInfoStateLoading} */
+      state: {
+        type: 'loading',
+        ...jenkinsInfo,
+      },
+    },
+  ],
+});
+
+export const elastic = makeStory(conf, {
+  /** @type {Partial<CcAddonInfo>[]} */
+  items: [
+    {
+      /** @type {AddonInfoStateLoaded} */
+      state: {
+        type: 'loaded',
+        ...elasticInfo,
+      },
+      innerHTML: `
+        <p slot="linked-services"><em>This add-on is part of the Elastic Stack offering. You can find and access related services above.</em></p>
+`,
+    },
+    {
+      /** @type {AddonInfoStateLoading} */
+      state: {
+        type: 'loading',
+        ...elasticInfo,
+      },
+      innerHTML: `
+        <p slot="linked-services"><em>This add-on is part of the Elastic Stack offering. You can find and access related services above.</em></p>
+`,
+    },
+  ],
+});
+
+export const pulsar = makeStory(conf, {
+  /** @type {Partial<CcAddonInfo>[]} */
+  items: [
+    {
+      /** @type {AddonInfoStateLoaded} */
+      state: {
+        type: 'loaded',
+        ...pulsarInfo,
+      },
+      innerHTML: `
+        <p slot="billing">The beta status means that the service is still being improved, but it is fully integrated into our billing system.</p>
+`,
+    },
+    {
+      /** @type {AddonInfoStateLoading} */
+      state: {
+        type: 'loading',
+        ...pulsarInfo,
+      },
+      innerHTML: `
+        <p slot="billing">The beta status means that the service is still being improved, but it is fully integrated into our billing system.</p>
+`,
+    },
+  ],
+});
+
+export const config = makeStory(conf, {
+  /** @type {Partial<CcAddonInfo>[]} */
+  items: [
+    {
+      /** @type {AddonInfoStateLoaded} */
+      state: {
+        type: 'loaded',
+        ...configInfo,
+      },
+    },
+    {
+      /** @type {AddonInfoStateLoading} */
+      state: {
+        type: 'loading',
+        ...configInfo,
+      },
+    },
+  ],
+});
+
+export const mailpace = makeStory(conf, {
+  /** @type {Partial<CcAddonInfo>[]} */
+  items: [
+    {
+      /** @type {AddonInfoStateLoaded} */
+      state: {
+        type: 'loaded',
+        ...mailpaceInfo,
+      },
+      innerHTML: `
+        <p slot="billing">This add-on is a partner product. Its invoicing is therefore entirely independent and managed by the partner. If you have any questions about this subject, please contact him.</p>
+`,
+    },
+    {
+      /** @type {AddonInfoStateLoading} */
+      state: {
+        type: 'loading',
+        ...mailpaceInfo,
+      },
+      innerHTML: `
+        <p slot="billing">This add-on is a partner product. Its invoicing is therefore entirely independent and managed by the partner. If you have any questions about this subject, please contact him.</p>
+`,
+    },
+  ],
+});
+
+export const mysql = makeStory(conf, {
+  /** @type {Partial<CcAddonInfo>[]} */
+  items: [
+    {
+      /** @type {AddonInfoStateLoaded} */
+      state: {
+        type: 'loaded',
+        ...mysqlInfo,
+      },
+    },
+    {
+      /** @type {AddonInfoStateLoading} */
+      state: {
+        type: 'loading',
+        ...mysqlInfo,
+      },
+    },
+  ],
+});
+
+export const postgresql = makeStory(conf, {
+  /** @type {Partial<CcAddonInfo>[]} */
+  items: [
+    {
+      /** @type {AddonInfoStateLoaded} */
+      state: {
+        type: 'loaded',
+        ...postgresqlInfo,
+      },
+    },
+    {
+      /** @type {AddonInfoStateLoading} */
+      state: {
+        type: 'loading',
+        ...postgresqlInfo,
+      },
+    },
+  ],
+});
+
+export const redis = makeStory(conf, {
+  /** @type {Partial<CcAddonInfo>[]} */
+  items: [
+    {
+      /** @type {AddonInfoStateLoaded} */
+      state: {
+        type: 'loaded',
+        ...redisInfo,
+      },
+    },
+    {
+      /** @type {AddonInfoStateLoading} */
+      state: {
+        type: 'loading',
+        ...redisInfo,
+      },
+    },
+  ],
+});
+
+export const mongodb = makeStory(conf, {
+  /** @type {Partial<CcAddonInfo>[]} */
+  items: [
+    {
+      /** @type {AddonInfoStateLoaded} */
+      state: {
+        type: 'loaded',
+        ...mongodbInfo,
+      },
+    },
+    {
+      /** @type {AddonInfoStateLoading} */
+      state: {
+        type: 'loading',
+        ...mongodbInfo,
+      },
+    },
+  ],
+});
+
+export const azimutt = makeStory(conf, {
+  /** @type {Partial<CcAddonInfo>[]} */
+  items: [
+    {
+      /** @type {AddonInfoStateLoaded} */
+      state: {
+        type: 'loaded',
+        ...azimuttInfo,
+      },
+      innerHTML: `
+        <p slot="billing">This add-on is a partner product. Its invoicing is therefore entirely independent and managed by the partner. If you have any questions about this subject, please contact him.</p>
+`,
+    },
+    {
+      /** @type {AddonInfoStateLoading} */
+      state: {
+        type: 'loading',
+        ...azimuttInfo,
+      },
+      innerHTML: `
+        <p slot="billing">This add-on is a partner product. Its invoicing is therefore entirely independent and managed by the partner. If you have any questions about this subject, please contact him.</p>
+`,
+    },
+  ],
+});
+
+export const kubernetes = makeStory(conf, {
+  /** @type {Partial<CcAddonInfo>[]} */
+  items: [
+    {
+      /** @type {AddonInfoStateLoaded} */
+      state: {
+        type: 'loaded',
+        ...kubernetesInfo,
+      },
+      innerHTML: `
+        <p slot="billing">Kubernetes is in Alpha phase and is therefore free during these test phases. Billing will evolve in line with the functionalities made available.</p>
+`,
+    },
+    {
+      /** @type {AddonInfoStateLoading} */
+      state: {
+        type: 'loading',
+        ...kubernetesInfo,
+      },
+      innerHTML: `
+        <p slot="billing">Kubernetes is in Alpha phase and is therefore free during these test phases. Billing will evolve in line with the functionalities made available.</p>
+`,
+    },
+  ],
+});
+
+export const updateAvailable = makeStory(conf, {
+  items: [
+    {
+      /** @type {AddonInfoStateLoaded} */
+      state: {
+        type: 'loaded',
+        version: {
+          latest: '1.3.0',
+          installed: '1.2.3',
+          stateType: 'update-available',
+          available: ['1.2.4', '1.3.0'],
+          changelogLink: 'https://example.com/changelog',
+        },
+        plan: 'DEV',
+        features: [
+          {
+            code: 'cpu',
+            type: 'number',
+            value: '1',
+          },
+          {
+            code: 'memory',
+            type: 'bytes',
+            value: '17179869184',
+          },
+          {
+            code: 'disk-size',
+            type: 'bytes',
+            value: '483183820800',
+          },
+          {
+            code: 'connection-limit',
+            type: 'number',
+            value: '15',
+          },
+        ],
+        creationDate: '2023-01-15T10:30:00Z',
+        openGrafanaLink: 'https://grafana.example.com',
+        openScalabilityLink: 'https://scalability.example.com',
+      },
+      innerHTML: `
+        <p slot="billing"><strong>This add-on is free but its dependencies, mentioned above, are billed based on their consumptions,</strong> just like other applications and add-ons.</p>`,
+    },
+  ],
+});

--- a/src/components/cc-addon-info/cc-addon-info.types.d.ts
+++ b/src/components/cc-addon-info/cc-addon-info.types.d.ts
@@ -1,0 +1,150 @@
+import { FormattedFeature, RawAddonProvider } from '../common.types.js';
+
+export type AddonInfoState = AddonInfoStateLoaded | AddonInfoStateLoading | AddonInfoStateError;
+
+export interface AddonInfoStateLoaded extends AddonInfoStateBaseProperties {
+  type: 'loaded';
+}
+
+export interface AddonInfoStateLoading extends AddonInfoStateBaseProperties {
+  type: 'loading';
+}
+
+export interface AddonInfoStateError {
+  type: 'error';
+}
+
+export interface AddonInfoStateBaseProperties {
+  version?: AddonVersionState;
+  plan?: string;
+  features?: Array<FormattedFeature>;
+  creationDate: string | number;
+  role?: string;
+  openGrafanaLink?: string;
+  openScalabilityLink?: string;
+  linkedServices?: Array<LinkedService>;
+  docUrlLink?: string;
+}
+
+export type AddonVersionState =
+  | AddonVersionStateUpToDate
+  | AddonVersionStateRequestingUpdate
+  | AddonVersionStateUpdateAvailable;
+
+export interface AddonVersionStateUpToDate extends AddonVersion {
+  stateType: 'up-to-date';
+}
+
+export interface AddonVersionStateRequestingUpdate extends AddonVersion {
+  stateType: 'requesting-update';
+  available: Array<string>;
+  changelogLink: string;
+}
+
+export interface AddonVersionStateUpdateAvailable extends AddonVersion {
+  stateType: 'update-available';
+  available: Array<string>;
+  changelogLink: string;
+}
+
+export type AddonVersion = {
+  installed: string;
+  latest: string;
+};
+
+export interface LinkedService {
+  type: 'addon' | 'app';
+  name: string;
+  logoUrl: string;
+  link: string;
+}
+
+interface AddonPlan {
+  name: string;
+  features?: {
+    name: string;
+    type: 'BOOLEAN' | 'BOOLEAN_SHARED' | 'NUMBER_CPU_RUNTIME' | 'OBJECT' | 'SHARED' | 'BYTES' | 'NUMBER' | 'STRING';
+    value: string;
+    computable_value: string;
+    name_code: string;
+  }[];
+}
+
+export type AddonProvider = Pick<RawAddonProvider, 'id' | 'name' | 'logoUrl'>;
+
+// Copies from cc-header-addon-beta, will need to mutualize
+export interface RawAddon {
+  id: string;
+  name: string;
+  realId: string;
+  region: string;
+  zoneId: string;
+  provider: AddonProvider;
+  plan: AddonPlan;
+  creationDate: number;
+  configKeys: string[];
+}
+
+export interface KeycloakOperatorInfo {
+  resourceId: string;
+  addonId: string;
+  name: string;
+  ownerId: string;
+  plan: string;
+  version: string;
+  javaVersion: string;
+  accessUrl: string;
+  availableVersions: string[];
+  resources: {
+    entrypoint: string;
+    fsbucketId: string;
+    pgsqlId: string;
+  };
+  features: {
+    networkGroup: null;
+  };
+  envVars: Record<string, string>;
+}
+
+export interface OperatorVersionInfo {
+  available: string[];
+  installed: string;
+  latest: string;
+  needUpdate: boolean;
+}
+
+export interface ElasticAddonInfo {
+  id: string;
+  app_id: string;
+  plan: string;
+  zone: string;
+  config: {
+    host: string;
+    user: string;
+    password: string;
+    apm_user: string;
+    apm_password: string;
+    apm_auth_token: string;
+    kibana_user: string;
+    kibana_password: string;
+  };
+  owner_id: string;
+  version: string;
+  backups: {
+    kibana_snapshots_url: string;
+  };
+  kibana_application: string;
+  apm_application: string;
+  services: [
+    {
+      name: string;
+      enabled: boolean;
+    },
+  ];
+  features: [
+    {
+      name: string;
+      enabled: boolean;
+    },
+  ];
+}

--- a/src/lib/events-map.types.d.ts
+++ b/src/lib/events-map.types.d.ts
@@ -9,6 +9,7 @@ import {
   CcNgEnable,
 } from '../components/cc-addon-credentials-content/cc-addon-credentials-content.events.js';
 import { CcAddonRebuildEvent, CcAddonRestartEvent } from '../components/cc-addon-header/cc-addon-header.events.js';
+import { CcAddonVersionChangeEvent } from '../components/cc-addon-info/cc-addon-info.events.js';
 import { CcAddonOptionFormSubmitEvent } from '../components/cc-addon-option-form/cc-addon-option-form.events.js';
 import { CcAddonOptionChangeEvent } from '../components/cc-addon-option/cc-addon-option.events.js';
 import {
@@ -167,6 +168,7 @@ declare global {
     'cc-addon-rebuild': CcAddonRebuildEvent;
     'cc-addon-restart': CcAddonRestartEvent;
     'cc-addon-tags-change': CcAddonTagsChangeEvent;
+    'cc-addon-version-change': CcAddonVersionChangeEvent;
     'cc-api-error': CcApiErrorEvent;
     'cc-application-restart': CcApplicationRestartEvent;
     'cc-application-start': CcApplicationStartEvent;

--- a/src/stories/fixtures/addon-info.js
+++ b/src/stories/fixtures/addon-info.js
@@ -1,0 +1,409 @@
+import { getAssetUrl } from '../../lib/assets-url.js';
+import { generateDevHubHref, generateDocsHref } from '../../lib/utils.js';
+
+/**
+ * @typedef {import('../../components/cc-addon-info/cc-addon-info.types.js').AddonInfoStateBaseProperties} AddonInfoStateBaseProperties
+ */
+
+/** @type {AddonInfoStateBaseProperties} */
+export const matomoInfo = {
+  version: {
+    installed: '5.3.0',
+    stateType: 'up-to-date',
+  },
+  creationDate: '2025-06-15T10:30:00Z',
+  openGrafanaLink: 'https://grafana.example.com',
+  openScalabilityLink: 'https://scalability.example.com',
+  linkedServices: [
+    {
+      type: 'app',
+      name: 'PHP',
+      logoUrl: getAssetUrl('/logos/php.svg'),
+      link: 'https://example.com/app',
+    },
+    {
+      type: 'addon',
+      name: 'MySQL add-on',
+      logoUrl: getAssetUrl('/logos/mysql.svg'),
+      link: 'https://example.com/addon',
+    },
+    {
+      type: 'addon',
+      name: 'Redis add-on',
+      logoUrl: getAssetUrl('/logos/redis.svg'),
+      link: 'https://example.com/addon',
+    },
+  ],
+  docUrlLink: generateDocsHref('addons/matomo'),
+}
+
+/** @type {AddonInfoStateBaseProperties} */
+export const metabaseInfo = {
+  version: {
+    installed: '55',
+    stateType: 'up-to-date',
+  },
+  creationDate: '2025-06-15T10:30:00Z',
+  openGrafanaLink: 'https://grafana.example.com',
+  openScalabilityLink: 'https://scalability.example.com',
+  linkedServices: [
+    {
+      type: 'app',
+      name: 'Java',
+      logoUrl: getAssetUrl('/logos/java-jar.svg'),
+      link: 'https://example.com/app',
+    },
+    {
+      type: 'addon',
+      name: 'PostgreSQL add-on',
+      logoUrl: getAssetUrl('/logos/pgsql.svg'),
+      link: 'https://example.com/addon',
+    },
+  ],
+  docUrlLink: generateDocsHref('addons/metabase'),
+}
+
+/** @type {AddonInfoStateBaseProperties} */
+export const keycloakInfo = {
+  version: {
+    installed: '26.3.0',
+    stateType: 'up-to-date',
+  },
+  creationDate: '2025-06-15T10:30:00Z',
+  openGrafanaLink: 'https://grafana.example.com',
+  openScalabilityLink: 'https://scalability.example.com',
+  linkedServices: [
+    {
+      type: 'app',
+      name: 'Java',
+      logoUrl: getAssetUrl('/logos/java-jar.svg'),
+      link: 'https://example.com/app',
+    },
+    {
+      type: 'addon',
+      name: 'PostgreSQL add-on',
+      logoUrl: getAssetUrl('/logos/pgsql.svg'),
+      link: 'https://example.com/addon',
+    },
+    {
+      type: 'addon',
+      name: 'FS Bucket add-on',
+      logoUrl: getAssetUrl('/logos/fsbucket.svg'),
+      link: 'https://example.com/addon',
+    },
+  ],
+  docUrlLink: generateDocsHref('addons/keycloak'),
+}
+
+/** @type {AddonInfoStateBaseProperties} */
+export const otoroshiInfo = {
+  version: {
+    installed: '17.4.0',
+    stateType: 'up-to-date',
+  },
+  creationDate: '2025-06-15T10:30:00Z',
+  openGrafanaLink: 'https://grafana.example.com',
+  openScalabilityLink: 'https://scalability.example.com',
+  linkedServices: [
+    {
+      type: 'app',
+      name: 'Java',
+      logoUrl: getAssetUrl('/logos/java-jar.svg'),
+      link: 'https://example.com/app',
+    },
+    {
+      type: 'addon',
+      name: 'Redis add-on',
+      logoUrl: getAssetUrl('/logos/redis.svg'),
+      link: 'https://example.com/addon',
+    },
+  ],
+  docUrlLink: generateDocsHref('addons/otoroshi'),
+}
+
+/** @type {AddonInfoStateBaseProperties} */
+export const materiaInfo = {
+  creationDate: '2025-06-15T10:30:00Z',
+  docUrlLink: generateDocsHref('addons/materia-kv'),
+}
+
+/** @type {AddonInfoStateBaseProperties} */
+export const jenkinsInfo = {
+  version: {
+    installed: '2.516.2',
+    stateType: 'up-to-date',
+  },
+  plan: 'XXS',
+  features: [
+    {
+      code: 'cpu',
+      type: 'number',
+      value: '2',
+    },
+    {
+      code: 'memory',
+      type: 'bytes',
+      value: '4294967296',
+    },
+    {
+      code: 'disk-size',
+      type: 'bytes',
+      value: '42949672960',
+    },
+    {
+      code: 'encryption-at-rest',
+      type: 'boolean',
+      value: 'true',
+    },
+  ],
+  creationDate: '2025-06-15T10:30:00Z',
+  docUrlLink: generateDocsHref('addons/jenkins'),
+}
+
+/** @type {AddonInfoStateBaseProperties} */
+export const elasticInfo = {
+  version: {
+    installed: '9.1.2',
+    stateType: 'up-to-date',
+  },
+  plan: 'M',
+  features: [
+    {
+      code: 'cpu',
+      type: 'number',
+      value: '2',
+    },
+    {
+      code: 'memory',
+      type: 'bytes',
+      value: '4294967296',
+    },
+    {
+      code: 'disk-size',
+      type: 'bytes',
+      value: '128849018880',
+    },
+    {
+      code: 'encryption-at-rest',
+      type: 'boolean',
+      value: 'true',
+    },
+  ],
+  creationDate: '2025-06-15T10:30:00Z',
+  openGrafanaLink: 'https://grafana.example.com',
+  openScalabilityLink: 'https://scalability.example.com',
+  linkedServices: [
+    {
+      type: 'app',
+      name: 'Kibana',
+      logoUrl: getAssetUrl('/logos/elasticsearch-kibana.svg'),
+      link: 'https://example.com/app',
+    },
+    {
+      type: 'app',
+      name: 'APM',
+      logoUrl: getAssetUrl('/logos/elasticsearch-apm.svg'),
+      link: 'https://example.com/addon',
+    },
+  ],
+  docUrlLink: generateDocsHref('addons/elastic'),
+}
+
+/** @type {AddonInfoStateBaseProperties} */
+export const pulsarInfo = {
+  version: {
+    installed: '4.0.6',
+    stateType: 'up-to-date',
+  },
+  creationDate: '2025-06-15T10:30:00Z',
+  docUrlLink: generateDocsHref('addons/pulsar'),
+}
+
+/** @type {AddonInfoStateBaseProperties} */
+export const configInfo = {
+  creationDate: '2025-06-15T10:30:00Z',
+  docUrlLink: generateDocsHref('addons/config-provider'),
+}
+
+/** @type {AddonInfoStateBaseProperties} */
+export const mailpaceInfo = {
+  plan: 'XS',
+  creationDate: '2025-06-15T10:30:00Z',
+  docUrlLink: generateDocsHref('addons/mailpace'),
+}
+
+/** @type {AddonInfoStateBaseProperties} */
+export const mysqlInfo = {
+  version: {
+    installed: '8.0.44',
+    stateType: 'up-to-date',
+  },
+  plan: 'XXS_SML',
+  features: [
+    {
+      code: 'cpu',
+      type: 'number',
+      value: '1',
+    },
+    {
+      code: 'memory',
+      type: 'bytes',
+      value: '536870912',
+    },
+    {
+      code: 'connection-limit',
+      type: 'number',
+      value: '15',
+    },
+    {
+      code: 'max-db-size',
+      type: 'bytes',
+      value: '536870912',
+    },
+  ],
+  creationDate: '2025-06-15T10:30:00Z',
+  docUrlLink: generateDocsHref('addons/mysql'),
+}
+
+/** @type {AddonInfoStateBaseProperties} */
+export const postgresqlInfo = {
+  version: {
+    installed: '17.6',
+    stateType: 'up-to-date',
+  },
+  plan: 'XXS_SML',
+  features: [
+    {
+      code: 'cpu',
+      type: 'number',
+      value: '1',
+    },
+    {
+      code: 'memory',
+      type: 'bytes',
+      value: '536870912',
+    },
+    {
+      code: 'connection-limit',
+      type: 'number',
+      value: '45',
+    },
+    {
+      code: 'max-db-size',
+      type: 'bytes',
+      value: '1073741824',
+    },
+    {
+      code: 'encryption-at-rest',
+      type: 'boolean',
+      value: 'true',
+    },
+  ],
+  creationDate: '2025-06-15T10:30:00Z',
+  role: 'Primary',
+  docUrlLink: generateDocsHref('addons/postgresql'),
+}
+
+/** @type {AddonInfoStateBaseProperties} */
+export const redisInfo = {
+  version: {
+    installed: '8.2.1',
+    stateType: 'up-to-date',
+  },
+  plan: 'S',
+  features: [
+    {
+      code: 'cpu',
+      type: 'number',
+      value: '1',
+    },
+    {
+      code: 'disk-size',
+      type: 'bytes',
+      value: '134217728',
+    },
+    {
+      code: 'connection-limit',
+      type: 'number',
+      value: '100',
+    },
+    {
+      code: 'databases',
+      type: 'number',
+      value: '1',
+    },
+    {
+      code: 'encryption-at-rest',
+      type: 'boolean',
+      value: 'true',
+    },
+  ],
+  creationDate: '2025-06-15T10:30:00Z',
+  docUrlLink: generateDocsHref('addons/redis'),
+}
+
+/** @type {AddonInfoStateBaseProperties} */
+export const mongodbInfo = {
+  version: {
+    installed: '8.0',
+    stateType: 'up-to-date',
+  },
+  plan: 'S',
+  features: [
+    {
+      code: 'cpu',
+      type: 'number',
+      value: '2',
+    },
+    {
+      code: 'memory',
+      type: 'bytes',
+      value: '2147483648',
+    },
+    {
+      code: 'max-db-size',
+      type: 'bytes',
+      value: '16106127360',
+    },
+    {
+      code: 'encryption-at-rest',
+      type: 'boolean',
+      value: 'true',
+    },
+  ],
+  creationDate: '2025-06-15T10:30:00Z',
+  docUrlLink: generateDocsHref('addons/mongodb'),
+}
+
+/** @type {AddonInfoStateBaseProperties} */
+export const azimuttInfo = {
+  plan: 'BASIC',
+  features: [
+    {
+      code: 'users',
+      type: 'number',
+      value: '1',
+    },
+    {
+      code: 'data-exploration',
+      type: 'boolean',
+      value: 'true',
+    },
+    {
+      code: 'db-analysis',
+      type: 'string',
+      value: 'PREVIEW',
+    },
+  ],
+  creationDate: '2025-06-15T10:30:00Z',
+}
+
+/** @type {AddonInfoStateBaseProperties} */
+export const kubernetesInfo = {
+  version: {
+    installed: '1.33',
+    stateType: 'up-to-date',
+  },
+  creationDate: '2025-06-15T10:30:00Z',
+  docUrlLink: generateDevHubHref('guides/kubernetes-operator/'),
+}

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -271,6 +271,67 @@ export const translations = {
   'cc-addon-header.state-msg.deployment-is-deploying': `Your add-on is deploying…`,
   'cc-addon-header.state-msg.unknown-state': `Unknown state, try to restart the add-on or contact our support if you have additional questions.`,
   //#endregion
+  //#region cc-addon-info
+  'cc-addon-info.billing.heading': `Billing`,
+  'cc-addon-info.creation-date.heading': `Creation date`,
+  'cc-addon-info.creation-date.human-friendly-date': /** @param {{ date: string | number }} _ */ ({ date }) =>
+    formatDatetime(date),
+  'cc-addon-info.doc-link.keycloak': `Keycloak - Documentation`,
+  'cc-addon-info.error': `Something went wrong while loading add-on information.`,
+  'cc-addon-info.feature.connection-limit': `Connection limit`,
+  'cc-addon-info.feature.cpu': `vCPUs`,
+  'cc-addon-info.feature.data-exploration': `Data Exploration`,
+  'cc-addon-info.feature.databases': `Databases`,
+  'cc-addon-info.feature.db-analysis': `DB Analysis`,
+  'cc-addon-info.feature.dedicated': `Dedicated`,
+  'cc-addon-info.feature.disk-size': `Disk size`,
+  'cc-addon-info.feature.encryption-at-rest': `Encryption at rest`,
+  'cc-addon-info.feature.gpu': `GPUs`,
+  'cc-addon-info.feature.has-logs': `Logs`,
+  'cc-addon-info.feature.has-metrics': `Metrics`,
+  'cc-addon-info.feature.heading': `Features`,
+  'cc-addon-info.feature.is-migratable': `Migration tool`,
+  'cc-addon-info.feature.max-db-size': `Max DB size`,
+  'cc-addon-info.feature.memory': `RAM`,
+  'cc-addon-info.feature.users': `Users`,
+  'cc-addon-info.feature.version': `Version`,
+  'cc-addon-info.grafana.link': `Open Grafana`,
+  'cc-addon-info.heading': `Information`,
+  'cc-addon-info.linked-services.heading': `Linked services`,
+  'cc-addon-info.plan.heading': `Plan`,
+  'cc-addon-info.role.heading': `Role`,
+  'cc-addon-info.scalability-link.heading': `Scalability`,
+  'cc-addon-info.scalability.link': `Configure scalability`,
+  'cc-addon-info.service.name.addon': /** @param {{name: string}} _ */ ({ name }) => `${name} add-on`,
+  'cc-addon-info.service.name.app': /** @param {{name: string}} _ */ ({ name }) => `${name} application`,
+  'cc-addon-info.type.boolean': /** @param {{boolean: boolean}} _ */ ({ boolean }) => `${boolean ? 'Yes' : 'No'}`,
+  'cc-addon-info.type.boolean-shared': /** @param {{shared: boolean}} _ */ ({ shared }) =>
+    `${shared ? 'Shared' : 'Dedicated'}`,
+  'cc-addon-info.type.bytes': /** @param {{bytes: number}} _ */ ({ bytes }) => formatBytes(bytes, 0, 3),
+  'cc-addon-info.type.number': /** @param {{number: number}} _ */ ({ number }) => formatNumber(lang, number),
+  'cc-addon-info.type.number-cpu-runtime': /** @param {{cpu: number, shared: boolean}} _ */ ({ cpu, shared }) => {
+    return shared
+      ? sanitize`<em title="Lower priority access to vCPU">${formatNumber(lang, cpu)}<code>*</code></em>`
+      : formatNumber(lang, cpu);
+  },
+  'cc-addon-info.version.btn': `Update available`,
+  'cc-addon-info.version.dialog.btn.cancel': `Cancel`,
+  'cc-addon-info.version.dialog.btn.submit': `Update and rebuild`,
+  'cc-addon-info.version.dialog.close': `Close`,
+  'cc-addon-info.version.dialog.desc': /** @param {{ url: string }} _ */ ({ url }) =>
+    sanitize`One or more new versions are available. Choose the version you wish to apply and confirm to start and rebuild the application. Learn more in our <cc-link href="${url}">Changelog</cc-link>.`,
+  'cc-addon-info.version.dialog.heading': `Update available`,
+  'cc-addon-info.version.dialog.select.desc': `Version from`,
+  'cc-addon-info.version.dialog.select.help': /** @param {{ currentVersion: string }} _ */ ({ currentVersion }) =>
+    `Select the target version to update from ${currentVersion}`,
+  'cc-addon-info.version.dialog.select.label': () => sanitize`<strong>to</strong>`,
+  'cc-addon-info.version.heading': `Version`,
+  'cc-addon-info.version.update.error': `Something went wrong while updating the version`,
+  'cc-addon-info.version.update.success.content': /** @param {{logsUrl: string}} _*/ ({ logsUrl }) =>
+    sanitize`An update and rebuild phase is in progress. See the application live <cc-link href="${logsUrl}">logs</cc-link>.`,
+  'cc-addon-info.version.update.success.heading': /** @param {{ version: string }} _ */ ({ version }) =>
+    `Update to ${version} in progress`,
+  //#endregion
   //#region cc-addon-jenkins-options
   'cc-addon-jenkins-options.description': `Choose the options you want for your Jenkins add-on.`,
   'cc-addon-jenkins-options.title': `Options for the Jenkins add-on`,

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -282,6 +282,67 @@ export const translations = {
   'cc-addon-header.state-msg.deployment-is-deploying': `L'add-on est en cours de déploiement…`,
   'cc-addon-header.state-msg.unknown-state': `État inconnu, essayez de redémarrer l'add-on ou de contacter notre support si vous avez des questions.`,
   //#endregion
+  //#region cc-addon-info
+  'cc-addon-info.billing.heading': `Facturation`,
+  'cc-addon-info.creation-date.heading': `Date de création`,
+  'cc-addon-info.creation-date.human-friendly-date': /** @param {{ date: string | number }} _ */ ({ date }) =>
+    formatDatetime(date),
+  'cc-addon-info.doc-link.keycloak': `Keycloak - Documentation`,
+  'cc-addon-info.error': `Une erreur est survenue pendant le chargement des informations de l'add-on.`,
+  'cc-addon-info.feature.connection-limit': `Limite de connexions`,
+  'cc-addon-info.feature.cpu': `vCPUs`,
+  'cc-addon-info.feature.data-exploration': `Exploration des données`,
+  'cc-addon-info.feature.databases': `Bases de données`,
+  'cc-addon-info.feature.db-analysis': `Analyse BDD`,
+  'cc-addon-info.feature.dedicated': `Dédié`,
+  'cc-addon-info.feature.disk-size': `Taille du disque`,
+  'cc-addon-info.feature.encryption-at-rest': `Chiffrement au repos`,
+  'cc-addon-info.feature.gpu': `GPUs`,
+  'cc-addon-info.feature.has-logs': `Logs`,
+  'cc-addon-info.feature.has-metrics': `Métriques`,
+  'cc-addon-info.feature.heading': `Fonctionnalités`,
+  'cc-addon-info.feature.is-migratable': `Outil de migration`,
+  'cc-addon-info.feature.max-db-size': `Taille BDD max`,
+  'cc-addon-info.feature.memory': `RAM`,
+  'cc-addon-info.feature.users': `Utilisateurs`,
+  'cc-addon-info.feature.version': `Version`,
+  'cc-addon-info.grafana.link': `Ouvrir Grafana`,
+  'cc-addon-info.heading': `Informations`,
+  'cc-addon-info.linked-services.heading': `Services liés`,
+  'cc-addon-info.plan.heading': `Plan`,
+  'cc-addon-info.role.heading': `Rôle`,
+  'cc-addon-info.scalability-link.heading': `Scalabilité`,
+  'cc-addon-info.scalability.link': `Configurer la scalabilité`,
+  'cc-addon-info.service.name.addon': /** @param {{name: string}} _ */ ({ name }) => `Add-on ${name}`,
+  'cc-addon-info.service.name.app': /** @param {{name: string}} _ */ ({ name }) => `Application ${name}`,
+  'cc-addon-info.type.boolean': /** @param {{boolean: boolean}} _ */ ({ boolean }) => `${boolean ? 'Oui' : 'Non'}`,
+  'cc-addon-info.type.boolean-shared': /** @param {{shared: boolean}} _ */ ({ shared }) =>
+    `${shared ? 'Partagé' : 'Dédié'}`,
+  'cc-addon-info.type.bytes': /** @param {{bytes: number}} _ */ ({ bytes }) => formatBytes(bytes, 0, 3),
+  'cc-addon-info.type.number': /** @param {{number: number}} _ */ ({ number }) => formatNumber(lang, number),
+  'cc-addon-info.type.number-cpu-runtime': /** @param {{cpu: number, shared: boolean}} _ */ ({ cpu, shared }) => {
+    return shared
+      ? sanitize`<em title="Accès au vCPU moins prioritaire">${formatNumber(lang, cpu)}<code>*</code></em>`
+      : formatNumber(lang, cpu);
+  },
+  'cc-addon-info.version.btn': `Mise à jour disponible`,
+  'cc-addon-info.version.dialog.btn.cancel': `Annuler`,
+  'cc-addon-info.version.dialog.btn.submit': `Mettre à jour et rebuild`,
+  'cc-addon-info.version.dialog.close': `Fermer`,
+  'cc-addon-info.version.dialog.desc': /** @param {{ url: string }} _ */ ({ url }) =>
+    sanitize`Une ou plusieurs nouvelles versions sont disponibles. Choisissez la version que vous souhaitez appliquer et confirmez pour rebuild et redémarrer application. Consultez notre <cc-link href="${url}">Changelog</cc-link> pour en savoir plus.`,
+  'cc-addon-info.version.dialog.heading': `Mise à jour disponible`,
+  'cc-addon-info.version.dialog.select.desc': `Version actuelle`,
+  'cc-addon-info.version.dialog.select.help': /** @param {{ currentVersion: string }} _ */ ({ currentVersion }) =>
+    `Sélectionnez la version cible à mettre à jour à partir de ${currentVersion}`,
+  'cc-addon-info.version.dialog.select.label': () => sanitize`<strong>vers</strong>`,
+  'cc-addon-info.version.heading': `Version`,
+  'cc-addon-info.version.update.error': `Une erreur est survenue pendant la mise à jour de la version`,
+  'cc-addon-info.version.update.success.content': /** @param {{logsUrl: string}} _*/ ({ logsUrl }) =>
+    sanitize`La mise à jour et le redémarrage de l'application est en cours. Consultez les <cc-link href="${logsUrl}">logs</cc-link>.`,
+  'cc-addon-info.version.update.success.heading': /** @param {{ version: string }} _ */ ({ version }) =>
+    `Mise à jour vers "${version}" en cours`,
+  //#endregion
   //#region cc-addon-jenkins-options
   'cc-addon-jenkins-options.description': `Sélectionnez les options que vous souhaitez pour votre add-on Jenkins.`,
   'cc-addon-jenkins-options.title': `Options pour l'add-on Jenkins`,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -97,7 +97,8 @@
           "copy",
           "paste",
           "transitionend"
-        ]
+        ],
+        "globalAttributes": ["closedby"]
       }
     ]
   }


### PR DESCRIPTION
## What does this PR do?

- Adds a new component:
  - `cc-addon-info` which display information of an add-on.
- Adds a smart component for keycloak info.

## How to review?

- Check the commits,
- Play with the stories in [preview](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-addon-info/init/index.html?path=/docs/%F0%9F%9B%A0-addon-cc-addon-info--docs).
- QA is available [here](https://www.notion.so/cc-addon-info-261fe1a33d388061bb7deb9c298ac139)
- The component is available on [staging-six](https://console-staging-six.cleverapps.io/organisations/orga_3547a882-d464-4c34-8168-add4b3e0c135/addons/addon_b0156348-3825-4026-895a-bcaacafc4746).

## TODO

- [x] Add QA