### PR TITLE
refactor(common.events): rename classes to use Event suffix

### DIFF
--- a/src/components/cc-dialog-confirm-actions/cc-dialog-confirm-actions.js
+++ b/src/components/cc-dialog-confirm-actions/cc-dialog-confirm-actions.js
@@ -2,7 +2,7 @@ import { LitElement, css, html } from 'lit';
 import { isStringEmpty } from '../../lib/utils.js';
 import { i18n } from '../../translations/translation.js';
 import '../cc-button/cc-button.js';
-import { CcCloseRequest, CcConfirmEvent } from '../common.events.js';
+import { CcCloseRequestEvent, CcConfirmEvent } from '../common.events.js';
 
 /**
  * A reusable action buttons component for `<cc-dialog>` with Cancel and Confirm/Submit buttons.
@@ -42,7 +42,7 @@ export class CcDialogConfirmActions extends LitElement {
   }
 
   _onCancel() {
-    this.dispatchEvent(new CcCloseRequest());
+    this.dispatchEvent(new CcCloseRequestEvent());
   }
 
   _onConfirm() {

--- a/src/components/cc-dialog/cc-dialog.js
+++ b/src/components/cc-dialog/cc-dialog.js
@@ -10,7 +10,7 @@ import { i18n } from '../../translations/translation.js';
 import '../cc-button/cc-button.js';
 import '../cc-icon/cc-icon.js';
 import '../cc-input-text/cc-input-text.js';
-import { CcCloseEvent, CcFocusRestorationFail, CcOpenEvent } from '../common.events.js';
+import { CcCloseEvent, CcFocusRestorationFailEvent, CcOpenEvent } from '../common.events.js';
 
 /**
  * @import { IconModel } from '../common.types.js';
@@ -137,7 +137,7 @@ export class CcDialog extends LitElement {
     if (this._openerElement instanceof HTMLElement && this._openerElement.isConnected) {
       this._openerElement.focus();
     } else {
-      this.dispatchEvent(new CcFocusRestorationFail(this._openerElement));
+      this.dispatchEvent(new CcFocusRestorationFailEvent(this._openerElement));
     }
   }
 

--- a/src/components/cc-dialog/cc-dialog.test.js
+++ b/src/components/cc-dialog/cc-dialog.test.js
@@ -5,7 +5,7 @@ import { html } from 'lit';
 import { addTranslations, setLanguage } from '../../lib/i18n/i18n.js';
 import { findActiveElement } from '../../lib/shadow-dom-utils.js';
 import { lang, translations } from '../../translations/translations.en.js';
-import { CcCloseEvent, CcFocusRestorationFail } from '../common.events.js';
+import { CcCloseEvent, CcFocusRestorationFailEvent } from '../common.events.js';
 import './cc-dialog.js';
 
 addTranslations(lang, translations);
@@ -260,7 +260,7 @@ describe('cc-dialog component', () => {
       `);
       const opener = container.querySelector('#opener');
       const dialog = container.querySelector('cc-dialog');
-      const failSpy = createEventSpy(dialog, CcFocusRestorationFail.TYPE);
+      const failSpy = createEventSpy(dialog, CcFocusRestorationFailEvent.TYPE);
 
       opener.focus();
       opener.click();
@@ -286,7 +286,7 @@ describe('cc-dialog component', () => {
       `);
       const opener = container.querySelector('#opener');
       const dialog = container.querySelector('cc-dialog');
-      const failSpy = createEventSpy(dialog, CcFocusRestorationFail.TYPE);
+      const failSpy = createEventSpy(dialog, CcFocusRestorationFailEvent.TYPE);
 
       opener.focus();
       opener.click();
@@ -314,7 +314,7 @@ describe('cc-dialog component', () => {
       `);
       const opener = container.querySelector('#opener');
       const dialog = container.querySelector('cc-dialog');
-      const failSpy = createEventSpy(dialog, CcFocusRestorationFail.TYPE);
+      const failSpy = createEventSpy(dialog, CcFocusRestorationFailEvent.TYPE);
 
       opener.focus();
       opener.click();
@@ -330,7 +330,7 @@ describe('cc-dialog component', () => {
       // Verify focus restoration fail event was dispatched with correct detail
       expect(failSpy.called).to.equal(true);
       const event = failSpy.lastCall.args[0];
-      expect(event).to.be.instanceOf(CcFocusRestorationFail);
+      expect(event).to.be.instanceOf(CcFocusRestorationFailEvent);
       expect(event.detail).to.equal(opener);
     });
   });
@@ -374,7 +374,7 @@ describe('cc-dialog component', () => {
       const opener = container.querySelector('#opener');
       const otherButton = container.querySelector('#other');
       const dialog = container.querySelector('cc-dialog');
-      const failSpy = createEventSpy(dialog, CcFocusRestorationFail.TYPE);
+      const failSpy = createEventSpy(dialog, CcFocusRestorationFailEvent.TYPE);
 
       opener.focus();
       opener.click();

--- a/src/components/common.events.js
+++ b/src/components/common.events.js
@@ -19,11 +19,11 @@ export class CcCloseEvent extends CcEvent {
  *
  * @extends {CcEvent}
  */
-export class CcCloseRequest extends CcEvent {
+export class CcCloseRequestEvent extends CcEvent {
   static TYPE = 'cc-close-request';
 
   constructor() {
-    super(CcCloseRequest.TYPE);
+    super(CcCloseRequestEvent.TYPE);
   }
 }
 
@@ -58,12 +58,12 @@ export class CcOpenEvent extends CcEvent {
  *
  * @extends {CcEvent<Element>}
  */
-export class CcFocusRestorationFail extends CcEvent {
+export class CcFocusRestorationFailEvent extends CcEvent {
   static TYPE = 'cc-focus-restoration-fail';
 
   /** @param {Element} element - the element that it tried to restore focus on */
   constructor(element) {
-    super(CcFocusRestorationFail.TYPE, element);
+    super(CcFocusRestorationFailEvent.TYPE, element);
   }
 }
 

--- a/src/controllers/lost-focus-controller.js
+++ b/src/controllers/lost-focus-controller.js
@@ -1,4 +1,4 @@
-import { CcFocusRestorationFail } from '../components/common.events.js';
+import { CcFocusRestorationFailEvent } from '../components/common.events.js';
 import { EventHandler } from '../lib/events.js';
 import { findActiveElement, isParentOf } from '../lib/shadow-dom-utils.js';
 
@@ -57,8 +57,8 @@ export class LostFocusController {
   hostConnected() {
     this.eventHandler = new EventHandler(
       this.host,
-      CcFocusRestorationFail.TYPE,
-      /** @param {CcFocusRestorationFail} event */
+      CcFocusRestorationFailEvent.TYPE,
+      /** @param {CcFocusRestorationFailEvent} event */
       async ({ detail: elementThatFailedToFocus }) => {
         await this.additionalWaiter?.();
         // compare elements to the previous one and check if some elements have been removed

--- a/src/lib/events-map.types.d.ts
+++ b/src/lib/events-map.types.d.ts
@@ -143,9 +143,9 @@ import {
 import {
   CcClickEvent,
   CcCloseEvent,
-  CcCloseRequest,
+  CcCloseRequestEvent,
   CcConfirmEvent,
-  CcFocusRestorationFail,
+  CcFocusRestorationFailEvent,
   CcOpenEvent,
   CcPasswordResetEvent,
   CcRequestSubmitEvent,
@@ -185,7 +185,7 @@ declare global {
     'cc-application-stop': CcApplicationStopEvent;
     'cc-click': CcClickEvent;
     'cc-close': CcCloseEvent;
-    'cc-close-request': CcCloseRequest;
+    'cc-close-request': CcCloseRequestEvent;
     'cc-confirm': CcConfirmEvent;
     'cc-deployment-cancel': CcDeploymentCancelEvent;
     'cc-domain-add': CcDomainAddEvent;
@@ -205,7 +205,7 @@ declare global {
     'cc-env-vars-was-updated': CcEnvVarsWasUpdatedEvent;
     'cc-error-message-change': CcErrorMessageChangeEvent;
     'cc-feature-setting-change': CcFeatureSettingChangeEvent;
-    'cc-focus-restoration-fail': CcFocusRestorationFail;
+    'cc-focus-restoration-fail': CcFocusRestorationFailEvent;
     'cc-form-invalid': CcFormInvalidEvent;
     'cc-form-valid': CcFormValidEvent;
     'cc-grafana-reset': CcGrafanaResetEvent;

--- a/test/controller/lost-focus-controller.test.js
+++ b/test/controller/lost-focus-controller.test.js
@@ -3,7 +3,7 @@ import { defineCE, fixture, nextFrame } from '@open-wc/testing';
 import * as hanbi from 'hanbi';
 import { LitElement, html } from 'lit';
 import { repeat } from 'lit/directives/repeat.js';
-import { CcFocusRestorationFail } from '../../src/components/common.events.js';
+import { CcFocusRestorationFailEvent } from '../../src/components/common.events.js';
 import { LostFocusController } from '../../src/controllers/lost-focus-controller.js';
 
 describe('lost-focus-controller', () => {
@@ -230,7 +230,7 @@ describe('lost-focus-controller', () => {
           }
 
           dispatchFocusRestorationFail(element) {
-            this.dispatchEvent(new CcFocusRestorationFail(element));
+            this.dispatchEvent(new CcFocusRestorationFailEvent(element));
           }
 
           render() {


### PR DESCRIPTION
## What does this PR do?

- Adds the `Event` suffix to event classes that were missing them.

## How to review?

- Check the commit,
- 1 reviewer should be enough for this one.