### PR TITLE
refactor(cc-logs-addon-runtime): use real addon id

### DIFF
--- a/sandbox/cc-logs-addon-runtime/cc-logs-addon-runtime-sandbox.js
+++ b/sandbox/cc-logs-addon-runtime/cc-logs-addon-runtime-sandbox.js
@@ -17,8 +17,8 @@ const DATE_RANGE_SELECTION_OPTIONS = [
   { label: 'yesterday', value: 'yesterday', range: { type: 'preset', preset: 'yesterday' } },
 ];
 
-const INITIAL_OWNER = 'orga_540caeb6-521c-4a19-a955-efe6da35d142';
-const INITIAL_ADDON = 'mysql_13fad7db-da7b-4a99-84ae-bbe71a4e2e08';
+const INITIAL_OWNER = 'orga_2eb942c9-ae24-40fe-9e4c-53c9982a02b1';
+const INITIAL_ADDON = 'postgresql_f0e6a134-885f-4cc6-8cf7-31bab52e6076';
 
 /**
  * @typedef {import('../../src/components/cc-smart-container/cc-smart-container.js').CcSmartContainer} CcSmartContainer
@@ -47,7 +47,7 @@ class CcLogsAddonRuntimeSandbox extends LitElement {
   _onFormSubmit(formData) {
     this._smartContainerRef.value.context = {
       ownerId: formData.ownerId,
-      addonId: formData.addonId,
+      realAddonId: formData.realAddonId,
       dateRangeSelection: DATE_RANGE_SELECTION_OPTIONS.find((o) => o.value === formData.dateRangeSelection)?.range,
     };
   }
@@ -56,7 +56,7 @@ class CcLogsAddonRuntimeSandbox extends LitElement {
     return html`
       <form class="ctrl-top" style="align-items: normal" ${ref(this._formRef)} ${formSubmit(this._onFormSubmit)}>
         <cc-input-text label="ownerId" name="ownerId" value=${INITIAL_OWNER} required></cc-input-text>
-        <cc-input-text label="addonId" name="addonId" value=${INITIAL_ADDON} required></cc-input-text>
+        <cc-input-text label="realAddonId" name="realAddonId" value=${INITIAL_ADDON} required></cc-input-text>
         <cc-select
           .options=${DATE_RANGE_SELECTION_OPTIONS}
           label="dateRangeSelection"

--- a/src/components/cc-logs-addon-runtime/cc-logs-addon-runtime.smart.js
+++ b/src/components/cc-logs-addon-runtime/cc-logs-addon-runtime.smart.js
@@ -21,14 +21,14 @@ defineSmartComponent({
   params: {
     apiConfig: { type: Object },
     ownerId: { type: String },
-    addonId: { type: String },
+    realAddonId: { type: String },
     dateRangeSelection: { type: Object, optional: true },
   },
   /**
    * @param {OnContextUpdateArgs} args
    */
   onContextUpdate({ component, context, onEvent, updateComponent, signal }) {
-    const { apiConfig, ownerId, addonId, dateRangeSelection } = context;
+    const { apiConfig, ownerId, realAddonId, dateRangeSelection } = context;
 
     if (dateRangeSelection != null) {
       updateComponent('dateRangeSelection', dateRangeSelection);
@@ -37,7 +37,7 @@ defineSmartComponent({
     const controller = new SmartController({
       apiConfig,
       ownerId,
-      addonId,
+      addonId: realAddonId,
       component,
       updateComponent,
     });

--- a/src/components/cc-logs-addon-runtime/cc-logs-addon-runtime.smart.md
+++ b/src/components/cc-logs-addon-runtime/cc-logs-addon-runtime.smart.md
@@ -19,7 +19,7 @@ title: '💡 Smart'
 |----------------------|:------------------------:|:--------:|---------------------------------------------|---------|
 | `apiConfig`          |       `ApiConfig`        |   Yes    | Object with API configuration (target host) |         |
 | `ownerId`            |         `string`         |   Yes    | UUID prefixed with `orga_` or `user_`       |         |
-| `addonId`            |         `string`         |   Yes    | Real addon ID                               |         |
+| `realAddonId`        |         `string`         |   Yes    | Real addon ID                               |         |
 | `dateRangeSelection` | `LogsDateRangeSelection` |    No    | Initial date range                          |         |
 
 ```ts
@@ -50,6 +50,8 @@ interface LogsDateRangeSelectionCustom {
   since: string;
   until: string;
 }
+
+type LogsDateRangePresetType = 'lastHour' | 'last4Hours' | 'last7Days' | 'today' | 'yesterday';
 ```
 
 ## 🌐 API endpoints
@@ -70,7 +72,7 @@ interface LogsDateRangeSelectionCustom {
       OAUTH_CONSUMER_SECRET: "",
     },
     "ownerId": "",
-    "addonId": "",
+    "realAddonId": "",
   }'>
   <cc-logs-addon-runtime-beta></cc-logs-addon-runtime-beta>
 <cc-smart-container>


### PR DESCRIPTION
## What this PR do?

change smart property `addonId` to `realAddonId`

## How to review?

- check the commit
- check the sandbox (with prod account)