### PR TITLE
refactor(rollup-common): replace `@lit-labs/rollup-plugin-minify-html-literals`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,6 @@
         "@eslint/js": "^9.8.0",
         "@esm-bundle/chai-as-promised": "^7.1.1",
         "@html-eslint/eslint-plugin": "^0.41.0",
-        "@lit-labs/rollup-plugin-minify-html-literals": "^0.1.0",
         "@open-wc/dev-server-hmr": "^0.1.3",
         "@open-wc/testing": "^4.0.0",
         "@open-wc/testing-helpers": "^3.0.1",
@@ -100,6 +99,7 @@
         "rollup-plugin-babel": "^4.4.0",
         "rollup-plugin-clear": "^2.0.7",
         "rollup-plugin-copy": "^3.4.0",
+        "rollup-plugin-minify-html-literals": "^1.2.6",
         "rollup-plugin-terser": "^7.0.2",
         "rollup-plugin-visualizer": "^5.5.0",
         "semver": "^7.7.2",
@@ -3675,23 +3675,6 @@
         "lit": "^3.1.2"
       }
     },
-    "node_modules/@lit-labs/rollup-plugin-minify-html-literals": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@lit-labs/rollup-plugin-minify-html-literals/-/rollup-plugin-minify-html-literals-0.1.0.tgz",
-      "integrity": "sha512-lSqAPswTa3rfsj9FqmuM8gsIg69xsiMOsmfdP4GhZTxQgeedADXsLxjc2FKw8L4/1EkJvUjabvY6Iq2WKaZTuQ==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "clean-css": "^4.2.1",
-        "html-minifier": "^4.0.0",
-        "magic-string": "^0.30.11",
-        "rollup-pluginutils": "^2.8.2",
-        "typescript": "^2.9.2 || ^3.0.0 || ^4.0.0 || ^5.0.0"
-      },
-      "peerDependencies": {
-        "rollup": "^0.65.2 || ^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
-      }
-    },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.1.tgz",
@@ -4846,6 +4829,17 @@
         "@types/chai": "*"
       }
     },
+    "node_modules/@types/clean-css": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@types/clean-css/-/clean-css-4.2.11.tgz",
+      "integrity": "sha512-Y8n81lQVTAfP2TOdtJJEsCoYl1AnOkqDqMvXb9/7pfgZZ7r8YrEyurrAvAoAjHOGXKRybay+5CsExqIH6liccw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "source-map": "^0.6.0"
+      }
+    },
     "node_modules/@types/co-body": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/@types/co-body/-/co-body-6.1.1.tgz",
@@ -4960,6 +4954,18 @@
       "dependencies": {
         "@types/minimatch": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/html-minifier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@types/html-minifier/-/html-minifier-3.5.3.tgz",
+      "integrity": "sha512-j1P/4PcWVVCPEy5lofcHnQ6BtXz9tHGiFPWzqm7TtGuWZEfCHEP446HlkSNc9fQgNJaJZ6ewPtp2aaFla/Uerg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/clean-css": "*",
+        "@types/relateurl": "*",
+        "@types/uglify-js": "*"
       }
     },
     "node_modules/@types/http-assert": {
@@ -5160,6 +5166,13 @@
         "csstype": "^3.0.2"
       }
     },
+    "node_modules/@types/relateurl": {
+      "version": "0.2.33",
+      "resolved": "https://registry.npmjs.org/@types/relateurl/-/relateurl-0.2.33.tgz",
+      "integrity": "sha512-bTQCKsVbIdzLqZhLkF5fcJQreE4y1ro4DIyVrlDNSCJRRwHhB8Z+4zXXa8jN6eDvc2HbRsEYgbvrnGvi54EpSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
@@ -5224,6 +5237,16 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
       "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
+    },
+    "node_modules/@types/uglify-js": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.17.5.tgz",
+      "integrity": "sha512-TU+fZFBTBcXj/GpDpDaBmgWk/gn96kMZ+uocaFUlV2f8a6WdMzzI44QBCmGcCiYR0Y6ZlNRiyUyKKt5nl/lbzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "source-map": "^0.6.1"
+      }
     },
     "node_modules/@types/unist": {
       "version": "2.0.3",
@@ -13403,16 +13426,6 @@
         "lz-string": "bin/bin.js"
       }
     },
-    "node_modules/magic-string": {
-      "version": "0.30.17",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
-      }
-    },
     "node_modules/make-dir": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
@@ -13854,6 +13867,30 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/minify-html-literals": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/minify-html-literals/-/minify-html-literals-1.3.5.tgz",
+      "integrity": "sha512-p8T8ryePRR8FVfJZLVFmM53WY25FL0moCCTycUDuAu6rf9GMLwy0gNjXBGNin3Yun7Y+tIWd28axOf0t2EpAlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/html-minifier": "^3.5.3",
+        "clean-css": "^4.2.1",
+        "html-minifier": "^4.0.0",
+        "magic-string": "^0.25.0",
+        "parse-literals": "^1.2.1"
+      }
+    },
+    "node_modules/minify-html-literals/node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
       }
     },
     "node_modules/minimatch": {
@@ -14855,6 +14892,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-literals": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/parse-literals/-/parse-literals-1.2.1.tgz",
+      "integrity": "sha512-Ml0w104Ph2wwzuRdxrg9booVWsngXbB4bZ5T2z6WyF8b5oaNkUmBiDtahi34yUIpXD8Y13JjAK6UyIyApJ73RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "typescript": "^2.9.2 || ^3.0.0 || ^4.0.0"
+      }
+    },
+    "node_modules/parse-literals/node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/parse5": {
@@ -16157,6 +16218,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/rollup-plugin-minify-html-literals": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-minify-html-literals/-/rollup-plugin-minify-html-literals-1.2.6.tgz",
+      "integrity": "sha512-JRq2fjlCTiw0zu+1Sy3ClHGCxA79dWGr4HLHWSQgd060StVW9fBVksuj8Xw/suPkNSGClJf/4xNQ1MF6JeXPaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minify-html-literals": "^1.3.5",
+        "rollup-pluginutils": "^2.8.2"
+      },
+      "peerDependencies": {
+        "rollup": "^0.65.2 || ^1.0.0 || ^2.0.0"
       }
     },
     "node_modules/rollup-plugin-terser": {
@@ -22502,19 +22577,6 @@
         "lit": "^3.1.2"
       }
     },
-    "@lit-labs/rollup-plugin-minify-html-literals": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@lit-labs/rollup-plugin-minify-html-literals/-/rollup-plugin-minify-html-literals-0.1.0.tgz",
-      "integrity": "sha512-lSqAPswTa3rfsj9FqmuM8gsIg69xsiMOsmfdP4GhZTxQgeedADXsLxjc2FKw8L4/1EkJvUjabvY6Iq2WKaZTuQ==",
-      "dev": true,
-      "requires": {
-        "clean-css": "5.3.3",
-        "html-minifier": "^4.0.0",
-        "magic-string": "^0.30.11",
-        "rollup-pluginutils": "^2.8.2",
-        "typescript": "^2.9.2 || ^3.0.0 || ^4.0.0 || ^5.0.0"
-      }
-    },
     "@lit-labs/ssr-dom-shim": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.1.tgz",
@@ -23345,6 +23407,16 @@
         "@types/chai": "*"
       }
     },
+    "@types/clean-css": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/@types/clean-css/-/clean-css-4.2.11.tgz",
+      "integrity": "sha512-Y8n81lQVTAfP2TOdtJJEsCoYl1AnOkqDqMvXb9/7pfgZZ7r8YrEyurrAvAoAjHOGXKRybay+5CsExqIH6liccw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "source-map": "^0.6.0"
+      }
+    },
     "@types/co-body": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/@types/co-body/-/co-body-6.1.1.tgz",
@@ -23459,6 +23531,17 @@
       "requires": {
         "@types/minimatch": "*",
         "@types/node": "*"
+      }
+    },
+    "@types/html-minifier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@types/html-minifier/-/html-minifier-3.5.3.tgz",
+      "integrity": "sha512-j1P/4PcWVVCPEy5lofcHnQ6BtXz9tHGiFPWzqm7TtGuWZEfCHEP446HlkSNc9fQgNJaJZ6ewPtp2aaFla/Uerg==",
+      "dev": true,
+      "requires": {
+        "@types/clean-css": "*",
+        "@types/relateurl": "*",
+        "@types/uglify-js": "*"
       }
     },
     "@types/http-assert": {
@@ -23658,6 +23741,12 @@
         "csstype": "^3.0.2"
       }
     },
+    "@types/relateurl": {
+      "version": "0.2.33",
+      "resolved": "https://registry.npmjs.org/@types/relateurl/-/relateurl-0.2.33.tgz",
+      "integrity": "sha512-bTQCKsVbIdzLqZhLkF5fcJQreE4y1ro4DIyVrlDNSCJRRwHhB8Z+4zXXa8jN6eDvc2HbRsEYgbvrnGvi54EpSw==",
+      "dev": true
+    },
     "@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
@@ -23722,6 +23811,15 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
       "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
+    },
+    "@types/uglify-js": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.17.5.tgz",
+      "integrity": "sha512-TU+fZFBTBcXj/GpDpDaBmgWk/gn96kMZ+uocaFUlV2f8a6WdMzzI44QBCmGcCiYR0Y6ZlNRiyUyKKt5nl/lbzQ==",
+      "dev": true,
+      "requires": {
+        "source-map": "^0.6.1"
+      }
     },
     "@types/unist": {
       "version": "2.0.3",
@@ -29942,15 +30040,6 @@
       "dev": true,
       "peer": true
     },
-    "magic-string": {
-      "version": "0.30.17",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
-      "dev": true,
-      "requires": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
-      }
-    },
     "make-dir": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
@@ -30344,6 +30433,30 @@
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "dev": true
+    },
+    "minify-html-literals": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/minify-html-literals/-/minify-html-literals-1.3.5.tgz",
+      "integrity": "sha512-p8T8ryePRR8FVfJZLVFmM53WY25FL0moCCTycUDuAu6rf9GMLwy0gNjXBGNin3Yun7Y+tIWd28axOf0t2EpAlQ==",
+      "dev": true,
+      "requires": {
+        "@types/html-minifier": "^3.5.3",
+        "clean-css": "5.3.3",
+        "html-minifier": "^4.0.0",
+        "magic-string": "^0.25.0",
+        "parse-literals": "^1.2.1"
+      },
+      "dependencies": {
+        "magic-string": {
+          "version": "0.25.9",
+          "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+          "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+          "dev": true,
+          "requires": {
+            "sourcemap-codec": "^1.4.8"
+          }
+        }
+      }
     },
     "minimatch": {
       "version": "3.1.2",
@@ -31072,6 +31185,23 @@
         "error-ex": "^1.3.1",
         "json-parse-even-better-errors": "^2.3.0",
         "lines-and-columns": "^1.1.6"
+      }
+    },
+    "parse-literals": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/parse-literals/-/parse-literals-1.2.1.tgz",
+      "integrity": "sha512-Ml0w104Ph2wwzuRdxrg9booVWsngXbB4bZ5T2z6WyF8b5oaNkUmBiDtahi34yUIpXD8Y13JjAK6UyIyApJ73RQ==",
+      "dev": true,
+      "requires": {
+        "typescript": "^2.9.2 || ^3.0.0 || ^4.0.0"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "4.9.5",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+          "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+          "dev": true
+        }
       }
     },
     "parse5": {
@@ -32059,6 +32189,16 @@
             "slash": "^3.0.0"
           }
         }
+      }
+    },
+    "rollup-plugin-minify-html-literals": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-minify-html-literals/-/rollup-plugin-minify-html-literals-1.2.6.tgz",
+      "integrity": "sha512-JRq2fjlCTiw0zu+1Sy3ClHGCxA79dWGr4HLHWSQgd060StVW9fBVksuj8Xw/suPkNSGClJf/4xNQ1MF6JeXPaw==",
+      "dev": true,
+      "requires": {
+        "minify-html-literals": "^1.3.5",
+        "rollup-pluginutils": "^2.8.2"
       }
     },
     "rollup-plugin-terser": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dist"
   ],
   "overrides": {
-    "@lit-labs/rollup-plugin-minify-html-literals": {
+    "minify-html-literals": {
       "clean-css": "5.3.3"
     }
   },
@@ -97,7 +97,7 @@
     "@eslint/js": "^9.8.0",
     "@esm-bundle/chai-as-promised": "^7.1.1",
     "@html-eslint/eslint-plugin": "^0.41.0",
-    "@lit-labs/rollup-plugin-minify-html-literals": "^0.1.0",
+    "rollup-plugin-minify-html-literals": "^1.2.6",
     "@open-wc/dev-server-hmr": "^0.1.3",
     "@open-wc/testing": "^4.0.0",
     "@open-wc/testing-helpers": "^3.0.1",

--- a/rollup/rollup-common.js
+++ b/rollup/rollup-common.js
@@ -1,9 +1,9 @@
-import minifyTemplateLiterals from '@lit-labs/rollup-plugin-minify-html-literals';
 import { importMetaAssets } from '@web/rollup-plugin-import-meta-assets';
 import CleanCSS from 'clean-css';
 import glob from 'glob';
 import path from 'path';
 import clear from 'rollup-plugin-clear';
+import minifyTemplateLiterals from 'rollup-plugin-minify-html-literals';
 import { terser } from 'rollup-plugin-terser';
 import visualizer from 'rollup-plugin-visualizer';
 import SVGO from 'svgo';


### PR DESCRIPTION
## What does this PR do?

The lit labs plugin made rollup treat the config as CJS instead of ESM and crash when trying to install the components locally from the console3 project:
```
[!] Error: While loading the Rollup configuration from "rollup/rollup-npm.config.js", Node tried to require an ES module from a CommonJS file, which is not supported. A common cause is if there is a package.json file with "type": "module" in the same
   folder. You can try to fix this by changing the extension of your configuration file to ".cjs" or ".mjs" depending on the content, which will prevent Rollup from trying to preprocess the file but rather hand it to Node directly.
  https://rollupjs.org/guide/en/#using-untranspiled-config-files
  Error: While loading the Rollup configuration from "rollup/rollup-npm.config.js", Node tried to require an ES module from a CommonJS file, which is not supported. A common cause is if there is a package.json file with "type": "module" in the same
  folder. You can try to fix this by changing the extension of your configuration file to ".cjs" or ".mjs" depending on the content, which will prevent Rollup from trying to preprocess the file but rather hand it to Node directly.
      at Object.error (/home/flo-pro/Projects/clever-components/node_modules/rollup/dist/shared/rollup.js:198:30)
      at loadConfigFromBundledFile (/home/flo-pro/Projects/clever-components/node_modules/rollup/dist/shared/loadConfigFile.js:637:27)
      at getDefaultFromTranspiledConfigFile (/home/flo-pro/Projects/clever-components/node_modules/rollup/dist/shared/loadConfigFile.js:613:12)
      at loadConfigFile (/home/flo-pro/Projects/clever-components/node_modules/rollup/dist/shared/loadConfigFile.js:572:11)
      at Object.loadAndParseConfigFile (/home/flo-pro/Projects/clever-components/node_modules/rollup/dist/shared/loadConfigFile.js:552:21)
      at getConfigs (/home/flo-pro/Projects/clever-components/node_modules/rollup/dist/bin/rollup:1691:39)
      at runRollup (/home/flo-pro/Projects/clever-components/node_modules/rollup/dist/bin/rollup:1665:43)
```

The `rollup-plugin-minify-html-literals` doesn't trigger this error and has the exact same API anyway so we'll use that instead.

## How to review?

- From the clever-components project, checkout this branch and run:
  - `npm i`
  - `npm run components:build`,
  - `VERSION=0.0.0 npm run cdn-release:build`,
- From the console3 project run:
   - `npm run install-local:components`.

Note: I've also checked that container queries were working fine after building the components so you don't really have to bother with that :wink: 