### PR TITLE
fix(skeleton): set animation:none for all elements by default

### DIFF
--- a/src/styles/skeleton.js
+++ b/src/styles/skeleton.js
@@ -12,6 +12,11 @@ export const skeletonStyles = css`
     }
   }
 
+  /* FIXME: temporary solution for Safari until we build a directive for skeletons. See https://github.com/CleverCloud/clever-components/issues/1111 for more info */
+  * {
+    animation: none;
+  }
+
   .skeleton {
     animation-direction: alternate;
     animation-duration: 500ms;


### PR DESCRIPTION
Fixes #1111

## What does this PR do?

- Uses the `*` selector to set an explicit `animation: none` rule for elements without the `skeleton` class.
- This forces Safari to stop animations when the `skeleton` class is removed.
- This is a workaround for a Safari-specific issue until a proper directive for skeletons is implemented.

## How to review?

- Compare [prod](https://www.clever.cloud/developers/clever-components/?path=/story/%F0%9F%9B%A0-addon-cc-addon-header--simulation-with-loading-error) with [preview](https://clever-components-preview.cellar-c2.services.clever-cloud.com/skeleton/fix-safari-issue/index.html?path=/story/%F0%9F%9B%A0-addon-cc-addon-header--simulation-with-loading-error):
  - The `cc-addon-header` simulation stories with a Webkit browser (load the error simulation, let it play, then switch to the loaded success simulation, this way you are 100% sure to reproduce),
  - In prod some elements should be stuck in loading mode,
  - From the preview, elements should switch from skeleton to loaded, animation should be gone :+1:.
- 1 reviewer should be enough for this one.

