### PR TITLE
ci(visual-tests): prevent clean up failure

### DIFF
--- a/.github/workflows/manage-visual-tests.yml
+++ b/.github/workflows/manage-visual-tests.yml
@@ -258,8 +258,6 @@ jobs:
     steps:
       - name: '[Prepare] Checkout'
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: '[Prepare] Setup Node.js'
         uses: actions/setup-node@v4
@@ -274,6 +272,7 @@ jobs:
         id: delete-report-and-assets
         run: node ./tasks/visual-tests/manage-visual-tests-data.js delete
         env:
+          BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
           VISUAL_TESTS_CELLAR_KEY_ID: ${{ secrets.VISUAL_TESTS_CELLAR_KEY_ID }}
           VISUAL_TESTS_CELLAR_SECRET_KEY: ${{ secrets.VISUAL_TESTS_CELLAR_SECRET_KEY }}
 


### PR DESCRIPTION
## What does this PR do?

- The job tried to checkout the current branch of the PR but it could fail because branches are automatically deleted when the PR is merged.
- The job will now checkout master instead and provide the BRANCH_NAME to the delete script through an environment variable.

## How to review?

- No review required, I'll simply run the tests in this PR and merge since it has no impact on end users or security :wink: 