### PR TITLE
feat(cc-network-group-member-list): only allow specific providers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "25.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@clevercloud/client": "^11.5.0",
+        "@clevercloud/client": "^12.3.0",
         "@lit-labs/motion": "^1.0.7",
         "@lit-labs/virtualizer": "^2.0.14",
         "@shoelace-style/shoelace": "^2.18.0",
@@ -1965,9 +1965,9 @@
       "dev": true
     },
     "node_modules/@clevercloud/client": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/@clevercloud/client/-/client-11.5.0.tgz",
-      "integrity": "sha512-ZfTC1scHam5gNO85T7npn2z3J84yP3V1kl+/ygTB4kjoiew1qR6C6NAitCkKLqIsa4BELPaBVp/OhJSkFVaCjg==",
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@clevercloud/client/-/client-12.3.0.tgz",
+      "integrity": "sha512-V4PcfXnZiC9oHKrBVb9RLrNcnS92SHBkPaQgQEe8gDtkDqTpDFVcvpoagiED9ODIWdKcs/vTMk5MqEwwWlH/vA==",
       "license": "Apache-2.0",
       "dependencies": {
         "component-emitter": "^1.3.0",
@@ -21929,9 +21929,9 @@
       "dev": true
     },
     "@clevercloud/client": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/@clevercloud/client/-/client-11.5.0.tgz",
-      "integrity": "sha512-ZfTC1scHam5gNO85T7npn2z3J84yP3V1kl+/ygTB4kjoiew1qR6C6NAitCkKLqIsa4BELPaBVp/OhJSkFVaCjg==",
+      "version": "12.3.0",
+      "resolved": "https://registry.npmjs.org/@clevercloud/client/-/client-12.3.0.tgz",
+      "integrity": "sha512-V4PcfXnZiC9oHKrBVb9RLrNcnS92SHBkPaQgQEe8gDtkDqTpDFVcvpoagiED9ODIWdKcs/vTMk5MqEwwWlH/vA==",
       "requires": {
         "component-emitter": "^1.3.0",
         "fetch-event-stream": "^0.1.6"

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "typecheck:stats": "node tasks/typechecking-stats.js"
   },
   "dependencies": {
-    "@clevercloud/client": "^11.5.0",
+    "@clevercloud/client": "^12.3.0",
     "@lit-labs/motion": "^1.0.7",
     "@lit-labs/virtualizer": "^2.0.14",
     "@shoelace-style/shoelace": "^2.18.0",

--- a/src/components/cc-network-group-member-list/cc-network-group-member-list.smart.js
+++ b/src/components/cc-network-group-member-list/cc-network-group-member-list.smart.js
@@ -6,6 +6,7 @@ import { CreateNetworkGroupMemberCommand } from '@clevercloud/client/cc-api-comm
 import { DeleteNetworkGroupMemberCommand } from '@clevercloud/client/cc-api-commands/network-group/delete-network-group-member-command.js';
 import { GetNetworkGroupCommand } from '@clevercloud/client/cc-api-commands/network-group/get-network-group-command.js';
 import { GetNetworkGroupWireguardConfigurationUrlCommand } from '@clevercloud/client/cc-api-commands/network-group/get-network-group-wireguard-configuration-url-command.js';
+import { isNetworkGroupAddonCandidate } from '@clevercloud/client/cc-api-commands/network-group/network-group-utils.js';
 import { getAssetUrl } from '../../lib/assets-url.js';
 import { getCcApiClientWithOAuth } from '../../lib/cc-api-client.js';
 import { notify, notifyError, notifySuccess } from '../../lib/notifications.js';
@@ -57,24 +58,18 @@ defineSmartComponent({
 
     /** Fetches network group, applications, and addons, then updates both states. */
     async function refreshData() {
-      const [memberList, applications, addons] = await Promise.all([
-        api.getNetworkGroupInfo(),
-        api.listApplications(),
-        api.listAddons(),
-      ]);
+      const [memberList, resources] = await Promise.all([api.getNetworkGroupInfo(), api.listResources()]);
 
       // Get IDs of members already in the network group
       const memberIds = new Set(memberList.map((member) => member.id));
 
-      // Build select options for apps and addons not already members
-      /** @param {Array<{ id: string, name: string, displayId: string }>} resources */
-      const toSelectOptions = (resources) =>
-        resources
-          .filter((resource) => !memberIds.has(resource.id))
-          .map((resource) => ({ label: `${resource.name} (${resource.displayId})`, value: resource.id }));
-
       /** @type {Array<Option>} */
-      const selectOptions = [...toSelectOptions(applications), ...toSelectOptions(addons)];
+      const selectOptions = resources
+        .filter((resource) => !memberIds.has(resource.id))
+        .map((resource) => ({
+          label: `${resource.name} (${resource.id})`,
+          value: resource.id,
+        }));
 
       updateComponent('memberListState', {
         type: 'loaded',
@@ -259,34 +254,27 @@ class Api {
   }
 
   /**
-   * Lists all addons for the owner.
-   * @returns {Promise<Array<{ id: string, name: string, displayId: string }>>}
+   * Lists all applications and addons for the owner that can be linked to a network group.
+   * @returns {Promise<Array<{ id: string, name: string }>>}
    */
-  async listAddons() {
-    const addons = await this.#ccApiClient.send(new ListAddonCommand({ ownerId: this.#ownerId }), {
-      signal: this.#signal,
-    });
-    return addons.map((addon) => ({
-      id: addon.id,
-      name: addon.name,
-      displayId: addon.realId,
-    }));
-  }
-
-  /**
-   * Lists all applications for the owner.
-   * @returns {Promise<Array<{ id: string, name: string, displayId: string }>>}
-   */
-  async listApplications() {
-    const applications = await this.#ccApiClient.send(
-      new ListApplicationCommand({ ownerId: this.#ownerId, withBranches: false }),
-      { signal: this.#signal },
-    );
-    return applications.map((app) => ({
-      id: app.id,
-      name: app.name,
-      displayId: app.id,
-    }));
+  async listResources() {
+    const [apps, addons] = await Promise.all([
+      this.#ccApiClient.send(new ListApplicationCommand({ ownerId: this.#ownerId, withBranches: false }), {
+        signal: this.#signal,
+      }),
+      this.#ccApiClient.send(new ListAddonCommand({ ownerId: this.#ownerId }), { signal: this.#signal }),
+    ]);
+    const supportedAddons = addons.filter((addon) => isNetworkGroupAddonCandidate(addon));
+    return [
+      ...apps.map((app) => ({
+        id: app.id,
+        name: app.name,
+      })),
+      ...supportedAddons.map((addon) => ({
+        id: addon.realId,
+        name: addon.name,
+      })),
+    ];
   }
 
   /**


### PR DESCRIPTION
## What does this PR do?

- Network Groups are not supported for all add-on providers (although the API lets you set them up for any add-on provider, they don't do anything for Matomo, Otoroshi, Metabase, Keycloak, Cellar, FSBucket, Jenkins, etc.).
- `dev` plans also should not support Network Groups,
- This means we need to filter out irrelevant resources from our select in the UI,
- Ideally, we would rely on the API to get the list of supported providers or resources but it's not possible at the moment so we need a temporary solution: we rely on the client to provide this temporary solution with helpers that filter out the list.
- Note that we also still expose underlying resources from operators (apps, add-ons) because it could make sense for some users to add a NG to one of those (in order to communicate with them through an external peer).

## How to review?

- Check the commit,
- Play with the component in `demo-smart`, you should only see relevant add-ons (`'es-addon', 'mongodb-addon', 'mysql-addon', 'postgresql-addon', 'redis-addon'`),
- 1 reviewer should be enough for this one.