### PR TITLE
fix(cc-domain-management): change `clever diag` to `clever domain diag`

### DIFF
--- a/src/components/cc-domain-management/cc-domain-management.js
+++ b/src/components/cc-domain-management/cc-domain-management.js
@@ -489,7 +489,7 @@ export class CcDomainManagement extends LitElement {
               <dl>
                 <dt>${i18n('cc-domain-management.dns.cli.content.diag-conf-command')}</dt>
                 <dd>
-                  <cc-code>clever diag --app ${this.applicationId}</cc-code>
+                  <cc-code>clever domain diag --app ${this.applicationId}</cc-code>
                 </dd>
               </dl>
             </div>


### PR DESCRIPTION
## What does this PR do?

- The CLI command example in the `Configure your DNS` block was wrong,
  - Changes `clever diag` to `clever domain diag`.

## How to review?

- Check the code,
- 1 review should be enough for this one.