### PR TITLE
fix(cc-addon-header): add missing `a11y-desc` on `cc-link`

### DIFF
--- a/src/components/cc-addon-header/cc-addon-header.js
+++ b/src/components/cc-addon-header/cc-addon-header.js
@@ -145,7 +145,12 @@ export class CcAddonHeader extends LitElement {
           <div class="actions">
             ${addonInfo.openLinks?.map(
               (link) => html`
-                <cc-link mode="button" href="${link.url}" ?skeleton=${skeleton}>
+                <cc-link
+                  mode="button"
+                  href="${link.url}"
+                  a11y-desc="${i18n('cc-addon-header.action.open-addon', { linkName: link.name })}"
+                  ?skeleton=${skeleton}
+                >
                   ${i18n('cc-addon-header.action.open-addon', { linkName: link.name })}
                 </cc-link>
               `,


### PR DESCRIPTION
## What does this PR do ?

Adds an  `a11y-desc`  attribute on the `cc-link` so the tooltip displays correctly.

## How to review ?

- check the commit,
- check on `demo-smart` that the tooltip displays and that the <a> inside the `OPEN` button has a title.

1 reviewer is enough. 