### PR TITLE
fix(cc-addon-info.client): use app's `entrypoint` instead of operator…

### DIFF
--- a/src/components/cc-addon-info/cc-addon-info.client.js
+++ b/src/components/cc-addon-info/cc-addon-info.client.js
@@ -109,7 +109,7 @@ export class CcAddonInfoClient {
     ]);
     const grafanaAppLink =
       this._grafanaLink != null
-        ? await this._getGrafanaAppLink({ resourceId: rawAddon.realId, signal: this._signal })
+        ? await this._getGrafanaAppLink({ resourceId: operator.resources.entrypoint, signal: this._signal })
         : null;
 
     return { addonInfo: rawAddon, operator, operatorVersionInfo, grafanaAppLink };


### PR DESCRIPTION
## What does this PR do?

- Replace operator's `realId` by app's `entrypoint` to build Grafana Link

In the information dashboard, we use to use the operator's `realId` to build Grafana link for Keycloak, Otoroshi and Metabase. It results by an empty data Grafana dashboard.

<img width="2060" height="776" alt="image (1)" src="https://github.com/user-attachments/assets/aab083b4-5dfc-4003-b578-ac7371e606a7" />

This PR fix it by using the Java app's `entrypoint` to get the right data.


## How to review?

- Check the commits,
- Check the code,
- Play with `demo-smart` and click on the Grafana link on `cc-addon-info` for Keycloak, Otoroshi and Metabase, you should see some data displayed.