### PR TITLE
fix(cc-addon-header): make documentation link dynamic

### DIFF
--- a/src/components/cc-addon-header/cc-addon-header.smart-keycloak.js
+++ b/src/components/cc-addon-header/cc-addon-header.smart-keycloak.js
@@ -6,9 +6,12 @@ import { fakeString } from '../../lib/fake-strings.js';
 import { notify, notifyError } from '../../lib/notifications.js';
 import { sendToApi } from '../../lib/send-to-api.js';
 import { defineSmartComponent } from '../../lib/smart/define-smart-component.js';
+import { generateDocsHref } from '../../lib/utils.js';
 import { i18n } from '../../translations/translation.js';
 import '../cc-smart-container/cc-smart-container.js';
 import './cc-addon-header.js';
+
+const DOCS_URL = generateDocsHref(`/addons/keycloak`);
 
 /**
  * @typedef {import('./cc-addon-header.types.js').RawAddon} RawAddon
@@ -95,7 +98,7 @@ defineSmartComponent({
         .then(() => {
           notify({
             intent: 'success',
-            message: i18n('cc-addon-header.restart.success.message', { logsUrl }),
+            message: i18n('cc-addon-header.restart.success.message', { logsUrl, docsUrl: DOCS_URL }),
             title: i18n('cc-addon-header.restart.success.title'),
             options: {
               timeout: 0,
@@ -124,7 +127,7 @@ defineSmartComponent({
         .then(() => {
           notify({
             intent: 'success',
-            message: i18n('cc-addon-header.rebuild.success.message', { logsUrl }),
+            message: i18n('cc-addon-header.rebuild.success.message', { logsUrl, docsUrl: DOCS_URL }),
             title: i18n('cc-addon-header.rebuild.success.title'),
             options: {
               timeout: 0,

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -253,12 +253,18 @@ export const translations = {
   'cc-addon-header.error': `Something went wrong while loading add-on info.`,
   'cc-addon-header.logs.link': `View logs`,
   'cc-addon-header.rebuild.error': `Something went wrong while rebuilding the add-on.`,
-  'cc-addon-header.rebuild.success.message': /** @param {{logsUrl: string}} _*/ ({ logsUrl }) =>
-    sanitize`The process of rebuilding and restarting your add-on and its linked services is in progress. See the <cc-link href="${logsUrl}">logs</cc-link> or the <cc-link href="${generateDocsHref('/addons/keycloak/')}">documentation</cc-link> for more information.`,
+  'cc-addon-header.rebuild.success.message': /** @param {{logsUrl: string, docsUrl: string}} _ */ ({
+    logsUrl,
+    docsUrl,
+  }) =>
+    sanitize`The process of rebuilding and restarting your add-on and its linked services is in progress. See the <cc-link href="${logsUrl}">logs</cc-link> or the <cc-link href=${docsUrl}>documentation</cc-link> for more information.`,
   'cc-addon-header.rebuild.success.title': `Re-build and restart in progress`,
   'cc-addon-header.restart.error': `Something went wrong while restarting the add-on.`,
-  'cc-addon-header.restart.success.message': /** @param {{logsUrl: string}} _*/ ({ logsUrl }) =>
-    sanitize`The process of restarting your add-on and its linked services is in progress. See the <cc-link href="${logsUrl}">logs</cc-link> or the <cc-link href="${generateDocsHref('/addons/keycloak/')}">documentation</cc-link> for more information.`,
+  'cc-addon-header.restart.success.message': /** @param {{logsUrl: string, docsUrl: string}} _ */ ({
+    logsUrl,
+    docsUrl,
+  }) =>
+    sanitize`The process of restarting your add-on and its linked services is in progress. See the <cc-link href="${logsUrl}">logs</cc-link> or the <cc-link href=${docsUrl}>documentation</cc-link> for more information.`,
   'cc-addon-header.restart.success.title': `Restart in progress`,
   'cc-addon-header.state-msg.deployment-failed': `The deployment has failed`,
   'cc-addon-header.state-msg.deployment-is-active': `Your add-on is active!`,

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -264,12 +264,18 @@ export const translations = {
   'cc-addon-header.error': `Une erreur est survenue pendant le chargement des informations de l'add-on.`,
   'cc-addon-header.logs.link': `Voir les logs`,
   'cc-addon-header.rebuild.error': `Une erreur est survenue pendant le re-build de l'add-on.`,
-  'cc-addon-header.rebuild.success.message': /** @param {{logsUrl: string}} _*/ ({ logsUrl }) =>
-    sanitize`Le processus de re-build et de redémarrage de votre add-on et de ses services associés est en cours.  Consultez les <cc-link href="${logsUrl}">logs</cc-link> ou la <cc-link href="${generateDocsHref('/addons/keycloak/')}">documentation</cc-link> pour plus d'informations.`,
+  'cc-addon-header.rebuild.success.message': /** @param {{logsUrl: string, docsUrl: string}} _ */ ({
+    logsUrl,
+    docsUrl,
+  }) =>
+    sanitize`Le processus de re-build et de redémarrage de votre add-on et de ses services associés est en cours.  Consultez les <cc-link href="${logsUrl}">logs</cc-link> ou la <cc-link href=${docsUrl}>documentation</cc-link> pour plus d'informations.`,
   'cc-addon-header.rebuild.success.title': `Re-build et redémarrage en cours`,
   'cc-addon-header.restart.error': `Une erreur est survenue pendant le redémarrage de l'add-on.`,
-  'cc-addon-header.restart.success.message': /** @param {{logsUrl: string}} _*/ ({ logsUrl }) =>
-    sanitize`Le processus de redémarrage de votre add-on et de ses services associés est en cours. Consultez les <cc-link href="${logsUrl}">logs</cc-link> ou la <cc-link href="${generateDocsHref('/addons/keycloak/')}">documentation</cc-link> pour plus d'informations.`,
+  'cc-addon-header.restart.success.message': /** @param {{logsUrl: string, docsUrl: string}} _ */ ({
+    logsUrl,
+    docsUrl,
+  }) =>
+    sanitize`Le processus de redémarrage de votre add-on et de ses services associés est en cours. Consultez les <cc-link href="${logsUrl}">logs</cc-link> ou la <cc-link href=${docsUrl}>documentation</cc-link> pour plus d'informations.`,
   'cc-addon-header.restart.success.title': `Redémarrage en cours`,
   'cc-addon-header.state-msg.deployment-failed': `Le déploiement de l'add-on a échoué.`,
   'cc-addon-header.state-msg.deployment-is-active': `Votre add-on est disponible !`,


### PR DESCRIPTION
## What does this PR do?

- Sets a `docName` in the smart and pass it to the success translation messages,
- Adds `docName` param in the success translation messages.

## How to review?

- Check the commit,
- Check on `demo-smart` ; select the `cc-addon-header.smart-keycloak`, restart the addon and click on the documentation link on the success message.

1 reviewer should be enough.
