### PR TITLE
refactor(cc-addon-credentials-beta): use helper for docs URL

### DIFF
--- a/src/components/cc-addon-credentials-beta/cc-addon-credentials-beta.smart-keycloak.js
+++ b/src/components/cc-addon-credentials-beta/cc-addon-credentials-beta.smart-keycloak.js
@@ -4,6 +4,7 @@ import '../cc-smart-container/cc-smart-container.js';
 // @ts-expect-error FIXME: remove when clever-client exports types
 import { get as getAddon } from '@clevercloud/client/esm/api/v2/addon.js';
 import { notifyError, notifySuccess } from '../../lib/notifications.js';
+import { generateDocsHref } from '../../lib/utils.js';
 import { i18n } from '../../translations/translation.js';
 import './cc-addon-credentials-beta.js';
 
@@ -80,7 +81,7 @@ defineSmartComponent({
     });
     updateComponent('docLink', {
       text: i18n('cc-addon-credentials-beta.doc-link.keycloak'),
-      href: 'https://www.clever-cloud.com/developers/doc/addons/keycloak/',
+      href: generateDocsHref('/doc/addons/keycloak/'),
     });
 
     api
@@ -103,10 +104,6 @@ defineSmartComponent({
                 value: formatNgData(operator.features.networkGroup),
               },
             ],
-          },
-          docLink: {
-            text: 'Keycloak - Documentation',
-            href: 'https://www.clever-cloud.com/developers/doc/addons/keycloak/',
           },
         });
       })


### PR DESCRIPTION
## What does this PR do?

- Relies on the `generateDocsHref` helper instead of hardcoded value,
- Removes the docLink set within the state within the smart (it was irrelevant since this is not part of the state anyway).

## How to review?

- Check the commit,
- Check demo-smart locally, the doc link should still lead to the keycloak docs :+1:,
- 1 reviewer should be enough for this one.