### PR TITLE
CEM: support @import JSDoc syntax

### DIFF
--- a/cem/support-typedef-jsdoc.js
+++ b/cem/support-typedef-jsdoc.js
@@ -2,6 +2,7 @@ import { readFileSync } from 'fs';
 import ts from 'typescript';
 import {
   convertInterface,
+  extractImportsFromImportTag,
   findInterfacesFromExtends,
   findPathAndTypesFromImports,
   findSubtypes,
@@ -133,34 +134,68 @@ export default function supportTypedefJsdoc() {
           return;
         }
 
-        // This finds the comment where the imports are located
+        // This finds the comment where the @typedef imports are located
         const typeDefNode = statement?.jsDoc?.filter((statement) =>
           statement.tags?.find((tag) => tag.kind === ts.SyntaxKind.JSDocTypedefTag),
         )?.[0];
 
-        // Check the jsDoc of the class and find the imports
-        typeDefNode?.tags?.forEach((tag) => {
-          // Extract the path from the @typedef import
-          const typePath = findTypePath(tag, ts, moduleDoc.path);
+        // Check the jsDoc of the class and find the @typedef imports
+        typeDefNode?.tags
+          ?.filter((tag) => tag.kind === ts.SyntaxKind.JSDocTypedefTag)
+          .forEach((tag) => {
+            // Extract the path from the @typedef import
+            const typePath = findTypePath(tag, ts, moduleDoc.path);
+
+            // If an import is not correct, warn the plugin user.
+            if (typePath == null) {
+              console.warn(`[${componentName}] - There's a problem with one of your @typedef - ${tag.getText()}`);
+              process.exitCode = 1;
+              return;
+            }
+
+            // Extract the type from the @typedef import
+            const typeDefDisplay = tag.name.getText();
+
+            const type = types.find((type) => type === typeDefDisplay);
+
+            if (type != null) {
+              if (!moduleTypeCache.has(typePath)) {
+                moduleTypeCache.set(typePath, new Set());
+              }
+              moduleTypeCache.get(typePath).add(type);
+            }
+          });
+
+        // Find all @import tags
+        const importTags =
+          statement?.jsDoc?.flatMap(
+            (doc) => doc.tags?.filter((tag) => tag.kind === ts.SyntaxKind.JSDocImportTag) || [],
+          ) || [];
+
+        // Process @import tags
+        importTags.forEach((tag) => {
+          const importData = extractImportsFromImportTag(tag, ts, moduleDoc.path);
 
           // If an import is not correct, warn the plugin user.
-          if (typePath == null) {
-            console.warn(`[${componentName}] - There's a problem with one of your @typedef - ${tag.getText()}`);
+          if (importData == null) {
+            console.warn(`[${componentName}] - There's a problem with one of your @import - ${tag.getText()}`);
             process.exitCode = 1;
             return;
           }
 
-          // Extract the type from the @typedef import
-          const typeDefDisplay = tag.name.getText();
+          const { path: typePath, types: importedTypes } = importData;
 
-          const type = types.find((type) => type === typeDefDisplay);
+          // Check which imported types are actually used in the component
+          importedTypes.forEach((importedType) => {
+            const type = types.find((type) => type === importedType);
 
-          if (type != null) {
-            if (!moduleTypeCache.has(typePath)) {
-              moduleTypeCache.set(typePath, new Set());
+            if (type != null) {
+              if (!moduleTypeCache.has(typePath)) {
+                moduleTypeCache.set(typePath, new Set());
+              }
+              moduleTypeCache.get(typePath).add(type);
             }
-            moduleTypeCache.get(typePath).add(type);
-          }
+          });
         });
 
         // Now that we have the types, and the path of where the types are located

--- a/test-mocha/cem/fixtures/cc-test-component-with-import.js
+++ b/test-mocha/cem/fixtures/cc-test-component-with-import.js
@@ -1,0 +1,26 @@
+import { LitElement } from 'lit';
+
+/**
+ * @import {Foo, Bar} from './cc-test-component.types.js'
+ * @import {TheInterface} from './cc-test-component.types.js'
+ * @import {TheType} from './cc-test-component.types.js'
+ */
+
+/**
+ * Test component using @import syntax instead of @typedef
+ */
+// eslint-disable-next-line wc/define-tag-after-class-definition
+export class CcTestComponentWithImport extends LitElement {
+  constructor() {
+    super();
+
+    /** @type {Foo|Bar} - lorem ipsum.  */
+    this.union = null;
+
+    /** @type {TheInterface} - lorem ipsum.  */
+    this.interface = null;
+
+    /** @type {TheType} - lorem ipsum.  */
+    this.typeDeclaration = null;
+  }
+}


### PR DESCRIPTION
## What does this PR do?

- Refactors the CEM plugin to use TypeScript's `resolveModuleName()` for import resolution instead of manual path manipulation,
- Adds support for the modern `@import` JSDoc syntax alongside the existing `@typedef` syntax for importing types,
- Updates tests to match new function signatures and adds comprehensive tests for `@import` functionality.

The `@import` syntax provides a cleaner alternative:
- Before: `@typedef {import('./types.js').Foo} Foo`
- After: `@import {Foo} from './types.js'`

## How to review?

- Check the commits,
- Run `npm run components:docs` and verify no warnings appear,
- Check that types are correctly documented in the generated manifest for components using `@import` by modifying one of the `@typedef` in the files (you can use `cc-badge` as an example),
- Run `npm run test:mocha` to verify all tests pass.