### PR TITLE
feat(logs): augment first log waiting timeout in cold mode

### DIFF
--- a/src/lib/logs/logs-stream.js
+++ b/src/lib/logs/logs-stream.js
@@ -10,7 +10,7 @@ const LOGS_THROTTLE_ELEMENTS = 1000;
 const THROTTLE_PER_IN_MILLISECONDS = 10;
 const MAX_RETRY_COUNT = 10;
 const WAITING_TIMEOUT_LIVE = 2000;
-const WAITING_TIMEOUT_COLD = 8000;
+const WAITING_TIMEOUT_COLD = 16000;
 
 // FIXME: We're using `@typedef` instead of `@import` here due to a false positive from TS
 // See: https://github.com/microsoft/TypeScript/issues/60908/


### PR DESCRIPTION
# Problem

When there are many logs, fetching the first log of a closed time window can be longer than the 8 seconds timeout.
The result is a display of 'no logs for this app' message and the SSE is closed.

# Solution

Augment the timeout to 16 seconds.
