### PR TITLE
Dashboard addons/refactor types

### DIFF
--- a/src/components/cc-addon-credentials-beta/cc-addon-credentials-beta.api.js
+++ b/src/components/cc-addon-credentials-beta/cc-addon-credentials-beta.api.js
@@ -1,0 +1,102 @@
+// @ts-expect-error FIXME: remove when clever-client exports types
+import { get as getAddon } from '@clevercloud/client/esm/api/v2/addon.js';
+import { sendToApi } from '../../lib/send-to-api.js';
+
+/**
+ * @typedef {import('./cc-addon-credentials-beta.types.js').RawAddon} RawAddon
+ * @typedef {import('../../lib/send-to-api.types.js').ApiConfig} ApiConfig
+ */
+
+export class CcAddonCredentialsBetaApi {
+  /**
+   * @param {object} params
+   * @param {ApiConfig} params.apiConfig
+   * @param {string} params.ownerId
+   * @param {string} params.addonId
+   * @param {string} params.providerId
+   * @param {AbortSignal} params.signal
+   */
+  constructor({ apiConfig, ownerId, addonId, providerId, signal }) {
+    this._apiConfig = apiConfig;
+    this._ownerId = ownerId;
+    this._addonId = addonId;
+    this._providerId = providerId;
+    this._realId = null;
+    this._signal = signal;
+  }
+
+  /** @return {Promise<RawAddon>} */
+  _getAddon() {
+    return getAddon({ id: this._ownerId, addonId: this._addonId }).then(
+      sendToApi({ apiConfig: this._apiConfig, signal: this._signal }),
+    );
+  }
+
+  /**
+   * @param {string} realId
+   * @returns {Promise<Object>}
+   */
+  _getOperator(realId) {
+    return getOperator({ providerId: this._providerId, realId }).then(
+      sendToApi({ apiConfig: this._apiConfig, signal: this._signal }),
+    );
+  }
+
+  /** @returns {Promise<Object>} */
+  async getAddonWithOperator() {
+    const rawAddon = await this._getAddon();
+    const operator = await this._getOperator(rawAddon.realId);
+    this._realId = rawAddon.realId;
+    this._providerId = /** @type {import('../common.types.js').RawAddonProvider} */ (rawAddon.provider).id;
+
+    return operator;
+  }
+
+  createNg() {
+    return createNg({ providerId: this._providerId, realId: this._realId }).then(
+      sendToApi({ apiConfig: this._apiConfig }),
+    );
+  }
+
+  deleteNg() {
+    return deleteNg({ providerId: this._providerId, realId: this._realId }).then(
+      sendToApi({ apiConfig: this._apiConfig }),
+    );
+  }
+}
+
+/**
+ * @param {{ providerId: string, realId: string }} params
+ */
+function getOperator(params) {
+  // no multipath for /self or /organisations/{id}
+  return Promise.resolve({
+    method: 'get',
+    url: `/v4/addon-providers/addon-${params.providerId}/addons/${params.realId}`,
+    headers: { Accept: 'application/json' },
+    // no queryParams
+    // no body
+  });
+}
+
+/**
+ * @param {{ providerId: string, realId: string }} params
+ */
+function createNg({ providerId, realId }) {
+  return Promise.resolve({
+    method: 'post',
+    url: `/v4/addon-providers/addon-${providerId}/addons/${realId}/networkgroup`,
+    headers: { Access: 'application/json' },
+  });
+}
+
+/**
+ * @param {{ providerId: string, realId: string }} params
+ */
+function deleteNg({ providerId, realId }) {
+  return Promise.resolve({
+    method: 'delete',
+    url: `/v4/addon-providers/addon-${providerId}/addons/${realId}/networkgroup`,
+    headers: { Access: 'application/json' },
+  });
+}

--- a/src/components/cc-addon-credentials-beta/cc-addon-credentials-beta.smart-keycloak.js
+++ b/src/components/cc-addon-credentials-beta/cc-addon-credentials-beta.smart-keycloak.js
@@ -1,11 +1,9 @@
-import { sendToApi } from '../../lib/send-to-api.js';
-import { defineSmartComponent } from '../../lib/smart/define-smart-component.js';
-import '../cc-smart-container/cc-smart-container.js';
-// @ts-expect-error FIXME: remove when clever-client exports types
-import { get as getAddon } from '@clevercloud/client/esm/api/v2/addon.js';
 import { notifyError, notifySuccess } from '../../lib/notifications.js';
+import { defineSmartComponent } from '../../lib/smart/define-smart-component.js';
 import { generateDocsHref } from '../../lib/utils.js';
 import { i18n } from '../../translations/translation.js';
+import '../cc-smart-container/cc-smart-container.js';
+import { CcAddonCredentialsBetaApi } from './cc-addon-credentials-beta.api.js';
 import './cc-addon-credentials-beta.js';
 
 /** @type {AddonCredential[]} */
@@ -25,16 +23,16 @@ const SKELETON_DATA = [
     },
   },
 ];
+const PROVIDER_ID = 'keycloak';
 
 /**
  * @typedef {import('./cc-addon-credentials-beta.js').CcAddonCredentialsBeta} CcAddonCredentialsBeta
  * @typedef {import('./cc-addon-credentials-beta.types.js').AddonCredentialsBetaStateLoaded} AddonCredentialsBetaStateLoaded
- * @typedef {import('./cc-addon-credentials-beta.types.js').RawAddon} RawAddon
- * @typedef {import('./cc-addon-credentials-beta.types.js').KeycloakOperatorInfo} KeycloakOperatorInfo
  * @typedef {import('../cc-addon-credentials-content/cc-addon-credentials-content.types.js').AddonCredential} AddonCredential
  * @typedef {import('../cc-addon-credentials-content/cc-addon-credentials-content.types.js').AddonCredentialNg} AddonCredentialNg
  * @typedef {import('../cc-addon-credentials-content/cc-addon-credentials-content.types.js').AddonCredentialNgEnabled} AddonCredentialNgEnabled
  * @typedef {import('../cc-addon-credentials-content/cc-addon-credentials-content.types.js').AddonCredentialNgDisabled} AddonCredentialNgDisabled
+ * @typedef {import('../../operators.types.js').KeycloakOperatorInfo} KeycloakOperatorInfo
  * @typedef {import('../../lib/send-to-api.js').ApiConfig} ApiConfig
  * @typedef {import('../../lib/smart/smart-component.types.js').OnContextUpdateArgs<CcAddonCredentialsBeta>} OnContextUpdateArgs
  */
@@ -85,25 +83,16 @@ defineSmartComponent({
     });
 
     api
-      .getAddonWithOperator()
-      .then((operator) => {
+      .getCredentials()
+      .then((credentials) => {
         updateComponent('state', {
           type: 'loaded',
           tabs: {
-            default: [
-              {
-                code: 'user',
-                value: operator.envVars.CC_KEYCLOAK_ADMIN,
-              },
-              {
-                code: 'password',
-                value: operator.envVars.CC_KEYCLOAK_ADMIN_DEFAULT_PASSWORD,
-              },
-              {
-                code: 'ng',
-                value: formatNgData(operator.features.networkGroup),
-              },
-            ],
+            default: credentials,
+          },
+          docLink: {
+            text: 'Keycloak - Documentation',
+            href: 'https://www.clever-cloud.com/developers/doc/addons/keycloak/',
           },
         });
       })
@@ -196,7 +185,7 @@ function formatNgData(data) {
   };
 }
 
-class Api {
+class Api extends CcAddonCredentialsBetaApi {
   /**
    * @param {object} params
    * @param {ApiConfig} params.apiConfig
@@ -205,86 +194,27 @@ class Api {
    * @param {AbortSignal} params.signal
    */
   constructor({ apiConfig, ownerId, addonId, signal }) {
-    this._apiConfig = apiConfig;
-    this._ownerId = ownerId;
-    this._addonId = addonId;
-    this._provideId = null;
-    this._realId = null;
-    this._signal = signal;
-  }
-
-  /** @return {Promise<RawAddon>} */
-  _getAddon() {
-    return getAddon({ id: this._ownerId, addonId: this._addonId }).then(
-      sendToApi({ apiConfig: this._apiConfig, signal: this._signal }),
-    );
+    super({ apiConfig, ownerId, addonId, providerId: PROVIDER_ID, signal });
   }
 
   /**
-   * @param {string} realId
-   * @returns {Promise<KeycloakOperatorInfo>}
+   * @return {Promise<AddonCredential[]>}
    */
-  _getOperator(realId) {
-    return getOperator({ providerId: 'keycloak', realId }).then(
-      sendToApi({ apiConfig: this._apiConfig, signal: this._signal }),
-    );
+  async getCredentials() {
+    const operator = /** @type {KeycloakOperatorInfo} */ (await this.getAddonWithOperator());
+    return [
+      {
+        code: 'user',
+        value: operator.envVars.CC_KEYCLOAK_ADMIN,
+      },
+      {
+        code: 'password',
+        value: operator.envVars.CC_KEYCLOAK_ADMIN_DEFAULT_PASSWORD,
+      },
+      {
+        code: 'ng',
+        value: formatNgData(operator.features.networkGroup),
+      },
+    ];
   }
-
-  /** @returns {Promise<KeycloakOperatorInfo>} */
-  async getAddonWithOperator() {
-    const rawAddon = await this._getAddon();
-    const operator = await this._getOperator(rawAddon.realId);
-    this._realId = rawAddon.realId;
-    this._provideId = /** @type {import('../common.types.js').RawAddonProvider} */ (rawAddon.provider).id;
-
-    return operator;
-  }
-
-  createNg() {
-    return createNg({ providerId: this._provideId, realId: this._realId }).then(
-      sendToApi({ apiConfig: this._apiConfig }),
-    );
-  }
-
-  deleteNg() {
-    return deleteNg({ providerId: this._provideId, realId: this._realId }).then(
-      sendToApi({ apiConfig: this._apiConfig }),
-    );
-  }
-}
-
-/**
- * @param {{ providerId: string, realId: string }} params
- */
-function getOperator(params) {
-  // no multipath for /self or /organisations/{id}
-  return Promise.resolve({
-    method: 'get',
-    url: `/v4/addon-providers/addon-${params.providerId}/addons/${params.realId}`,
-    headers: { Accept: 'application/json' },
-    // no queryParams
-    // no body
-  });
-}
-
-/**
- * @param {{ providerId: string, realId: string }} params
- */
-function createNg({ providerId, realId }) {
-  return Promise.resolve({
-    method: 'post',
-    url: `/v4/addon-providers/addon-${providerId}/addons/${realId}/networkgroup`,
-    headers: { Access: 'application/json' },
-  });
-}
-
-/**
- * @param {{ providerId: string, realId: string }} params
- */
-function deleteNg({ providerId, realId }) {
-  return Promise.resolve({
-    method: 'delete',
-    url: `/v4/addon-providers/addon-${providerId}/addons/${realId}/networkgroup`,
-    headers: { Access: 'application/json' },
-  });
 }

--- a/src/components/cc-addon-credentials-beta/cc-addon-credentials-beta.types.d.ts
+++ b/src/components/cc-addon-credentials-beta/cc-addon-credentials-beta.types.d.ts
@@ -38,39 +38,3 @@ export interface RawAddon {
   creationDate: number;
   configKeys: string[];
 }
-
-export interface KeycloakOperatorInfo {
-  resourceId: string;
-  addonId: string;
-  name: string;
-  ownerId: string;
-  plan: string;
-  version: string;
-  javaVersion: string;
-  accessUrl: string;
-  availableVersions: string[];
-  resources: {
-    entrypoint: string;
-    fsbucketId: string;
-    pgsqlId: string;
-  };
-  features: {
-    networkGroup: null;
-  };
-  envVars: {
-    CC_KEYCLOAK_ADMIN: string;
-    CC_RUN_COMMAND: string;
-    CC_KEYCLOAK_DB_POOL_INITIAL_SIZE: string;
-    CC_METRICS_PROMETHEUS_PATH: string;
-    CC_JAVA_VERSION: string;
-    CC_PRE_RUN_HOOK: string;
-    CC_METRICS_PROMETHEUS_PORT: string;
-    CC_POST_BUILD_HOOK: string;
-    CC_KEYCLOAK_REALMS: string;
-    CC_KEYCLOAK_HOSTNAME: string;
-    CC_FS_BUCKET: string;
-    CC_KEYCLOAK_ADMIN_DEFAULT_PASSWORD: string;
-    CC_KEYCLOAK_VERSION: string;
-    CC_KEYCLOAK_DB_POOL_MAX_SIZE: string;
-  };
-}

--- a/src/components/cc-addon-header/cc-addon-header.api.js
+++ b/src/components/cc-addon-header/cc-addon-header.api.js
@@ -1,0 +1,119 @@
+// @ts-expect-error FIXME: remove when clever-client exports types
+import { get as getAddon } from '@clevercloud/client/esm/api/v2/addon.js';
+// @ts-expect-error FIXME: remove when clever-client exports types
+import { getZone } from '@clevercloud/client/esm/api/v4/product.js';
+import { sendToApi } from '../../lib/send-to-api.js';
+
+/**
+ * @typedef {import('./cc-addon-header.types.js').RawAddon} RawAddon
+ * @typedef {import('../cc-zone/cc-zone.types.js').ZoneStateLoaded} ZoneStateLoaded
+ * @typedef {import('../../operators.types.js').RawOperator} RawOperator
+ * @typedef {import('../../lib/send-to-api.types.js').ApiConfig} ApiConfig
+ */
+
+export class CcAddonHeaderApi {
+  /**
+   * @param {object} params
+   * @param {ApiConfig} params.apiConfig
+   * @param {string} params.ownerId
+   * @param {string} params.addonId
+   * @param {string} params.providerId
+   * @param {AbortSignal} params.signal
+   */
+  constructor({ apiConfig, ownerId, addonId, providerId, signal }) {
+    this._apiConfig = apiConfig;
+    this._ownerId = ownerId;
+    this._addonId = addonId;
+    this._provider = providerId;
+    this._realId = null;
+    this._signal = signal;
+  }
+
+  /** @return {Promise<RawAddon>} */
+  getAddon() {
+    return getAddon({ id: this._ownerId, addonId: this._addonId }).then(
+      sendToApi({ apiConfig: this._apiConfig, signal: this._signal }),
+    );
+  }
+
+  /**
+   * @param {string} realId
+   * @return {Promise<RawOperator>}
+   */
+  getOperator(realId) {
+    return getOperator({ provider: this._provider, realId }).then(
+      sendToApi({ apiConfig: this._apiConfig, signal: this._signal }),
+    );
+  }
+
+  /**
+   * @param {string} zoneName
+   * @return {Promise<ZoneStateLoaded>}
+   */
+  getZone(zoneName) {
+    return getZone({ zoneName }).then(sendToApi({ apiConfig: this._apiConfig, signal: this._signal }));
+  }
+
+  /** @returns {Promise<{ rawAddon: RawAddon, operator: RawOperator, zone: ZoneStateLoaded }>} */
+  async getAddonWithOperatorAndZone() {
+    const rawAddon = await this.getAddon();
+    this._realId = rawAddon.realId;
+    const [operator, zone] = await Promise.all([this.getOperator(rawAddon.realId), this.getZone(rawAddon.region)]);
+
+    return { rawAddon, operator, zone };
+  }
+
+  /** @return {Promise<void>} */
+  async restartAddon() {
+    return rebootOperator({ provider: this._provider, realId: this._realId }).then(
+      sendToApi({ apiConfig: this._apiConfig }),
+    );
+  }
+
+  /** @return {Promise<void>} */
+  async rebuildAndRestartAddon() {
+    return rebuildOperator({ provider: this._provider, realId: this._realId }).then(
+      sendToApi({ apiConfig: this._apiConfig }),
+    );
+  }
+}
+
+/**
+ * @param {{ provider: string, realId: string }} params
+ * @returns {Promise<Object>}
+ */
+function getOperator(params) {
+  return Promise.resolve({
+    method: 'get',
+    url: `/v4/addon-providers/addon-${params.provider}/addons/${params.realId}`,
+    headers: { Accept: 'application/json' },
+    // no queryParams
+    // no body
+  });
+}
+
+// FIXME: remove and use the clever-client call from the new clever-client
+/** @param {{ provider: string, realId: string }} params */
+function rebootOperator(params) {
+  // no multipath for /self or /organisations/{id}
+  return Promise.resolve({
+    method: 'post',
+    url: `/v4/addon-providers/addon-${params.provider}/addons/${params.realId}/reboot`,
+    headers: { Accept: 'application/json' },
+    // no queryParams
+    // no body
+  });
+}
+
+// FIXME: remove and use the clever-client call from the new clever-client
+/** @param {{ provider: string, realId: string }} params */
+function rebuildOperator(params) {
+  // no multipath for /self or /organisations/{id}
+  return Promise.resolve({
+    method: 'post',
+    url: `/v4/addon-providers/addon-${params.provider}/addons/${params.realId}/rebuild`,
+    headers: { Accept: 'application/json' },
+    // no queryParams
+    // no body
+  });
+}

--- a/src/components/cc-addon-header/cc-addon-header.js
+++ b/src/components/cc-addon-header/cc-addon-header.js
@@ -29,7 +29,7 @@ const STATUS_ICON = {
 
 /** @type {Partial<CcAddonHeaderStateLoaded>} */
 const SKELETON_ADDON_INFO = {
-  providerName: fakeString(15),
+  providerId: fakeString(15),
   providerLogoUrl: null,
   name: fakeString(15),
   id: fakeString(15),
@@ -123,7 +123,7 @@ export class CcAddonHeader extends LitElement {
               class="logo"
               ?skeleton=${skeleton}
               src=${ifDefined(addonInfo.providerLogoUrl)}
-              a11y-name=${addonInfo.providerName}
+              a11y-name=${addonInfo.providerId}
             ></cc-img>
 
             <div class="details">

--- a/src/components/cc-addon-header/cc-addon-header.smart-keycloak.js
+++ b/src/components/cc-addon-header/cc-addon-header.smart-keycloak.js
@@ -62,7 +62,7 @@ defineSmartComponent({
 
         updateComponent('state', {
           type: 'loaded',
-          providerName: rawAddon.provider.name,
+          providerId: rawAddon.provider.name,
           providerLogoUrl: rawAddon.provider.logoUrl,
           name: rawAddon.name,
           id: rawAddon.realId,

--- a/src/components/cc-addon-header/cc-addon-header.smart-keycloak.js
+++ b/src/components/cc-addon-header/cc-addon-header.smart-keycloak.js
@@ -1,24 +1,17 @@
-// @ts-expect-error FIXME: remove when clever-client exports types
-import { get as getAddon } from '@clevercloud/client/esm/api/v2/addon.js';
-// @ts-expect-error FIXME: remove when clever-client exports types
-import { getZone } from '@clevercloud/client/esm/api/v4/product.js';
 import { fakeString } from '../../lib/fake-strings.js';
 import { notify, notifyError } from '../../lib/notifications.js';
-import { sendToApi } from '../../lib/send-to-api.js';
 import { defineSmartComponent } from '../../lib/smart/define-smart-component.js';
 import { generateDocsHref } from '../../lib/utils.js';
 import { i18n } from '../../translations/translation.js';
 import '../cc-smart-container/cc-smart-container.js';
+import { CcAddonHeaderApi } from './cc-addon-header.api.js';
 import './cc-addon-header.js';
 
 const DOCS_URL = generateDocsHref(`/addons/keycloak`);
+const PROVIDER_ID = 'keycloak';
 
 /**
- * @typedef {import('./cc-addon-header.types.js').RawAddon} RawAddon
- * @typedef {import('./cc-addon-header.types.js').RawOperator} RawOperator
  * @typedef {import('./cc-addon-header.js').CcAddonHeader} CcAddonHeader
- * @typedef {import('../cc-zone/cc-zone.types.js').ZoneStateLoaded} ZoneStateLoaded
- * @typedef {import('../../lib/send-to-api.types.js').ApiConfig} ApiConfig
  * @typedef {import('../../lib/smart/smart-component.types.js').OnContextUpdateArgs<CcAddonHeader>} OnContextUpdateArgs
  */
 
@@ -35,7 +28,8 @@ defineSmartComponent({
   /** @param {OnContextUpdateArgs} args */
   onContextUpdate({ context, updateComponent, onEvent, signal }) {
     const { apiConfig, ownerId, addonId, productStatus } = context;
-    const api = new Api(apiConfig, ownerId, addonId, signal);
+    const providerId = PROVIDER_ID;
+    const api = new CcAddonHeaderApi({ apiConfig, ownerId, addonId, providerId: providerId, signal });
     let logsUrl = '';
 
     updateComponent('state', {
@@ -147,107 +141,3 @@ defineSmartComponent({
     });
   },
 });
-
-class Api {
-  /**
-   * @param {ApiConfig} apiConfig
-   * @param {string} ownerId
-   * @param {string} addonId
-   * @param {AbortSignal} signal
-   */
-  constructor(apiConfig, ownerId, addonId, signal) {
-    this._apiConfig = apiConfig;
-    this._ownerId = ownerId;
-    this._addonId = addonId;
-    this._realId = null;
-    this._signal = signal;
-  }
-
-  /** @return {Promise<RawAddon>} */
-  getAddon() {
-    return getAddon({ id: this._ownerId, addonId: this._addonId }).then(
-      sendToApi({ apiConfig: this._apiConfig, signal: this._signal }),
-    );
-  }
-
-  /**
-   * @param {string} realId
-   * @return {Promise<RawOperator>}
-   */
-  getOperator(realId) {
-    return this._getOperator({ provider: 'keycloak', realId }).then(
-      sendToApi({ apiConfig: this._apiConfig, signal: this._signal }),
-    );
-  }
-
-  /**
-   * @param {string} zoneName
-   * @return {Promise<ZoneStateLoaded>}
-   */
-  getZone(zoneName) {
-    return getZone({ zoneName }).then(sendToApi({ apiConfig: this._apiConfig, signal: this._signal }));
-  }
-
-  /** @returns {Promise<{ rawAddon: RawAddon, operator: RawOperator, zone: ZoneStateLoaded }>} */
-  async getAddonWithOperatorAndZone() {
-    const rawAddon = await this.getAddon();
-    this._realId = rawAddon.realId;
-    const [operator, zone] = await Promise.all([this.getOperator(rawAddon.realId), this.getZone(rawAddon.region)]);
-
-    return { rawAddon, operator, zone };
-  }
-
-  /** @return {Promise<void>} */
-  async restartAddon() {
-    return rebootOperator({ provider: 'keycloak', realId: this._realId }).then(
-      sendToApi({ apiConfig: this._apiConfig }),
-    );
-  }
-
-  /** @return {Promise<void>} */
-  async rebuildAndRestartAddon() {
-    return rebuildOperator({ provider: 'keycloak', realId: this._realId }).then(
-      sendToApi({ apiConfig: this._apiConfig }),
-    );
-  }
-
-  /**
-   * @param {{ provider: string, realId: string }} params
-   * @returns {Promise<Object>}
-   */
-  _getOperator(params) {
-    return Promise.resolve({
-      method: 'get',
-      url: `/v4/addon-providers/addon-${params.provider}/addons/${params.realId}`,
-      headers: { Accept: 'application/json' },
-      // no queryParams
-      // no body
-    });
-  }
-}
-
-// FIXME: remove and use the clever-client call from the new clever-client
-/** @param {{ provider: string, realId: string }} params */
-export function rebootOperator(params) {
-  // no multipath for /self or /organisations/{id}
-  return Promise.resolve({
-    method: 'post',
-    url: `/v4/addon-providers/addon-${params.provider}/addons/${params.realId}/reboot`,
-    headers: { Accept: 'application/json' },
-    // no queryParams
-    // no body
-  });
-}
-
-// FIXME: remove and use the clever-client call from the new clever-client
-/** @param {{ provider: string, realId: string }} params */
-export function rebuildOperator(params) {
-  // no multipath for /self or /organisations/{id}
-  return Promise.resolve({
-    method: 'post',
-    url: `/v4/addon-providers/addon-${params.provider}/addons/${params.realId}/rebuild`,
-    headers: { Accept: 'application/json' },
-    // no queryParams
-    // no body
-  });
-}

--- a/src/components/cc-addon-header/cc-addon-header.types.d.ts
+++ b/src/components/cc-addon-header/cc-addon-header.types.d.ts
@@ -9,7 +9,7 @@ export type CcAddonHeaderState =
   | CcAddonHeaderStateRebuilding;
 
 interface BaseProperties {
-  providerName: string;
+  providerId: string;
   providerLogoUrl: string;
   name: string;
   id: string;
@@ -65,27 +65,6 @@ export interface RawAddon {
   plan: AddonPlan;
   creationDate: number;
   configKeys: string[];
-}
-
-export interface RawOperator {
-  resourceId: string;
-  addonId: string;
-  name: string;
-  ownerId: string;
-  plan: string;
-  version: string;
-  javaVersion: string;
-  accessUrl: string;
-  availableVersions: string[];
-  resources: {
-    entrypoint: string;
-    fsbucketId: string;
-    pgsqlId: string;
-  };
-  features: {
-    networkGroup?: string;
-  };
-  envVars: Record<string, string>;
 }
 
 export type Addon = BaseProperties & OptionalProperties;

--- a/src/components/cc-addon-info/cc-addon-info.api.js
+++ b/src/components/cc-addon-info/cc-addon-info.api.js
@@ -1,0 +1,186 @@
+// @ts-expect-error FIXME: remove when clever-client exports types
+import { get as getAddon } from '@clevercloud/client/esm/api/v2/addon.js';
+// @ts-expect-error FIXME: remove when clever-client exports types
+import { getGrafanaOrganisation } from '@clevercloud/client/esm/api/v4/saas.js';
+import { sendToApi } from '../../lib/send-to-api.js';
+import { generateDevHubHref } from '../../lib/utils.js';
+
+/**
+ * @typedef {import('./cc-addon-info.types.js').AddonInfoStateLoaded} AddonInfoStateLoaded
+ * @typedef {import('./cc-addon-info.types.js').RawAddon} RawAddon
+ * @typedef {import('../../operators.types.js').OperatorVersionInfo} OperatorVersionInfo
+ * @typedef {import('../../operators.types.js').RawOperator} RawOperator
+ * @typedef {import('../../lib/send-to-api.types.js').ApiConfig} ApiConfig
+ * @typedef {import('../../lib/send-to-api.types.js').AuthBridgeConfig} AuthBridgeConfig
+ */
+
+export class CcAddonInfoApi {
+  /**
+   * @param {Object} config - Configuration object
+   * @param {ApiConfig} config.apiConfig - API configuration
+   * @param {string} config.ownerId - Owner identifier
+   * @param {string} config.addonId - Addon identifier
+   * @param {string} config.providerId
+   * @param {{ base: string, console: string }} [config.grafanaLink] - Base url to build a grafana link to the app
+   * @param {AbortSignal} config.signal - Signal to abort calls
+   */
+  constructor({ apiConfig, ownerId, addonId, providerId, grafanaLink, signal }) {
+    this._apiConfig = apiConfig;
+    this._ownerId = ownerId;
+    this._addonId = addonId;
+    this.providerId = providerId;
+    this._grafanaLink = grafanaLink;
+    this._realId = null;
+    this._signal = signal;
+  }
+
+  /** @return {Promise<RawAddon>} */
+  _getAddon() {
+    return getAddon({ id: this._ownerId, addonId: this._addonId }).then(
+      sendToApi({ apiConfig: this._apiConfig, signal: this._signal }),
+    );
+  }
+
+  /**
+   * @param {string} providerId
+   * @param {string} realId
+   * @returns {Promise<RawOperator>}
+   */
+  _getOperator(providerId, realId) {
+    return getOperator({ providerId, realId }).then(sendToApi({ apiConfig: this._apiConfig, signal: this._signal }));
+  }
+
+  /** @returns {Promise<OperatorVersionInfo>} */
+  getOperatorVersionInfo() {
+    return checkOperatorVersion({ providerId: this.providerId, realId: this._realId }).then(
+      sendToApi({ apiConfig: this._apiConfig, signal: this._signal }),
+    );
+  }
+
+  /**
+   * @param {Object} parameters
+   * @param {string} parameters.appId
+   * @param {AbortSignal} parameters.signal
+   * @returns {Promise<string>}
+   */
+  _getGrafanaAppLink({ appId, signal }) {
+    return getGrafanaOrganisation({ id: this._ownerId })
+      .then(sendToApi({ apiConfig: this._apiConfig, signal }))
+      .then(
+        /** @param {{id: string}} grafanaOrg*/
+        (grafanaOrg) => {
+          const grafanaLink = new URL('/d/runtime/application-runtime', this._grafanaLink.base);
+          grafanaLink.searchParams.set('orgId', grafanaOrg.id);
+          grafanaLink.searchParams.set('var-SELECT_APP', appId);
+          return grafanaLink.toString();
+        },
+      )
+      .catch(
+        /** @param {Error & { response?: { status?: number }}} error */
+        (error) => {
+          if (error.response?.status === 404) {
+            return this._grafanaLink.console;
+          }
+          return error;
+        },
+      );
+  }
+
+  /**
+   * @param {string} targetVersion
+   * @returns {Promise<RawOperator>}
+   **/
+  updateOperatorVersion(targetVersion) {
+    return updateOperatorVersion({ providerId: this.providerId, realId: this._realId }, { targetVersion }).then(
+      sendToApi({ apiConfig: this._apiConfig }),
+    );
+  }
+
+  /**
+   * @return {Promise<{addonInfo: RawAddon, operator: RawOperator, operatorVersionInfo: OperatorVersionInfo, grafanaAppLink: string}>}
+   */
+  async getAddonInfo() {
+    // Fetch addon to get realId,
+    const rawAddon = await this._getAddon();
+    this._realId = rawAddon.realId;
+    this.providerId = /** @type {import('../common.types.js').RawAddonProvider} */ rawAddon.provider.id;
+    // Fetch operator with realId,
+    const [operator, operatorVersionInfo] = await Promise.all([
+      this._getOperator(this.providerId, this._realId),
+      this.getOperatorVersionInfo(),
+    ]);
+    const grafanaAppLink =
+      this._grafanaLink != null
+        ? await this._getGrafanaAppLink({ appId: operator.resources.entrypoint, signal: this._signal })
+        : null;
+
+    return { addonInfo: rawAddon, operator, operatorVersionInfo, grafanaAppLink };
+  }
+}
+
+/**
+ * @param {{ providerId: string, realId: string }} params
+ */
+function getOperator(params) {
+  // no multipath for /self or /organisations/{id}
+  return Promise.resolve({
+    method: 'get',
+    url: `/v4/addon-providers/addon-${params.providerId}/addons/${params.realId}`,
+    headers: { Accept: 'application/json' },
+    // no queryParams
+    // no body
+  });
+}
+
+/**
+ * @param {{ providerId: string, realId: string }} params
+ */
+function checkOperatorVersion(params) {
+  // no multipath for /self or /organisations/{id}
+  return Promise.resolve({
+    method: 'get',
+    url: `/v4/addon-providers/addon-${params.providerId}/addons/${params.realId}/version/check`,
+    headers: { Accept: 'application/json' },
+    // no queryParams
+    // no body
+  });
+}
+
+/**
+ * @param {object} params
+ * @param {string} params.providerId
+ * @param {string} params.realId
+ * @param {object} body
+ */
+export function updateOperatorVersion(params, body) {
+  // no multipath for /self or /organisations/{id}
+  return Promise.resolve({
+    method: 'post',
+    url: `/v4/addon-providers/addon-${params.providerId}/addons/${params.realId}/version/update`,
+    headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+    // no queryParams
+    body,
+  });
+}
+
+/**
+ * @param {OperatorVersionInfo} operatorVersionInfo
+ * @returns {AddonInfoStateLoaded['version']}
+ **/
+export function formatVersionState(operatorVersionInfo) {
+  if (operatorVersionInfo.needUpdate) {
+    return {
+      stateType: 'update-available',
+      installed: operatorVersionInfo.installed,
+      available: operatorVersionInfo.available.filter((version) => version !== operatorVersionInfo.installed),
+      latest: operatorVersionInfo.latest,
+      changelogLink: `${generateDevHubHref('/changelog')}`,
+    };
+  }
+
+  return {
+    stateType: 'up-to-date',
+    installed: operatorVersionInfo.installed,
+    latest: operatorVersionInfo.latest,
+  };
+}

--- a/src/components/cc-addon-info/cc-addon-info.smart-keycloak.js
+++ b/src/components/cc-addon-info/cc-addon-info.smart-keycloak.js
@@ -1,29 +1,21 @@
-import { defineSmartComponent } from '../../lib/smart/define-smart-component.js';
-// @ts-expect-error FIXME: remove when clever-client exports types
-import { get as getAddon } from '@clevercloud/client/esm/api/v2/addon.js';
-// @ts-expect-error FIXME: remove when clever-client exports types
-import { getGrafanaOrganisation } from '@clevercloud/client/esm/api/v4/saas.js';
 import { getAssetUrl } from '../../lib/assets-url.js';
 import { notifyError, notifySuccess } from '../../lib/notifications.js';
-import { sendToApi } from '../../lib/send-to-api.js';
-import { generateDevHubHref, generateDocsHref } from '../../lib/utils.js';
+import { defineSmartComponent } from '../../lib/smart/define-smart-component.js';
+import { generateDocsHref } from '../../lib/utils.js';
 import { i18n } from '../../translations/translation.js';
 import '../cc-smart-container/cc-smart-container.js';
+import { CcAddonInfoApi, formatVersionState } from './cc-addon-info.api.js';
 import './cc-addon-info.js';
+
+const PROVIDER_ID = 'keycloak';
 
 /**
  * @typedef {import('./cc-addon-info.js').CcAddonInfo} CcAddonInfo
  * @typedef {import('./cc-addon-info.types.js').AddonInfoStateLoaded} AddonInfoStateLoaded
  * @typedef {import('./cc-addon-info.types.js').AddonInfoStateLoading} AddonInfoStateLoading
  * @typedef {import('./cc-addon-info.types.js').AddonVersionStateUpdateAvailable} AddonVersionStateUpdateAvailable
- * @typedef {import('./cc-addon-info.types.js').AddonVersionStateUpToDate} AddonVersionStateUpToDate
  * @typedef {import('./cc-addon-info.types.js').AddonVersionStateRequestingUpdate} AddonVersionStateRequestingUpdate
- * @typedef {import('./cc-addon-info.types.js').AddonInfoStateBaseProperties} AddonInfoStateBaseProperties
- * @typedef {import('./cc-addon-info.types.js').RawAddon} RawAddon
- * @typedef {import('./cc-addon-info.types.js').KeycloakOperatorInfo} KeycloakOperatorInfo
- * @typedef {import('./cc-addon-info.types.js').OperatorVersionInfo} OperatorVersionInfo
  * @typedef {import('../../lib/smart/smart-component.types.js').OnContextUpdateArgs<CcAddonInfo>} OnContextUpdateArgs
- * @typedef {import('../../lib/send-to-api.types.js').ApiConfig} ApiConfig
  * @typedef {import('../../lib/send-to-api.types.js').AuthBridgeConfig} AuthBridgeConfig
  */
 
@@ -52,7 +44,7 @@ defineSmartComponent({
     } = context;
     let logsUrl = '';
 
-    const api = new Api({ apiConfig, ownerId, addonId, grafanaLink, signal });
+    const api = new CcAddonInfoApi({ apiConfig, ownerId, addonId, providerId: PROVIDER_ID, grafanaLink, signal });
 
     /** @type {AddonInfoStateLoading} */
     const LOADING_STATE = {
@@ -184,172 +176,3 @@ defineSmartComponent({
     });
   },
 });
-
-class Api {
-  /**
-   * @param {Object} config - Configuration object
-   * @param {ApiConfig} config.apiConfig - API configuration
-   * @param {string} config.ownerId - Owner identifier
-   * @param {string} config.addonId - Addon identifier
-   * @param {{ base: string, console: string }} [config.grafanaLink] - Base url to build a grafana link to the app
-   * @param {AbortSignal} config.signal - Signal to abort calls
-   */
-  constructor({ apiConfig, ownerId, addonId, grafanaLink, signal }) {
-    this._apiConfig = apiConfig;
-    this._ownerId = ownerId;
-    this._addonId = addonId;
-    this._grafanaLink = grafanaLink;
-    this._realId = null;
-    this._signal = signal;
-  }
-
-  /** @return {Promise<RawAddon>} */
-  _getAddon() {
-    return getAddon({ id: this._ownerId, addonId: this._addonId }).then(
-      sendToApi({ apiConfig: this._apiConfig, signal: this._signal }),
-    );
-  }
-
-  /**
-   * @param {string} providerId
-   * @param {string} realId
-   * @returns {Promise<KeycloakOperatorInfo>}
-   */
-  _getOperator(providerId, realId) {
-    return getOperator({ providerId, realId }).then(sendToApi({ apiConfig: this._apiConfig, signal: this._signal }));
-  }
-
-  /** @returns {Promise<OperatorVersionInfo>} */
-  getOperatorVersionInfo() {
-    return checkOperatorVersion({ providerId: this._providerId, realId: this._realId }).then(
-      sendToApi({ apiConfig: this._apiConfig, signal: this._signal }),
-    );
-  }
-
-  /**
-   * @param {Object} parameters
-   * @param {string} parameters.appId
-   * @param {AbortSignal} parameters.signal
-   * @returns {Promise<string>}
-   */
-  _getGrafanaAppLink({ appId, signal }) {
-    return getGrafanaOrganisation({ id: this._ownerId })
-      .then(sendToApi({ apiConfig: this._apiConfig, signal }))
-      .then(
-        /** @param {{id: string}} grafanaOrg*/
-        (grafanaOrg) => {
-          const grafanaLink = new URL('/d/runtime/application-runtime', this._grafanaLink.base);
-          grafanaLink.searchParams.set('orgId', grafanaOrg.id);
-          grafanaLink.searchParams.set('var-SELECT_APP', appId);
-          return grafanaLink.toString();
-        },
-      )
-      .catch(
-        /** @param {Error & { response?: { status?: number }}} error */
-        (error) => {
-          if (error.response?.status === 404) {
-            return this._grafanaLink.console;
-          }
-          return error;
-        },
-      );
-  }
-
-  /**
-   * @param {string} targetVersion
-   * @returns {Promise<KeycloakOperatorInfo>}
-   **/
-  updateOperatorVersion(targetVersion) {
-    return updateOperatorVersion({ providerId: this._providerId, realId: this._realId }, { targetVersion }).then(
-      sendToApi({ apiConfig: this._apiConfig }),
-    );
-  }
-
-  /**
-   * @return {Promise<{addonInfo: RawAddon, operator: KeycloakOperatorInfo, operatorVersionInfo: OperatorVersionInfo, grafanaAppLink: string}>}
-   */
-  async getAddonInfo() {
-    // Fetch addon to get realId,
-    const rawAddon = await this._getAddon();
-    this._realId = rawAddon.realId;
-    this._providerId = /** @type {import('../common.types.js').RawAddonProvider} */ rawAddon.provider.id;
-    // Fetch operator with realId,
-    const [operator, operatorVersionInfo] = await Promise.all([
-      this._getOperator(this._providerId, this._realId),
-      this.getOperatorVersionInfo(),
-    ]);
-    const grafanaAppLink =
-      this._grafanaLink != null
-        ? await this._getGrafanaAppLink({ appId: operator.resources.entrypoint, signal: this._signal })
-        : null;
-
-    return { addonInfo: rawAddon, operator, operatorVersionInfo, grafanaAppLink };
-  }
-}
-
-/**
- * @param {{ providerId: string, realId: string }} params
- */
-function getOperator(params) {
-  // no multipath for /self or /organisations/{id}
-  return Promise.resolve({
-    method: 'get',
-    url: `/v4/addon-providers/addon-${params.providerId}/addons/${params.realId}`,
-    headers: { Accept: 'application/json' },
-    // no queryParams
-    // no body
-  });
-}
-
-/**
- * @param {{ providerId: string, realId: string }} params
- */
-function checkOperatorVersion(params) {
-  // no multipath for /self or /organisations/{id}
-  return Promise.resolve({
-    method: 'get',
-    url: `/v4/addon-providers/addon-${params.providerId}/addons/${params.realId}/version/check`,
-    headers: { Accept: 'application/json' },
-    // no queryParams
-    // no body
-  });
-}
-
-/**
- * @param {object} params
- * @param {string} params.providerId
- * @param {string} params.realId
- * @param {object} body
- */
-export function updateOperatorVersion(params, body) {
-  // no multipath for /self or /organisations/{id}
-  return Promise.resolve({
-    method: 'post',
-    url: `/v4/addon-providers/addon-${params.providerId}/addons/${params.realId}/version/update`,
-    headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
-    // no queryParams
-    body,
-  });
-}
-
-/**
- * @param {OperatorVersionInfo} operatorVersionInfo
- * @returns {AddonInfoStateLoaded['version']}
- **/
-function formatVersionState(operatorVersionInfo) {
-  if (operatorVersionInfo.needUpdate) {
-    return {
-      stateType: 'update-available',
-      installed: operatorVersionInfo.installed,
-      available: operatorVersionInfo.available.filter((version) => version !== operatorVersionInfo.installed),
-      latest: operatorVersionInfo.latest,
-      changelogLink: `${generateDevHubHref('/changelog')}`,
-    };
-  }
-
-  return {
-    stateType: 'up-to-date',
-    installed: operatorVersionInfo.installed,
-    latest: operatorVersionInfo.latest,
-  };
-}

--- a/src/components/cc-addon-info/cc-addon-info.types.d.ts
+++ b/src/components/cc-addon-info/cc-addon-info.types.d.ts
@@ -85,34 +85,6 @@ export interface RawAddon {
   configKeys: string[];
 }
 
-export interface KeycloakOperatorInfo {
-  resourceId: string;
-  addonId: string;
-  name: string;
-  ownerId: string;
-  plan: string;
-  version: string;
-  javaVersion: string;
-  accessUrl: string;
-  availableVersions: string[];
-  resources: {
-    entrypoint: string;
-    fsbucketId: string;
-    pgsqlId: string;
-  };
-  features: {
-    networkGroup: null;
-  };
-  envVars: Record<string, string>;
-}
-
-export interface OperatorVersionInfo {
-  available: string[];
-  installed: string;
-  latest: string;
-  needUpdate: boolean;
-}
-
 export interface ElasticAddonInfo {
   id: string;
   app_id: string;

--- a/src/operators.types.d.ts
+++ b/src/operators.types.d.ts
@@ -1,0 +1,118 @@
+export interface RawOperator {
+  resourceId: string;
+  addonId: string;
+  name: string;
+  ownerId: string;
+  plan: string;
+  version: string;
+  appVersion: string;
+  accessUrl: string;
+  availableVersions: string[];
+  resources: {
+    entrypoint: string;
+    [key: string]: string;
+  };
+  features: {
+    networkGroup?: string;
+  };
+  envVars: Record<string, string>;
+}
+
+export interface OperatorVersionInfo {
+  available: string[];
+  installed: string;
+  latest: string;
+  needUpdate: boolean;
+}
+
+export interface KeycloakOperatorInfo {
+  resourceId: string;
+  addonId: string;
+  name: string;
+  ownerId: string;
+  plan: string;
+  version: string;
+  javaVersion: string;
+  accessUrl: string;
+  availableVersions: string[];
+  resources: {
+    entrypoint: string;
+    fsbucketId: string;
+    pgsqlId: string;
+  };
+  features: {
+    networkGroup: null;
+  };
+  envVars: {
+    CC_KEYCLOAK_ADMIN: string;
+    CC_RUN_COMMAND: string;
+    CC_KEYCLOAK_DB_POOL_INITIAL_SIZE: string;
+    CC_METRICS_PROMETHEUS_PATH: string;
+    CC_JAVA_VERSION: string;
+    CC_PRE_RUN_HOOK: string;
+    CC_METRICS_PROMETHEUS_PORT: string;
+    CC_POST_BUILD_HOOK: string;
+    CC_KEYCLOAK_REALMS: string;
+    CC_KEYCLOAK_HOSTNAME: string;
+    CC_FS_BUCKET: string;
+    CC_KEYCLOAK_ADMIN_DEFAULT_PASSWORD: string;
+    CC_KEYCLOAK_VERSION: string;
+    CC_KEYCLOAK_DB_POOL_MAX_SIZE: string;
+  };
+}
+
+export interface OtoroshiOperatorInfo {
+  resourceId: string;
+  addonId: string;
+  name: string;
+  ownerId: string;
+  plan: string;
+  version: string;
+  javaVersion: string;
+  accessUrl: string;
+  availableVersions: string[];
+  resources: {
+    entrypoint: string;
+    redisId: string;
+  };
+  features: {
+    networkGroup: null;
+  };
+  envVars: {
+    ADMIN_API_CLIENT_ID: string;
+    ADMIN_API_CLIENT_SECRET: string;
+    ADMIN_API_EXPOSED_SUBDOMAIN: string;
+    ADMIN_API_GROUP: string;
+    ADMIN_API_SERVICE_ID: string;
+    ADMIN_API_TARGET_SUBDOMAIN: string;
+    APP_BACKOFFICE_SUBDOMAIN: string;
+    APP_DOMAIN: string;
+    APP_ENV: string;
+    APP_PRIVATEAPPS_SUBDOMAIN: string;
+    APP_ROOT_SCHEME: string;
+    APP_STORAGE: string;
+    CC_JAR_PATH: string;
+    CC_JAVA_VERSION: string;
+    CC_OTOROSHI_API_URL: string;
+    CC_OTOROSHI_INITIAL_ADMIN_LOGIN: string;
+    CC_OTOROSHI_INITIAL_ADMIN_PASSWORD: string;
+    CC_OTOROSHI_SSO_URL: string;
+    CC_OTOROSHI_VERSION: string;
+    CC_PRE_BUILD_HOOK: string;
+    CC_RUN_COMMAND: string;
+    CLAIM_SHAREDKEY: string;
+    OTOROSHI_ANONYMOUS_REPORTING_ENABLED: string;
+    OTOROSHI_CHECK_FOR_UPDATES: string;
+    OTOROSHI_EXPOSED_PORTS_HTTP: string;
+    OTOROSHI_EXPOSED_PORTS_HTTPS: string;
+    OTOROSHI_INSTANCE_LOGO: string;
+    OTOROSHI_INSTANCE_NAME: string;
+    OTOROSHI_REDIS_LETTUCE_URI: string;
+    OTOROSHI_ROUTE_BASE_DOMAIN: string;
+    OTOROSHI_SECRET: string;
+    PLAY_CRYPTO_SECRET: string;
+    PORT: string;
+    SESSION_DOMAIN: string;
+    SESSION_SECURE_ONLY: string;
+  };
+}

--- a/src/stories/fixtures/addon.js
+++ b/src/stories/fixtures/addon.js
@@ -7,7 +7,7 @@ import { ZONE } from "./zones.js";
 
 /** @type {Addon} */
 export const configProviderData = {
-  providerName: 'Configuration provider',
+  providerId: 'Configuration provider',
   providerLogoUrl: getAssetUrl('/logos/configprovider.svg'),
   name: 'my-config',
   id: 'config_59xml9zd-f1rg-2jj2-z733-p564812374122',
@@ -19,7 +19,7 @@ export const configProviderData = {
 
 /** @type {Addon} */
 export const pulsarData = {
-  providerName: 'Pulsar',
+  providerId: 'Pulsar',
   providerLogoUrl: getAssetUrl('/logos/pulsar.svg'),
   name: 'my-pulsar',
   id: 'pulsar_695g1427-sn3t-0200-36mw-h56983vb3653',
@@ -32,7 +32,7 @@ export const pulsarData = {
 
 /** @type {Addon} */
 export const jenkinsData = {
-  providerName: 'Jenkins',
+  providerId: 'Jenkins',
   providerLogoUrl: getAssetUrl('/logos/jenkins.svg'),
   name: 'my-jenkins',
   id: 'jenkins_fgh7evv9-q21m-9129-mm3b-04f77lo56w36',
@@ -51,7 +51,7 @@ export const jenkinsData = {
 
 /** @type {Addon} */
 export const elasticData = {
-  providerName: 'Elastic Stack',
+  providerId: 'Elastic Stack',
   providerLogoUrl: getAssetUrl('/logos/elastic.svg'),
   name: 'my-elastic',
   id: 'elasticsearch_23694507-44yt-023u-ib5o-6vc7d0mp99a2',
@@ -74,7 +74,7 @@ export const elasticData = {
 
 /** @type {Addon} */
 export const matomoData = {
-  providerName: 'Matomo Analytics',
+  providerId: 'Matomo Analytics',
   providerLogoUrl: getAssetUrl('/logos/matomo.svg'),
   name: 'my-matomo',
   id: 'matomo_0985go7t-2kda-6dv2-x978-h63r45o11q6p',
@@ -97,7 +97,7 @@ export const matomoData = {
 
 /** @type {Addon} */
 export const keycloakData = {
-  providerName: 'Keycloak',
+  providerId: 'Keycloak',
   providerLogoUrl: 'https://cc-keycloak.cellar-c2.services.clever-cloud.com/keycloak_logo.svg',
   name: 'my-keycloak',
   id: 'keycloak_511f6k82-9r44-6w90-86s3-az6m5kvyy478',
@@ -121,7 +121,7 @@ export const keycloakData = {
 
 /** @type {Addon} */
 export const materiaData = {
-  providerName: 'Materia',
+  providerId: 'Materia',
   providerLogoUrl: getAssetUrl('/logos/materia-db-kv.png'),
   name: 'my-materia',
   id: 'kv_54PE021ROIUTYZ8GH4DFGMB33Z',
@@ -145,7 +145,7 @@ export const materiaData = {
 
 /** @type {Addon} */
 export const redisData = {
-  providerName: 'Redis',
+  providerId: 'Redis',
   providerLogoUrl: getAssetUrl('/logos/redis.svg'),
   name: 'my-redis',
   id: 'redis_236590c14-5119-4aca-9888-3b16523486b',
@@ -169,7 +169,7 @@ export const redisData = {
 
 /** @type {Addon} */
 export const kubernetesData = {
-  providerName: 'Kubernetes',
+  providerId: 'Kubernetes',
   // FIXME: change the provider logo URL once Kubernetes has been uploaded to static assets
   providerLogoUrl: 'https://img.icons8.com/?size=100&id=cvzmaEA4kC0o&format=png&color=000000',
   name: 'my-kubernetes',


### PR DESCRIPTION
## What does this PR do?

- Changes `providerName` to `providerId` to match the API,
- Refactors `RawOperator` to make it more generic,
- Creates a `operators.types.d.ts` file and move common API calls in it,
- Creates `cc-addon-*.api.js` files in each dashboard components and move common API calls in it.

## How to review?

- Check the commits,
- Check the code,
- Check on `demo-smart` that anything is broken.

Please pay a special attention to the `cc-addon-info` files has I rebase on the recent `cc-addon-info` PR and had to deal severals conflicts 👀 