### PR TITLE
feat(cc-link): add `download` attribute to handle download links

### DIFF
--- a/src/components/cc-link/cc-link.js
+++ b/src/components/cc-link/cc-link.js
@@ -1,7 +1,7 @@
 import { css, html, LitElement } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { iconRemixExternalLinkLine as externalLinkIcon } from '../../assets/cc-remix.icons.js';
+import { iconRemixExternalLinkLine as externalLinkIcon, iconRemixDownloadLine } from '../../assets/cc-remix.icons.js';
 import { isStringEmpty } from '../../lib/utils.js';
 import { skeletonStyles } from '../../styles/skeleton.js';
 import { i18n } from '../../translations/translation.js';
@@ -33,6 +33,7 @@ export class CcLink extends LitElement {
     return {
       a11yDesc: { type: String, attribute: 'a11y-desc' },
       disableExternalLinkIcon: { type: Boolean, attribute: 'disable-external-link-icon' },
+      download: { type: String },
       href: { type: String },
       icon: { type: Object },
       iconA11yName: { type: String, attribute: 'icon-a11y-name' },
@@ -52,6 +53,9 @@ export class CcLink extends LitElement {
 
     /** @type {boolean} Disables the external link icon. */
     this.disableExternalLinkIcon = false;
+
+    /** @type {string|null} If set, enables `download` attribute value on the inner native `<a>` element. */
+    this.download = null;
 
     /** @type {string} The URL for the link. */
     this.href = '';
@@ -150,7 +154,13 @@ export class CcLink extends LitElement {
         ${this.icon != null
           ? html` <cc-icon class="cc-link__icon" .icon="${this.icon}" a11y-name="${this.iconA11yName}"></cc-icon> `
           : ''}
-        <a href=${ifDefined(href)} target=${ifDefined(target)} rel=${ifDefined(rel)} title="${ifDefined(title)}">
+        <a
+          href=${ifDefined(href)}
+          target=${ifDefined(target)}
+          rel=${ifDefined(rel)}
+          title="${ifDefined(title)}"
+          download=${ifDefined(this.download)}
+        >
           <span class="link-slot">
             <slot @slotchange="${this._onSlotChange}"></slot>
           </span>
@@ -159,6 +169,12 @@ export class CcLink extends LitElement {
                 class="cc-link__external-icon"
                 .icon=${externalLinkIcon}
                 a11y-name=${i18n('cc-link.new-window.name')}
+              ></cc-icon>`
+            : ''}
+          ${this.download != null
+            ? html`<cc-icon
+                .icon=${iconRemixDownloadLine}
+                a11y-name=${i18n('cc-link.download.icon-a11y-name')}
               ></cc-icon>`
             : ''}
         </a>

--- a/src/components/cc-link/cc-link.stories.js
+++ b/src/components/cc-link/cc-link.stories.js
@@ -83,6 +83,33 @@ export const buttonWithFullWidth = makeStory(conf, {
   ],
 });
 
+export const downloadLink = makeStory(conf, {
+  items: [
+    {
+      href: '/path/to/invoice.pdf',
+      download: 'invoice.pdf',
+      innerHTML: '',
+    },
+    {
+      href: '/path/to/invoice.pdf',
+      download: 'invoice.pdf',
+      innerHTML: 'Download PDF',
+    },
+    {
+      href: '/path/to/invoice.pdf',
+      download: 'invoice.pdf',
+      innerHTML: 'Download PDF',
+      skeleton: true,
+    },
+    {
+      mode: 'button',
+      href: '/path/to/config.json',
+      download: 'config.json',
+      innerHTML: 'Get config',
+    },
+  ],
+});
+
 export const withA11yDesc = makeStory(conf, {
   items: [
     {

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -865,6 +865,7 @@ export const translations = {
   'cc-kv-terminal.warning': `All commands executed in this terminal are immediately sent to the database`,
   //#endregion
   //#region cc-link
+  'cc-link.download.icon-a11y-name': `Download`,
   'cc-link.new-window.name': `new window`,
   'cc-link.new-window.title': /** @param {{linkText: string}} _ */ ({ linkText }) => `${linkText} - new window`,
   //#endregion

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -877,6 +877,7 @@ export const translations = {
   'cc-kv-terminal.warning': `Les commandes exécutées dans ce terminal sont directement envoyées à la base de données`,
   //#endregion
   //#region cc-link
+  'cc-link.download.icon-a11y-name': `Télécharger`,
   'cc-link.new-window.name': `nouvelle fenêtre`,
   'cc-link.new-window.title': /** @param {{linkText: string}} _ */ ({ linkText }) => `${linkText} - nouvelle fenêtre`,
   //#endregion


### PR DESCRIPTION
## What does this PR do?

- Fixes #1461
- adds a `download` attribute on the `cc-link` to handle download links cases

## How to review?

- check the commit,
- check the stories (especially the new `Download link` story)  in the [preview](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-link/handle-download/index.html?path=/story/%F0%9F%A7%AC-atoms-cc-link--download-link),
- 2 reviewers should be enough.