### PR TITLE
refactor(cc-addon-credentials-beta): align error translation

### DIFF
--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -179,7 +179,7 @@ export const translations = {
   'cc-addon-credentials-beta.choice.elastic': `Elastic`,
   'cc-addon-credentials-beta.choice.kibana': `Kibana`,
   'cc-addon-credentials-beta.doc-link.keycloak': `Keycloak - Documentation`,
-  'cc-addon-credentials-beta.error': `Something went wrong while loading the add-on information.`,
+  'cc-addon-credentials-beta.error': `Something went wrong while loading add-on information.`,
   'cc-addon-credentials-beta.heading': `Access`,
   'cc-addon-credentials-beta.ng.disabling.error': `Something went wrong while trying to disable the Network Group`,
   'cc-addon-credentials-beta.ng.disabling.success': `The Network Group has been successfully disabled`,


### PR DESCRIPTION
## What does this PR do?

- Removes `the` from the error message when loading fails. This way the error message is exactly the same as other dashboard components.

## How to review?

- Check the commit,
- Check the error story => it should match the `cc-addon-info` & `cc-addon-header` error messages (in English).