### PR TITLE
feat(cc-addon-credentials-beta): change Keycloak docs URL and text

### DIFF
--- a/src/components/cc-addon-credentials-beta/cc-addon-credentials-beta.smart-keycloak.js
+++ b/src/components/cc-addon-credentials-beta/cc-addon-credentials-beta.smart-keycloak.js
@@ -80,7 +80,7 @@ defineSmartComponent({
     });
     updateComponent('docLink', {
       text: i18n('cc-addon-credentials-beta.doc-link.keycloak'),
-      href: generateDocsHref('/doc/addons/keycloak/'),
+      href: generateDocsHref('/addons/keycloak/#secured-multi-instances'),
     });
 
     api

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -189,13 +189,13 @@ export const translations = {
   'cc-addon-credentials-beta.choice.direct': `Direct`,
   'cc-addon-credentials-beta.choice.elastic': `Elastic`,
   'cc-addon-credentials-beta.choice.kibana': `Kibana`,
-  'cc-addon-credentials-beta.doc-link.keycloak': `Keycloak - Documentation`,
+  'cc-addon-credentials-beta.doc-link.keycloak': `Secured multi-instances - Documentation`,
   'cc-addon-credentials-beta.error': `Something went wrong while loading add-on information.`,
   'cc-addon-credentials-beta.heading': `Access`,
-  'cc-addon-credentials-beta.ng-multi-instances.disabling.error': `Something went wrong while trying to disable the secure multi-instances`,
-  'cc-addon-credentials-beta.ng-multi-instances.disabling.success': `The secure multi-instances have been successfully disabled`,
-  'cc-addon-credentials-beta.ng-multi-instances.enabling.error': `Something went wrong while trying to enable the secure multi-instances`,
-  'cc-addon-credentials-beta.ng-multi-instances.enabling.success': `The secure multi-instances have been successfully enabled`,
+  'cc-addon-credentials-beta.ng-multi-instances.disabling.error': `Something went wrong while trying to disable the secured multi-instances`,
+  'cc-addon-credentials-beta.ng-multi-instances.disabling.success': `The secured multi-instances have been successfully disabled`,
+  'cc-addon-credentials-beta.ng-multi-instances.enabling.error': `Something went wrong while trying to enable the secured multi-instances`,
+  'cc-addon-credentials-beta.ng-multi-instances.enabling.success': `The secured multi-instances have been successfully enabled`,
   //#endregion
   //#region cc-addon-credentials-content
   'cc-addon-credentials-content.code.api-client-secret': `API client secret`,

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -200,7 +200,7 @@ export const translations = {
   'cc-addon-credentials-beta.choice.direct': `Direct`,
   'cc-addon-credentials-beta.choice.elastic': `Elastic`,
   'cc-addon-credentials-beta.choice.kibana': `Kibana`,
-  'cc-addon-credentials-beta.doc-link.keycloak': `Keycloak - Documentation`,
+  'cc-addon-credentials-beta.doc-link.keycloak': `Multi-instances sécurisé - Documentation`,
   'cc-addon-credentials-beta.error': `Une erreur est survenue pendant le chargement des informations de l'add-on.`,
   'cc-addon-credentials-beta.heading': `Accès`,
   'cc-addon-credentials-beta.ng-multi-instances.disabling.error': `Une erreur est survenue lors de la désactivation du multi-instances sécurisé`,


### PR DESCRIPTION
## What does this PR do?

- Changes the docs URL and text for the Keycloak `cc-addon-credentials-beta` to highlight the `secured multi-instances` feature.

## How to review?

- Check the commit,
- Check demo-smart keycloak and click on the docs link.