### PR TITLE
fix(cc-block-details): improve focus outline and button transition

### DIFF
--- a/src/components/cc-block-details/cc-block-details.js
+++ b/src/components/cc-block-details/cc-block-details.js
@@ -36,10 +36,12 @@ export class CcBlockDetails extends LitElement {
   render() {
     return html`
       <div class="wrapper">
-        <button class="button" aria-expanded="${this.isOpen}" aria-controls="content" @click=${this._onClickToggle}>
-          <slot name="button-text"></slot>
-          <cc-icon .icon="${iconArrowDown}"></cc-icon>
-        </button>
+        <div class="btn-wrapper">
+          <button class="button" aria-expanded="${this.isOpen}" aria-controls="content" @click=${this._onClickToggle}>
+            <slot name="button-text"></slot>
+            <cc-icon .icon="${iconArrowDown}"></cc-icon>
+          </button>
+        </div>
         <div id="content" class="content">
           <slot name="content"></slot>
         </div>
@@ -77,27 +79,36 @@ export class CcBlockDetails extends LitElement {
           }
         }
 
+        .btn-wrapper {
+          border-radius: var(--cc-border-radius-default, 0.25em);
+          grid-area: button;
+        }
+
+        :host([is-open]) .btn-wrapper {
+          background-color: var(--cc-color-bg-default, #fff);
+          border-radius: var(--cc-border-radius-default, 0.25em) var(--cc-border-radius-default, 0.25em) 0 0;
+        }
+
         .button {
           align-items: center;
           background-color: transparent;
           border: solid 1px transparent;
+          border-radius: var(--cc-border-radius-default, 0.25em);
           display: flex;
           font-family: inherit;
           font-size: 1em;
-          grid-area: button;
           padding: 0.25em 0.6em 0.35em;
-          transition: all 0.3s;
-        }
-
-        :host([is-open]) .button {
-          background-color: var(--cc-color-bg-default, #fff);
-          border-radius: var(--cc-border-radius-default, 0.25em) var(--cc-border-radius-default, 0.25em) 0 0;
-          margin-bottom: 0;
+          position: relative;
+          z-index: 1;
         }
 
         .button:hover {
           border: solid 1px var(--cc-color-border-neutral-strong, #8c8c8c);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+        }
+
+        .button:focus-visible {
+          outline: var(--cc-focus-outline, #000 solid 2px);
+          outline-offset: var(--cc-focus-outline-offset, 2px);
         }
 
         .button cc-icon {


### PR DESCRIPTION
Fixes #1547

## What does this PR do?                   
 
* Adds a focus-visible outline to the button,                                                                                                    
* Moves the transition from the button to its hover state as it was transitioning when in focus which we don't want.                                                                                                                                                                            
 
Question: transitioning the focus from square to rounded feels weird to me, should we round it too beforehand?

## How to review?

* Check the commit,
* Check the preview,
* One or two reviewers is enough.

