### PR TITLE
`cc-network-group-dashboard`: support description

### DIFF
--- a/src/components/cc-addon-info/cc-addon-info.js
+++ b/src/components/cc-addon-info/cc-addon-info.js
@@ -10,6 +10,7 @@ import { hasSlottedChildren } from '../../directives/has-slotted-children.js';
 import { getAssetUrl } from '../../lib/assets-url.js';
 import { fakeString } from '../../lib/fake-strings.js';
 import { formSubmit } from '../../lib/form/form-submit-directive.js';
+import { isStringEmpty } from '../../lib/utils.js';
 import { accessibilityStyles } from '../../styles/accessibility.js';
 import { skeletonStyles } from '../../styles/skeleton.js';
 import { i18n } from '../../translations/translation.js';
@@ -191,6 +192,16 @@ export class CcAddonInfo extends LitElement {
       <cc-block>
         <div slot="header-title">${i18n('cc-addon-info.heading')}</div>
         <div slot="content" class="main">
+          ${!isStringEmpty(this.state.description)
+            ? html`
+                <div class="section">
+                  <strong class="heading">${i18n('cc-addon-info.description.heading')}</strong>
+                  <div class="value">
+                    <p class="${classMap({ skeleton })}">${this.state.description}</p>
+                  </div>
+                </div>
+              `
+            : ''}
           ${this.state.version != null
             ? html`
                 <div class="section" tabindex="-1" ${ref(this._versionTextRef)}>

--- a/src/components/cc-addon-info/cc-addon-info.types.d.ts
+++ b/src/components/cc-addon-info/cc-addon-info.types.d.ts
@@ -15,6 +15,7 @@ export interface AddonInfoStateError {
 }
 
 export interface AddonInfoStateBaseProperties {
+  description?: string;
   version?: AddonVersionState;
   plan?: string;
   subnet?: string;

--- a/src/components/cc-network-group-dashboard/cc-network-group-dashboard.js
+++ b/src/components/cc-network-group-dashboard/cc-network-group-dashboard.js
@@ -29,6 +29,7 @@ const SKELETON_HEADER_STATE = {
 
 const SKELETON_INFO_STATE = {
   type: /** @type {const} */ ('loading'),
+  description: fakeString(32),
   subnet: fakeString(6),
   lastIp: fakeString(6),
   numberOfMembers: 0,
@@ -105,6 +106,7 @@ export class CcNetworkGroupDashboard extends LitElement {
     if (state.type === 'loaded' || state.type === 'deleting') {
       return {
         type: 'loaded',
+        description: state.description,
         subnet: state.subnet,
         lastIp: state.lastIp,
         numberOfMembers: state.numberOfMembers,

--- a/src/components/cc-network-group-dashboard/cc-network-group-dashboard.smart.js
+++ b/src/components/cc-network-group-dashboard/cc-network-group-dashboard.smart.js
@@ -39,6 +39,7 @@ defineSmartComponent({
 
         updateComponent('state', {
           type: 'loaded',
+          description: ng.description,
           name: ng.label,
           id: ng.id,
           subnet: ng.networkIp,

--- a/src/components/cc-network-group-dashboard/cc-network-group-dashboard.stories.js
+++ b/src/components/cc-network-group-dashboard/cc-network-group-dashboard.stories.js
@@ -19,6 +19,7 @@ const conf = {
 const networkGroupDashboard = {
   id: 'ng_XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX',
   name: 'My Network Group',
+  description: 'Internal network for staging environment - connects API services, databases, and caching layer.',
   subnet: '10.0.0.0/16',
   lastIp: '10.0.0.1/24',
   numberOfMembers: 4,
@@ -32,6 +33,23 @@ export const defaultStory = makeStory(conf, {
       state: {
         type: 'loaded',
         ...networkGroupDashboard,
+      },
+    },
+  ],
+});
+
+export const dataLoadedWithNoDescription = makeStory(conf, {
+  /** @type {Partial<CcNetworkGroupDashboard>[]} */
+  items: [
+    {
+      state: {
+        type: 'loaded',
+        id: networkGroupDashboard.id,
+        name: networkGroupDashboard.name,
+        subnet: networkGroupDashboard.subnet,
+        lastIp: networkGroupDashboard.lastIp,
+        numberOfMembers: networkGroupDashboard.numberOfMembers,
+        numberOfPeers: networkGroupDashboard.numberOfPeers,
       },
     },
   ],

--- a/src/components/cc-network-group-dashboard/cc-network-group-dashboard.types.d.ts
+++ b/src/components/cc-network-group-dashboard/cc-network-group-dashboard.types.d.ts
@@ -4,7 +4,10 @@ import { AddonInfoStateBaseProperties } from '../cc-addon-info/cc-addon-info.typ
 export interface NetworkGroupDashboardHeaderProperties extends Pick<AddonHeaderBaseProperties, 'id' | 'name'> {}
 
 export interface NetworkGroupDashboardInfoProperties
-  extends Pick<AddonInfoStateBaseProperties, 'subnet' | 'lastIp' | 'numberOfMembers' | 'numberOfPeers'> {}
+  extends Pick<
+    AddonInfoStateBaseProperties,
+    'description' | 'subnet' | 'lastIp' | 'numberOfMembers' | 'numberOfPeers'
+  > {}
 
 export type NetworkGroupDashboardState =
   | NetworkGroupDashboardStateLoaded

--- a/src/stories/fixtures/addon-info.js
+++ b/src/stories/fixtures/addon-info.js
@@ -410,6 +410,7 @@ export const kubernetesInfo = {
 
 /** @type {AddonInfoStateBaseProperties} */
 export const networkGroupInfo = {
+  description: 'Internal network for staging environment - connects API services, databases, and caching layer.',
   subnet: '10.0.0.1/24',
   lastIp: '10.0.0.1/22',
   numberOfMembers: 4,

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -1357,7 +1357,8 @@ export const translations = {
   //#endregion
   //#region cc-network-group-dashboard
   'cc-network-group-dashboard.danger-zone.btn': `Delete Network Group`,
-  'cc-network-group-dashboard.danger-zone.desc': `Deleting this Network Group is a permanent action. All members associated with this group will be removed from the Network Group as well.`,
+  'cc-network-group-dashboard.danger-zone.desc': () =>
+    sanitize`Deleting this Network Group is a permanent action.<br>All members will be unlinked and removed.`,
   'cc-network-group-dashboard.danger-zone.dialog.confirm-input-label': `Enter the Network Group name`,
   'cc-network-group-dashboard.danger-zone.dialog.desc': `Deleting this Network Group is a permanent action. All members associated with this group will be removed from the Network Group. All existing peers linked to this group will be disconnected. This action cannot be undone. Make sure you have migrated or reconfigured any dependencies before proceeding.`,
   'cc-network-group-dashboard.danger-zone.dialog.heading': `Confirm deletion`,

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -283,6 +283,7 @@ export const translations = {
   'cc-addon-info.creation-date.heading': `Creation date`,
   'cc-addon-info.creation-date.human-friendly-date': /** @param {{ date: string | number }} _ */ ({ date }) =>
     formatDatetime(date),
+  'cc-addon-info.description.heading': `Description`,
   'cc-addon-info.doc-link.cellar': `Cellar - Documentation`,
   'cc-addon-info.doc-link.elastic': `Elastic Stack - Documentation`,
   'cc-addon-info.doc-link.jenkins': `Jenkins - Documentation`,

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -294,6 +294,7 @@ export const translations = {
   'cc-addon-info.creation-date.heading': `Date de création`,
   'cc-addon-info.creation-date.human-friendly-date': /** @param {{ date: string | number }} _ */ ({ date }) =>
     formatDatetime(date),
+  'cc-addon-info.description.heading': `Description`,
   'cc-addon-info.doc-link.cellar': `Cellar - Documentation`,
   'cc-addon-info.doc-link.elastic': `Elastic Stack - Documentation`,
   'cc-addon-info.doc-link.jenkins': `Jenkins - Documentation`,

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -1368,7 +1368,8 @@ export const translations = {
   //#endregion
   //#region cc-network-group-dashboard
   'cc-network-group-dashboard.danger-zone.btn': `Supprimer le Network Group`,
-  'cc-network-group-dashboard.danger-zone.desc': `La suppression de ce Network Group est une action permanente. Tous les membres seront dissociés.`,
+  'cc-network-group-dashboard.danger-zone.desc': () =>
+    sanitize`La suppression de ce Network Group est une action permanente.<br>Tous les membres seront dissociés et supprimés.`,
   'cc-network-group-dashboard.danger-zone.dialog.confirm-input-label': `Saisissez le nom du Network Group`,
   'cc-network-group-dashboard.danger-zone.dialog.desc': `La suppression de ce Network group est une action permanente. Tous les membres et pairs associés seront dissociés. Cette action ne peut pas être annulée. Assurez-vous d'avoir migré ou reconfiguré toutes les dépendances avant de continuer.`,
   'cc-network-group-dashboard.danger-zone.dialog.heading': `Confirmer la suppression`,


### PR DESCRIPTION
## What does this PR do?

- Adds support for the description field in `cc-addon-info`,
- Adds support for the description field in `cc-network-group-dashboard` component.

## How to review?

- Check the commit,
- Check the stories,
- 1 reviewer should be enough for this one.