### PR TITLE
`cc-network-group-list`: support unlinking

### DIFF
--- a/src/components/cc-network-group-list/cc-network-group-list.events.js
+++ b/src/components/cc-network-group-list/cc-network-group-list.events.js
@@ -13,3 +13,17 @@ export class CcNetworkGroupLinkEvent extends CcEvent {
     super(CcNetworkGroupLinkEvent.TYPE, detail);
   }
 }
+
+/**
+ * Dispatched when a network group is requested to be unlinked from a resource.
+ *
+ * @extends CcEvent<string>
+ */
+export class CcNetworkGroupUnlinkEvent extends CcEvent {
+  static TYPE = 'cc-network-group-unlink';
+
+  /** @param {string} detail */
+  constructor(detail) {
+    super(CcNetworkGroupUnlinkEvent.TYPE, detail);
+  }
+}

--- a/src/components/cc-network-group-list/cc-network-group-list.js
+++ b/src/components/cc-network-group-list/cc-network-group-list.js
@@ -13,6 +13,8 @@ import '../cc-block/cc-block.js';
 import '../cc-button/cc-button.js';
 import '../cc-clipboard/cc-clipboard.js';
 import '../cc-code/cc-code.js';
+import '../cc-dialog-confirm-actions/cc-dialog-confirm-actions.js';
+import '../cc-dialog/cc-dialog.js';
 import '../cc-icon/cc-icon.js';
 import '../cc-img/cc-img.js';
 import '../cc-link/cc-link.js';
@@ -20,13 +22,14 @@ import '../cc-loader/cc-loader.js';
 import '../cc-network-group-peer-card/cc-network-group-peer-card.js';
 import '../cc-notice/cc-notice.js';
 import '../cc-select/cc-select.js';
-import { CcNetworkGroupLinkEvent } from './cc-network-group-list.events.js';
+import { CcNetworkGroupLinkEvent, CcNetworkGroupUnlinkEvent } from './cc-network-group-list.events.js';
 
 /**
  * @import { NetworkGroupListState, NetworkGroupLinkFormState, NetworkGroup } from './cc-network-group-list.types.js'
  * @import { Ref } from 'lit/directives/ref.js'
  * @import { Option } from '../cc-select/cc-select.types.js'
  * @import { CcLink } from '../cc-link/cc-link.js'
+ * @import { PropertyValues } from 'lit'
  */
 
 /**
@@ -47,6 +50,7 @@ export class CcNetworkGroupList extends LitElement {
       linkFormState: { type: Object, attribute: 'link-form-state' },
       listState: { type: Object, attribute: 'list-state' },
       resourceId: { type: String, attribute: 'resource-id' },
+      _networkGroupIdToUnlink: { type: String, state: true },
     };
   }
 
@@ -62,8 +66,25 @@ export class CcNetworkGroupList extends LitElement {
     /** @type {string} Sets the resource ID for CLI command documentation */
     this.resourceId = '<RESOURCE_ID>';
 
+    /** @type {string|null} */
+    this._networkGroupIdToUnlink = null;
+
     /** @type {Ref<CcLink>} */
     this._createNetworkGroupLinkRef = createRef();
+
+    /** @type {Ref<HTMLElement>} */
+    this._emptyListRef = createRef();
+
+    new LostFocusController(this, '.unlink-btn', ({ suggestedElement }) => {
+      if (suggestedElement == null) {
+        this._emptyListRef.value?.focus();
+        return;
+      }
+
+      if (suggestedElement instanceof HTMLElement) {
+        suggestedElement.focus();
+      }
+    });
 
     // When last Network Group available to link is linked, the form is replaced by a link to create a new Network Group. This controller allows to focus this link when it appears
     new LostFocusController(this, '.link-form__submit', () => {
@@ -76,7 +97,36 @@ export class CcNetworkGroupList extends LitElement {
     this.dispatchEvent(new CcNetworkGroupLinkEvent(formData['network-group']));
   }
 
+  /** @param {string} networkGroupId */
+  _onUnlinkRequest(networkGroupId) {
+    this._networkGroupIdToUnlink = networkGroupId;
+  }
+
+  _onDialogClose() {
+    this._networkGroupIdToUnlink = null;
+  }
+
+  _onDialogConfirm() {
+    if (this._networkGroupIdToUnlink != null) {
+      this.dispatchEvent(new CcNetworkGroupUnlinkEvent(this._networkGroupIdToUnlink));
+    }
+  }
+
+  /** @param {PropertyValues<CcNetworkGroupList>} changedProperties */
+  willUpdate(changedProperties) {
+    if (changedProperties.has('listState')) {
+      const previousListState = changedProperties.get('listState');
+      const wasUnlinking = previousListState?.type === 'unlinking';
+      const isNotUnlinking = this.listState.type !== 'unlinking';
+      if (wasUnlinking && isNotUnlinking) {
+        this._networkGroupIdToUnlink = null;
+      }
+    }
+  }
+
   render() {
+    const isUnlinking = this.listState.type === 'unlinking';
+
     const selectOptions =
       this.linkFormState.type === 'idle' || this.linkFormState.type === 'linking'
         ? this.linkFormState.selectOptions
@@ -107,6 +157,7 @@ export class CcNetworkGroupList extends LitElement {
                 selectOptions,
                 isLoading: this.linkFormState.type === 'loading',
                 isLinking: this.linkFormState.type === 'linking',
+                isDisabled: this.listState.type === 'unlinking',
               })
             : ''}
         </div>
@@ -155,7 +206,9 @@ export class CcNetworkGroupList extends LitElement {
             ? html`<cc-notice intent="warning" message="${i18n('cc-network-group-list.list.error')}"></cc-notice>`
             : ''}
           ${this.listState.type === 'loading' ? html`<cc-loader></cc-loader>` : ''}
-          ${this.listState.type === 'loaded' ? this._renderNetworkGroupList(this.listState.linkedNetworkGroupList) : ''}
+          ${this.listState.type === 'loaded' || this.listState.type === 'unlinking'
+            ? this._renderNetworkGroupList(this.listState.linkedNetworkGroupList, isUnlinking)
+            : ''}
         </div>
         <div slot="footer-right">
           <cc-link href="${getDocUrl('/develop/network-groups')}">
@@ -163,6 +216,8 @@ export class CcNetworkGroupList extends LitElement {
           </cc-link>
         </div>
       </cc-block>
+
+      ${this._renderUnlinkDialog(this._networkGroupIdToUnlink, isUnlinking)}
     `;
   }
 
@@ -171,8 +226,9 @@ export class CcNetworkGroupList extends LitElement {
    * @param {Array<Option>} _.selectOptions
    * @param {boolean} _.isLoading
    * @param {boolean} _.isLinking
+   * @param {boolean} _.isDisabled
    */
-  _renderNetworkGroupLinkForm({ selectOptions, isLoading, isLinking }) {
+  _renderNetworkGroupLinkForm({ selectOptions, isLoading, isLinking, isDisabled }) {
     const sortedSelectOptions = selectOptions.toSorted((optionA, optionB) =>
       optionA.label.localeCompare(optionB.label),
     );
@@ -183,7 +239,7 @@ export class CcNetworkGroupList extends LitElement {
         <cc-select
           label="${i18n('cc-network-group-list.form.select-label')}"
           class="link-form__select"
-          ?disabled="${isLoading || isLinking}"
+          ?disabled="${isLoading || isLinking || isDisabled}"
           .options="${sortedSelectOptions}"
           name="network-group"
           .value="${defaultValue}"
@@ -196,6 +252,7 @@ export class CcNetworkGroupList extends LitElement {
           type="submit"
           ?skeleton="${isLoading}"
           ?waiting="${isLinking}"
+          ?disabled="${isDisabled}"
         >
           ${i18n('cc-network-group-list.form.button')}
         </cc-button>
@@ -203,11 +260,14 @@ export class CcNetworkGroupList extends LitElement {
     `;
   }
 
-  /** @param {Array<NetworkGroup>} networkGroupList */
-  _renderNetworkGroupList(networkGroupList) {
+  /**
+   * @param {Array<NetworkGroup>} networkGroupList
+   * @param {boolean} isUnlinking
+   */
+  _renderNetworkGroupList(networkGroupList, isUnlinking) {
     if (networkGroupList.length === 0) {
       return html`
-        <div class="empty">
+        <div class="empty" tabindex="-1" ${ref(this._emptyListRef)}>
           <p>${i18n('cc-network-group-list.list.empty')}</p>
         </div>
       `;
@@ -230,12 +290,6 @@ export class CcNetworkGroupList extends LitElement {
                   ></cc-img>
                   <span>${networkGroup.name}</span>
                 </div>
-                <div class="network-group-card__header__link">
-                  <cc-link href="${networkGroup.dashboardUrl}">
-                    <span>${i18n('cc-network-group-list.list.dashboard-link')}</span>
-                  </cc-link>
-                  <cc-icon .icon="${iconLink}"></cc-icon>
-                </div>
               </div>
               <div class="network-group-card__id">
                 <span>${networkGroup.id}</span>
@@ -246,10 +300,51 @@ export class CcNetworkGroupList extends LitElement {
                   (peer) => html`<cc-network-group-peer-card .peer="${peer}"></cc-network-group-peer-card>`,
                 )}
               </div>
+              <div class="network-group-card__footer">
+                <div class="network-group-card__footer__link">
+                  <cc-link href="${networkGroup.dashboardUrl}">
+                    <span>${i18n('cc-network-group-list.list.dashboard-link')}</span>
+                  </cc-link>
+                  <cc-icon .icon="${iconLink}"></cc-icon>
+                </div>
+                <!-- Be careful, the button class is used by the LostFocusController to manage focus when the form disapears after linking the last network group available -->
+                <cc-button
+                  class="unlink-btn"
+                  danger
+                  outlined
+                  ?waiting="${isUnlinking}"
+                  a11y-name="${i18n('cc-network-group-list.list.unlink.a11y-name', { name: networkGroup.name })}"
+                  @cc-click="${() => this._onUnlinkRequest(networkGroup.id)}"
+                >
+                  ${i18n('cc-network-group-list.list.unlink')}
+                </cc-button>
+              </div>
             </div>
           `,
         )}
       </div>
+    `;
+  }
+
+  /**
+   * @param {string|null} networkGroupIdToUnlink
+   * @param {boolean} isUnlinking
+   */
+  _renderUnlinkDialog(networkGroupIdToUnlink, isUnlinking) {
+    return html`
+      <cc-dialog
+        ?open="${networkGroupIdToUnlink != null}"
+        heading="${i18n('cc-network-group-list.unlink.dialog.heading')}"
+        @cc-close="${this._onDialogClose}"
+      >
+        <p>${i18n('cc-network-group-list.unlink.dialog.desc')}</p>
+        <cc-dialog-confirm-actions
+          submit-intent="danger"
+          submit-label="${i18n('cc-network-group-list.unlink.dialog.unlink-btn')}"
+          ?waiting="${isUnlinking}"
+          @cc-confirm="${this._onDialogConfirm}"
+        ></cc-dialog-confirm-actions>
+      </cc-dialog>
     `;
   }
 
@@ -334,13 +429,6 @@ export class CcNetworkGroupList extends LitElement {
           width: 1.375em;
         }
 
-        .network-group-card__header__link {
-          align-items: center;
-          color: var(--cc-color-text-primary-highlight);
-          display: flex;
-          gap: 0.25em;
-        }
-
         .network-group-card__id {
           color: var(--cc-color-text-weak);
           font-style: italic;
@@ -355,6 +443,36 @@ export class CcNetworkGroupList extends LitElement {
         .peer-list {
           display: grid;
           gap: 0.5em;
+        }
+
+        .network-group-card__footer {
+          align-items: center;
+          display: flex;
+          justify-content: space-between;
+          margin-top: 1em;
+        }
+
+        .network-group-card__footer__link {
+          align-items: center;
+          color: var(--cc-color-text-primary-highlight);
+          display: flex;
+          gap: 0.25em;
+        }
+
+        cc-dialog p {
+          margin: 0;
+        }
+
+        @container host (max-width: 35em) {
+          .network-group-card__footer {
+            align-items: flex-start;
+            flex-direction: column;
+            gap: 1em;
+          }
+
+          .unlink-btn {
+            width: 100%;
+          }
         }
       `,
     ];

--- a/src/components/cc-network-group-list/cc-network-group-list.smart.js
+++ b/src/components/cc-network-group-list/cc-network-group-list.smart.js
@@ -1,4 +1,5 @@
 import { CreateNetworkGroupMemberCommand } from '@clevercloud/client/cc-api-commands/network-group/create-network-group-member-command.js';
+import { DeleteNetworkGroupMemberCommand } from '@clevercloud/client/cc-api-commands/network-group/delete-network-group-member-command.js';
 import { ListNetworkGroupCommand } from '@clevercloud/client/cc-api-commands/network-group/list-network-group-command.js';
 import { getCcApiClientWithOAuth } from '../../lib/cc-api-client.js';
 import { notify, notifyError, notifySuccess } from '../../lib/notifications.js';
@@ -107,6 +108,41 @@ defineSmartComponent({
         console.error(refreshError);
         updateComponent('linkFormState', (state) => {
           state.type = 'idle';
+        });
+        notify({
+          message: i18n('cc-network-group-list.refresh.error'),
+          intent: 'danger',
+          options: { timeout: 0 },
+        });
+      }
+    });
+
+    onEvent('cc-network-group-unlink', async (networkGroupId) => {
+      updateComponent('listState', (listState) => {
+        listState.type = 'unlinking';
+      });
+
+      try {
+        await ccApiClient.send(new DeleteNetworkGroupMemberCommand({ memberId: resourceId, networkGroupId, ownerId }), {
+          signal,
+        });
+      } catch (error) {
+        console.error(error);
+        updateComponent('listState', (state) => {
+          state.type = 'loaded';
+        });
+        notifyError(i18n('cc-network-group-list.unlink.error'));
+        return;
+      }
+
+      notifySuccess(i18n('cc-network-group-list.unlink.success'));
+
+      try {
+        await refreshFormAndList();
+      } catch (refreshError) {
+        console.error(refreshError);
+        updateComponent('listState', (state) => {
+          state.type = 'loaded';
         });
         notify({
           message: i18n('cc-network-group-list.refresh.error'),

--- a/src/components/cc-network-group-list/cc-network-group-list.smart.md
+++ b/src/components/cc-network-group-list/cc-network-group-list.smart.md
@@ -35,10 +35,11 @@ interface ApiConfig {
 
 ## 🌐 API endpoints
 
-| Method | URL                                                                                | Cache?  |
-| ------ | ---------------------------------------------------------------------------------- | ------- |
-| `GET`  | `/v4/networkgroups/organisations/{ownerId}/networkgroups`                          | Default |
-| `POST` | `/v4/networkgroups/organisations/{ownerId}/networkgroups/{networkGroupId}/members` | N/A     |
+| Method   | URL                                                                                           | Cache?  |
+| -------- | --------------------------------------------------------------------------------------------- | ------- |
+| `GET`    | `/v4/networkgroups/organisations/{ownerId}/networkgroups`                                     | Default |
+| `POST`   | `/v4/networkgroups/organisations/{ownerId}/networkgroups/{networkGroupId}/members`            | N/A     |
+| `DELETE` | `/v4/networkgroups/organisations/{ownerId}/networkgroups/{networkGroupId}/members/{memberId}` | N/A     |
 
 ## ⬇️️ Examples
 

--- a/src/components/cc-network-group-list/cc-network-group-list.stories.js
+++ b/src/components/cc-network-group-list/cc-network-group-list.stories.js
@@ -107,3 +107,20 @@ export const waitingWithLinking = makeStory(conf, {
     },
   ],
 });
+
+export const waitingWithUnlinking = makeStory(conf, {
+  /** @type {Partial<CcNetworkGroupList>[]} */
+  items: [
+    {
+      resourceId: RESOURCE_ID,
+      linkFormState: {
+        type: 'idle',
+        selectOptions: networkGroupSelectOptions,
+      },
+      listState: {
+        type: 'unlinking',
+        linkedNetworkGroupList,
+      },
+    },
+  ],
+});

--- a/src/components/cc-network-group-list/cc-network-group-list.types.d.ts
+++ b/src/components/cc-network-group-list/cc-network-group-list.types.d.ts
@@ -33,11 +33,17 @@ export interface NetworkGroupLinkFormStateEmpty {
 
 export type NetworkGroupListState =
   | NetworkGroupListStateLoaded
+  | NetworkGroupListStateUnlinking
   | NetworkGroupListStateLoading
   | NetworkGroupListStateError;
 
 export interface NetworkGroupListStateLoaded {
   type: 'loaded';
+  linkedNetworkGroupList: NetworkGroup[];
+}
+
+export interface NetworkGroupListStateUnlinking {
+  type: 'unlinking';
   linkedNetworkGroupList: NetworkGroup[];
 }
 

--- a/src/lib/events-map.types.d.ts
+++ b/src/lib/events-map.types.d.ts
@@ -128,7 +128,10 @@ import {
   CcNetworkGroupDeleteEvent,
   CcNetworkGroupWasDeletedEvent,
 } from '../components/cc-network-group-dashboard/cc-network-group-dashboard.events.js';
-import { CcNetworkGroupLinkEvent } from '../components/cc-network-group-list/cc-network-group-list.events.js';
+import {
+  CcNetworkGroupLinkEvent,
+  CcNetworkGroupUnlinkEvent,
+} from '../components/cc-network-group-list/cc-network-group-list.events.js';
 import { CcNetworkGroupMemberUnlinkRequestEvent } from '../components/cc-network-group-member-card/cc-network-group-member-card.events.js';
 import {
   CcNetworkGroupMemberLinkEvent,
@@ -317,6 +320,7 @@ declare global {
     'cc-network-group-member-link': CcNetworkGroupMemberLinkEvent;
     'cc-network-group-member-unlink': CcNetworkGroupMemberUnlinkEvent;
     'cc-network-group-member-unlink-request': CcNetworkGroupMemberUnlinkRequestEvent;
+    'cc-network-group-unlink': CcNetworkGroupUnlinkEvent;
     'cc-network-group-was-deleted': CcNetworkGroupWasDeletedEvent;
     'cc-ng-disable': CcNgDisable;
     'cc-ng-enable': CcNgEnable;

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -1385,7 +1385,7 @@ export const translations = {
   'cc-network-group-list.form.select-label': `Choose a Network Group to link`,
   'cc-network-group-list.link.error': `Something went wrong while linking the Network Group`,
   'cc-network-group-list.link.success': `The Network Group has been linked successfully`,
-  'cc-network-group-list.list.dashboard-link': `Go to Network Group`,
+  'cc-network-group-list.list.dashboard-link': `Go to the Network Group`,
   'cc-network-group-list.list.empty': `You don't have any Network Groups linked to your resource`,
   'cc-network-group-list.list.error': `Something went wrong while loading the list of linked Network Groups`,
   'cc-network-group-list.list.heading': `Linked Network Groups`,

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -1389,7 +1389,15 @@ export const translations = {
   'cc-network-group-list.list.empty': `You don't have any Network Groups linked to your resource`,
   'cc-network-group-list.list.error': `Something went wrong while loading the list of linked Network Groups`,
   'cc-network-group-list.list.heading': `Linked Network Groups`,
+  'cc-network-group-list.list.unlink': `Unlink Network Group`,
+  'cc-network-group-list.list.unlink.a11y-name': /** @param {{ name: string }} _ */ ({ name }) =>
+    `Unlink Network Group - ${name}`,
   'cc-network-group-list.refresh.error': `The Network Group member was linked successfully but something went wrong while refreshing the list`,
+  'cc-network-group-list.unlink.dialog.desc': `Unlinking this resource from the Network Group will disconnect it and all its instances from the group's private network. Are you sure you want to continue?`,
+  'cc-network-group-list.unlink.dialog.heading': `Confirm unlink`,
+  'cc-network-group-list.unlink.dialog.unlink-btn': `Confirm and unlink`,
+  'cc-network-group-list.unlink.error': `Something went wrong while unlinking the Network Group`,
+  'cc-network-group-list.unlink.success': `The Network Group has been unlinked successfully`,
   //#endregion
   //#region cc-network-group-member-card
   'cc-network-group-member-card.deleted-member.badge': `Resource deleted`,

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -1400,7 +1400,15 @@ export const translations = {
   'cc-network-group-list.list.empty': `Vous n'avez aucun Network Group lié à votre ressource`,
   'cc-network-group-list.list.error': `Une erreur est survenue pendant le chargement de la liste des Network Groups liés`,
   'cc-network-group-list.list.heading': `Network Groups liés`,
+  'cc-network-group-list.list.unlink': `Dissocier le Network Group`,
+  'cc-network-group-list.list.unlink.a11y-name': /** @param {{ name: string }} _ */ ({ name }) =>
+    `Dissocier le Network Group - ${name}`,
   'cc-network-group-list.refresh.error': `Le membre a bien été lié au Network Group mais une erreur est survenue pendant le rafraîchissement de la liste`,
+  'cc-network-group-list.unlink.dialog.desc': `La dissociation de cette ressource du Network Group la déconnectera, ainsi que toutes ses instances, du réseau privé du groupe. Souhaitez-vous continuer\u00A0?`,
+  'cc-network-group-list.unlink.dialog.heading': `Confirmer la dissociation`,
+  'cc-network-group-list.unlink.dialog.unlink-btn': `Confirmer et dissocier`,
+  'cc-network-group-list.unlink.error': `Une erreur est survenue pendant la dissociation du Network Group`,
+  'cc-network-group-list.unlink.success': `La dissociation du Network Group a bien été effectuée`,
   //#endregion
   //#region cc-network-group-member-card
   'cc-network-group-member-card.deleted-member.badge': `Ressource supprimée`,


### PR DESCRIPTION
## What does this PR do?

- Adds `unlink` buttons to the `cc-network-group-list` component:
  - this allows users to unlink a Network Group right from this screen instead of having to access the members and peers screen to do so.

## How to review?

- Check the commits,
- Play with the new feature using the `demo-smart` locally, try to block a few `delete` requests just to make sure we're good :wink:
- 2 reviewers should be enough.  