### PR TITLE
Visual tests : fix stories order and move to prod CDN

### DIFF
--- a/src/components/cc-visual-tests-report-menu/cc-visual-tests-report-menu.js
+++ b/src/components/cc-visual-tests-report-menu/cc-visual-tests-report-menu.js
@@ -73,9 +73,14 @@ export class CcVisualTestsReportMenu extends LitElement {
         return componentCompare;
       }
 
-      const storyCompare = a.storyName.localeCompare(b.storyName);
-      if (storyCompare !== 0) {
-        return storyCompare;
+      if (a.storyName !== b.storyName) {
+        if (a.storyName === 'defaultStory') {
+          return -1;
+        }
+        if (b.storyName === 'defaultStory') {
+          return 1;
+        }
+        return a.storyName.localeCompare(b.storyName);
       }
 
       if (a.viewportType !== b.viewportType) {

--- a/tasks/visual-tests/generate-visual-tests-html-report.js
+++ b/tasks/visual-tests/generate-visual-tests-html-report.js
@@ -18,10 +18,12 @@ const html = `
     <head>
       <meta charset="UTF-8" />
       <title>PR ${visualTestsFinalReport.prNumber} - Visual tests Report</title>
-      <link rel="stylesheet" href="https://components.clever-cloud.com/styles.css" />
+      <!-- Pinning to a specific version to avoid dealing with breaking changes, if you update the report components, then you need to bump this version -->
+      <link rel="stylesheet" href="https://components.clever-cloud.com/styles.css?version=25.1.0" />
+      <!-- Pinning to a specific version to avoid dealing with breaking changes, if you update the report components, then you need to bump this version -->
       <script
         type="module"
-        src="https://preview-components.clever-cloud.com/load.js?version=tests-visual-changes&lang=en&components=cc-visual-tests-report"
+        src="https://components.clever-cloud.com/load.js?version=25.1.0&lang=en&components=cc-visual-tests-report"
       ></script>
       <style>
         html, body {


### PR DESCRIPTION
## What does this PR do?

- Fixes the visual tests report menu to always display the `defaultStory` stories first,
- Makes the report rely on the prod CDN instead of the preview now that components for the report are available in prod (components were part of the PR that initially added the report so we had to rely on the preview at first).

## How to review?

- Check the commits,
- 1 reviewer should be enough.