### PR TITLE
feat(cc-addon-header): add Kubernetes

### DIFF
--- a/src/components/cc-addon-header/cc-addon-header.js
+++ b/src/components/cc-addon-header/cc-addon-header.js
@@ -150,6 +150,13 @@ export class CcAddonHeader extends LitElement {
                 </cc-link>
               `,
             )}
+            ${!isStringEmpty(addonInfo.configLink)
+              ? html`
+                  <cc-link mode="button" href="${addonInfo.configLink}" ?skeleton=${skeleton} download
+                    >${i18n('cc-addon-header.action.get-config')}
+                  </cc-link>
+                `
+              : ''}
             ${addonInfo.actions?.restart === true
               ? html`
                   <cc-button

--- a/src/components/cc-addon-header/cc-addon-header.stories.js
+++ b/src/components/cc-addon-header/cc-addon-header.stories.js
@@ -4,6 +4,7 @@ import {
   elasticData,
   jenkinsData,
   keycloakData,
+  kubernetesData,
   materiaData,
   matomoData,
   pulsarData,
@@ -225,6 +226,98 @@ export const withLongProductStatus = makeStory(conf, {
           rebuildAndRestart: true,
         },
         productStatus: fakeString(10),
+      },
+    },
+  ],
+});
+
+export const deploymentStatusWithDeployingState = makeStory(conf, {
+  items: [
+    {
+      /** @type {CcAddonHeaderStateLoaded} */
+      state: {
+        type: 'loaded',
+        ...kubernetesData,
+        deploymentStatus: 'deploying',
+      },
+    },
+    {
+      /** @type {CcAddonHeaderStateLoading} */
+      state: {
+        type: 'loading',
+        openLinks: [
+          {
+            url: fakeString(15),
+            name: fakeString(5),
+          },
+        ],
+        actions: {
+          restart: true,
+          rebuildAndRestart: true,
+        },
+        productStatus: fakeString(10),
+        deploymentStatus: 'deploying',
+      },
+    },
+  ],
+});
+
+export const deploymentStatusWithActiveState = makeStory(conf, {
+  items: [
+    {
+      /** @type {CcAddonHeaderStateLoaded} */
+      state: {
+        type: 'loaded',
+        ...kubernetesData,
+      },
+    },
+    {
+      /** @type {CcAddonHeaderStateLoading} */
+      state: {
+        type: 'loading',
+        openLinks: [
+          {
+            url: fakeString(15),
+            name: fakeString(5),
+          },
+        ],
+        actions: {
+          restart: true,
+          rebuildAndRestart: true,
+        },
+        productStatus: fakeString(10),
+        deploymentStatus: 'active',
+      },
+    },
+  ],
+});
+
+export const deploymentStatusWithFailedState = makeStory(conf, {
+  items: [
+    {
+      /** @type {CcAddonHeaderStateLoaded} */
+      state: {
+        type: 'loaded',
+        ...kubernetesData,
+        deploymentStatus: 'failed',
+      },
+    },
+    {
+      /** @type {CcAddonHeaderStateLoading} */
+      state: {
+        type: 'loading',
+        openLinks: [
+          {
+            url: fakeString(15),
+            name: fakeString(5),
+          },
+        ],
+        actions: {
+          restart: true,
+          rebuildAndRestart: true,
+        },
+        productStatus: fakeString(10),
+        deploymentStatus: 'failed',
       },
     },
   ],

--- a/src/components/cc-addon-header/cc-addon-header.types.d.ts
+++ b/src/components/cc-addon-header/cc-addon-header.types.d.ts
@@ -25,6 +25,7 @@ interface OptionalProperties {
   };
   productStatus?: string;
   deploymentStatus?: DeploymentStatus;
+  configLink?: string;
 }
 
 interface OpenLink {

--- a/src/stories/fixtures/addon.js
+++ b/src/stories/fixtures/addon.js
@@ -166,3 +166,23 @@ export const redisData = {
   },
   deploymentStatus: 'active'
 };
+
+/** @type {Addon} */
+export const kubernetesData = {
+  providerName: 'Kubernetes',
+  // FIXME: change the provider logo URL once Kubernetes has been uploaded to static assets
+  providerLogoUrl: 'https://img.icons8.com/?size=100&id=cvzmaEA4kC0o&format=png&color=000000',
+  name: 'my-kubernetes',
+  id: 'kubernetes_807d9f82-242b-4cd9-ac9f-96c73c1d074f',
+  zone: {
+    type: 'loaded',
+    ...ZONE,
+  },
+  configLink: 'https://example.com/kubeconfig.json',
+  actions: {
+    restart: true,
+    rebuildAndRestart: true,
+  },
+  productStatus: 'Alpha',
+  deploymentStatus: 'active'
+};

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -246,6 +246,7 @@ export const translations = {
   'cc-addon-features.title': `Features`,
   //#endregion
   //#region cc-addon-header
+  'cc-addon-header.action.get-config': `Get Kubeconfig`,
   'cc-addon-header.action.open-addon': /** @param {{ linkName: string }} _ */ ({ linkName }) => `Open ${linkName}`,
   'cc-addon-header.action.restart': `Restart`,
   'cc-addon-header.action.restart-rebuild': `Re-build and restart`,
@@ -259,7 +260,7 @@ export const translations = {
   'cc-addon-header.restart.success.message': /** @param {{logsUrl: string}} _*/ ({ logsUrl }) =>
     sanitize`The process of restarting your add-on and its linked services is in progress. See the <cc-link href="${logsUrl}">logs</cc-link> or the <cc-link href="${generateDocsHref('/addons/keycloak/')}">documentation</cc-link> for more information.`,
   'cc-addon-header.restart.success.title': `Restart in progress`,
-  'cc-addon-header.state-msg.deployment-failed': `The deployement failed.`,
+  'cc-addon-header.state-msg.deployment-failed': `The deployment has failed`,
   'cc-addon-header.state-msg.deployment-is-active': `Your add-on is active!`,
   'cc-addon-header.state-msg.deployment-is-deploying': `Your add-on is deploying…`,
   'cc-addon-header.state-msg.unknown-state': `Unknown state, try to restart the add-on or contact our support if you have additional questions.`,

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -257,6 +257,7 @@ export const translations = {
   'cc-addon-features.title': `Spécifications`,
   //#endregion
   //#region cc-addon-header
+  'cc-addon-header.action.get-config': `Obtenir le Kubeconfig`,
   'cc-addon-header.action.open-addon': /** @param {{ linkName: string }} _ */ ({ linkName }) => `Ouvrir ${linkName}`,
   'cc-addon-header.action.restart': `Redémarrer`,
   'cc-addon-header.action.restart-rebuild': `Re-build et redémarrer`,


### PR DESCRIPTION
## What does this PR do?

- Adds `configLink` property to the state,
- Adds Kubernetes product to the stories.

## How to review?

- Check the commits,
- Check the stories, espacially the [Kubernetes ones](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-addon-header/add-kube/index.html?path=/docs/%F0%9F%9B%A0-addon-cc-addon-header--docs)

1 reviewer should be enough.
