### PR TITLE
fix(cc-logs-instances): support null commitId

### DIFF
--- a/src/components/cc-logs-instances/cc-logs-instances.js
+++ b/src/components/cc-logs-instances/cc-logs-instances.js
@@ -336,7 +336,7 @@ export class CcLogsInstances extends LitElement {
       <legend class="section-header">
         ${icon != null ? html` <cc-icon class="section-header-icon" .icon=${icon}></cc-icon> ` : ''}
         <span class="section-header-title">${title}</span>
-        ${commit != null ? this._renderCommit(commit) : ''}
+        ${this._renderCommit(commit)}
       </legend>
     `;
   }
@@ -513,9 +513,12 @@ export class CcLogsInstances extends LitElement {
   }
 
   /**
-   * @param {string} commit
+   * @param {string|undefined} commit
    */
   _renderCommit(commit) {
+    if (commit == null) {
+      return '';
+    }
     return html` <span class="commit" title=${i18n('cc-logs-instances.commit.title', { commit })}>
       ${commit.substring(0, 7)}
     </span>`;

--- a/src/components/cc-logs-instances/cc-logs-instances.stories.js
+++ b/src/components/cc-logs-instances/cc-logs-instances.stories.js
@@ -81,6 +81,21 @@ const ALL_INSTANCES = [
 /** @type {Array<Instance|GhostInstance>} */
 const ALL_INSTANCES_WITH_GHOSTS = [...ALL_INSTANCES, createGhostInstance(), createGhostInstance()];
 
+/**
+ * @param {Array<Instance|GhostInstance>} instances
+ * @returns {Array<Instance|GhostInstance>}
+ */
+function removeCommitId(instances) {
+  return instances.map((instance) => {
+    if (instance.ghost === true) {
+      return instance;
+    }
+    const deployment = { ...instance.deployment };
+    delete deployment.commitId;
+    return { ...instance, deployment };
+  });
+}
+
 export default {
   tags: ['autodocs'],
   title: '🚧 Beta/🛠 Logs/<cc-logs-instances-beta>',
@@ -165,6 +180,20 @@ export const cancelledDeployment = makeStory(conf, {
 export const withGhostInstances = makeStory(conf, {
   /** @type {Array<Partial<CcLogsInstances>>} */
   items: [{ state: { state: 'loaded', mode: 'live', selection: [], instances: ALL_INSTANCES_WITH_GHOSTS } }],
+});
+
+export const withoutCommitId = makeStory(conf, {
+  /** @type {Array<Partial<CcLogsInstances>>} */
+  items: [
+    {
+      state: {
+        state: 'loaded',
+        mode: 'live',
+        selection: [],
+        instances: removeCommitId(ALL_INSTANCES_WITH_GHOSTS),
+      },
+    },
+  ],
 });
 
 export const coldMode = makeStory(conf, {

--- a/src/components/cc-logs-instances/cc-logs-instances.types.d.ts
+++ b/src/components/cc-logs-instances/cc-logs-instances.types.d.ts
@@ -23,7 +23,7 @@ export interface Deployment {
   id: string;
   state: DeploymentState;
   creationDate: Date;
-  commitId: string;
+  commitId?: string;
   endDate?: Date;
 }
 


### PR DESCRIPTION
# Context

PHP apps with FTP/SFTP deployment mode generate deployments without commit id.

# Problem

`cc-logs-instances` component does not support this nullity.

# Solution

add nullity check in `cc-logs-instances` when rendering the commit id. When commit id is null, just renders nothing.