### PR TITLE
fix(cc-picker): replace `fieldset` with `ARIA` equivalent

### DIFF
--- a/src/components/cc-picker/cc-picker.js
+++ b/src/components/cc-picker/cc-picker.js
@@ -192,26 +192,31 @@ export class CcPicker extends CcFormControlElement {
     const hasErrorMessage = this.errorMessage != null && this.errorMessage !== '';
 
     return html`
-      <fieldset class="fieldset" @input=${this._onTileSelect} ${ref(this._pickerRef)} tabindex="-1">
-        <div class="fieldset-content">
-          <legend class="legend">
-            <span class="legend-text">${this.label}</span>
-            ${this.required ? html` <span class="required">${i18n('cc-picker.required')}</span> ` : ''}
-          </legend>
+      <div
+        class="fieldset"
+        @input=${this._onTileSelect}
+        ${ref(this._pickerRef)}
+        role="group"
+        aria-labelledby="legend"
+        tabindex="-1"
+      >
+        <p class="legend" id="legend">
+          <span class="legend-text">${this.label}</span>
+          ${this.required ? html` <span class="required">${i18n('cc-picker.required')}</span> ` : ''}
+        </p>
 
-          <div class="tiles" part="tiles">
-            ${this.options.map((option, index) => this._renderOption(option, hasErrorMessage, index))}
-          </div>
-
-          <div class="help-container" id="help-id">
-            <slot name="help"></slot>
-          </div>
-
-          ${hasErrorMessage
-            ? html`<p class="error-container" id="error-id" ${ref(this._errorRef)}>${this.errorMessage}</p>`
-            : ''}
+        <div class="tiles" part="tiles">
+          ${this.options.map((option, index) => this._renderOption(option, hasErrorMessage, index))}
         </div>
-      </fieldset>
+
+        <div class="help-container" id="help-id">
+          <slot name="help"></slot>
+        </div>
+
+        ${hasErrorMessage
+          ? html`<p class="error-container" id="error-id" ${ref(this._errorRef)}>${this.errorMessage}</p>`
+          : ''}
+      </div>
     `;
   }
 
@@ -268,22 +273,15 @@ export class CcPicker extends CcFormControlElement {
         /* endregion */
 
         /* region fieldset */
-        fieldset {
-          border: none;
+        .fieldset {
           display: inline-block;
-          margin: 0;
-          padding: 0;
+          width: var(--cc-picker-tiles-width, fit-content);
         }
 
-        fieldset:focus-visible {
+        .fieldset:focus-visible {
           border-radius: var(--cc-border-radius-default, 0.25em);
           outline: var(--cc-focus-outline-error);
           outline-offset: 0.5em;
-        }
-
-        fieldset,
-        .fieldset-content {
-          width: var(--cc-picker-tiles-width, fit-content);
         }
         /* endregion */
 
@@ -294,6 +292,7 @@ export class CcPicker extends CcFormControlElement {
           display: flex;
           gap: 2em;
           justify-content: space-between;
+          margin: 0;
           padding-block-end: var(--cc-form-label-gap, 0.35em);
           width: 100%;
         }
@@ -337,7 +336,7 @@ export class CcPicker extends CcFormControlElement {
         /* endregion */
 
         /* region inline layout */
-        :host([inline]) .fieldset-content {
+        :host([inline]) .fieldset {
           align-items: baseline;
           display: grid;
           gap: 0 var(--cc-form-label-gap-inline, 0.75em);


### PR DESCRIPTION
Fixes #1679

## What does this PR do?

- `<legend>` needs to be a direct child of `<fieldset>` (HTML spec, breaks the `fieldset` / `legend` association if it's not the case) but in the `cc-picker`, there is a `<div class="fieldset-content">` between them,
  - This is because we need to support an `inline` layout where the `legend` is on the left of the picker options,
  - This is a case we've already faced ([ADR 25](https://www.clever.cloud/developers/clever-components/?path=/docs/%F0%9F%93%8C-architecture-decision-records-adr-0025-moving-away-from-fieldset-and-legend--docs))
  - This PR goes for the solution explained in the ADR: `<div role="group" aria-labelledby="legend-id"><p id="legend-id">My legend</p>...</div>` and removes the `.fieldset-content`.

## How to review?

- Check the code,
- Check that nothing has changed visually (tests should cover this but you can check manually too, it doesn't hurt :+1:)