### PR TITLE
feat(cc-env-var-linked-services): display CLI examples

### DIFF
--- a/demo-smart/index.html
+++ b/demo-smart/index.html
@@ -85,8 +85,13 @@
         >
       </li>
       <li>
-        <a class="definition-link" href="?definition=cc-env-var-linked-services.smart"
-          >cc-env-var-linked-services.smart</a
+        <a class="definition-link" href="?definition=cc-env-var-linked-services.smart-addon&type=addon"
+          >cc-env-var-linked-services.smart-addon</a
+        >
+      </li>
+      <li>
+        <a class="definition-link" href="?definition=cc-env-var-linked-services.smart-app&type=app"
+          >cc-env-var-linked-services.smart-app</a
         >
       </li>
       <li>

--- a/src/components/cc-env-var-form/cc-env-var-form.js
+++ b/src/components/cc-env-var-form/cc-env-var-form.js
@@ -451,6 +451,30 @@ export class CcEnvVarForm extends LitElement {
                           </dd>
                         `
                       : ''}
+                    ${this.context === 'linked-addon'
+                      ? html`
+                          <dt>${i18n('cc-env-var-form.cli.content.list-var-command')}</dt>
+                          <dd>
+                            <cc-code>clever addon env ${this.resourceId}</cc-code>
+                          </dd>
+                          <dt>${i18n('cc-env-var-form.cli.content.get-file-var-command')}</dt>
+                          <dd>
+                            <cc-code>clever addon env ${this.resourceId} -F shell</cc-code>
+                          </dd>
+                        `
+                      : ''}
+                    ${this.context === 'linked-app'
+                      ? html`
+                          <dt>${i18n('cc-env-var-form.cli.content.list-var-command')}</dt>
+                          <dd>
+                            <cc-code>clever env --app ${this.resourceId}</cc-code>
+                          </dd>
+                          <dt>${i18n('cc-env-var-form.cli.content.get-file-var-command')}</dt>
+                          <dd>
+                            <cc-code>clever env --app ${this.resourceId} -F shell</cc-code>
+                          </dd>
+                        `
+                      : ''}
                   </dl>
                 </div>
               </cc-block-details>

--- a/src/components/cc-env-var-form/cc-env-var-form.stories.js
+++ b/src/components/cc-env-var-form/cc-env-var-form.stories.js
@@ -101,7 +101,7 @@ export const dataLoadedWithContextEnvVarSimple = makeStory(conf, {
 export const dataLoadedWithContextEnvVarAddon = makeStory(conf, {
   items: [
     {
-      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
+      resourceId: 'addon_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       context: 'env-var-addon',
       state: { type: 'loaded', validationMode: 'simple', variables: VARIABLES_FULL },
     },
@@ -133,9 +133,31 @@ export const dataLoadedWithContextExposedConfig = makeStory(conf, {
 export const dataLoadedWithContextConfigProvider = makeStory(conf, {
   items: [
     {
-      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
+      resourceId: 'addon_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
       addonName: 'My shared config',
       context: 'config-provider',
+      state: { type: 'loaded', validationMode: 'simple', variables: VARIABLES_FULL },
+    },
+  ],
+});
+
+export const dataLoadedWithContextLinkedAddon = makeStory(conf, {
+  items: [
+    {
+      resourceId: 'addon_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
+      context: 'linked-addon',
+      readonly: true,
+      state: { type: 'loaded', validationMode: 'simple', variables: VARIABLES_FULL },
+    },
+  ],
+});
+
+export const dataLoadedWithContextLinkedApp = makeStory(conf, {
+  items: [
+    {
+      resourceId: 'app_3f9b1c8e-2d7a-4c4f-91a6-8bde78f4a21b',
+      context: 'linked-app',
+      readonly: true,
       state: { type: 'loaded', validationMode: 'simple', variables: VARIABLES_FULL },
     },
   ],

--- a/src/components/cc-env-var-form/cc-env-var-form.types.d.ts
+++ b/src/components/cc-env-var-form/cc-env-var-form.types.d.ts
@@ -26,6 +26,13 @@ export interface EnvVarFormStateError {
   type: 'error';
 }
 
-type EnvVarFormContextType = 'env-var-app' | 'env-var-simple' | 'env-var-addon' | 'exposed-config' | 'config-provider';
+type EnvVarFormContextType =
+  | 'env-var-app'
+  | 'env-var-simple'
+  | 'env-var-addon'
+  | 'exposed-config'
+  | 'config-provider'
+  | 'linked-app'
+  | 'linked-addon';
 
 export type EnvVarFormMode = 'SIMPLE' | 'EXPERT' | 'JSON';

--- a/src/components/cc-env-var-linked-services/cc-env-var-linked-services.js
+++ b/src/components/cc-env-var-linked-services/cc-env-var-linked-services.js
@@ -121,12 +121,16 @@ export class CcEnvVarLinkedServices extends LitElement {
       return html` <div class="empty-msg">${this._getEmptyMessage()}</div> `;
     }
 
+    const context = this.type === 'addon' ? 'linked-addon' : 'linked-app';
+
     return html`
       <div class="service-list">
         ${services.map(
           (service) => html`
             <cc-env-var-form
               readonly
+              context="${context}"
+              resource-id="${service.id}"
               .state=${{ type: 'loaded', variables: service.variables, validationMode: 'simple' }}
               heading=${this._getServiceHeading(service.name)}
             >

--- a/src/components/cc-env-var-linked-services/cc-env-var-linked-services.js
+++ b/src/components/cc-env-var-linked-services/cc-env-var-linked-services.js
@@ -21,7 +21,7 @@ export class CcEnvVarLinkedServices extends LitElement {
     return {
       appName: { type: String, attribute: 'app-name' },
       state: { type: Object },
-      type: { type: String },
+      type: { type: String, reflect: true },
     };
   }
 

--- a/src/components/cc-env-var-linked-services/cc-env-var-linked-services.js
+++ b/src/components/cc-env-var-linked-services/cc-env-var-linked-services.js
@@ -7,8 +7,6 @@ import '../cc-notice/cc-notice.js';
 /**
  * @typedef {import('./cc-env-var-linked-services.types.js').EnvVarLinkedServicesState} EnvVarLinkedServicesState
  * @typedef {import('./cc-env-var-linked-services.types.js').EnvVarLinkedServicesType} EnvVarLinkedServicesType
- * @typedef {import('./cc-env-var-linked-services.types.js').LinkedServiceState} LinkedServiceState
- * @typedef {import('../cc-env-var-form/cc-env-var-form.types.js').EnvVarFormState} EnvVarFormState
  */
 
 /**
@@ -104,20 +102,6 @@ export class CcEnvVarLinkedServices extends LitElement {
     }
   }
 
-  /**
-   * @param {LinkedServiceState} linkedServiceState
-   * @return {EnvVarFormState}
-   */
-  _getEnvVarFormState(linkedServiceState) {
-    if (linkedServiceState.type === 'loading') {
-      return { type: 'loading' };
-    }
-    if (linkedServiceState.type === 'error') {
-      return { type: 'error' };
-    }
-    return { type: 'loaded', variables: linkedServiceState.variables, validationMode: 'simple' };
-  }
-
   render() {
     if (this.state.type === 'error') {
       return html`
@@ -131,22 +115,22 @@ export class CcEnvVarLinkedServices extends LitElement {
       return html` <div class="loading"><cc-loader></cc-loader><span>${this._getLoadingMessage()}</span></div> `;
     }
 
-    const servicesStates = this.state.servicesStates;
+    const services = this.state.services;
 
-    if (servicesStates.length === 0) {
+    if (services.length === 0) {
       return html` <div class="empty-msg">${this._getEmptyMessage()}</div> `;
     }
 
     return html`
       <div class="service-list">
-        ${servicesStates.map(
-          (serviceState) => html`
+        ${services.map(
+          (service) => html`
             <cc-env-var-form
               readonly
-              .state=${this._getEnvVarFormState(serviceState)}
-              heading=${this._getServiceHeading(serviceState.name)}
+              .state=${{ type: 'loaded', variables: service.variables, validationMode: 'simple' }}
+              heading=${this._getServiceHeading(service.name)}
             >
-              ${this._getServiceDescription(serviceState.name)}
+              ${this._getServiceDescription(service.name)}
             </cc-env-var-form>
           `,
         )}

--- a/src/components/cc-env-var-linked-services/cc-env-var-linked-services.smart-addon.js
+++ b/src/components/cc-env-var-linked-services/cc-env-var-linked-services.smart-addon.js
@@ -1,0 +1,93 @@
+// @ts-expect-error FIXME: remove when clever-client exports types
+import { get, getAllEnvVarsForAddons } from '@clevercloud/client/esm/api/v2/application.js';
+import { sendToApi } from '../../lib/send-to-api.js';
+import { defineSmartComponent } from '../../lib/smart/define-smart-component.js';
+import '../cc-smart-container/cc-smart-container.js';
+import './cc-env-var-linked-services.js';
+
+/**
+ * @typedef {import('./cc-env-var-linked-services.js').CcEnvVarLinkedServices} CcEnvVarLinkedServices
+ * @typedef {import('./cc-env-var-linked-services.types.js').LinkedService} LinkedService
+ * @typedef {import('../../lib/send-to-api.js').ApiConfig} ApiConfig
+ * @typedef {import('../../lib/smart/smart-component.types.js').OnContextUpdateArgs<CcEnvVarLinkedServices>} OnContextUpdateArgs
+ */
+
+defineSmartComponent({
+  selector: 'cc-env-var-linked-services[type="addon"]',
+  params: {
+    apiConfig: { type: Object },
+    ownerId: { type: String },
+    appId: { type: String },
+  },
+  /**
+   * @param {OnContextUpdateArgs} args
+   */
+  onContextUpdate({ context, updateComponent, signal }) {
+    const { apiConfig, ownerId, appId } = context;
+
+    updateComponent('state', { type: 'loading', name: '' });
+
+    const api = new Api(apiConfig, signal);
+
+    api.fetchAppName({ ownerId, appId }).then((name) => {
+      updateComponent('appName', name);
+    });
+
+    api
+      .fetchEnvVarLinkedAddons({ ownerId, appId })
+      .then((linkedServices) => {
+        updateComponent('state', {
+          type: 'loaded',
+          services: linkedServices,
+        });
+      })
+      .catch((e) => {
+        console.error(e);
+        updateComponent('state', {
+          type: 'error',
+        });
+      });
+  },
+});
+
+// -- API calls
+class Api {
+  /**
+   * @param {ApiConfig} apiConfig
+   * @param {AbortSignal} signal
+   */
+  constructor(apiConfig, signal) {
+    this.apiConfig = apiConfig;
+    this.signal = signal;
+  }
+
+  /**
+   * @param {object} params
+   * @param {string} params.ownerId
+   * @param {string} params.appId
+   * @returns {Promise<LinkedService[]>}
+   */
+  async fetchEnvVarLinkedAddons({ ownerId, appId }) {
+    const linkedAddons = await getAllEnvVarsForAddons({ id: ownerId, appId }).then(
+      sendToApi({ apiConfig: this.apiConfig, signal: this.signal }),
+    );
+
+    return linkedAddons.map((/** @type {any} */ linkedAddon) => {
+      return {
+        id: linkedAddon.addon_id,
+        name: linkedAddon.addon_name,
+        variables: linkedAddon.env,
+      };
+    });
+  }
+
+  /**
+   * @param {object} params
+   * @param {string} params.ownerId
+   * @param {string} params.appId
+   */
+  async fetchAppName({ ownerId, appId }) {
+    const app = await get({ id: ownerId, appId }).then(sendToApi({ apiConfig: this.apiConfig, signal: this.signal }));
+    return app.name;
+  }
+}

--- a/src/components/cc-env-var-linked-services/cc-env-var-linked-services.smart-addon.md
+++ b/src/components/cc-env-var-linked-services/cc-env-var-linked-services.smart-addon.md
@@ -1,0 +1,60 @@
+---
+kind: '🛠 Environment variables/<cc-env-var-linked-services>'
+title: '💡 Smart (for linked addons)'
+---
+# 💡 Smart `<cc-env-var-linked-services>` for linked addons
+
+## ℹ️ Details
+
+<table>
+  <tr><td><strong>Component    </strong> <td><a href="🛠-environment-variables-cc-env-var-linked-services--loaded-with-linked-addons"><code>&lt;cc-env-var-linked-services&gt;</code></a>
+  <tr><td><strong>Selector     </strong> <td><code>cc-env-var-linked-services[type="addon"]</code>
+  <tr><td><strong>Requires auth</strong> <td>Yes
+</table>
+
+## ⚙️ Params
+
+<table>
+  <tr><th>Name                   <th>Type                   <th>Details                                                     <th>Default
+  <tr><td><code>apiConfig</code> <td><code>ApiConfig</code> <td>Object with API configuration (target host, tokens...)      <td>
+  <tr><td><code>ownerId</code>   <td><code>String</code>    <td>UUID prefixed with <code>user_</code> or <code>orga_</code> <td>
+  <tr><td><code>appId</code>     <td><code>String</code>    <td>UUID prefixed with <code>app_</code>                        <td>
+</table>
+
+```ts
+interface ApiConfig {
+  API_HOST: String,
+  API_OAUTH_TOKEN: String,
+  API_OAUTH_TOKEN_SECRET: String,
+  OAUTH_CONSUMER_KEY: String,
+  OAUTH_CONSUMER_SECRET: String,
+}
+```
+
+## 🌐 API endpoints
+
+<!-- List API endpoints used by the component here with the details. -->
+
+<table>
+  <tr><th>Method <th>URL                                                    <th>Cache?
+  <tr><td>GET    <td><code>/v2/applications/{appId}</code>                  <td>Default
+  <tr><td>GET    <td><code>/v2/applications/{appId}/addons/env</code>       <td>Default
+</table>
+
+## ⬇️️ Examples
+
+```html
+<cc-smart-container context='{
+  "apiConfig": {
+    API_HOST: "",
+    API_OAUTH_TOKEN: "",
+    API_OAUTH_TOKEN_SECRET: "",
+    OAUTH_CONSUMER_KEY: "",
+    OAUTH_CONSUMER_SECRET: "",
+  },
+  "ownerId": "",
+  "appId": "",
+}'>
+  <cc-env-var-linked-services type="addon"></cc-env-var-linked-services>
+</cc-smart-container>
+```

--- a/src/components/cc-env-var-linked-services/cc-env-var-linked-services.smart-app.md
+++ b/src/components/cc-env-var-linked-services/cc-env-var-linked-services.smart-app.md
@@ -1,14 +1,14 @@
 ---
 kind: '🛠 Environment variables/<cc-env-var-linked-services>'
-title: '💡 Smart (env-var-linked-services)'
+title: '💡 Smart (for linked applications)'
 ---
-# 💡 Smart `<cc-env-var-linked-services>`
+# 💡 Smart `<cc-env-var-linked-services>` for linked applications
 
 ## ℹ️ Details
 
 <table>
-  <tr><td><strong>Component    </strong> <td><a href="🛠-environment-variables-cc-env-var-linked-services"><code>&lt;cc-env-var-linked-services&gt;</code></a>
-  <tr><td><strong>Selector     </strong> <td><code>cc-env-var-linked-services</code>
+  <tr><td><strong>Component    </strong> <td><a href="🛠-environment-variables-cc-env-var-linked-services--loaded-with-linked-apps"><code>&lt;cc-env-var-linked-services&gt;</code></a>
+  <tr><td><strong>Selector     </strong> <td><code>cc-env-var-linked-services[type="app"]</code>
   <tr><td><strong>Requires auth</strong> <td>Yes
 </table>
 
@@ -17,7 +17,6 @@ title: '💡 Smart (env-var-linked-services)'
 <table>
   <tr><th>Name                   <th>Type                   <th>Details                                                     <th>Default
   <tr><td><code>apiConfig</code> <td><code>ApiConfig</code> <td>Object with API configuration (target host, tokens...)      <td>
-  <tr><td><code>type</code>      <td><code>'app' | 'addon'</code>    <td>Type of env vars to display linked add-ons or linked apps   <td>
   <tr><td><code>ownerId</code>   <td><code>String</code>    <td>UUID prefixed with <code>user_</code> or <code>orga_</code> <td>
   <tr><td><code>appId</code>     <td><code>String</code>    <td>UUID prefixed with <code>app_</code>                        <td>
 </table>
@@ -38,13 +37,12 @@ interface ApiConfig {
 
 <table>
   <tr><th>Method <th>URL                                                    <th>Cache?
+  <tr><td>GET    <td><code>/v2/applications/{appId}</code>                  <td>Default  
   <tr><td>GET    <td><code>/v2/applications/{appId}/dependencies/env</code> <td>Default
-  <tr><td>GET    <td><code>/v2/applications/{appId}/addons/env</code>       <td>Default
 </table>
 
 ## ⬇️️ Examples
 
-- Linked applications:
 ```html
 <cc-smart-container context='{
   "apiConfig": {
@@ -54,28 +52,9 @@ interface ApiConfig {
     OAUTH_CONSUMER_KEY: "",
     OAUTH_CONSUMER_SECRET: "",
   },
-  "type": "app",
   "ownerId": "",
   "appId": "",
 }'>
-  <cc-env-var-linked-services></cc-env-var-linked-services>
-</cc-smart-container>
-```
-
-- Linked addons:
-```html
-<cc-smart-container context='{
-  "apiConfig": {
-    API_HOST: "",
-    API_OAUTH_TOKEN: "",
-    API_OAUTH_TOKEN_SECRET: "",
-    OAUTH_CONSUMER_KEY: "",
-    OAUTH_CONSUMER_SECRET: "",
-  },
-  "type": "addon",
-  "ownerId": "",
-  "appId": "",
-}'>
-  <cc-env-var-linked-services></cc-env-var-linked-services>
+  <cc-env-var-linked-services type="app"></cc-env-var-linked-services>
 </cc-smart-container>
 ```

--- a/src/components/cc-env-var-linked-services/cc-env-var-linked-services.smart.js
+++ b/src/components/cc-env-var-linked-services/cc-env-var-linked-services.smart.js
@@ -81,6 +81,7 @@ class Api {
 
     return linkedAddons.map((/** @type {any} */ linkedAddon) => {
       return {
+        id: linkedAddon.addon_id,
         name: linkedAddon.addon_name,
         variables: linkedAddon.env,
       };
@@ -100,6 +101,7 @@ class Api {
 
     return linkedApps.map((/** @type {any} */ linkedApp) => {
       return {
+        id: linkedApp.app_id,
         name: linkedApp.app_name,
         variables: linkedApp.env,
       };

--- a/src/components/cc-env-var-linked-services/cc-env-var-linked-services.smart.js
+++ b/src/components/cc-env-var-linked-services/cc-env-var-linked-services.smart.js
@@ -8,7 +8,7 @@ import './cc-env-var-linked-services.js';
 
 /**
  * @typedef {import('./cc-env-var-linked-services.js').CcEnvVarLinkedServices} CcEnvVarLinkedServices
- * @typedef {import('./cc-env-var-linked-services.types.js').LinkedServiceState} LinkedServiceState
+ * @typedef {import('./cc-env-var-linked-services.types.js').LinkedService} LinkedService
  * @typedef {import('./cc-env-var-linked-services.types.js').EnvVarLinkedServicesType} EnvVarLinkedServicesType
  * @typedef {import('../common.types.js').App} App
  * @typedef {import('../common.types.js').Addon} Addon
@@ -42,10 +42,10 @@ defineSmartComponent({
 
     api
       .fetchEnvVarLinkedService({ ownerId, appId, type })
-      .then((linkedServiceList) => {
+      .then((linkedServices) => {
         updateComponent('state', {
           type: 'loaded',
-          servicesStates: linkedServiceList,
+          services: linkedServices,
         });
       })
       .catch((e) => {
@@ -72,7 +72,7 @@ class Api {
    * @param {object} params
    * @param {string} params.ownerId
    * @param {string} params.appId
-   * @returns {Promise<LinkedServiceState[]>}
+   * @returns {Promise<LinkedService[]>}
    */
   async fetchEnvVarLinkedAddons({ ownerId, appId }) {
     const linkedAddons = await getAllEnvVarsForAddons({ id: ownerId, appId }).then(
@@ -81,7 +81,6 @@ class Api {
 
     return linkedAddons.map((/** @type {any} */ linkedAddon) => {
       return {
-        type: 'loaded',
         name: linkedAddon.addon_name,
         variables: linkedAddon.env,
       };
@@ -92,17 +91,18 @@ class Api {
    * @param {object} params
    * @param {string} params.ownerId
    * @param {string} params.appId
+   * @returns {Promise<LinkedService[]>}
    */
   async fetchEnvVarLinkedApps({ ownerId, appId }) {
-    const apps = await getAllEnvVarsForDependencies({ id: ownerId, appId })
-      .then(sendToApi({ apiConfig: this.apiConfig, signal: this.signal }))
-      .then((/** @type {any[]} */ linkedApps) => linkedApps.map((app) => ({ ...app, name: app.app_name })));
-    return apps.map((/** @type {App & { env: Array<EnvVar> }} */ app) => {
-      return /** @type {LinkedServiceState} */ ({
-        type: 'loaded',
-        name: app.name,
-        variables: app.env,
-      });
+    const linkedApps = await getAllEnvVarsForDependencies({ id: ownerId, appId }).then(
+      sendToApi({ apiConfig: this.apiConfig, signal: this.signal }),
+    );
+
+    return linkedApps.map((/** @type {any} */ linkedApp) => {
+      return {
+        name: linkedApp.app_name,
+        variables: linkedApp.env,
+      };
     });
   }
 

--- a/src/components/cc-env-var-linked-services/cc-env-var-linked-services.smart.md
+++ b/src/components/cc-env-var-linked-services/cc-env-var-linked-services.smart.md
@@ -38,9 +38,8 @@ interface ApiConfig {
 
 <table>
   <tr><th>Method <th>URL                                                    <th>Cache?
-  <tr><td>GET    <td><code>/v2/addons/{addonId}/env</code>                  <td>Default
   <tr><td>GET    <td><code>/v2/applications/{appId}/dependencies/env</code> <td>Default
-  <tr><td>GET    <td><code>/v2/applications/{appId}/addons</code>           <td>Default
+  <tr><td>GET    <td><code>/v2/applications/{appId}/addons/env</code>       <td>Default
 </table>
 
 ## ⬇️️ Examples

--- a/src/components/cc-env-var-linked-services/cc-env-var-linked-services.stories.js
+++ b/src/components/cc-env-var-linked-services/cc-env-var-linked-services.stories.js
@@ -31,8 +31,12 @@ export const defaultStory = makeStory(conf, {
       state: {
         type: 'loaded',
         services: [
-          { name: 'My Awesome PG database', variables: VARIABLES_FULL },
-          { name: 'Redis cache (PROD)', variables: VARIABLES_FULL },
+          {
+            id: 'addon_01234567-89ab-cdef-0123-456789abcde0',
+            name: 'My Awesome PG database',
+            variables: VARIABLES_FULL,
+          },
+          { id: 'addon_01234567-89ab-cdef-0123-456789abcde1', name: 'Redis cache (PROD)', variables: VARIABLES_FULL },
         ],
       },
     },
@@ -42,9 +46,21 @@ export const defaultStory = makeStory(conf, {
       state: {
         type: 'loaded',
         services: [
-          { name: 'The mighty maven Java app', variables: VARIABLES_FULL },
-          { name: 'Node.js frontend preprod', variables: VARIABLES_FULL },
-          { name: 'Auth gateway for backend', variables: VARIABLES_FULL },
+          {
+            id: 'app_01234567-89ab-cdef-0123-456789abcde0',
+            name: 'The mighty maven Java app',
+            variables: VARIABLES_FULL,
+          },
+          {
+            id: 'app_01234567-89ab-cdef-0123-456789abcde1',
+            name: 'Node.js frontend preprod',
+            variables: VARIABLES_FULL,
+          },
+          {
+            id: 'app_01234567-89ab-cdef-0123-456789abcde2',
+            name: 'Auth gateway for backend',
+            variables: VARIABLES_FULL,
+          },
         ],
       },
     },
@@ -104,8 +120,12 @@ export const loadedWithLinkedAddons = makeStory(conf, {
       state: {
         type: 'loaded',
         services: [
-          { name: 'My Awesome PG database', variables: VARIABLES_FULL },
-          { name: 'Redis cache (PROD)', variables: VARIABLES_FULL },
+          {
+            id: 'addon_01234567-89ab-cdef-0123-456789abcde0',
+            name: 'My Awesome PG database',
+            variables: VARIABLES_FULL,
+          },
+          { id: 'addon_01234567-89ab-cdef-0123-456789abcde1', name: 'Redis cache (PROD)', variables: VARIABLES_FULL },
         ],
       },
     },
@@ -121,9 +141,21 @@ export const loadedWithLinkedApps = makeStory(conf, {
       state: {
         type: 'loaded',
         services: [
-          { name: 'The mighty maven Java app', variables: VARIABLES_FULL },
-          { name: 'Node.js frontend preprod', variables: VARIABLES_FULL },
-          { name: 'Auth gateway for backend', variables: VARIABLES_FULL },
+          {
+            id: 'app_01234567-89ab-cdef-0123-456789abcde0',
+            name: 'The mighty maven Java app',
+            variables: VARIABLES_FULL,
+          },
+          {
+            id: 'app_01234567-89ab-cdef-0123-456789abcde1',
+            name: 'Node.js frontend preprod',
+            variables: VARIABLES_FULL,
+          },
+          {
+            id: 'app_01234567-89ab-cdef-0123-456789abcde2',
+            name: 'Auth gateway for backend',
+            variables: VARIABLES_FULL,
+          },
         ],
       },
     },
@@ -156,8 +188,12 @@ export const simulationsWithAddons = makeStory(conf, {
         component.state = {
           type: 'loaded',
           services: [
-            { name: 'My Awesome PG database', variables: VARIABLES_FULL },
-            { name: 'Redis cache (PROD)', variables: VARIABLES_FULL },
+            {
+              id: 'addon_01234567-89ab-cdef-0123-456789abcde0',
+              name: 'My Awesome PG database',
+              variables: VARIABLES_FULL,
+            },
+            { id: 'addon_01234567-89ab-cdef-0123-456789abcde1', name: 'Redis cache (PROD)', variables: VARIABLES_FULL },
           ],
         };
       },
@@ -181,9 +217,21 @@ export const simulationsWithLinkedApps = makeStory(conf, {
         component.state = {
           type: 'loaded',
           services: [
-            { name: 'The mighty maven Java app', variables: VARIABLES_FULL },
-            { name: 'Node.js frontend preprod', variables: VARIABLES_FULL },
-            { name: 'Auth gateway for backend', variables: VARIABLES_FULL },
+            {
+              id: 'app_01234567-89ab-cdef-0123-456789abcde0',
+              name: 'The mighty maven Java app',
+              variables: VARIABLES_FULL,
+            },
+            {
+              id: 'app_01234567-89ab-cdef-0123-456789abcde1',
+              name: 'Node.js frontend preprod',
+              variables: VARIABLES_FULL,
+            },
+            {
+              id: 'app_01234567-89ab-cdef-0123-456789abcde2',
+              name: 'Auth gateway for backend',
+              variables: VARIABLES_FULL,
+            },
           ],
         };
       },

--- a/src/components/cc-env-var-linked-services/cc-env-var-linked-services.stories.js
+++ b/src/components/cc-env-var-linked-services/cc-env-var-linked-services.stories.js
@@ -14,20 +14,25 @@ export default {
   component: 'cc-env-var-linked-services',
 };
 
+/**
+ * @typedef {import('./cc-env-var-linked-services.js').CcEnvVarLinkedServices} CcEnvVarLinkedServices
+ */
+
 const conf = {
   component: 'cc-env-var-linked-services',
 };
 
 export const defaultStory = makeStory(conf, {
+  /** @type {Partial<CcEnvVarLinkedServices>[]} */
   items: [
     {
       type: 'addon',
       appName: 'Foobar backend python',
       state: {
         type: 'loaded',
-        servicesStates: [
-          { name: 'My Awesome PG database', type: 'loaded', variables: VARIABLES_FULL },
-          { name: 'Redis cache (PROD)', type: 'loaded', variables: VARIABLES_FULL },
+        services: [
+          { name: 'My Awesome PG database', variables: VARIABLES_FULL },
+          { name: 'Redis cache (PROD)', variables: VARIABLES_FULL },
         ],
       },
     },
@@ -36,10 +41,10 @@ export const defaultStory = makeStory(conf, {
       appName: 'Foobar backend python',
       state: {
         type: 'loaded',
-        servicesStates: [
-          { name: 'The mighty maven Java app', type: 'loaded', variables: VARIABLES_FULL },
-          { name: 'Node.js frontend preprod', type: 'loaded', variables: VARIABLES_FULL },
-          { name: 'Auth gateway for backend', type: 'loaded', variables: VARIABLES_FULL },
+        services: [
+          { name: 'The mighty maven Java app', variables: VARIABLES_FULL },
+          { name: 'Node.js frontend preprod', variables: VARIABLES_FULL },
+          { name: 'Auth gateway for backend', variables: VARIABLES_FULL },
         ],
       },
     },
@@ -47,6 +52,7 @@ export const defaultStory = makeStory(conf, {
 });
 
 export const loadingWithLinkedAddons = makeStory(conf, {
+  /** @type {Partial<CcEnvVarLinkedServices>[]} */
   items: [
     {
       type: 'addon',
@@ -57,6 +63,7 @@ export const loadingWithLinkedAddons = makeStory(conf, {
 });
 
 export const loadingWithLinkedApps = makeStory(conf, {
+  /** @type {Partial<CcEnvVarLinkedServices>[]} */
   items: [
     {
       type: 'app',
@@ -66,67 +73,37 @@ export const loadingWithLinkedApps = makeStory(conf, {
   ],
 });
 
-export const loadedWithSomeLoadingLinkedAddons = makeStory(conf, {
-  items: [
-    {
-      type: 'addon',
-      appName: 'Foobar backend python',
-      state: {
-        type: 'loaded',
-        servicesStates: [
-          { name: 'My Awesome PG database', type: 'loading' },
-          { name: 'Redis cache (PROD)', type: 'loaded', variables: VARIABLES_FULL },
-        ],
-      },
-    },
-  ],
-});
-
-export const loadedWithSomeLoadingLinkedApps = makeStory(conf, {
-  items: [
-    {
-      type: 'app',
-      appName: 'Foobar backend python',
-      state: {
-        type: 'loaded',
-        servicesStates: [
-          { name: 'The mighty maven Java app', type: 'loading' },
-          { name: 'Node.js frontend preprod', type: 'loaded', variables: VARIABLES_FULL },
-          { name: 'Auth gateway for backend', type: 'loading' },
-        ],
-      },
-    },
-  ],
-});
-
 export const loadedWithEmptyLinkedAddons = makeStory(conf, {
+  /** @type {Partial<CcEnvVarLinkedServices>[]} */
   items: [
     {
       type: 'addon',
       appName: 'Foobar backend python',
-      state: { type: 'loaded', servicesStates: [] },
+      state: { type: 'loaded', services: [] },
     },
   ],
 });
 
 export const loadedWithEmptyLinkedApps = makeStory(conf, {
+  /** @type {Partial<CcEnvVarLinkedServices>[]} */
   items: [
     {
       type: 'app',
       appName: 'Foobar backend python',
-      state: { type: 'loaded', servicesStates: [] },
+      state: { type: 'loaded', services: [] },
     },
   ],
 });
 
 export const loadedWithLinkedAddons = makeStory(conf, {
+  /** @type {Partial<CcEnvVarLinkedServices>[]} */
   items: [
     {
       type: 'addon',
       appName: 'Foobar backend python',
       state: {
         type: 'loaded',
-        servicesStates: [
+        services: [
           { name: 'My Awesome PG database', variables: VARIABLES_FULL },
           { name: 'Redis cache (PROD)', variables: VARIABLES_FULL },
         ],
@@ -136,13 +113,14 @@ export const loadedWithLinkedAddons = makeStory(conf, {
 });
 
 export const loadedWithLinkedApps = makeStory(conf, {
+  /** @type {Partial<CcEnvVarLinkedServices>[]} */
   items: [
     {
       type: 'app',
       appName: 'Foobar backend python',
       state: {
         type: 'loaded',
-        servicesStates: [
+        services: [
           { name: 'The mighty maven Java app', variables: VARIABLES_FULL },
           { name: 'Node.js frontend preprod', variables: VARIABLES_FULL },
           { name: 'Auth gateway for backend', variables: VARIABLES_FULL },
@@ -153,102 +131,62 @@ export const loadedWithLinkedApps = makeStory(conf, {
 });
 
 export const errorWithLinkedAddons = makeStory(conf, {
+  /** @type {Partial<CcEnvVarLinkedServices>[]} */
   items: [{ type: 'addon', appName: 'Foobar backend python', state: { type: 'error' } }],
 });
 
-export const errorWithOneLinkedAddon = makeStory(conf, {
-  items: [
-    {
-      type: 'addon',
-      appName: 'Foobar backend python',
-      state: {
-        type: 'loaded',
-        servicesStates: [
-          { name: 'My Awesome PG database', type: 'error' },
-          { name: 'Redis cache (PROD)', type: 'loaded', variables: VARIABLES_FULL },
-        ],
-      },
-    },
-  ],
-});
-
 export const errorWithLinkedApps = makeStory(conf, {
+  /** @type {Partial<CcEnvVarLinkedServices>[]} */
   items: [{ type: 'app', appName: 'Foobar backend python', state: { type: 'error' } }],
 });
 
-export const errorWithOneLinkedApp = makeStory(conf, {
-  items: [
-    {
-      type: 'app',
-      appName: 'Foobar backend python',
-      state: {
-        type: 'loaded',
-        servicesStates: [
-          { name: 'The mighty maven Java app', type: 'loaded', variables: VARIABLES_FULL },
-          { name: 'Node.js frontend preprod', type: 'error' },
-          { name: 'Auth gateway for backend', type: 'loaded', variables: VARIABLES_FULL },
-        ],
-      },
-    },
-  ],
-});
-
 export const simulationsWithAddons = makeStory(conf, {
+  /** @type {Partial<CcEnvVarLinkedServices>[]} */
   items: [
     {
       type: 'addon',
       appName: 'Foobar backend python',
+      state: { type: 'loading' },
     },
   ],
   simulations: [
-    storyWait(2000, ([component]) => {
-      component.state = {
-        type: 'loaded',
-        servicesStates: [
-          { name: 'My Awesome PG database', type: 'loading' },
-          { name: 'Redis cache (PROD)', type: 'loading' },
-        ],
-      };
-    }),
-    storyWait(2000, ([component]) => {
-      component.state = {
-        type: 'loaded',
-        servicesStates: [
-          { name: 'My Awesome PG database', type: 'loaded', variables: VARIABLES_FULL },
-          { name: 'Redis cache (PROD)', type: 'error' },
-        ],
-      };
-    }),
+    storyWait(
+      2000,
+      /** @param {CcEnvVarLinkedServices[]} components */ ([component]) => {
+        component.state = {
+          type: 'loaded',
+          services: [
+            { name: 'My Awesome PG database', variables: VARIABLES_FULL },
+            { name: 'Redis cache (PROD)', variables: VARIABLES_FULL },
+          ],
+        };
+      },
+    ),
   ],
 });
 
 export const simulationsWithLinkedApps = makeStory(conf, {
+  /** @type {Partial<CcEnvVarLinkedServices>[]} */
   items: [
     {
       type: 'app',
       appName: 'Foobar backend python',
+      state: { type: 'loading' },
     },
   ],
   simulations: [
-    storyWait(2000, ([component]) => {
-      component.state = {
-        type: 'loaded',
-        servicesStates: [
-          { name: 'The mighty maven Java app', type: 'loading' },
-          { name: 'Node.js frontend preprod', type: 'loading' },
-          { name: 'Auth gateway for backend', type: 'loading' },
-        ],
-      };
-    }),
-    storyWait(2000, ([component]) => {
-      component.state = {
-        type: 'loaded',
-        servicesStates: [
-          { name: 'The mighty maven Java app', type: 'loaded', variables: VARIABLES_FULL },
-          { name: 'Node.js frontend preprod', type: 'loaded', variables: VARIABLES_FULL },
-          { name: 'Auth gateway for backend', type: 'error' },
-        ],
-      };
-    }),
+    storyWait(
+      2000,
+      /** @param {CcEnvVarLinkedServices[]} components */ ([component]) => {
+        component.state = {
+          type: 'loaded',
+          services: [
+            { name: 'The mighty maven Java app', variables: VARIABLES_FULL },
+            { name: 'Node.js frontend preprod', variables: VARIABLES_FULL },
+            { name: 'Auth gateway for backend', variables: VARIABLES_FULL },
+          ],
+        };
+      },
+    ),
   ],
 });

--- a/src/components/cc-env-var-linked-services/cc-env-var-linked-services.types.d.ts
+++ b/src/components/cc-env-var-linked-services/cc-env-var-linked-services.types.d.ts
@@ -11,29 +11,16 @@ interface EnvVarLinkedServicesStateLoading {
 
 interface EnvVarLinkedServicesStateLoaded {
   type: 'loaded';
-  servicesStates: Array<LinkedServiceState>;
+  services: Array<LinkedService>;
 }
 
 interface EnvVarLinkedServicesStateError {
   type: 'error';
 }
 
-type EnvVarLinkedServicesType = 'addon' | 'app';
+export type EnvVarLinkedServicesType = 'addon' | 'app';
 
-export type LinkedServiceState = LinkedServiceStateLoading | LinkedServiceStateLoaded | LinkedServiceStateError;
-
-interface LinkedServiceStateLoading {
-  type: 'loading';
-  name: string;
-}
-
-interface LinkedServiceStateLoaded {
-  type: 'loaded';
+export interface LinkedService {
   name: string;
   variables: Array<EnvVar>;
-}
-
-interface LinkedServiceStateError {
-  type: 'error';
-  name: string;
 }

--- a/src/components/cc-env-var-linked-services/cc-env-var-linked-services.types.d.ts
+++ b/src/components/cc-env-var-linked-services/cc-env-var-linked-services.types.d.ts
@@ -21,6 +21,7 @@ interface EnvVarLinkedServicesStateError {
 export type EnvVarLinkedServicesType = 'addon' | 'app';
 
 export interface LinkedService {
+  id: string;
   name: string;
   variables: Array<EnvVar>;
 }


### PR DESCRIPTION
## What this PR do ?

This PR adds some CLI usage examples in the cc-env-var-form footer of every linked addons/applications.

- Additionally, it adds an optimization on how the linked addons env vars are fetched. Instead of fetching addons, and then fetching env var for every addons, it uses a single fetch to the right endpoint.
- After this optimization, the need of a dedicated state for each linked service is no more needed. This PR proposes to introduce a breaking change that simplifies the `state` property shape.
- To ease integration in console, this PR splits the smart component by `type`

## How to review ?

- check the code
- verify smart-demo locally
- verify [stories](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-env-var-linked-services/add-cli-examples/index.html?path=/story/%F0%9F%9B%A0-environment-variables-cc-env-var-linked-services--default-story)
- verify [addon type smart documentation](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-env-var-linked-services/add-cli-examples/index.html?path=/docs/%F0%9F%9B%A0-environment-variables-cc-env-var-linked-services-%F0%9F%92%A1-smart-for-linked-addons--docs)
- verify [app type smart documentation](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-env-var-linked-services/add-cli-examples/index.html?path=/docs/%F0%9F%9B%A0-environment-variables-cc-env-var-linked-services-%F0%9F%92%A1-smart-for-linked-applications--docs)