### PR TITLE
fix(cc-addon-info): remove border-top when first section is after billing slot

### DIFF
--- a/src/components/cc-addon-info/cc-addon-info.js
+++ b/src/components/cc-addon-info/cc-addon-info.js
@@ -561,6 +561,17 @@ export class CcAddonInfo extends LitElement {
           border-top: solid 1px var(--cc-color-border-neutral-weak);
         }
 
+        /*
+         * .section--billing is always in the DOM but hidden via display:none when nothing is slotted.
+         * When it happens to be the first child, :not(:first-child) on the next section still matches
+         * (because billing is structurally the first child, even if invisible), producing an unwanted
+         * top border on what is visually the first visible section.
+         * This rule cancels that border for billing's immediate sibling in that specific case.
+         */
+        .section--billing:not([billing-is-slotted]):first-child + .section {
+          border-top: none;
+        }
+
         .section.section--billing:not([billing-is-slotted]) {
           display: none;
         }


### PR DESCRIPTION
## What does this do?

This fixes this case:
<img width="1304" height="530" alt="image" src="https://github.com/user-attachments/assets/ad509c2d-f149-4c77-b014-0cda5500dac8" />

When the `description` is not set, the following section (`subnet` in the screenshot above) gets a top border even though it's the first visible section.

This is because it's not the first child within the DOM, there's the `.section--billing` first, that is just hidden with `display: none` and still counts as first child.

## Possible solutions

- Move the `subnet` and network group related sections above the `.section--billing` section but it would mean we'd have to be really careful in the future to avoid making the same mistake,
- Use a specific selector: when the first child is `.section--billing` and it's not slotted => cancel the top border of the following section.

I went for the CSS selector solution because I think it's more robust but feel free to challenge if you don't agree.

## How to review?

- In the `Network Group` story, remove the description using the storybook UI,
- Visual tests should ensure I didn't break other existing cases :+1: ,
- 1 reviewer should be enough for this one, preferably @HeleneAmouzou.