### PR TITLE
fix(cc-addon-header.smart-kubernetes): set provider name in status message

### DIFF
--- a/src/components/cc-addon-header/cc-addon-header.js
+++ b/src/components/cc-addon-header/cc-addon-header.js
@@ -116,7 +116,10 @@ export class CcAddonHeader extends LitElement {
     const isRestarting = this.state.type === 'restarting';
     const isRebuilding = this.state.type === 'rebuilding';
     const deploymentStatus = this.state.deploymentStatus;
-    const providerId = this.state.type === 'loaded' ? this.state.providerId : '';
+    const providerId =
+      this.state.type === 'loaded' || this.state.type === 'restarting' || this.state.type === 'rebuilding'
+        ? this.state.providerId
+        : '';
 
     return html`
       <cc-block>

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -301,8 +301,8 @@ export const translations = {
     sanitize`Le processus de redémarrage de votre add-on et de ses ressources est en cours. Consultez les <cc-link href="${logsUrl}">logs</cc-link> ou la <cc-link href=${docsUrl}>documentation</cc-link> pour plus d'informations.`,
   'cc-addon-header.restart.success.title': `Redémarrage en cours`,
   'cc-addon-header.state-msg.deployment-failed': `Le déploiement a échoué`,
-  'cc-addon-header.state-msg.deployment-is-active': /** @param {{ productId: string }} _ */ ({ productId }) =>
-    `Votre ${productId === 'kubernetes' ? 'cluster' : 'instance'} ${productId} est disponible !`,
+  'cc-addon-header.state-msg.deployment-is-active': /** @param {{ providerId: string }} _ */ ({ providerId }) =>
+    `Votre ${providerId === 'kubernetes' ? 'cluster' : 'instance'} ${providerId} est disponible !`,
   'cc-addon-header.state-msg.deployment-is-deploying': `En cours de déploiement…`,
   'cc-addon-header.state-msg.unknown-state': `État inconnu, essayez de redémarrer ou de contacter notre support si vous avez des questions`,
   //#endregion


### PR DESCRIPTION
## What does this PR do?

When reworking the deployment status messages to remove the `add-on` mention, I accidentally used `productId` instead of `providerId` as i18n key param.

This results in the following message in French:

> Votre instance undefined est disponible !

This PR fixes that :see_no_evil: 

## How to review?

- No review necessary, this is a quick fix for the release