### PR TITLE
fix(cc-article-list): update article feed URLs to `clever.cloud` domain

### DIFF
--- a/src/components/cc-article-list/cc-article-list.smart.js
+++ b/src/components/cc-article-list/cc-article-list.smart.js
@@ -51,8 +51,8 @@ defineSmartComponent({
 async function fetchArticleList({ signal, lang, limit = 9 }) {
   const url =
     lang === 'fr'
-      ? 'https://www.clever-cloud.com/fr/feed/?format=excerpt'
-      : 'https://www.clever-cloud.com/feed/?format=excerpt';
+      ? 'https://www.clever.cloud/fr/feed/?format=excerpt'
+      : 'https://www.clever.cloud/feed/?format=excerpt';
 
   const requestParams = {
     method: 'get',


### PR DESCRIPTION
## What does this PR do?

- Currently, the `cc-article-list` fails to load because of CORS issues. The website has moved to `clever.cloud` so CORS rules for `clever-cloud.com` no longer apply.
- Corrects the feed URLs from `clever-cloud.com` to `clever.cloud` for both French and default language feeds.

## How to review?

- Check the commit,
- Check demo-smart,
- 1 reviewer should be enough.