### PR TITLE
fix(cc-token-api-*): pass API bridge URL as a prop instead of hardcoding it

### DIFF
--- a/src/components/cc-token-api-creation-form/cc-token-api-creation-form.js
+++ b/src/components/cc-token-api-creation-form/cc-token-api-creation-form.js
@@ -62,6 +62,7 @@ const DURATION_TO_NB_OF_DAYS_MAP = new Map([
 export class CcTokenApiCreationForm extends LitElement {
   static get properties() {
     return {
+      apiBridgeBaseUrl: { type: String, attribute: 'api-bridge-base-url' },
       apiTokenListHref: { type: String, attribute: 'api-token-list-href' },
       state: { type: Object },
     };
@@ -91,6 +92,9 @@ export class CcTokenApiCreationForm extends LitElement {
 
   constructor() {
     super();
+
+    /** @type {string} Sets the base URL of the API bridge used in the curl example. */
+    this.apiBridgeBaseUrl = 'https://api-bridge.clever-cloud.com';
 
     /** @type {string} URL for the API token list screen */
     this.apiTokenListHref = '';
@@ -394,7 +398,7 @@ export class CcTokenApiCreationForm extends LitElement {
               <dt>${i18n('cc-token-api-creation-form.cli.content.use-token')}</dt>
               <dd>
                 <cc-code>
-                  curl -H "Authorization: Bearer &lt;TOKEN&gt;" https://api-bridge.clever-cloud.com/v2/self
+                  curl -H "Authorization: Bearer &lt;TOKEN&gt;" ${new URL('/v2/self', this.apiBridgeBaseUrl).href}
                 </cc-code>
               </dd>
             </dl>

--- a/src/components/cc-token-api-creation-form/cc-token-api-creation-form.smart.js
+++ b/src/components/cc-token-api-creation-form/cc-token-api-creation-form.smart.js
@@ -23,6 +23,7 @@ defineSmartComponent({
     const { apiConfig } = context;
     const api = new Api(apiConfig);
 
+    updateComponent('apiBridgeBaseUrl', apiConfig.AUTH_BRIDGE_HOST);
     updateComponent('state', { type: 'loading' });
 
     api

--- a/src/components/cc-token-api-creation-form/cc-token-api-creation-form.stories.js
+++ b/src/components/cc-token-api-creation-form/cc-token-api-creation-form.stories.js
@@ -81,6 +81,21 @@ export const dataLoadedWithValidationStep = makeStory(conf, {
   ],
 });
 
+export const withCustomApiBridgeBaseUrl = makeStory(conf, {
+  /** @type {Partial<CcTokenApiCreationForm>[]} */
+  items: [
+    {
+      apiBridgeBaseUrl: 'https://custom-api-bridge.example.com',
+      state: {
+        type: 'loaded',
+        activeStep: 'configuration',
+        isMfaEnabled: true,
+        values: CcTokenApiCreationForm.DEFAULT_FORM_VALUES,
+      },
+    },
+  ],
+});
+
 export const dataLoadedWithApiTokenCreated = makeStory(conf, {
   /** @type {Partial<CcTokenApiCreationForm>[]} */
   items: [

--- a/src/components/cc-token-api-list/cc-token-api-list.js
+++ b/src/components/cc-token-api-list/cc-token-api-list.js
@@ -44,6 +44,7 @@ import { CcPasswordResetEvent, CcTokenRevokeEvent } from '../common.events.js';
 export class CcTokenApiList extends LitElement {
   static get properties() {
     return {
+      apiBridgeBaseUrl: { type: String, attribute: 'api-bridge-base-url' },
       apiTokenCreationHref: { type: String, attribute: 'api-token-creation-href' },
       apiTokenUpdateHref: { type: String, attribute: 'api-token-update-href' },
       state: { type: Object },
@@ -52,6 +53,9 @@ export class CcTokenApiList extends LitElement {
 
   constructor() {
     super();
+
+    /** @type {string} Sets the base URL of the API bridge used in the curl example. */
+    this.apiBridgeBaseUrl = 'https://api-bridge.clever-cloud.com';
 
     /** @type {string|null} Sets the URL leading to the API token creation screen */
     this.apiTokenCreationHref = null;
@@ -207,7 +211,7 @@ export class CcTokenApiList extends LitElement {
               <dt>${i18n('cc-token-api-list.cli.content.use-token')}</dt>
               <dd>
                 <cc-code>
-                  curl -H "Authorization: Bearer &lt;TOKEN&gt;" https://api-bridge.clever-cloud.com/v2/self
+                  curl -H "Authorization: Bearer &lt;TOKEN&gt;" ${new URL('/v2/self', this.apiBridgeBaseUrl).href}
                 </cc-code>
               </dd>
             </dl>

--- a/src/components/cc-token-api-list/cc-token-api-list.smart.js
+++ b/src/components/cc-token-api-list/cc-token-api-list.smart.js
@@ -24,6 +24,8 @@ defineSmartComponent({
     const { apiConfig } = context;
     const api = new Api(apiConfig);
 
+    updateComponent('apiBridgeBaseUrl', apiConfig.AUTH_BRIDGE_HOST);
+
     /**
      * Updates a single session token
      *

--- a/src/components/cc-token-api-list/cc-token-api-list.stories.js
+++ b/src/components/cc-token-api-list/cc-token-api-list.stories.js
@@ -108,6 +108,20 @@ export const dataLoaded = makeStory(conf, {
   ],
 });
 
+export const withCustomApiBridgeBaseUrl = makeStory(conf, {
+  /** @type {Partial<CcTokenApiList>[]} */
+  items: [
+    {
+      apiBridgeBaseUrl: 'https://custom-api-bridge.example.com',
+      apiTokenUpdateHref,
+      state: {
+        type: 'loaded',
+        apiTokens: baseTokens,
+      },
+    },
+  ],
+});
+
 export const dataLoadedWithNoPassword = makeStory(conf, {
   /** @type {Partial<CcTokenApiList>[]} */
   items: [

--- a/src/components/cc-token-api-update-form/cc-token-api-update-form.js
+++ b/src/components/cc-token-api-update-form/cc-token-api-update-form.js
@@ -34,6 +34,7 @@ const SKELETON_VALUES = { name: '', description: '' };
 export class CcTokenApiUpdateForm extends LitElement {
   static get properties() {
     return {
+      apiBridgeBaseUrl: { type: String, attribute: 'api-bridge-base-url' },
       apiTokenListHref: { type: String, attribute: 'api-token-list-href' },
       state: { type: Object },
     };
@@ -41,6 +42,9 @@ export class CcTokenApiUpdateForm extends LitElement {
 
   constructor() {
     super();
+
+    /** @type {string} Sets the base URL of the API bridge used in the curl example. */
+    this.apiBridgeBaseUrl = 'https://api-bridge.clever-cloud.com';
 
     /** @type {string|null} Sets the URL to navigate back to the API token list. */
     this.apiTokenListHref = null;
@@ -102,7 +106,7 @@ export class CcTokenApiUpdateForm extends LitElement {
               <dt>${i18n('cc-token-api-update-form.cli.content.use-token')}</dt>
               <dd>
                 <cc-code>
-                  curl -H "Authorization: Bearer &lt;TOKEN&gt;" https://api-bridge.clever-cloud.com/v2/self
+                  curl -H "Authorization: Bearer &lt;TOKEN&gt;" ${new URL('/v2/self', this.apiBridgeBaseUrl).href}
                 </cc-code>
               </dd>
             </dl>

--- a/src/components/cc-token-api-update-form/cc-token-api-update-form.smart.js
+++ b/src/components/cc-token-api-update-form/cc-token-api-update-form.smart.js
@@ -24,6 +24,7 @@ defineSmartComponent({
     const { apiConfig, apiTokenId } = context;
     const api = new Api(apiConfig, apiTokenId);
 
+    updateComponent('apiBridgeBaseUrl', apiConfig.AUTH_BRIDGE_HOST);
     updateComponent('state', { type: 'loading' });
 
     api

--- a/src/components/cc-token-api-update-form/cc-token-api-update-form.stories.js
+++ b/src/components/cc-token-api-update-form/cc-token-api-update-form.stories.js
@@ -79,6 +79,20 @@ export const errorWithEmptyName = makeStory(conf, {
   },
 });
 
+export const withCustomApiBridgeBaseUrl = makeStory(conf, {
+  /** @type {Partial<CcTokenApiUpdateForm>[]} */
+  items: [
+    {
+      apiBridgeBaseUrl: 'https://custom-api-bridge.example.com',
+      apiTokenListHref: CC_TOKEN_API_LIST_STORY_HREF,
+      state: {
+        type: 'loaded',
+        values: baseValues,
+      },
+    },
+  ],
+});
+
 export const updating = makeStory(conf, {
   /** @type {Partial<CcTokenApiUpdateForm>[]} */
   items: [


### PR DESCRIPTION
Fixes #1714

## What does this PR do?

- Adds an `apiBridgeHref` prop to `cc-token-api-update-form`, `cc-token-api-list`, and `cc-token-api-creation-form`,
- Replaces the hardcoded `https://api-bridge.clever-cloud.com` in the curl example with the prop value,
- Uses `new URL()` to safely join the path (handles trailing slashes),
- Smart components pass `apiConfig.AUTH_BRIDGE_HOST` to the new prop,
- Defaults to `https://api-bridge.clever-cloud.com` when the prop is not set.

## How to review?

- Check the code,
- Check the `withCustomApiBridgeHref` story in Storybook for each component,
- Two reviewers should be enough.