### PR TITLE
feat(cellar-explorer): add directory creation and objects upload

### DIFF
--- a/sandbox/cc-cellar-explorer/cc-cellar-explorer-sandbox.js
+++ b/sandbox/cc-cellar-explorer/cc-cellar-explorer-sandbox.js
@@ -25,7 +25,7 @@ class CcCellarExplorerSandbox extends LitElement {
   constructor() {
     super();
 
-    this._addonId = 'addon_ad9e692d-3d28-47b9-82db-76840db955a7';
+    this._addonId = 'addon_9262abfc-3394-479e-8f15-491c97b906d3';
 
     /** @type {Ref<CcInputText>} */
     this._addonIdInputRef = createRef();

--- a/src/components/cc-cellar-explorer/cc-cellar-explorer.client.js
+++ b/src/components/cc-cellar-explorer/cc-cellar-explorer.client.js
@@ -154,6 +154,36 @@ export class CellarExplorerClient {
       .then(sendToApi({ apiConfig: this._apiConfig }))
       .catch(catchError);
   }
+
+  /**
+   * @param {string} bucketName
+   * @param {string} objectName
+   * @param {File} file
+   */
+  async uploadObject(bucketName, objectName, file) {
+    const result = await Promise.resolve({
+      method: 'post',
+      url: `/v4/cellar/organisations/${this._ownerId}/cellar/${this._addonId}/buckets/${encodeURIComponent(bucketName)}/objects/${encodeURIComponent(objectName)}/presigned-url`,
+    })
+      .then(sendToApi({ apiConfig: this._apiConfig }))
+      .catch(catchError);
+
+    const presignedUrl = result.url;
+
+    const response = await fetch(presignedUrl, {
+      method: 'post',
+      headers: { 'Content-Type': file.type ?? 'application/octet-stream' },
+      body: file,
+    });
+
+    if (!response.ok) {
+      const body = await response.json().catch(() => /** @type {null} */ (null));
+      if (body?.code != null) {
+        throw new CellarExplorerError(body.code, body.error, body.context);
+      }
+      throw new Error(`Upload failed with status ${response.status}`);
+    }
+  }
 }
 
 /**

--- a/src/components/cc-cellar-explorer/cc-cellar-explorer.client.types.d.ts
+++ b/src/components/cc-cellar-explorer/cc-cellar-explorer.client.types.d.ts
@@ -34,6 +34,7 @@ export interface CellarDirectory {
   type: 'directory';
   key: string;
   name: string;
+  volatile?: boolean;
 }
 
 export interface CellarFileDetails extends CellarFile {

--- a/src/components/cc-cellar-explorer/cc-cellar-explorer.client.types.d.ts
+++ b/src/components/cc-cellar-explorer/cc-cellar-explorer.client.types.d.ts
@@ -28,6 +28,7 @@ export interface CellarFile {
   name: string;
   updatedAt: string;
   contentLength: number;
+  volatile?: boolean;
 }
 
 export interface CellarDirectory {

--- a/src/components/cc-cellar-object-list/cc-cellar-object-list.ctrl.js
+++ b/src/components/cc-cellar-object-list/cc-cellar-object-list.ctrl.js
@@ -1,7 +1,7 @@
 import { Abortable } from '../../lib/abortable.js';
 import { i18n } from '../../lib/i18n/i18n.js';
 import { notifyError, notifySuccess } from '../../lib/notifications.js';
-import { isCellarExplorerErrorWithCode } from '../cc-cellar-explorer/cc-cellar-explorer.client.js';
+import { isCellarExplorerErrorWithCode, pathToString } from '../cc-cellar-explorer/cc-cellar-explorer.client.js';
 import '../cc-smart-container/cc-smart-container.js';
 import { CcCellarNavigateToHomeEvent } from './cc-cellar-object-list.events.js';
 import './cc-cellar-object-list.js';
@@ -92,6 +92,14 @@ export class ObjectListController {
 
     onEvent('cc-cellar-object-create-directory', (directoryName) => {
       this.createDirectory(directoryName);
+    });
+
+    onEvent('cc-cellar-object-download', (objectKey) => {
+      this.download(objectKey);
+    });
+
+    onEvent('cc-cellar-object-upload', (file) => {
+      this.uploadObject(file);
     });
   }
 
@@ -219,6 +227,32 @@ export class ObjectListController {
     }
   }
 
+  /**
+   * @param {string} objectKey
+   * @returns {Promise<void>}
+   */
+  async download(objectKey) {
+    this.#updateDetails({ state: 'downloading' });
+    try {
+      const signedUrl = await this.#cellarClient.getObjectSignedUrl(this.#bucketName, objectKey);
+
+      const element = document.createElement('a');
+      element.setAttribute('href', signedUrl.url);
+      element.setAttribute('target', '_blank');
+      document.body.appendChild(element);
+      element.click();
+      document.body.removeChild(element);
+    } catch (error) {
+      this.#handleErrorOnObject({
+        error,
+        objectKey,
+        orElse: () => notifyError(i18n('cc-cellar-object-list.error.object-download-failed', { objectKey })),
+      });
+    } finally {
+      this.#updateDetails({ state: 'idle' });
+    }
+  }
+
   async #fetchObjects() {
     try {
       const response = await this.#abortable.run(() =>
@@ -227,7 +261,9 @@ export class ObjectListController {
           filter: this.#filter,
         }),
       );
-      this.#objects = [...response.directories, ...response.content].map((object) => ({ state: 'idle', ...object }));
+      this.#objects = [...response.directories, ...response.content].map((object) =>
+        object.type === 'file' ? /** @type {CellarFileState} */ ({ ...object, state: 'idle' }) : object,
+      );
       this.#nextCursor = response.cursor;
       this.#updateState({
         type: 'loaded',
@@ -367,6 +403,66 @@ export class ObjectListController {
       },
     );
     notifySuccess(i18n('cc-cellar-object-list.success.directory-created', { directoryName }));
+  }
+
+  /**
+   * @param {File} file
+   * @returns {Promise<void>}
+   */
+  async uploadObject(file) {
+    const pathAtUploadStart = this.#path;
+    const objectKey = pathToString(this.#path) + file.name;
+    this.#updateUploadState({ type: 'uploading' });
+
+    try {
+      await this.#cellarClient.uploadObject(this.#bucketName, objectKey, file);
+      notifySuccess(i18n('cc-cellar-object-list.success.object-uploaded', { objectKey }));
+
+      if (this.#path === pathAtUploadStart) {
+        /** @type {CellarFileState} */
+        const newFile = {
+          type: 'file',
+          key: objectKey,
+          name: file.name,
+          updatedAt: new Date().toISOString(),
+          contentLength: file.size,
+          volatile: true,
+          state: 'idle',
+        };
+        this.#objects = [newFile, ...this.#objects.filter((obj) => obj.key !== objectKey)];
+        this.#updateState(
+          /** @param {CellarObjectListStateLoaded} state */ (state) => {
+            state.objects = this.#objects;
+            state.uploadState = { type: 'idle' };
+          },
+        );
+      }
+    } catch (error) {
+      if (this.#path === pathAtUploadStart) {
+        this.#handleErrorOnObject({
+          error,
+          objectKey,
+          orElse: () => notifyError(i18n('cc-cellar-object-list.error.object-upload-failed', { objectKey })),
+        });
+      } else {
+        notifyError(i18n('cc-cellar-object-list.error.object-upload-failed', { objectKey }));
+      }
+    } finally {
+      if (this.#path === pathAtUploadStart) {
+        this.#updateUploadState({ type: 'idle' });
+      }
+    }
+  }
+
+  /**
+   * @param {import('./cc-cellar-object-list.types.js').CellarObjectUploadState} newState
+   */
+  #updateUploadState(newState) {
+    this.#updateState(
+      /** @param {CellarObjectListStateLoaded} state */ (state) => {
+        state.uploadState = newState;
+      },
+    );
   }
 
   /**

--- a/src/components/cc-cellar-object-list/cc-cellar-object-list.ctrl.js
+++ b/src/components/cc-cellar-object-list/cc-cellar-object-list.ctrl.js
@@ -8,11 +8,14 @@ import './cc-cellar-object-list.js';
 
 /**
  * @import { CcCellarObjectList } from './cc-cellar-object-list.js'
- * @import { CellarObjectListState, CellarObjectListStateLoaded, CellarObjectState, CellarFileState, CellarFileDetailsState } from './cc-cellar-object-list.types.js'
+ * @import { CellarObjectListState, CellarObjectListStateLoaded, CellarObjectState, CellarFileState, CellarFileDetailsState, CellarDirectoryCreateFormState } from './cc-cellar-object-list.types.js'
  * @import { CellarExplorerClient } from '../cc-cellar-explorer/cc-cellar-explorer.client.js'
+ * @import { CellarDirectory } from '../cc-cellar-explorer/cc-cellar-explorer.client.types.js'
  * @import { UpdateCallback } from '../common.types.js'
  * @import { OnEventCallback } from '../../lib/smart/smart-component.types.js'
  */
+
+const DIRECTORY_INVALID_CHARS = /[/\\{}^%`\]">[~<#|\u0080-\u00FF]/;
 
 export class ObjectListController {
   /** @type {CellarExplorerClient} */
@@ -85,6 +88,10 @@ export class ObjectListController {
 
     onEvent('cc-cellar-object-delete', (objectKey) => {
       this.deleteObject(objectKey);
+    });
+
+    onEvent('cc-cellar-object-create-directory', (directoryName) => {
+      this.createDirectory(directoryName);
     });
   }
 
@@ -309,5 +316,71 @@ export class ObjectListController {
       clearInterval(this.#signedUrlInterval);
       this.#signedUrlInterval = null;
     }
+  }
+
+  /**
+   * @param {string} directoryName
+   */
+  async createDirectory(directoryName) {
+    this.#updateCreateForm({ type: 'creating', directoryName, error: null });
+
+    if (DIRECTORY_INVALID_CHARS.test(directoryName)) {
+      this.#updateCreateForm({ type: 'idle', directoryName, error: 'directory-name-invalid' });
+      return;
+    }
+
+    const alreadyExists = this.#objects.some((obj) => obj.type === 'directory' && obj.name === directoryName);
+
+    if (alreadyExists) {
+      this.#updateCreateForm({ type: 'idle', directoryName, error: 'directory-already-exists' });
+      return;
+    }
+
+    /** @type {CellarDirectory} */
+    const newDir = {
+      type: 'directory',
+      key: [...this.#path, directoryName].join('/'),
+      name: directoryName,
+      volatile: true,
+    };
+
+    this.#objects = [...this.#objects, newDir].sort((a, b) => {
+      if (a.volatile && !b.volatile) {
+        return -1;
+      }
+      if (!a.volatile && b.volatile) {
+        return 1;
+      }
+      if (a.type === 'directory' && b.type === 'file') {
+        return -1;
+      }
+      if (a.type === 'file' && b.type === 'directory') {
+        return 1;
+      }
+      return a.name.localeCompare(b.name);
+    });
+
+    this.#updateState(
+      /** @param {CellarObjectListStateLoaded} state */ (state) => {
+        state.objects = this.#objects;
+        state.createDirectoryForm = null;
+      },
+    );
+    notifySuccess(i18n('cc-cellar-object-list.success.directory-created', { directoryName }));
+  }
+
+  /**
+   * @param {Partial<CellarDirectoryCreateFormState>|null} newState
+   */
+  #updateCreateForm(newState) {
+    this.#updateState(
+      /** @param {CellarObjectListStateLoaded} state */ (state) => {
+        if (newState == null) {
+          state.createDirectoryForm = null;
+        } else {
+          state.createDirectoryForm = { ...state.createDirectoryForm, ...newState };
+        }
+      },
+    );
   }
 }

--- a/src/components/cc-cellar-object-list/cc-cellar-object-list.events.js
+++ b/src/components/cc-cellar-object-list/cc-cellar-object-list.events.js
@@ -124,6 +124,21 @@ export class CcCellarObjectDeleteEvent extends CcEvent {
 }
 
 /**
+ * Dispatched when a Cellar object download is requested.
+ * @extends {CcEvent<string>}
+ */
+export class CcCellarObjectDownloadEvent extends CcEvent {
+  static TYPE = 'cc-cellar-object-download';
+
+  /**
+   * @param {string} details
+   */
+  constructor(details) {
+    super(CcCellarObjectDownloadEvent.TYPE, details);
+  }
+}
+
+/**
  * Dispatched when a new directory is created.
  * @extends {CcEvent<string>}
  */
@@ -135,5 +150,20 @@ export class CcCellarObjectCreateDirectoryEvent extends CcEvent {
    */
   constructor(details) {
     super(CcCellarObjectCreateDirectoryEvent.TYPE, details);
+  }
+}
+
+/**
+ * Dispatched when a file upload is requested.
+ * @extends {CcEvent<File>}
+ */
+export class CcCellarObjectUploadEvent extends CcEvent {
+  static TYPE = 'cc-cellar-object-upload';
+
+  /**
+   * @param {File} file
+   */
+  constructor(file) {
+    super(CcCellarObjectUploadEvent.TYPE, file);
   }
 }

--- a/src/components/cc-cellar-object-list/cc-cellar-object-list.events.js
+++ b/src/components/cc-cellar-object-list/cc-cellar-object-list.events.js
@@ -122,3 +122,18 @@ export class CcCellarObjectDeleteEvent extends CcEvent {
     super(CcCellarObjectDeleteEvent.TYPE, details);
   }
 }
+
+/**
+ * Dispatched when a new directory is created.
+ * @extends {CcEvent<string>}
+ */
+export class CcCellarObjectCreateDirectoryEvent extends CcEvent {
+  static TYPE = 'cc-cellar-object-create-directory';
+
+  /**
+   * @param {string} details
+   */
+  constructor(details) {
+    super(CcCellarObjectCreateDirectoryEvent.TYPE, details);
+  }
+}

--- a/src/components/cc-cellar-object-list/cc-cellar-object-list.js
+++ b/src/components/cc-cellar-object-list/cc-cellar-object-list.js
@@ -17,6 +17,7 @@ import {
   iconRemixMoreFill as iconMore,
   iconRemixArrowRightSFill as iconNext,
   iconRemixArrowLeftSFill as iconPrevious,
+  iconRemixFileUploadLine as iconUpload,
 } from '../../assets/cc-remix.icons.js';
 import { formSubmit } from '../../lib/form/form-submit-directive.js';
 import { random, randomString } from '../../lib/utils.js';
@@ -25,6 +26,8 @@ import { i18n } from '../../translations/translation.js';
 import '../cc-breadcrumbs/cc-breadcrumbs.js';
 import '../cc-button/cc-button.js';
 import '../cc-clipboard/cc-clipboard.js';
+import '../cc-dialog-confirm-form/cc-dialog-confirm-form.js';
+import '../cc-dialog/cc-dialog.js';
 import '../cc-drawer/cc-drawer.js';
 import '../cc-grid/cc-grid.js';
 import '../cc-icon/cc-icon.js';
@@ -36,19 +39,22 @@ import {
   CcCellarNavigateToNextPageEvent,
   CcCellarNavigateToPathEvent,
   CcCellarNavigateToPreviousPageEvent,
+  CcCellarObjectCreateDirectoryEvent,
   CcCellarObjectDeleteEvent,
   CcCellarObjectFilterEvent,
   CcCellarObjectHideEvent,
   CcCellarObjectShowEvent,
+  CcCellarObjectUploadEvent,
 } from './cc-cellar-object-list.events.js';
 
 /**
- * @import { CellarObjectListState, CellarObjectListStateLoading, CellarObjectListStateLoaded, CellarObjectListStateFiltering, CellarObjectState, CellarFileDetailsState } from './cc-cellar-object-list.types.js'
+ * @import { CellarObjectListState, CellarObjectListStateLoading, CellarObjectListStateLoaded, CellarObjectListStateFiltering, CellarObjectState, CellarFileDetailsState, CellarDirectoryCreateFormState, CreationFormError } from './cc-cellar-object-list.types.js'
  * @import { CcBreadcrumbClickEvent } from '../cc-breadcrumbs/cc-breadcrumbs.events.js'
  * @import { CcGrid } from '../cc-grid/cc-grid.js'
  * @import { CcGridColumnDefinition } from '../cc-grid/cc-grid.types.js'
  * @import { TemplateResult } from 'lit'
  * @import { Ref } from 'lit/directives/ref.js'
+ * @import { ErrorMessage } from '../../lib/form/validation.types.js'
  */
 
 /** @type {Array<Omit<CellarObjectState, 'key'>>} */
@@ -110,12 +116,29 @@ export class CcCellarObjectList extends LitElement {
 
     /** @type {Ref<CcGrid>} */
     this._gridRef = createRef();
+
+    /** @type {Ref<HTMLFormElement>} */
+    this._createDirectoryFormRef = createRef();
   }
 
   focusFirstCell() {
     this.updateComplete.then(() => {
       this._gridRef.value?.focusFirstCell();
     });
+  }
+
+  /**
+   * @param {CreationFormError} errorCode
+   * @param {string} directoryName
+   * @return {ErrorMessage}
+   */
+  _getErrorMessage(errorCode, directoryName) {
+    switch (errorCode) {
+      case 'directory-already-exists':
+        return i18n('cc-cellar-object-list.error.directory-already-exists', { directoryName });
+      case 'directory-name-invalid':
+        return i18n('cc-cellar-object-list.error.directory-name-invalid');
+    }
   }
 
   /**
@@ -194,6 +217,51 @@ export class CcCellarObjectList extends LitElement {
     this.dispatchEvent(new CcCellarObjectDeleteEvent(objectKey));
   }
 
+  _onCreateDirectoryButtonClick() {
+    if (this.state.type === 'loaded') {
+      this.state = {
+        ...this.state,
+        createDirectoryForm: {
+          type: 'idle',
+          directoryName: '',
+        },
+      };
+    }
+  }
+
+  _onCancelDirectoryCreation() {
+    if (this.state.type === 'loaded') {
+      this.state = {
+        ...this.state,
+        createDirectoryForm: null,
+      };
+      this._createDirectoryFormRef.value.reset();
+    }
+  }
+
+  _onConfirmDirectoryCreation() {
+    this._createDirectoryFormRef.value.requestSubmit();
+  }
+
+  /**
+   * @param {{directoryName: string}} formData
+   */
+  _onCreateDirectoryFormSubmit({ directoryName: directoryName }) {
+    this.dispatchEvent(new CcCellarObjectCreateDirectoryEvent(directoryName));
+  }
+
+  _onUploadButtonClick() {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.addEventListener('change', (event) => {
+      const file = /** @type {HTMLInputElement} */ (event.target).files?.[0];
+      if (file != null) {
+        this.dispatchEvent(new CcCellarObjectUploadEvent(file));
+      }
+    });
+    input.click();
+  }
+
   render() {
     if (this.state.type === 'error') {
       return html`<cc-notice intent="warning" message=${i18n('cc-cellar-object-list.error')}></cc-notice>`;
@@ -202,6 +270,7 @@ export class CcCellarObjectList extends LitElement {
     return html`<div class="wrapper">
       ${this._renderHeading(this.state)} ${this._renderPath(this.state)} ${this._renderList(this.state)}
       ${this._renderPagination(this.state)} ${this.state.type === 'loaded' ? this._renderFileDetails(this.state) : ''}
+      ${this.state.type === 'loaded' ? this._renderDirectoryCreationForm(this.state.createDirectoryForm) : ''}
     </div>`;
   }
 
@@ -211,6 +280,8 @@ export class CcCellarObjectList extends LitElement {
    */
   _renderHeading(state) {
     const filter = state.type === 'loaded' || state.type === 'filtering' ? state.filter : '';
+    const isUploading = state.type === 'loaded' && state.uploadState?.type === 'uploading';
+    const isSkeleton = state.type === 'loading';
 
     return html`
       <div class="list-heading">
@@ -224,7 +295,7 @@ export class CcCellarObjectList extends LitElement {
               inline
               label=${i18n('cc-cellar-object-list.heading.filter.label')}
               ?readonly=${state.type === 'filtering'}
-              ?disabled=${state.type !== 'loaded' && state.type !== 'filtering'}
+              ?disabled=${(state.type !== 'loaded' && state.type !== 'filtering') || isUploading}
               .value=${filter}
             ></cc-input-text>
             <cc-button
@@ -233,11 +304,32 @@ export class CcCellarObjectList extends LitElement {
               hide-text
               outlined
               ?waiting=${state.type === 'filtering'}
-              ?disabled=${state.type !== 'loaded' && state.type !== 'filtering'}
+              ?disabled=${(state.type !== 'loaded' && state.type !== 'filtering') || isUploading}
             >
               ${i18n('cc-cellar-object-list.heading.filter.button')}
             </cc-button>
           </form>
+          <cc-button
+            primary
+            type="button"
+            .icon=${iconUpload}
+            ?skeleton=${isSkeleton}
+            ?disabled=${this.state.type === 'filtering'}
+            ?waiting=${this.state.type === 'loaded' && this.state.uploadState?.type === 'uploading'}
+            @cc-click=${this._onUploadButtonClick}
+            >${i18n('cc-cellar-object-list.button.upload')}</cc-button
+          >
+          <cc-button
+            class="add-new-directory"
+            outlined
+            primary
+            type="button"
+            .icon=${iconDirectory}
+            ?skeleton=${isSkeleton}
+            ?disabled=${this.state.type === 'filtering'}
+            @cc-click=${this._onCreateDirectoryButtonClick}
+            >${i18n('cc-cellar-object-list.heading.add.directory')}</cc-button
+          >
         </div>
       </div>
     `;
@@ -287,6 +379,7 @@ export class CcCellarObjectList extends LitElement {
               value: object.name,
               icon: iconDirectory,
               enableCopyToClipboard: true,
+              badge: object.volatile ? i18n('cc-cellar-object-list.badge.new') : null,
               onClick: () => {
                 this.dispatchEvent(new CcCellarNavigateToPathEvent([...state.path, object.name]));
               },
@@ -297,6 +390,7 @@ export class CcCellarObjectList extends LitElement {
             value: object.name,
             icon: iconFile,
             enableCopyToClipboard: true,
+            badge: object.volatile ? i18n('cc-cellar-object-list.badge.new') : null,
           };
         },
         width: 'minmax(max-content, 1fr)',
@@ -467,6 +561,42 @@ export class CcCellarObjectList extends LitElement {
   _renderIconDetails(object) {
     const fileIcon = this._getFileIcon(object.contentType);
     return html`<cc-icon .icon=${fileIcon.icon} .a11yName=${fileIcon.a11yName}></cc-icon>`;
+  }
+
+  /**
+   * @param {CellarDirectoryCreateFormState} state
+   * @returns {TemplateResult}
+   */
+  _renderDirectoryCreationForm(state) {
+    const errorMessage = this._getErrorMessage(state?.error, state?.directoryName);
+
+    return html`<cc-dialog
+      class="create-directory-dialog"
+      heading=${i18n('cc-cellar-object-list.add-directory.dialog.heading')}
+      ?open=${state != null}
+      @cc-close=${this._onCancelDirectoryCreation}
+    >
+      <cc-notice intent="warning" message="${i18n('cc-cellar-object-list.add-directory.dialog.notice')}"></cc-notice>
+      <form ${formSubmit(this._onCreateDirectoryFormSubmit.bind(this))} ${ref(this._createDirectoryFormRef)}>
+        <cc-input-text
+          label=${i18n('cc-cellar-object-list.add-directory.dialog.label')}
+          name="directoryName"
+          required
+          ?readonly=${state?.type === 'creating'}
+          .value=${state?.directoryName ?? ''}
+          .errorMessage=${errorMessage}
+        >
+          <div slot="help" class="bucket-name-help">
+            <p>${i18n('cc-cellar-object-list.create.directory-name.help')}</p>
+          </div>
+        </cc-input-text>
+        <cc-dialog-confirm-actions
+          submit-label=${i18n('cc-cellar-object-list.add-directory.dialog.submit')}
+          ?waiting=${state?.type === 'creating'}
+          @cc-confirm=${this._onConfirmDirectoryCreation}
+        ></cc-dialog-confirm-actions>
+      </form>
+    </cc-dialog>`;
   }
 
   static get styles() {

--- a/src/components/cc-cellar-object-list/cc-cellar-object-list.types.d.ts
+++ b/src/components/cc-cellar-object-list/cc-cellar-object-list.types.d.ts
@@ -30,6 +30,12 @@ export interface CellarObjectListStateLoaded {
   details?: CellarFileDetailsState;
   hasPrevious: boolean;
   hasNext: boolean;
+  createDirectoryForm?: CellarDirectoryCreateFormState;
+  uploadState?: CellarObjectUploadState;
+}
+
+export interface CellarObjectUploadState {
+  type: 'idle' | 'uploading';
 }
 
 export interface CellarObjectListStateFiltering {
@@ -46,6 +52,14 @@ export interface CellarFileState extends CellarFile {
 }
 
 export interface CellarFileDetailsState extends CellarFileDetails {
-  state: 'idle' | 'deleting';
+  state: 'idle' | 'deleting' | 'downloading';
   signedUrl: string;
 }
+
+export interface CellarDirectoryCreateFormState {
+  type: 'idle' | 'creating';
+  directoryName: string;
+  error?: 'directory-already-exists' | 'directory-name-invalid';
+}
+
+export type CreationFormError = 'directory-already-exists' | 'directory-name-invalid';

--- a/src/components/cc-grid/cc-grid.js
+++ b/src/components/cc-grid/cc-grid.js
@@ -350,6 +350,7 @@ export class CcGrid extends LitElement {
                 value=${cell.value}
               ></cc-clipboard>`
             : ''}
+          ${cell.badge != null ? html`<cc-badge intent="info">${cell.badge}</cc-badge>` : ''}
         </div>`,
       };
     }
@@ -378,6 +379,7 @@ export class CcGrid extends LitElement {
                 value=${cell.value}
               ></cc-clipboard>`
             : ''}
+          ${cell.badge != null ? html`<cc-badge intent="info">${cell.badge}</cc-badge>` : ''}
         </div>`,
       };
     }

--- a/src/components/cc-grid/cc-grid.types.d.ts
+++ b/src/components/cc-grid/cc-grid.types.d.ts
@@ -20,6 +20,7 @@ interface CcGridCellText {
   iconA11yName?: string;
   skeleton?: boolean;
   enableCopyToClipboard?: boolean;
+  badge?: string;
 }
 
 interface CcGridCellLink {
@@ -30,6 +31,7 @@ interface CcGridCellLink {
   onClick: () => void;
   skeleton?: boolean;
   enableCopyToClipboard?: boolean;
+  badge?: string;
 }
 
 interface CcGridCellButton {

--- a/src/lib/events-map.types.d.ts
+++ b/src/lib/events-map.types.d.ts
@@ -31,6 +31,7 @@ import {
   CcCellarNavigateToNextPageEvent,
   CcCellarNavigateToPathEvent,
   CcCellarNavigateToPreviousPageEvent,
+  CcCellarObjectCreateDirectoryEvent,
   CcCellarObjectDeleteEvent,
   CcCellarObjectFilterEvent,
   CcCellarObjectHideEvent,
@@ -241,6 +242,7 @@ declare global {
     'cc-cellar-navigate-to-next-page': CcCellarNavigateToNextPageEvent;
     'cc-cellar-navigate-to-path': CcCellarNavigateToPathEvent;
     'cc-cellar-navigate-to-previous-page': CcCellarNavigateToPreviousPageEvent;
+    'cc-cellar-object-create-directory': CcCellarObjectCreateDirectoryEvent;
     'cc-cellar-object-delete': CcCellarObjectDeleteEvent;
     'cc-cellar-object-filter': CcCellarObjectFilterEvent;
     'cc-cellar-object-hide': CcCellarObjectHideEvent;

--- a/src/lib/events-map.types.d.ts
+++ b/src/lib/events-map.types.d.ts
@@ -33,9 +33,11 @@ import {
   CcCellarNavigateToPreviousPageEvent,
   CcCellarObjectCreateDirectoryEvent,
   CcCellarObjectDeleteEvent,
+  CcCellarObjectDownloadEvent,
   CcCellarObjectFilterEvent,
   CcCellarObjectHideEvent,
   CcCellarObjectShowEvent,
+  CcCellarObjectUploadEvent,
 } from '../components/cc-cellar-object-list/cc-cellar-object-list.events.js';
 import {
   CcDomainAddEvent,
@@ -244,9 +246,11 @@ declare global {
     'cc-cellar-navigate-to-previous-page': CcCellarNavigateToPreviousPageEvent;
     'cc-cellar-object-create-directory': CcCellarObjectCreateDirectoryEvent;
     'cc-cellar-object-delete': CcCellarObjectDeleteEvent;
+    'cc-cellar-object-download': CcCellarObjectDownloadEvent;
     'cc-cellar-object-filter': CcCellarObjectFilterEvent;
     'cc-cellar-object-hide': CcCellarObjectHideEvent;
     'cc-cellar-object-show': CcCellarObjectShowEvent;
+    'cc-cellar-object-upload': CcCellarObjectUploadEvent;
     'cc-click': CcClickEvent;
     'cc-close': CcCloseEvent;
     'cc-close-request': CcCloseRequestEvent;

--- a/src/stories/fixtures/cellar.js
+++ b/src/stories/fixtures/cellar.js
@@ -14,7 +14,7 @@ export const bucket1 = {
   updatedAt: new Date().toISOString(),
   sizeInBytes: random(150_000, 2_000_000),
   objectsCount: random(1_000, 1_000_000),
-  versioning: 'enabled',
+  versioning: 'ENABLED',
 };
 
 /** @type {CellarBucketState} */
@@ -36,7 +36,7 @@ export const bucketEmpty = {
   updatedAt: new Date().toISOString(),
   sizeInBytes: 0,
   objectsCount: 0,
-  versioning: 'enabled',
+  versioning: 'ENABLED',
 };
 
 /** @type {CellarBucketState} */
@@ -129,6 +129,7 @@ export function fileState(extension, path ) {
 export function fileDetailsState(extension, path ) {
   return {
     state: 'idle',
+    signedUrl:'https://cellar-c2.services.clever-cloud.com/bucket-name/file-1.extension?X-Amz-Signature=fake',
     ...fileDetails(extension, path),
   }
 }

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -496,7 +496,13 @@ export const translations = {
   'cc-cellar-explorer.error': `Error while loading component`,
   //#endregion
   //#region cc-cellar-object-list
+  'cc-cellar-object-list.add-directory.dialog.heading': `Add a new directory`,
+  'cc-cellar-object-list.add-directory.dialog.label': `Directory name`,
+  'cc-cellar-object-list.add-directory.dialog.notice': `Upload an object after creating a directory, otherwise the directory will not be persisted in your bucket.`,
+  'cc-cellar-object-list.add-directory.dialog.submit': `Create directory`,
   'cc-cellar-object-list.back-to-bucket-list': `Go back to list of buckets`,
+  'cc-cellar-object-list.badge.new': `New`,
+  'cc-cellar-object-list.create.directory-name.help': `Directory name cannot contain non-printable characters (128–255 decimal characters) or the following characters: / \\ { } ^ % \` [ ] " < > ~ # |`,
   'cc-cellar-object-list.date': /** @param {{date: string}} _ */ ({ date }) => formatDateOnly(date),
   'cc-cellar-object-list.details.actions.delete.button': `Delete object`,
   'cc-cellar-object-list.details.actions.download.button': `Download object`,
@@ -520,6 +526,10 @@ export const translations = {
   'cc-cellar-object-list.error': `Something went wrong while loading the list of objects`,
   'cc-cellar-object-list.error.bucket-not-found': /** @param {{bucketName: string}} _ */ ({ bucketName }) =>
     `Bucket ${bucketName} does not exist`,
+  'cc-cellar-object-list.error.directory-already-exists': /** @param {{directoryName: string}} _ */ ({
+    directoryName,
+  }) => `Directory ${directoryName} already exists`,
+  'cc-cellar-object-list.error.directory-name-invalid': `The directory name contains an invalid character (see the help message above)`,
   'cc-cellar-object-list.error.object-deletion-failed': /** @param {{objectKey: string}} _ */ ({ objectKey }) =>
     `Failed to delete object ${objectKey}`,
   'cc-cellar-object-list.error.object-fetch-failed': /** @param {{objectKey: string}} _ */ ({ objectKey }) =>
@@ -532,6 +542,7 @@ export const translations = {
   'cc-cellar-object-list.grid.column.size': `Size`,
   'cc-cellar-object-list.grid.show-details.a11y-name': /** @param {{objectName: string}} _ */ ({ objectName }) =>
     `Show details for object ${objectName}`,
+  'cc-cellar-object-list.heading.add.directory': `New directory`,
   'cc-cellar-object-list.heading.filter.button': `Filter`,
   'cc-cellar-object-list.heading.filter.label': `Filter`,
   'cc-cellar-object-list.heading.title': `List of objects`,
@@ -546,6 +557,8 @@ export const translations = {
   'cc-cellar-object-list.page.next': `Next page`,
   'cc-cellar-object-list.page.previous': `Previous page`,
   'cc-cellar-object-list.size': /** @param {{size: number}} _ */ ({ size }) => formatBytes(size),
+  'cc-cellar-object-list.success.directory-created': /** @param {{directoryName: string}} _ */ ({ directoryName }) =>
+    `Directory "${directoryName}" created successfully`,
   'cc-cellar-object-list.success.object-already-deleted': /** @param {{objectKey: string}} _ */ ({ objectKey }) =>
     `Object ${objectKey} was already deleted`,
   'cc-cellar-object-list.success.object-deleted': /** @param {{objectKey: string}} _ */ ({ objectKey }) =>

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -502,6 +502,7 @@ export const translations = {
   'cc-cellar-object-list.add-directory.dialog.submit': `Create directory`,
   'cc-cellar-object-list.back-to-bucket-list': `Go back to list of buckets`,
   'cc-cellar-object-list.badge.new': `New`,
+  'cc-cellar-object-list.button.upload': `Upload object`,
   'cc-cellar-object-list.create.directory-name.help': `Directory name cannot contain non-printable characters (128–255 decimal characters) or the following characters: / \\ { } ^ % \` [ ] " < > ~ # |`,
   'cc-cellar-object-list.date': /** @param {{date: string}} _ */ ({ date }) => formatDateOnly(date),
   'cc-cellar-object-list.details.actions.delete.button': `Delete object`,
@@ -532,10 +533,14 @@ export const translations = {
   'cc-cellar-object-list.error.directory-name-invalid': `The directory name contains an invalid character (see the help message above)`,
   'cc-cellar-object-list.error.object-deletion-failed': /** @param {{objectKey: string}} _ */ ({ objectKey }) =>
     `Failed to delete object ${objectKey}`,
+  'cc-cellar-object-list.error.object-download-failed': /** @param {{objectKey: string}} _ */ ({ objectKey }) =>
+    `Failed to download object ${objectKey}`,
   'cc-cellar-object-list.error.object-fetch-failed': /** @param {{objectKey: string}} _ */ ({ objectKey }) =>
     `Failed to get object ${objectKey}`,
   'cc-cellar-object-list.error.object-not-found': /** @param {{objectKey: string}} _ */ ({ objectKey }) =>
     `Object ${objectKey} does not exist`,
+  'cc-cellar-object-list.error.object-upload-failed': /** @param {{objectKey: string}} _ */ ({ objectKey }) =>
+    `Failed to upload object ${objectKey}`,
   'cc-cellar-object-list.grid.a11y-name': `List of objects`,
   'cc-cellar-object-list.grid.column.last-update': `Last update`,
   'cc-cellar-object-list.grid.column.name': `Name`,
@@ -563,6 +568,8 @@ export const translations = {
     `Object ${objectKey} was already deleted`,
   'cc-cellar-object-list.success.object-deleted': /** @param {{objectKey: string}} _ */ ({ objectKey }) =>
     `Object ${objectKey} deleted successfully`,
+  'cc-cellar-object-list.success.object-uploaded': /** @param {{objectKey: string}} _ */ ({ objectKey }) =>
+    `Object ${objectKey} uploaded successfully`,
   //#endregion
   //#region cc-clipboard
   'cc-clipboard.copied': `The text has been copied`,

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -513,7 +513,7 @@ export const translations = {
   'cc-cellar-object-list.add-directory.dialog.submit': `Créer le dossier`,
   'cc-cellar-object-list.back-to-bucket-list': `Retour à la liste des buckets`,
   'cc-cellar-object-list.badge.new': `Nouveau`,
-  'cc-cellar-object-list.button.upload': `Téléverser un objet`,
+  'cc-cellar-object-list.button.upload': `Uploader un objet`,
   'cc-cellar-object-list.create.directory-name.help': `Le nom du dossier ne peut pas contenir de caractères ASCII non imprimables (128–255 caractères décimaux) ni les caractères suivants : / \\ { } ^ % \` [ ] " < > ~ # |`,
   'cc-cellar-object-list.date': /** @param {{date: string}} _ */ ({ date }) => formatDateOnly(date),
   'cc-cellar-object-list.details.actions.delete.button': `Supprimer l'objet`,
@@ -551,7 +551,7 @@ export const translations = {
   'cc-cellar-object-list.error.object-not-found': /** @param {{objectKey: string}} _ */ ({ objectKey }) =>
     `L'objet ${objectKey} n'existe pas`,
   'cc-cellar-object-list.error.object-upload-failed': /** @param {{objectKey: string}} _ */ ({ objectKey }) =>
-    `Le téléversement de l'objet ${objectKey} a échoué`,
+    `L'upload de l'objet ${objectKey} a échoué`,
   'cc-cellar-object-list.grid.a11y-name': `Liste des objets`,
   'cc-cellar-object-list.grid.column.last-update': `Dernière modification`,
   'cc-cellar-object-list.grid.column.name': `Nom`,
@@ -580,7 +580,7 @@ export const translations = {
   'cc-cellar-object-list.success.object-deleted': /** @param {{objectKey: string}} _ */ ({ objectKey }) =>
     `L'objet ${objectKey} a été supprimé avec succès`,
   'cc-cellar-object-list.success.object-uploaded': /** @param {{objectKey: string}} _ */ ({ objectKey }) =>
-    `L'objet ${objectKey} a été téléversé avec succès`,
+    `L'objet ${objectKey} a été uploadé avec succès`,
   //#endregion
   //#region cc-clipboard
   'cc-clipboard.copied': `Le texte a été copié`,

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -507,7 +507,14 @@ export const translations = {
   'cc-cellar-explorer.error': `Une erreur est survenue pendant le chargement`,
   //#endregion
   //#region cc-cellar-object-list
+  'cc-cellar-object-list.add-directory.dialog.heading': `Ajouter un nouveau dossier`,
+  'cc-cellar-object-list.add-directory.dialog.label': `Nom du dossier`,
+  'cc-cellar-object-list.add-directory.dialog.notice': `Uploadez un objet après avoir créé un dossier, sinon celui-ci ne sera pas conservé dans votre bucket.`,
+  'cc-cellar-object-list.add-directory.dialog.submit': `Créer le dossier`,
   'cc-cellar-object-list.back-to-bucket-list': `Retour à la liste des buckets`,
+  'cc-cellar-object-list.badge.new': `Nouveau`,
+  'cc-cellar-object-list.button.upload': `Téléverser un objet`,
+  'cc-cellar-object-list.create.directory-name.help': `Le nom du dossier ne peut pas contenir de caractères ASCII non imprimables (128–255 caractères décimaux) ni les caractères suivants : / \\ { } ^ % \` [ ] " < > ~ # |`,
   'cc-cellar-object-list.date': /** @param {{date: string}} _ */ ({ date }) => formatDateOnly(date),
   'cc-cellar-object-list.details.actions.delete.button': `Supprimer l'objet`,
   'cc-cellar-object-list.details.actions.download.button': `Télécharger l'objet`,
@@ -531,18 +538,27 @@ export const translations = {
   'cc-cellar-object-list.error': `Une erreur est survenue pendant le chargement de la liste des objets`,
   'cc-cellar-object-list.error.bucket-not-found': /** @param {{bucketName: string}} _ */ ({ bucketName }) =>
     `Le bucket ${bucketName} n'existe pas`,
+  'cc-cellar-object-list.error.directory-already-exists': /** @param {{directoryName: string}} _ */ ({
+    directoryName,
+  }) => `Le dossier ${directoryName} existe déjà`,
+  'cc-cellar-object-list.error.directory-name-invalid': `Le nom du dossier contient un caractère invalide (voir le message d'aide ci-dessus)`,
   'cc-cellar-object-list.error.object-deletion-failed': /** @param {{objectKey: string}} _ */ ({ objectKey }) =>
     `La suppression de l'objet ${objectKey} a échoué`,
+  'cc-cellar-object-list.error.object-download-failed': /** @param {{objectKey: string}} _ */ ({ objectKey }) =>
+    `Le téléchargement de l'objet ${objectKey} a échoué`,
   'cc-cellar-object-list.error.object-fetch-failed': /** @param {{objectKey: string}} _ */ ({ objectKey }) =>
     `Impossible de récupérer l'objet ${objectKey}`,
   'cc-cellar-object-list.error.object-not-found': /** @param {{objectKey: string}} _ */ ({ objectKey }) =>
     `L'objet ${objectKey} n'existe pas`,
+  'cc-cellar-object-list.error.object-upload-failed': /** @param {{objectKey: string}} _ */ ({ objectKey }) =>
+    `Le téléversement de l'objet ${objectKey} a échoué`,
   'cc-cellar-object-list.grid.a11y-name': `Liste des objets`,
   'cc-cellar-object-list.grid.column.last-update': `Dernière modification`,
   'cc-cellar-object-list.grid.column.name': `Nom`,
   'cc-cellar-object-list.grid.column.size': `Taille`,
   'cc-cellar-object-list.grid.show-details.a11y-name': /** @param {{objectName: string}} _ */ ({ objectName }) =>
     `Afficher les détails de l'objet ${objectName}`,
+  'cc-cellar-object-list.heading.add.directory': `Nouveau dossier`,
   'cc-cellar-object-list.heading.filter.button': `Filtrer`,
   'cc-cellar-object-list.heading.filter.label': `Filtre`,
   'cc-cellar-object-list.heading.title': `Liste des objets`,
@@ -557,10 +573,14 @@ export const translations = {
   'cc-cellar-object-list.page.next': `Page suivante`,
   'cc-cellar-object-list.page.previous': `Page précédente`,
   'cc-cellar-object-list.size': /** @param {{size: number}} _ */ ({ size }) => formatBytes(size),
+  'cc-cellar-object-list.success.directory-created': /** @param {{directoryName: string}} _ */ ({ directoryName }) =>
+    `Le dossier "${directoryName}" a été créé avec succès`,
   'cc-cellar-object-list.success.object-already-deleted': /** @param {{objectKey: string}} _ */ ({ objectKey }) =>
     `L'objet ${objectKey} était déjà supprimé`,
   'cc-cellar-object-list.success.object-deleted': /** @param {{objectKey: string}} _ */ ({ objectKey }) =>
     `L'objet ${objectKey} a été supprimé avec succès`,
+  'cc-cellar-object-list.success.object-uploaded': /** @param {{objectKey: string}} _ */ ({ objectKey }) =>
+    `L'objet ${objectKey} a été téléversé avec succès`,
   //#endregion
   //#region cc-clipboard
   'cc-clipboard.copied': `Le texte a été copié`,


### PR DESCRIPTION
## What does this PR do?

- Adds a `cc-badge` possibility on the text and link cells on the `cc-grid`,
- Adds directory creation on the `cellar-explorer`,
- Adds objects upload on the `cellar-explorer`.

## How to review?

- Check the commits,
- Play with the `cellar-explorer` on sandbox to check if everything work fine.

2 or 3 reviewers would be great.

## TODO

- [ ]  validate texts