### PR TITLE
feat(cc-domain-management): add dialog for HTTP only domain creation

### DIFF
--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -459,6 +459,14 @@ export const translations = {
   'cc-domain-management.certif.custom': () =>
     sanitize`You can provide your own certificate by using the <cc-link href="https://api.clever-cloud.com/v2/certificates/new">Clever Cloud Certificate Manager</cc-link>.`,
   'cc-domain-management.certif.heading': `Secure your application`,
+  'cc-domain-management.create-dialog.confirm-button': `Add domain`,
+  'cc-domain-management.create-dialog.desc': /** @param {{ domainWithPathPrefix: string }} _ */ ({
+    domainWithPathPrefix,
+  }) =>
+    sanitize`The subdomain <code>${domainWithPathPrefix}</code> will be created without SSL certificate, allowing HTTP access only.`,
+  'cc-domain-management.create-dialog.heading': `Create HTTP only subdomain`,
+  'cc-domain-management.create-dialog.warning': () =>
+    sanitize`Only direct domains of <code>cleverapps.io</code> are secured with SSL certificates, not <code>xx.yy.cleverapps.io</code> domains.`,
   'cc-domain-management.delete-dialog.confirm-button': `Delete`,
   'cc-domain-management.delete-dialog.desc': `By deleting this domain name, your application will immediatly become unreachable from that specific domain name.`,
   'cc-domain-management.delete-dialog.heading': `Remove the domain name`,

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -470,6 +470,13 @@ export const translations = {
   'cc-domain-management.certif.custom': () =>
     sanitize`Vous pouvez fournir votre propre certificat grâce au <cc-link href="https://api.clever-cloud.com/v2/certificates/new">gestionnaire de certificats Clever Cloud</cc-link>.`,
   'cc-domain-management.certif.heading': `Sécurisez votre application`,
+  'cc-domain-management.create-dialog.confirm-button': `Ajouter le domaine`,
+  'cc-domain-management.create-dialog.desc': /** @param {{ domainWithPathPrefix: string }} _ */ ({
+    domainWithPathPrefix,
+  }) => sanitize`Le nom de domaine <code>${domainWithPathPrefix}</code> sera disponible en HTTP uniquement.`,
+  'cc-domain-management.create-dialog.heading': `Sous-domaine disponible en HTTP uniquement`,
+  'cc-domain-management.create-dialog.warning': () =>
+    sanitize`Seuls les domaines directs de <code>cleverapps.io</code> bénéficient d'un certificat SSL, pas ceux de type <code>xx.yy.cleverapps.io</code>.`,
   'cc-domain-management.delete-dialog.confirm-button': `Supprimer`,
   'cc-domain-management.delete-dialog.desc': `Supprimer ce nom de domain rendra immédiatement votre application inaccessible depuis ce dernier.`,
   'cc-domain-management.delete-dialog.heading': `Supprimer le nom de domaine`,


### PR DESCRIPTION
## What does this PR do?

- Adds `cc-dialog` for when users try to add a subdomain for the test domain, for instance `sub.domain.cleverapps.io`
  - This asks for user confirmation because this domain is not covered by HTTPS.
  - This warning used to be handled by the console but now needs to be done from the component itself to benefit from the dialog component and simplify the console code.
  - This warning used to be displayed with a confirmation input but this was mostly because the console dialog didn't allow us to do what we wanted. I changed to a simple cancel / confirm buttons pattern for this case.
  - We can easily change it to a confirm form if you think it's better so do not hesitate to say it :wink: 

## How to review?

- Check the commit,
- Check the impacted stories (I updated them so that they show the dialog, so we don't forget about these usecases and we benefit from visual tests in the future),
- Check the component in demo-smart: 
  - try to add a regular domain `toto40392.cleverapps.io` =>waiting state => success,
  - error case with dialog: 
    - block requests to `api.clever-cloud.com`,
    - try to add a `sub.toto40392.cleverapps.io` domain => confirmation dialog => confirm => waiting state => error toast => dialog closed => back on the submit button (or input if you submitted from there).
 - success case with dialog:
   - unblock requests to `api.clever-cloud.com`,
   - try to add a `sub.toto40392.cleverapps.io` domain => confirmation dialog => confirm => waiting state => success toast => dialog closed => back on the submit button (or input if you submitted from there).
 - 1 cautious reviewer should be enough for this one!