### PR TITLE
fix(cc-env-var-form.smart-env-var-app): set timeout for restart toast

### DIFF
--- a/src/components/cc-env-var-form/cc-env-var-form.smart-env-var-app.js
+++ b/src/components/cc-env-var-form/cc-env-var-form.smart-env-var-app.js
@@ -3,7 +3,7 @@
 import { getAllDeployments,getAllEnvVars,redeploy,updateAllEnvVars } from '@clevercloud/client/esm/api/v2/application.js';
 // @ts-expect-error FIXME: remove when clever-client exports types
 import { toNameValueObject } from '@clevercloud/client/esm/utils/env-vars.js';
-import { notify, notifyError, notifySuccess } from '../../lib/notifications.js';
+import { notifyError, notifySuccess } from '../../lib/notifications.js';
 import { sendToApi } from '../../lib/send-to-api.js';
 import { defineSmartComponent } from '../../lib/smart/define-smart-component.js';
 import { i18n } from '../../translations/translation.js';
@@ -107,15 +107,10 @@ defineSmartComponent({
         .then(() => {
           updateComponent('restartApp', false);
 
-          notify({
-            intent: 'success',
-            message: i18n('cc-env-var-form.redeploy.success.text', { logsUrl: logsUrlPattern.replace(':id', appId) }),
-            title: i18n('cc-env-var-form.redeploy.success.heading'),
-            options: {
-              timeout: 0,
-              closeable: true,
-            },
-          });
+          notifySuccess(
+            i18n('cc-env-var-form.redeploy.success.text', { logsUrl: logsUrlPattern.replace(':id', appId) }),
+            i18n('cc-env-var-form.redeploy.success.heading'),
+          );
         })
         .catch((/** @type {Error & { id: number }} */ error) => {
           console.error(error);


### PR DESCRIPTION
Fixes #1520

## What does this PR do?

- Relies on a standard toast with timeout for the restart feature within the `cc-env-var-form.smart-env-var-app` component.

The toast contains a link which is why I went for no timeout initially but the link is available from the menu anyway and it's annoying to force users to close this toast manually in this case.

## How to review?

- Run locally and go check the `demo-smart` > env-var-form-app > app-node,
  - Modify  or add some env var, update and then restart using the button => the toast should have the default timeout.
- 1 reviewer is enough for this one.