### PR TITLE
fix: fix date formatting by handling inconsistent timezone output format

### DIFF
--- a/src/lib/date/date-formatter.js
+++ b/src/lib/date/date-formatter.js
@@ -168,7 +168,10 @@ export class DateFormatter {
     }
 
     if (this._isZoneOffsetIncluded) {
-      result.timezone = dateParts.timeZoneName === 'GMT' ? 'Z' : dateParts.timeZoneName.slice(3);
+      result.timezone =
+        dateParts.timeZoneName === 'GMT' || dateParts.timeZoneName === 'GMT+00:00'
+          ? 'Z'
+          : dateParts.timeZoneName.slice(3);
     }
 
     return result;


### PR DESCRIPTION
# What this PR do?

This PR resolves this issue
`Intl.DateTimeFormat` with `timeZoneName: 'longOffset' `returns inconsistent formats across browsers/environments:
  - Some return "GMT"
  - Others return "GMT+00:00"
