### PR TITLE
fix(cc-link): only display download `cc-icon` on default mode

### DIFF
--- a/src/components/cc-link/cc-link.js
+++ b/src/components/cc-link/cc-link.js
@@ -171,7 +171,7 @@ export class CcLink extends LitElement {
                 a11y-name=${i18n('cc-link.new-window.name')}
               ></cc-icon>`
             : ''}
-          ${this.download != null
+          ${this.download != null && this.mode === 'default'
             ? html`<cc-icon
                 .icon=${iconRemixDownloadLine}
                 a11y-name=${i18n('cc-link.download.icon-a11y-name')}


### PR DESCRIPTION
## What does this PR do?

When the `download` attribute is set on the `cc-link`, the `cc-icon` was always display on the right of the text, but we only want this icon to be displayed when the `cc-link` mode is set to `default` and not when the mode is set to `button` or `subtle`. This PR fixes that.

## How to review?

- Check the commit,
- Check and inspect the [download story.](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-link/fix-download-icon/index.html?path=/story/%F0%9F%A7%AC-atoms-cc-link--download-link)

1 reviewer is enough.