### PR TITLE
`cc-network-group-member-*`: support `DELETED` resources

### DIFF
--- a/src/components/cc-network-group-member-card/cc-network-group-member-card.events.js
+++ b/src/components/cc-network-group-member-card/cc-network-group-member-card.events.js
@@ -1,14 +1,16 @@
 import { CcEvent } from '../../lib/events.js';
 
+/** @import { NetworkGroupMember } from './cc-network-group-member-card.types.js'; */
+
 /**
  * Dispatched when the user requests to unlink a member.
  * The parent component should handle the confirmation dialog.
- * @extends {CcEvent<string>}
+ * @extends {CcEvent<{ id: string, kind: NetworkGroupMember['kind'] }>}
  */
 export class CcNetworkGroupMemberUnlinkRequestEvent extends CcEvent {
   static TYPE = 'cc-network-group-member-unlink-request';
 
-  /** @param {string} detail - The member ID to unlink */
+  /** @param {{ id: string, kind: NetworkGroupMember['kind'] }} detail - The member ID to unlink and its kind */
   constructor(detail) {
     super(CcNetworkGroupMemberUnlinkRequestEvent.TYPE, detail);
   }

--- a/src/components/cc-network-group-member-card/cc-network-group-member-card.js
+++ b/src/components/cc-network-group-member-card/cc-network-group-member-card.js
@@ -3,9 +3,11 @@ import { createRef, ref } from 'lit/directives/ref.js';
 import {
   iconRemixArrowRightLine as iconArrowRight,
   iconRemixArrowUpSLine as iconArrowUp,
+  iconRemixCloseFill as iconDelete,
 } from '../../assets/cc-remix.icons.js';
 import { isStringEmpty } from '../../lib/utils.js';
 import { i18n } from '../../translations/translation.js';
+import '../cc-badge/cc-badge.js';
 import '../cc-button/cc-button.js';
 import '../cc-clipboard/cc-clipboard.js';
 import '../cc-expand/cc-expand.js';
@@ -16,7 +18,7 @@ import '../cc-network-group-peer-card/cc-network-group-peer-card.js';
 import { CcNetworkGroupMemberUnlinkRequestEvent } from './cc-network-group-member-card.events.js';
 
 /**
- * @import { NetworkGroupMember } from './cc-network-group-member-card.types.js'
+ * @import { NetworkGroupMember, NetworkGroupMemberClever, NetworkGroupMemberDeleted, NetworkGroupMemberExternal, NetworkGroupMemberLogo } from './cc-network-group-member-card.types.js'
  * @import { NetworkGroupPeer } from '../cc-network-group-peer-card/cc-network-group-peer-card.types.js'
  * @import { CcButton } from '../cc-button/cc-button.js'
  * @import { Ref } from 'lit/directives/ref.js'
@@ -69,7 +71,7 @@ export class CcNetworkGroupMemberCard extends LitElement {
   }
 
   _onUnlinkRequest() {
-    this.dispatchEvent(new CcNetworkGroupMemberUnlinkRequestEvent(this.member.id));
+    this.dispatchEvent(new CcNetworkGroupMemberUnlinkRequestEvent({ id: this.member.id, kind: this.member.kind }));
   }
 
   /**
@@ -85,6 +87,7 @@ export class CcNetworkGroupMemberCard extends LitElement {
       case 'ADDON':
         return i18n('cc-network-group-member-card.link.dashboard-addon');
       case 'EXTERNAL':
+      case 'DELETED':
         return '';
     }
   }
@@ -94,7 +97,7 @@ export class CcNetworkGroupMemberCard extends LitElement {
    * @returns {string|null}
    */
   _getDashboardUrl(member) {
-    if (member.kind !== 'EXTERNAL') {
+    if (member.kind === 'APPLICATION' || member.kind === 'ADDON') {
       return member.dashboardUrl;
     }
     return null;
@@ -113,6 +116,14 @@ export class CcNetworkGroupMemberCard extends LitElement {
   }
 
   render() {
+    if (this.member.kind === 'DELETED') {
+      return this._renderMemberDeleted({
+        member: this.member,
+        isUnlinking: this.isUnlinking,
+        isDisabled: this.isDisabled,
+      });
+    }
+
     const hasPeers = this.member.peerList.length > 0;
 
     if (hasPeers) {
@@ -133,7 +144,7 @@ export class CcNetworkGroupMemberCard extends LitElement {
 
   /**
    * @param {Object} params
-   * @param {NetworkGroupMember} params.member
+   * @param {NetworkGroupMemberClever|NetworkGroupMemberExternal} params.member
    * @param {boolean} params.isUnlinking
    * @param {boolean} params.isDisabled
    *
@@ -158,7 +169,7 @@ export class CcNetworkGroupMemberCard extends LitElement {
 
   /**
    * @param {Object} params
-   * @param {NetworkGroupMember} params.member
+   * @param {NetworkGroupMemberClever | NetworkGroupMemberExternal} params.member
    * @param {boolean} params.isUnlinking
    * @param {boolean} params.isDisabled
    * @param {boolean} params.isOpen
@@ -194,7 +205,44 @@ export class CcNetworkGroupMemberCard extends LitElement {
   }
 
   /**
-   * @param {{ url: string, a11yName: string }} logo
+   * @param {Object} params
+   * @param {NetworkGroupMemberDeleted} params.member
+   * @param {boolean} params.isUnlinking
+   * @param {boolean} params.isDisabled
+   */
+  _renderMemberDeleted({ member, isUnlinking, isDisabled }) {
+    return html`
+      <div class="member-card">
+        <div class="header">
+          <span class="deleted-member-identity">
+            <span class="deleted-member-identity-label reduced-opacity">${member.label}</span>
+            <cc-badge>${i18n('cc-network-group-member-card.deleted-member.badge')}</cc-badge>
+          </span>
+          <span class="reduced-opacity">${this._renderPeersCount(0)}</span>
+        </div>
+        <div class="deleted-member-footer">
+          <span class="deleted-member-footer-warning reduced-opacity">
+            ${i18n('cc-network-group-member-card.deleted-member.warning')}
+          </span>
+          <cc-button
+            class="unlink-btn"
+            danger
+            .icon="${iconDelete}"
+            a11y-name="${i18n('cc-network-group-member-card.unlink.a11y-name', { label: member.label })}"
+            ?waiting="${isUnlinking}"
+            ?disabled="${isDisabled}"
+            @cc-click="${this._onUnlinkRequest}"
+            ${ref(this._unlinkButtonRef)}
+          >
+            ${i18n('cc-network-group-member-card.unlink')}
+          </cc-button>
+        </div>
+      </div>
+    `;
+  }
+
+  /**
+   * @param {NetworkGroupMemberLogo} logo
    * @param {string} label
    *
    * Renders the member identity section (logo + label)
@@ -298,6 +346,10 @@ export class CcNetworkGroupMemberCard extends LitElement {
           padding: var(--member-card-padding);
         }
 
+        .reduced-opacity {
+          opacity: var(--cc-opacity-when-disabled);
+        }
+
         /* region Header */
 
         .header {
@@ -349,6 +401,17 @@ export class CcNetworkGroupMemberCard extends LitElement {
         .identity-label {
           color: var(--cc-color-text-primary-strongest);
           flex: 1 1 10em;
+          font-weight: bold;
+        }
+
+        .deleted-member-identity {
+          align-items: center;
+          display: flex;
+          flex-wrap: wrap;
+          gap: 0.5em;
+        }
+
+        .deleted-member-identity-label {
           font-weight: bold;
         }
 
@@ -436,7 +499,26 @@ export class CcNetworkGroupMemberCard extends LitElement {
           margin-left: auto;
         }
 
+        .deleted-member-footer {
+          align-items: center;
+          display: flex;
+          flex-wrap: wrap;
+          gap: 1em;
+        }
+
+        .deleted-member-footer-warning {
+          flex: 1 1 25em;
+        }
+
         @container member-card (max-width: 25em) {
+          .deleted-member-footer {
+            flex-direction: column;
+          }
+
+          .deleted-member-footer-warning {
+            flex: 1 1 0;
+          }
+
           .unlink-btn {
             width: 100%;
           }

--- a/src/components/cc-network-group-member-card/cc-network-group-member-card.stories.js
+++ b/src/components/cc-network-group-member-card/cc-network-group-member-card.stories.js
@@ -2,6 +2,8 @@ import {
   memberAddon,
   memberAddonWithoutPeers,
   memberAppWithoutPeers,
+  memberDeletedAddon,
+  memberDeletedApp,
   memberExternalWithoutPeers,
   memberExternalWithPeers,
   memberWithoutDashboardUrl,
@@ -84,6 +86,18 @@ export const withoutDashboardUrl = makeStory(conf, {
   items: [
     {
       member: memberWithoutDashboardUrl,
+    },
+  ],
+});
+
+export const deleted = makeStory(conf, {
+  /** @type {Partial<CcNetworkGroupMemberCard>[]} */
+  items: [
+    {
+      member: memberDeletedApp,
+    },
+    {
+      member: memberDeletedAddon,
     },
   ],
 });

--- a/src/components/cc-network-group-member-card/cc-network-group-member-card.types.d.ts
+++ b/src/components/cc-network-group-member-card/cc-network-group-member-card.types.d.ts
@@ -1,14 +1,16 @@
 import { NetworkGroupPeer } from '../cc-network-group-peer-card/cc-network-group-peer-card.types.js';
 
-export type NetworkGroupMember = NetworkGroupMemberClever | NetworkGroupMemberExternal;
+export type NetworkGroupMember = NetworkGroupMemberClever | NetworkGroupMemberExternal | NetworkGroupMemberDeleted;
+
+export interface NetworkGroupMemberLogo {
+  url: string;
+  a11yName: string;
+}
 
 interface NetworkGroupMemberBaseProperties {
   id: string;
   label: string;
-  logo: {
-    url: string;
-    a11yName: string;
-  };
+  logo: NetworkGroupMemberLogo;
   domainName: string;
   peerList: NetworkGroupPeer[];
 }
@@ -20,4 +22,10 @@ export interface NetworkGroupMemberClever extends NetworkGroupMemberBaseProperti
 
 export interface NetworkGroupMemberExternal extends NetworkGroupMemberBaseProperties {
   kind: 'EXTERNAL';
+}
+
+export interface NetworkGroupMemberDeleted {
+  kind: 'DELETED';
+  id: string;
+  label: string;
 }

--- a/src/components/cc-network-group-member-list/cc-network-group-member-list.js
+++ b/src/components/cc-network-group-member-list/cc-network-group-member-list.js
@@ -44,6 +44,7 @@ export class CcNetworkGroupMemberList extends LitElement {
       memberListState: { type: Object, attribute: 'member-list-state' },
       networkGroupId: { type: String, attribute: 'network-group-id' },
       _memberIdToUnlink: { type: String, state: true },
+      _showUnlinkDialog: { type: Boolean, state: true },
     };
   }
 
@@ -67,6 +68,9 @@ export class CcNetworkGroupMemberList extends LitElement {
 
     /** @type {string|null} Used to track the id of the member to unlink to dispatch the proper event payload */
     this._memberIdToUnlink = null;
+
+    /** @type {boolean} Used to track whether the unlink confirmation dialog should be shown */
+    this._showUnlinkDialog = false;
 
     new LostFocusController(this, 'cc-network-group-member-card', ({ suggestedElement }) => {
       if (suggestedElement == null) {
@@ -94,11 +98,17 @@ export class CcNetworkGroupMemberList extends LitElement {
    * @param {CcNetworkGroupMemberUnlinkRequestEvent} e
    */
   _onUnlinkMemberRequest(e) {
-    this._memberIdToUnlink = e.detail;
+    this._memberIdToUnlink = e.detail.id;
+    if (e.detail.kind === 'DELETED') {
+      this.dispatchEvent(new CcNetworkGroupMemberUnlinkEvent(e.detail.id));
+    } else {
+      this._showUnlinkDialog = true;
+    }
   }
 
   _onDialogClose() {
     this._memberIdToUnlink = null;
+    this._showUnlinkDialog = false;
   }
 
   resetLinkForm() {
@@ -112,6 +122,7 @@ export class CcNetworkGroupMemberList extends LitElement {
     const isNotUnlinking = this.memberListState.type !== 'unlinking';
     if (wasUnlinking && isNotUnlinking) {
       this._memberIdToUnlink = null;
+      this._showUnlinkDialog = false;
     }
   }
 
@@ -125,7 +136,11 @@ export class CcNetworkGroupMemberList extends LitElement {
         emptyTextRef: this._emptyTextRef,
       })}
       ${this._renderLinkForm({ state: this.linkFormState })}
-      ${this._renderUnlinkDialog(this._memberIdToUnlink, isUnlinking)}
+      ${this._renderUnlinkDialog({
+        showDialog: this._showUnlinkDialog,
+        memberIdToUnlink: this._memberIdToUnlink,
+        isUnlinking,
+      })}
     `;
   }
 
@@ -141,6 +156,20 @@ export class CcNetworkGroupMemberList extends LitElement {
   _renderMemberList({ state, memberIdToUnlink, emptyTextRef }) {
     const isUnlinking = state.type === 'unlinking';
     const hasMembers = state.type === 'loaded' || state.type === 'unlinking' ? state.memberList.length > 0 : false;
+    const sortedMemberList =
+      state.type === 'loaded' || state.type === 'unlinking'
+        ? state.memberList.toSorted((a, b) => {
+            // Put 'DELETED' kind last
+            if (a.kind === 'DELETED' && b.kind !== 'DELETED') {
+              return 1;
+            }
+            if (a.kind !== 'DELETED' && b.kind === 'DELETED') {
+              return -1;
+            }
+            // Otherwise, sort alphabetically by label
+            return a.label.localeCompare(b.label);
+          })
+        : [];
 
     return html`
       <cc-block>
@@ -162,7 +191,7 @@ export class CcNetworkGroupMemberList extends LitElement {
             ? html`
                 <div class="member-list">
                   ${repeat(
-                    state.memberList,
+                    sortedMemberList,
                     (member) => member.id,
                     (member, index) => html`
                       <cc-network-group-member-card
@@ -211,13 +240,12 @@ export class CcNetworkGroupMemberList extends LitElement {
   }
 
   /**
-   * @param {string} memberIdToUnlink
-   * @param {boolean} isUnlinking
+   * @param {{ showDialog: boolean, memberIdToUnlink: string|null, isUnlinking: boolean }} params
    **/
-  _renderUnlinkDialog(memberIdToUnlink, isUnlinking) {
+  _renderUnlinkDialog({ showDialog, memberIdToUnlink, isUnlinking }) {
     return html`
       <cc-dialog
-        ?open="${memberIdToUnlink != null}"
+        ?open="${showDialog}"
         heading="${i18n('cc-network-group-member-list.unlink.dialog.heading')}"
         @cc-close="${this._onDialogClose}"
       >

--- a/src/components/cc-network-group-member-list/cc-network-group-member-list.smart.js
+++ b/src/components/cc-network-group-member-list/cc-network-group-member-list.smart.js
@@ -19,7 +19,7 @@ const FIFTY_MINUTES = 50 * 60 * 1000;
 /**
  * @import { ApiConfig } from '../../lib/send-to-api.types.js'
  * @import { NetworkGroupMemberLinkFormStateIdle, NetworkGroupMemberLinkFormStateLinking } from './cc-network-group-member-list.types.js'
- * @import { NetworkGroupMember } from '../cc-network-group-member-card/cc-network-group-member-card.types.js';
+ * @import { NetworkGroupMember, NetworkGroupMemberLogo } from '../cc-network-group-member-card/cc-network-group-member-card.types.js';
  * @import { CcNetworkGroupMemberList } from './cc-network-group-member-list.js'
  * @import { NetworkGroupPeer } from '../cc-network-group-peer-card/cc-network-group-peer-card.types.js';
  * @import { NetworkGroup } from '@clevercloud/client/cc-api-commands/network-group/network-group.types.js';
@@ -291,7 +291,7 @@ class Api {
 
   /**
    * @param {string} resourceId
-   * @param {NetworkGroupMember['kind']} kind
+   * @param {Exclude<NetworkGroupMember['kind'], 'DELETED'>} kind
    * @returns {string|null}
    */
   #getMemberDashboardUrl(resourceId, kind) {
@@ -307,16 +307,21 @@ class Api {
 
   /**
    * @param {string} resourceId
-   * @param {NetworkGroupMember['kind']} kind
-   * @returns {Promise<NetworkGroupMember['logo']>}
+   * @param {Exclude<NetworkGroupMember['kind'], 'DELETED'>} kind
+   * @returns {Promise<NetworkGroupMemberLogo>}
    */
   async #getMemberLogo(resourceId, kind) {
     switch (kind) {
       case 'APPLICATION': {
         const applicationData = await this.#ccApiClient.send(
           new GetApplicationCommand({ applicationId: resourceId, ownerId: this.#ownerId }),
-          { signal: this.#signal },
+          {
+            signal: this.#signal,
+          },
         );
+        if (applicationData == null) {
+          return null;
+        }
         return {
           url: applicationData.instance.variant.logo,
           a11yName: applicationData.instance.variant.name,
@@ -327,6 +332,9 @@ class Api {
           new GetAddonCommand({ addonId: resourceId, ownerId: this.#ownerId }),
           { signal: this.#signal },
         );
+        if (addonData == null) {
+          return null;
+        }
         return {
           url: addonData.provider.logoUrl,
           a11yName: addonData.provider.name,
@@ -346,12 +354,20 @@ class Api {
    * @returns {Promise<NetworkGroupMember>}
    * */
   async #getMemberWithInfo(member, rawPeerList) {
-    const logoPromise = this.#getMemberLogo(member.id, member.kind);
-    const peerListPromise = Promise.all(
-      rawPeerList.filter((peer) => peer.parentMember === member.id).map((peer) => this.#getPeerWithInfo(peer)),
-    );
+    const [logo, peerList] = await Promise.all([
+      this.#getMemberLogo(member.id, member.kind),
+      Promise.all(
+        rawPeerList.filter((peer) => peer.parentMember === member.id).map((peer) => this.#getPeerWithInfo(peer)),
+      ),
+    ]);
 
-    const [logo, peerList] = await Promise.all([logoPromise, peerListPromise]);
+    if (logo == null) {
+      return {
+        kind: 'DELETED',
+        id: member.id,
+        label: member.label,
+      };
+    }
 
     return {
       id: member.id,

--- a/src/components/cc-network-group-member-list/cc-network-group-member-list.stories.js
+++ b/src/components/cc-network-group-member-list/cc-network-group-member-list.stories.js
@@ -1,4 +1,9 @@
-import { networkGroupMemberList, sampleSelectOptions } from '../../stories/fixtures/network-groups.js';
+import {
+  memberDeletedAddon,
+  memberDeletedApp,
+  networkGroupMemberList,
+  sampleSelectOptions,
+} from '../../stories/fixtures/network-groups.js';
 import { makeStory } from '../../stories/lib/make-story.js';
 import './cc-network-group-member-list.js';
 
@@ -47,6 +52,20 @@ export const loading = makeStory(conf, {
   ],
 });
 
+export const loadingWithLinkForm = makeStory(conf, {
+  /** @type {Partial<CcNetworkGroupMemberList>[]} */
+  items: [
+    {
+      networkGroupId,
+      memberListState: {
+        type: 'loaded',
+        memberList: networkGroupMemberList,
+      },
+      linkFormState: { type: 'loading' },
+    },
+  ],
+});
+
 export const error = makeStory(conf, {
   /** @type {Partial<CcNetworkGroupMemberList>[]} */
   items: [
@@ -75,7 +94,7 @@ export const dataLoadedWithNoMembers = makeStory(conf, {
   ],
 });
 
-export const linkFormLoading = makeStory(conf, {
+export const dataLoadedWithLinkFormEmpty = makeStory(conf, {
   /** @type {Partial<CcNetworkGroupMemberList>[]} */
   items: [
     {
@@ -84,12 +103,32 @@ export const linkFormLoading = makeStory(conf, {
         type: 'loaded',
         memberList: networkGroupMemberList,
       },
-      linkFormState: { type: 'loading' },
+      linkFormState: {
+        type: 'idle',
+        selectOptions: [],
+      },
     },
   ],
 });
 
-export const linkFormLinking = makeStory(conf, {
+export const dataLoadedWithDeletedMembers = makeStory(conf, {
+  /** @type {Partial<CcNetworkGroupMemberList>[]} */
+  items: [
+    {
+      networkGroupId,
+      memberListState: {
+        type: 'loaded',
+        memberList: [...networkGroupMemberList, memberDeletedApp, memberDeletedAddon],
+      },
+      linkFormState: {
+        type: 'idle',
+        selectOptions: sampleSelectOptions,
+      },
+    },
+  ],
+});
+
+export const waitingWithLinkFormLinking = makeStory(conf, {
   /** @type {Partial<CcNetworkGroupMemberList>[]} */
   items: [
     {
@@ -106,7 +145,7 @@ export const linkFormLinking = makeStory(conf, {
   ],
 });
 
-export const memberListUnlinking = makeStory(conf, {
+export const waitingWithMemberListUnlinking = makeStory(conf, {
   docs: 'Shows the state when a member is being unlinked. The dialog is open with a waiting state, the targeted member shows a waiting state on its unlink button, while other members are disabled.',
   /** @type {Partial<CcNetworkGroupMemberList>[]} */
   items: [
@@ -137,21 +176,4 @@ export const memberListUnlinking = makeStory(conf, {
       };
     });
   },
-});
-
-export const linkFormEmpty = makeStory(conf, {
-  /** @type {Partial<CcNetworkGroupMemberList>[]} */
-  items: [
-    {
-      networkGroupId,
-      memberListState: {
-        type: 'loaded',
-        memberList: networkGroupMemberList,
-      },
-      linkFormState: {
-        type: 'idle',
-        selectOptions: [],
-      },
-    },
-  ],
 });

--- a/src/stories/fixtures/network-groups.js
+++ b/src/stories/fixtures/network-groups.js
@@ -269,6 +269,20 @@ export const memberWithoutDashboardUrl = {
   peerList: memberExternalWithPeers.peerList,
 };
 
+/** @type {NetworkGroupMember} */
+export const memberDeletedApp = {
+  kind: 'DELETED',
+  id: 'app_c3d4e5f6-3333-4444-5555-666677778888',
+  label: 'My Java App',
+};
+
+/** @type {NetworkGroupMember} */
+export const memberDeletedAddon = {
+  kind: 'DELETED',
+  id: 'addon_d4e5f6a7-4444-5555-6666-777788889999',
+  label: 'MongoDB Staging',
+};
+
 /** @type {NetworkGroupMember[]} */
 export const networkGroupMemberList = [
   memberWithPeers,

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -1392,6 +1392,8 @@ export const translations = {
   'cc-network-group-list.refresh.error': `The Network Group member was linked successfully but something went wrong while refreshing the list`,
   //#endregion
   //#region cc-network-group-member-card
+  'cc-network-group-member-card.deleted-member.badge': `Resource deleted`,
+  'cc-network-group-member-card.deleted-member.warning': `This resource has been deleted, so it no longer has any associated peers. The member still appears in this Network Group even though it is no longer valid. You can unlink it now to clear your Network Group.`,
   'cc-network-group-member-card.link.dashboard-addon': `Add-on overview`,
   'cc-network-group-member-card.link.dashboard-application': `Application overview`,
   'cc-network-group-member-card.nb-of-peers': /** @param {{ nbOfPeers: number}} _ */ ({ nbOfPeers }) =>

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -1403,6 +1403,8 @@ export const translations = {
   'cc-network-group-list.refresh.error': `Le membre a bien été lié au Network Group mais une erreur est survenue pendant le rafraîchissement de la liste`,
   //#endregion
   //#region cc-network-group-member-card
+  'cc-network-group-member-card.deleted-member.badge': `Ressource supprimée`,
+  'cc-network-group-member-card.deleted-member.warning': `Cette ressource a été supprimée, elle n'a donc plus de pairs. Ce membre apparaît toujours dans ce Network Group même s'il n'est plus valide. Vous pouvez le dissocier maintenant pour nettoyer votre Network Group.`,
   'cc-network-group-member-card.link.dashboard-addon': `Vue d'ensemble de l'add-on`,
   'cc-network-group-member-card.link.dashboard-application': `Vue d'ensemble de l'application`,
   'cc-network-group-member-card.nb-of-peers': /** @param {{ nbOfPeers: number}} _ */ ({ nbOfPeers }) =>


### PR DESCRIPTION
## What does this PR do?

When Clever Cloud resources are deleted, they are not cleared from Network Groups.
This means we need to support members referring to deleted resources.

This PR adds a new type of member card to show members referring to deleted resources and allow users to unlink these "ghost" members.

## How to review?

- Check the commits,
- Check the stories,
- Small QA:
  1. From your prod console Create an app / addon in `ACME BAR`,
  2. From your local demo-smart, link your newly created resource to the Network Group used for testing,
  3. From your prod console, delete the resource,
  4. Refresh your local demo-smart: you should see the ghost member as last member with different look (opacity, sentence + plain danger button),
  5. Delete the ghost member: you should get no confirm dialog, directly into waiting, then success toast. (no need to test other stuff since the only difference with other members is we skip the dialog, the rest of the unlink process / code is exactly the same).
- 2 reviewers should be enough.