### PR TITLE
`cc-dialog`: fix close button positioning

### DIFF
--- a/src/components/cc-dialog/cc-dialog.js
+++ b/src/components/cc-dialog/cc-dialog.js
@@ -230,6 +230,7 @@ export class CcDialog extends LitElement {
 
         .dialog-close {
           --close-btn-size: 2em;
+          --close-btn-offset: calc(var(--cc-dialog-padding, var(--default-dialog-padding)) / 1.5);
 
           align-items: center;
           background: none;
@@ -244,7 +245,7 @@ export class CcDialog extends LitElement {
           margin-top: calc(var(--close-btn-size) * -1);
           position: sticky;
           top: 0;
-          transform: translate(2.75em, -2.75em);
+          transform: translate(var(--close-btn-offset), calc(var(--close-btn-offset) * -1));
           width: var(--close-btn-size);
         }
 


### PR DESCRIPTION
Fixes #1637 

## What does this PR do?

- Fixes the close button positioning when screen is narrow,
- Fixes `--cc-dialog-padding` that was not doing what it was supposed to :see_no_evil:.

## How to review?

- Check the [visual tests report](https://clever-components-visual-tests.cellar-c2.services.clever-cloud.com/cc-dialog/fix-responsive-close-btn/visual-tests-reports/index.html) or the stories (there's a slight difference in how the button is positionned even in desktop),
- Try setting a different value for `--cc-dialog-padding` on the `cc-dialog` element or its parents.
  - The close button positioning is tricky, I wonder if we should expose a way to modify it directly instead of computing it like that, I don't really like how it's currently done.
- 2 reviewers should be enough for this one but it would be nice to have @roberttran-cc 's opinion about the way we position the close button (if we don't have a definite solution right now, it can be merged as is and reworked later on in sync).