### PR TITLE
feat(cc-addon-credentials-content): make credentials labels more responsive

### DIFF
--- a/src/components/cc-addon-credentials-content/cc-addon-credentials-content.js
+++ b/src/components/cc-addon-credentials-content/cc-addon-credentials-content.js
@@ -241,8 +241,9 @@ export class CcAddonCredentialsContent extends LitElement {
         }
 
         dt {
-          flex: 0 1 21em;
+          flex: 1 1 33%;
           font-weight: bold;
+          max-width: 21em;
         }
 
         dd {

--- a/src/components/cc-addon-credentials-content/cc-addon-credentials-content.js
+++ b/src/components/cc-addon-credentials-content/cc-addon-credentials-content.js
@@ -148,7 +148,7 @@ export class CcAddonCredentialsContent extends LitElement {
   _renderCredential({ code, value }, skeleton) {
     const label = this._getLabelFromCode(code);
     return html`
-      <div class="credential">
+      <div class="credential ${classMap({ 'credential--align-center': credentialsToDisplayAsInput.has(code) })}">
         <dt>${label}</dt>
         <dd>
           ${credentialsToDisplayAsString.has(code)
@@ -229,11 +229,15 @@ export class CcAddonCredentialsContent extends LitElement {
         }
 
         .credential {
-          align-items: center;
+          align-items: baseline;
           display: flex;
           flex-wrap: wrap;
           gap: 0.5em;
           padding-block: 1em;
+        }
+
+        .credential--align-center {
+          align-items: center;
         }
 
         .credential:not(:last-of-type) {


### PR DESCRIPTION
## What does this PR do?

- Tweaks the CSS for labels so that they shrink progressively until they wrap (thanks @roberttran-cc for the idea :muscle:).

## How to review?

- Check the commit,
- Check the preview and reduce the viewport progressively for the [default story](https://clever-components-preview.cellar-c2.services.clever-cloud.com/cc-addon-credentials-beta/improve-labels-wrapping/index.html?path=/story/%F0%9F%9B%A0-addon-cc-addon-credentials-content--default-story),
- 1 reviewer should be enough for this one.