### PR TITLE
feat(cc-network-group-list): show notice if add-on plan is dev

### DIFF
--- a/demo-smart/index.html
+++ b/demo-smart/index.html
@@ -967,6 +967,16 @@
                   <span class="ctx-subtitle">ownerId, networkGroupId</span>
                 </button>
               </div>
+              <div class="ctx-group">
+                <button
+                  class="ctx-btn"
+                  title="ownerId, networkGroupId"
+                  data-context='{"ownerId":"orga_3547a882-d464-4c34-8168-add4b3e0c135","networkGroupId":"ng_b8711640-f593-437f-bae1-5b5e52d0fcc1","resourceId":"addon_50bfc371-d5b7-46b5-920b-2796a2ee9660","networkGroupDashboardUrlPattern":"/organisations/orga_3547a882-d464-4c34-8168-add4b3e0c135/network-groups/:id","appOverviewUrlPattern":"/organisations/orga_3547a882-d464-4c34-8168-add4b3e0c135/applications/:id","addonDashboardUrlPattern":"/organisations/orga_3547a882-d464-4c34-8168-add4b3e0c135/addons/:id","networkGroupCreationUrl":"/network-groups/new","addonMigrationScreenUrl":"/organisations/orga_3547a882-d464-4c34-8168-add4b3e0c135/addons/postgresql/addon_50bfc371-d5b7-46b5-920b-2796a2ee9660/migrations"}'
+                >
+                  <span class="ctx-label">Network Group (add-on with dev plan)</span>
+                  <span class="ctx-subtitle">ownerId, networkGroupId</span>
+                </button>
+              </div>
             </div>
 
             <!-- OAuth -->

--- a/src/components/cc-network-group-list/cc-network-group-list.js
+++ b/src/components/cc-network-group-list/cc-network-group-list.js
@@ -25,7 +25,7 @@ import '../cc-select/cc-select.js';
 import { CcNetworkGroupLinkEvent, CcNetworkGroupUnlinkEvent } from './cc-network-group-list.events.js';
 
 /**
- * @import { NetworkGroupListState, NetworkGroupLinkFormState, NetworkGroup } from './cc-network-group-list.types.js'
+ * @import { NetworkGroupListState, NetworkGroup } from './cc-network-group-list.types.js'
  * @import { Ref } from 'lit/directives/ref.js'
  * @import { Option } from '../cc-select/cc-select.types.js'
  * @import { CcLink } from '../cc-link/cc-link.js'
@@ -47,9 +47,9 @@ import { CcNetworkGroupLinkEvent, CcNetworkGroupUnlinkEvent } from './cc-network
 export class CcNetworkGroupList extends LitElement {
   static get properties() {
     return {
-      linkFormState: { type: Object, attribute: 'link-form-state' },
-      listState: { type: Object, attribute: 'list-state' },
       resourceId: { type: String, attribute: 'resource-id' },
+      state: { type: Object },
+      _isUnlinkDialogOpen: { type: Boolean, state: true },
       _networkGroupIdToUnlink: { type: String, state: true },
     };
   }
@@ -57,11 +57,8 @@ export class CcNetworkGroupList extends LitElement {
   constructor() {
     super();
 
-    /** @type {NetworkGroupLinkFormState} Sets the state of the form */
-    this.linkFormState = { type: 'loading' };
-
-    /** @type {NetworkGroupListState} Sets the state of the list */
-    this.listState = { type: 'loading' };
+    /** @type {NetworkGroupListState} Sets the state of the component */
+    this.state = { type: 'loading' };
 
     /** @type {string} Sets the resource ID for CLI command documentation */
     this.resourceId = '<RESOURCE_ID>';
@@ -74,6 +71,9 @@ export class CcNetworkGroupList extends LitElement {
 
     /** @type {Ref<HTMLElement>} */
     this._emptyListRef = createRef();
+
+    /** @type {boolean} */
+    this._isUnlinkDialogOpen = false;
 
     new LostFocusController(this, '.unlink-btn', ({ suggestedElement }) => {
       if (suggestedElement == null) {
@@ -92,6 +92,18 @@ export class CcNetworkGroupList extends LitElement {
     });
   }
 
+  /**
+   * @param {NetworkGroupListState} state
+   * @returns {Option[]}
+   **/
+  _getSelectOptions(state) {
+    if (state.type !== 'loaded' || state.linkFormState.type === 'empty') {
+      return [];
+    }
+
+    return state.linkFormState.selectOptions;
+  }
+
   /** @param {{ 'network-group': string }} formData */
   _onLink(formData) {
     this.dispatchEvent(new CcNetworkGroupLinkEvent(formData['network-group']));
@@ -99,11 +111,12 @@ export class CcNetworkGroupList extends LitElement {
 
   /** @param {string} networkGroupId */
   _onUnlinkRequest(networkGroupId) {
+    this._isUnlinkDialogOpen = true;
     this._networkGroupIdToUnlink = networkGroupId;
   }
 
   _onDialogClose() {
-    this._networkGroupIdToUnlink = null;
+    this._isUnlinkDialogOpen = false;
   }
 
   _onDialogConfirm() {
@@ -114,50 +127,62 @@ export class CcNetworkGroupList extends LitElement {
 
   /** @param {PropertyValues<CcNetworkGroupList>} changedProperties */
   willUpdate(changedProperties) {
-    if (changedProperties.has('listState')) {
-      const previousListState = changedProperties.get('listState');
-      const wasUnlinking = previousListState?.type === 'unlinking';
-      const isNotUnlinking = this.listState.type !== 'unlinking';
+    if (changedProperties.has('state')) {
+      const previousState = changedProperties.get('state');
+      const wasUnlinking = previousState?.type === 'loaded' && previousState?.listState?.type === 'unlinking';
+      const isNotUnlinking = this.state.type !== 'loaded' || this.state.listState.type !== 'unlinking';
       if (wasUnlinking && isNotUnlinking) {
+        this._isUnlinkDialogOpen = false;
         this._networkGroupIdToUnlink = null;
       }
     }
   }
 
   render() {
-    const isUnlinking = this.listState.type === 'unlinking';
+    if (this.state.type === 'unsupported') {
+      return html`
+        <cc-notice intent="info" heading="${i18n('cc-network-group-list.unsupported-notice.heading')}">
+          <div slot="message">
+            ${i18n('cc-network-group-list.unsupported-notice.message', {
+              addonMigrationScreenUrl: this.state.addonMigrationScreenUrl,
+            })}
+          </div>
+        </cc-notice>
+      `;
+    }
 
-    const selectOptions =
-      this.linkFormState.type === 'idle' || this.linkFormState.type === 'linking'
-        ? this.linkFormState.selectOptions
-        : [];
+    const isLoading = this.state.type === 'loading';
+    const isError = this.state.type === 'error';
+    const isLoaded = this.state.type === 'loaded';
+    const linkFormState = this.state.type === 'loaded' ? this.state.linkFormState : null;
+    const listState = this.state.type === 'loaded' ? this.state.listState : null;
+    const isUnlinking = isLoaded && listState.type === 'unlinking';
+    const selectOptions = this._getSelectOptions(this.state);
 
     return html`
       <cc-block>
         <div slot="header-title">${i18n('cc-network-group-list.form.heading')}</div>
         <div slot="content">
           <p class="intro">${i18n('cc-network-group-list.form.description')}</p>
-          ${this.linkFormState.type === 'error'
+          ${isError
             ? html`<cc-notice intent="warning" message="${i18n('cc-network-group-list.form.error')}"></cc-notice>`
             : ''}
-          ${this.linkFormState.type === 'empty'
+          ${isLoaded && linkFormState.type === 'empty'
             ? html`<cc-link
                 class="link-create-network-group"
                 mode="button"
-                href="${this.linkFormState.networkGroupDashboardUrl}"
+                href="${linkFormState.networkGroupDashboardUrl}"
                 ${ref(this._createNetworkGroupLinkRef)}
               >
                 ${i18n('cc-network-group-list.create')}
               </cc-link>`
             : ''}
-          ${this.linkFormState.type === 'idle' ||
-          this.linkFormState.type === 'loading' ||
-          this.linkFormState.type === 'linking'
+          ${isLoading || (isLoaded && (linkFormState.type === 'idle' || linkFormState.type === 'linking'))
             ? this._renderNetworkGroupLinkForm({
                 selectOptions,
-                isLoading: this.linkFormState.type === 'loading',
-                isLinking: this.linkFormState.type === 'linking',
-                isDisabled: this.listState.type === 'unlinking',
+                isLoading,
+                isLinking: isLoaded && linkFormState.type === 'linking',
+                isDisabled: isLoaded && listState.type === 'unlinking',
               })
             : ''}
         </div>
@@ -202,12 +227,12 @@ export class CcNetworkGroupList extends LitElement {
       <cc-block>
         <div slot="header-title">${i18n('cc-network-group-list.list.heading')}</div>
         <div slot="content">
-          ${this.listState.type === 'error'
+          ${isError
             ? html`<cc-notice intent="warning" message="${i18n('cc-network-group-list.list.error')}"></cc-notice>`
             : ''}
-          ${this.listState.type === 'loading' ? html`<cc-loader></cc-loader>` : ''}
-          ${this.listState.type === 'loaded' || this.listState.type === 'unlinking'
-            ? this._renderNetworkGroupList(this.listState.linkedNetworkGroupList, isUnlinking)
+          ${isLoading ? html`<cc-loader></cc-loader>` : ''}
+          ${isLoaded && (listState.type === 'loaded' || listState.type === 'unlinking')
+            ? this._renderNetworkGroupList(listState.linkedNetworkGroupList, isUnlinking)
             : ''}
         </div>
         <div slot="footer-right">
@@ -217,7 +242,7 @@ export class CcNetworkGroupList extends LitElement {
         </div>
       </cc-block>
 
-      ${this._renderUnlinkDialog(this._networkGroupIdToUnlink, isUnlinking)}
+      ${this._renderUnlinkDialog(this._isUnlinkDialogOpen, isUnlinking)}
     `;
   }
 
@@ -312,7 +337,8 @@ export class CcNetworkGroupList extends LitElement {
                   class="unlink-btn"
                   danger
                   outlined
-                  ?waiting="${isUnlinking}"
+                  ?disabled="${isUnlinking && this._networkGroupIdToUnlink !== networkGroup.id}"
+                  ?waiting="${isUnlinking && this._networkGroupIdToUnlink === networkGroup.id}"
                   a11y-name="${i18n('cc-network-group-list.list.unlink.a11y-name', { name: networkGroup.name })}"
                   @cc-click="${() => this._onUnlinkRequest(networkGroup.id)}"
                 >
@@ -327,13 +353,13 @@ export class CcNetworkGroupList extends LitElement {
   }
 
   /**
-   * @param {string|null} networkGroupIdToUnlink
+   * @param {boolean} isOpen
    * @param {boolean} isUnlinking
    */
-  _renderUnlinkDialog(networkGroupIdToUnlink, isUnlinking) {
+  _renderUnlinkDialog(isOpen, isUnlinking) {
     return html`
       <cc-dialog
-        ?open="${networkGroupIdToUnlink != null}"
+        ?open="${isOpen}"
         heading="${i18n('cc-network-group-list.unlink.dialog.heading')}"
         @cc-close="${this._onDialogClose}"
       >

--- a/src/components/cc-network-group-list/cc-network-group-list.smart.js
+++ b/src/components/cc-network-group-list/cc-network-group-list.smart.js
@@ -1,6 +1,8 @@
+import { GetAddonCommand } from '@clevercloud/client/cc-api-commands/addon/get-addon-command.js';
 import { CreateNetworkGroupMemberCommand } from '@clevercloud/client/cc-api-commands/network-group/create-network-group-member-command.js';
 import { DeleteNetworkGroupMemberCommand } from '@clevercloud/client/cc-api-commands/network-group/delete-network-group-member-command.js';
 import { ListNetworkGroupCommand } from '@clevercloud/client/cc-api-commands/network-group/list-network-group-command.js';
+import { ONE_DAY } from '@clevercloud/client/esm/with-cache.js';
 import { getCcApiClientWithOAuth } from '../../lib/cc-api-client.js';
 import { notify, notifyError, notifySuccess } from '../../lib/notifications.js';
 import { defineSmartComponent } from '../../lib/smart/define-smart-component.js';
@@ -9,9 +11,20 @@ import '../cc-smart-container/cc-smart-container.js';
 import './cc-network-group-list.js';
 
 /**
+ * @typedef Context
+ * @property {ApiConfig} apiConfig
+ * @property {string} resourceId
+ * @property {string} ownerId
+ * @property {string} networkGroupDashboardUrlPattern
+ * @property {string} networkGroupCreationUrl
+ * @property {string} [addonMigrationScreenUrl]
+ */
+
+/**
  * @import { OnContextUpdateArgs } from '../../lib/smart/smart-component.types.js';
  * @import { CcNetworkGroupList } from './cc-network-group-list.js';
  * @import { ApiConfig } from '../../lib/send-to-api.types.js';
+ * @import { NetworkGroupListStateLoaded } from './cc-network-group-list.types.js';
  */
 
 defineSmartComponent({
@@ -22,45 +35,66 @@ defineSmartComponent({
     ownerId: { type: String },
     networkGroupDashboardUrlPattern: { type: String },
     networkGroupCreationUrl: { type: String },
+    addonMigrationScreenUrl: { type: String, optional: true },
   },
   /** @param {OnContextUpdateArgs<CcNetworkGroupList>} _ */
-  onContextUpdate({ context, updateComponent, onEvent, signal }) {
-    const { apiConfig, resourceId, ownerId, networkGroupDashboardUrlPattern, networkGroupCreationUrl } =
-      /** @type {{ apiConfig: ApiConfig, resourceId: string, ownerId: string, networkGroupDashboardUrlPattern: string, networkGroupCreationUrl: string }} */ (
-        context
-      );
-    updateComponent('linkFormState', { type: 'loading' });
-    updateComponent('listState', { type: 'loading' });
+  async onContextUpdate({ context, updateComponent, onEvent, signal }) {
+    const {
+      apiConfig,
+      resourceId,
+      ownerId,
+      networkGroupDashboardUrlPattern,
+      networkGroupCreationUrl,
+      addonMigrationScreenUrl,
+    } = /** @type {Context} */ context;
+    updateComponent('state', { type: 'loading' });
     updateComponent('resourceId', resourceId);
 
     const ccApiClient = getCcApiClientWithOAuth(apiConfig);
+    let resolvedResourceId;
 
-    function refreshFormAndList() {
-      return ccApiClient.send(new ListNetworkGroupCommand({ ownerId }), { signal }).then((networkGroupList) => {
-        const unlinkedNetworkGroups = networkGroupList.filter(
-          (ng) => !ng.members.some((member) => member.id === resourceId),
-        );
+    async function resolveResource() {
+      if (!resourceId.startsWith('addon_')) {
+        return { resolvedResourceId: resourceId, isSupported: true };
+      }
+      const addon = await ccApiClient.send(new GetAddonCommand({ ownerId, addonId: resourceId }), {
+        signal,
+        cache: { ttl: ONE_DAY },
+      });
+      return {
+        resolvedResourceId: addon.realId,
+        isSupported: addon.plan.slug !== 'dev',
+      };
+    }
 
-        const linkedNetworkGroups = networkGroupList.filter((ng) =>
-          ng.members.some((member) => member.id === resourceId),
-        );
+    /** @param {string} resolvedResourceId */
+    async function refreshFormAndList(resolvedResourceId) {
+      const networkGroupList = await ccApiClient.send(new ListNetworkGroupCommand({ ownerId }), { signal });
 
-        if (unlinkedNetworkGroups.length === 0) {
-          updateComponent('linkFormState', {
-            type: 'empty',
-            networkGroupDashboardUrl: networkGroupCreationUrl,
-          });
-        } else {
-          updateComponent('linkFormState', {
-            type: 'idle',
-            selectOptions: unlinkedNetworkGroups.map((networkGroup) => ({
-              label: networkGroup.label,
-              value: networkGroup.id,
-            })),
-          });
-        }
+      const unlinkedNetworkGroups = networkGroupList.filter(
+        (ng) => !ng.members.some((member) => member.id === resolvedResourceId),
+      );
 
-        updateComponent('listState', {
+      const linkedNetworkGroups = networkGroupList.filter((ng) =>
+        ng.members.some((member) => member.id === resolvedResourceId),
+      );
+
+      updateComponent('state', {
+        type: 'loaded',
+        linkFormState:
+          unlinkedNetworkGroups.length === 0
+            ? {
+                type: 'empty',
+                networkGroupDashboardUrl: networkGroupCreationUrl,
+              }
+            : {
+                type: 'idle',
+                selectOptions: unlinkedNetworkGroups.map((networkGroup) => ({
+                  label: networkGroup.label,
+                  value: networkGroup.id,
+                })),
+              },
+        listState: {
           type: 'loaded',
           linkedNetworkGroupList: linkedNetworkGroups.map((networkGroup) => ({
             id: networkGroup.id,
@@ -74,27 +108,40 @@ defineSmartComponent({
               type: peer.type,
             })),
           })),
-        });
+        },
       });
     }
 
-    refreshFormAndList().catch((error) => {
+    try {
+      const resource = await resolveResource();
+      resolvedResourceId = resource.resolvedResourceId;
+      if (!resource.isSupported) {
+        updateComponent('state', {
+          type: 'unsupported',
+          addonMigrationScreenUrl,
+        });
+        return;
+      }
+      await refreshFormAndList(resolvedResourceId);
+    } catch (error) {
       console.error(error);
-      updateComponent('linkFormState', { type: 'error' });
-      updateComponent('listState', { type: 'error' });
-    });
+      updateComponent('state', { type: 'error' });
+      return;
+    }
 
     onEvent('cc-network-group-link', async (networkGroupId) => {
-      updateComponent('linkFormState', (linkFormState) => {
-        linkFormState.type = 'linking';
+      updateComponent('state', (state) => {
+        /** @type {NetworkGroupListStateLoaded} */ (state).linkFormState.type = 'linking';
       });
 
       try {
-        await ccApiClient.send(new CreateNetworkGroupMemberCommand({ ownerId, memberId: resourceId, networkGroupId }));
+        await ccApiClient.send(
+          new CreateNetworkGroupMemberCommand({ ownerId, memberId: resolvedResourceId, networkGroupId }),
+        );
       } catch (error) {
         console.error(error);
-        updateComponent('linkFormState', (state) => {
-          state.type = 'idle';
+        updateComponent('state', (state) => {
+          /** @type {NetworkGroupListStateLoaded} */ (state).linkFormState.type = 'idle';
         });
         notifyError(i18n('cc-network-group-list.link.error'));
         return;
@@ -103,11 +150,11 @@ defineSmartComponent({
       notifySuccess(i18n('cc-network-group-list.link.success'));
 
       try {
-        await refreshFormAndList();
+        await refreshFormAndList(resolvedResourceId);
       } catch (refreshError) {
         console.error(refreshError);
-        updateComponent('linkFormState', (state) => {
-          state.type = 'idle';
+        updateComponent('state', (state) => {
+          /** @type {NetworkGroupListStateLoaded} */ (state).linkFormState.type = 'idle';
         });
         notify({
           message: i18n('cc-network-group-list.refresh.error'),
@@ -118,18 +165,18 @@ defineSmartComponent({
     });
 
     onEvent('cc-network-group-unlink', async (networkGroupId) => {
-      updateComponent('listState', (listState) => {
-        listState.type = 'unlinking';
+      updateComponent('state', (state) => {
+        /** @type {NetworkGroupListStateLoaded} */ (state).listState.type = 'unlinking';
       });
 
       try {
-        await ccApiClient.send(new DeleteNetworkGroupMemberCommand({ memberId: resourceId, networkGroupId, ownerId }), {
-          signal,
-        });
+        await ccApiClient.send(
+          new DeleteNetworkGroupMemberCommand({ memberId: resolvedResourceId, networkGroupId, ownerId }),
+        );
       } catch (error) {
         console.error(error);
-        updateComponent('listState', (state) => {
-          state.type = 'loaded';
+        updateComponent('state', (state) => {
+          /** @type {NetworkGroupListStateLoaded} */ (state).listState.type = 'loaded';
         });
         notifyError(i18n('cc-network-group-list.unlink.error'));
         return;
@@ -138,11 +185,11 @@ defineSmartComponent({
       notifySuccess(i18n('cc-network-group-list.unlink.success'));
 
       try {
-        await refreshFormAndList();
+        await refreshFormAndList(resolvedResourceId);
       } catch (refreshError) {
         console.error(refreshError);
-        updateComponent('listState', (state) => {
-          state.type = 'loaded';
+        updateComponent('state', (state) => {
+          /** @type {NetworkGroupListStateLoaded} */ (state).listState.type = 'loaded';
         });
         notify({
           message: i18n('cc-network-group-list.refresh.error'),

--- a/src/components/cc-network-group-list/cc-network-group-list.smart.md
+++ b/src/components/cc-network-group-list/cc-network-group-list.smart.md
@@ -15,13 +15,14 @@ title: '💡 Smart'
 
 ## ⚙️ Params
 
-| Name                              | Type        | Details                                                                                                              | Default |
-| --------------------------------- | ----------- | -------------------------------------------------------------------------------------------------------------------- | ------- |
-| `apiConfig`                       | `ApiConfig` | Object with API configuration (target host, tokens...)                                                               |         |
-| `ownerId`                         | `String`    | UUID prefixed with <code>user_</code> or <code>orga_</code>                                                          |         |
-| `resourceId`                      | `String`    | UUID of the resource (application or addon) to link/unlink from network groups                                       |         |
-| `networkGroupDashboardUrlPattern` | `String`    | URL pattern for network group dashboard links. Use <code>:id</code> as placeholder for the network group ID         |         |
-| `networkGroupCreationUrl`         | `String`    | URL to redirect users to when there are no network groups available to link (e.g. a page to create a new one)       |         |
+| Name                              | Type        | Required | Details                                                                                                                                                                                                     | Default |
+| --------------------------------- | ----------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `apiConfig`                       | `ApiConfig` | Yes      | Object with API configuration (target host, tokens...)                                                                                                                                                      |         |
+| `ownerId`                         | `String`    | Yes      | UUID prefixed with <code>user_</code> or <code>orga_</code>                                                                                                                                                 |         |
+| `resourceId`                      | `String`    | Yes      | UUID of the resource (application or addon) to link/unlink from network groups. If prefixed with <code>addon_</code>, the addon is resolved and checked for plan support (dev plan addons are unsupported). |         |
+| `networkGroupDashboardUrlPattern` | `String`    | Yes      | URL pattern for network group dashboard links. Use <code>:id</code> as placeholder for the network group ID                                                                                                 |         |
+| `networkGroupCreationUrl`         | `String`    | Yes      | URL to redirect users to when there are no network groups available to link (e.g. a page to create a new one)                                                                                               |         |
+| `addonMigrationScreenUrl`         | `String`    | No       | URL of the migration screen shown when the resource is an unsupported addon (dev plan)                                                                                                                      |         |
 
 ```typescript
 interface ApiConfig {
@@ -37,6 +38,7 @@ interface ApiConfig {
 
 | Method   | URL                                                                                           | Cache?  |
 | -------- | --------------------------------------------------------------------------------------------- | ------- |
+| `GET`    | `/v2/organisations/{ownerId}/addons/{addonId}`                                                | 1 day   |
 | `GET`    | `/v4/networkgroups/organisations/{ownerId}/networkgroups`                                     | Default |
 | `POST`   | `/v4/networkgroups/organisations/{ownerId}/networkgroups/{networkGroupId}/members`            | N/A     |
 | `DELETE` | `/v4/networkgroups/organisations/{ownerId}/networkgroups/{networkGroupId}/members/{memberId}` | N/A     |
@@ -55,7 +57,8 @@ interface ApiConfig {
   "ownerId": "",
   "resourceId": "",
   "networkGroupDashboardUrlPattern": "/organisations/:ownerId/network-groups/:id",
-  "networkGroupCreationUrl": "/network-groups/new"
+  "networkGroupCreationUrl": "/network-groups/new",
+  "addonMigrationScreenUrl": ""
 }'>
   <cc-network-group-list></cc-network-group-list>
 </cc-smart-container>

--- a/src/components/cc-network-group-list/cc-network-group-list.stories.js
+++ b/src/components/cc-network-group-list/cc-network-group-list.stories.js
@@ -10,6 +10,7 @@ export default {
 
 /**
  * @import { CcNetworkGroupList } from './cc-network-group-list.js'
+ * @import { NetworkGroupListStateLoaded } from './cc-network-group-list.types.js';
  */
 
 const RESOURCE_ID = 'app_XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX';
@@ -23,13 +24,16 @@ export const defaultStory = makeStory(conf, {
   items: [
     {
       resourceId: RESOURCE_ID,
-      linkFormState: {
-        type: 'idle',
-        selectOptions: networkGroupSelectOptions,
-      },
-      listState: {
+      state: {
         type: 'loaded',
-        linkedNetworkGroupList,
+        linkFormState: {
+          type: 'idle',
+          selectOptions: networkGroupSelectOptions,
+        },
+        listState: {
+          type: 'loaded',
+          linkedNetworkGroupList,
+        },
       },
     },
   ],
@@ -40,13 +44,16 @@ export const dataLoadedWithEmpty = makeStory(conf, {
   items: [
     {
       resourceId: RESOURCE_ID,
-      linkFormState: {
-        type: 'idle',
-        selectOptions: networkGroupSelectOptions,
-      },
-      listState: {
+      state: {
         type: 'loaded',
-        linkedNetworkGroupList: [],
+        linkFormState: {
+          type: 'idle',
+          selectOptions: networkGroupSelectOptions,
+        },
+        listState: {
+          type: 'loaded',
+          linkedNetworkGroupList: [],
+        },
       },
     },
   ],
@@ -57,13 +64,16 @@ export const dataLoadedWithNoNetworkGroupToLink = makeStory(conf, {
   items: [
     {
       resourceId: RESOURCE_ID,
-      linkFormState: {
-        type: 'empty',
-        networkGroupDashboardUrl: '/network-groups/new',
-      },
-      listState: {
+      state: {
         type: 'loaded',
-        linkedNetworkGroupList: [],
+        linkFormState: {
+          type: 'empty',
+          networkGroupDashboardUrl: '/network-groups/new',
+        },
+        listState: {
+          type: 'loaded',
+          linkedNetworkGroupList: [],
+        },
       },
     },
   ],
@@ -74,8 +84,7 @@ export const loading = makeStory(conf, {
   items: [
     {
       resourceId: RESOURCE_ID,
-      linkFormState: { type: 'loading' },
-      listState: { type: 'loading' },
+      state: { type: 'loading' },
     },
   ],
 });
@@ -85,8 +94,20 @@ export const error = makeStory(conf, {
   items: [
     {
       resourceId: RESOURCE_ID,
-      linkFormState: { type: 'error' },
-      listState: { type: 'error' },
+      state: { type: 'error' },
+    },
+  ],
+});
+
+export const unsupported = makeStory(conf, {
+  /** @type {Partial<CcNetworkGroupList>[]} */
+  items: [
+    {
+      resourceId: RESOURCE_ID,
+      state: {
+        type: 'unsupported',
+        addonMigrationScreenUrl: '/addons/migrate',
+      },
     },
   ],
 });
@@ -96,13 +117,16 @@ export const waitingWithLinking = makeStory(conf, {
   items: [
     {
       resourceId: RESOURCE_ID,
-      linkFormState: {
-        type: 'linking',
-        selectOptions: networkGroupSelectOptions,
-      },
-      listState: {
+      state: {
         type: 'loaded',
-        linkedNetworkGroupList,
+        linkFormState: {
+          type: 'linking',
+          selectOptions: networkGroupSelectOptions,
+        },
+        listState: {
+          type: 'loaded',
+          linkedNetworkGroupList,
+        },
       },
     },
   ],
@@ -113,14 +137,29 @@ export const waitingWithUnlinking = makeStory(conf, {
   items: [
     {
       resourceId: RESOURCE_ID,
-      linkFormState: {
-        type: 'idle',
-        selectOptions: networkGroupSelectOptions,
-      },
-      listState: {
-        type: 'unlinking',
-        linkedNetworkGroupList,
+      state: {
+        type: 'loaded',
+        linkFormState: {
+          type: 'idle',
+          selectOptions: networkGroupSelectOptions,
+        },
+        listState: {
+          type: 'loaded',
+          linkedNetworkGroupList,
+        },
       },
     },
   ],
+  /** @param {CcNetworkGroupList & { state: NetworkGroupListStateLoaded }} component */
+  onUpdateComplete(component) {
+    const ccButton = component.shadowRoot.querySelector('cc-button.unlink-btn');
+    ccButton.shadowRoot.querySelector('button').click();
+    component.state = /** @type {NetworkGroupListStateLoaded} */ {
+      ...component.state,
+      listState: {
+        ...component.state.listState,
+        type: 'unlinking',
+      },
+    };
+  },
 });

--- a/src/components/cc-network-group-list/cc-network-group-list.types.d.ts
+++ b/src/components/cc-network-group-list/cc-network-group-list.types.d.ts
@@ -1,51 +1,11 @@
 import { NetworkGroupPeer } from '../cc-network-group-peer-card/cc-network-group-peer-card.types.js';
 import { Option } from '../cc-select/cc-select.types.js';
 
-export type NetworkGroupLinkFormState =
-  | NetworkGroupLinkFormStateIdle
-  | NetworkGroupLinkFormStateLoading
-  | NetworkGroupLinkFormStateLinking
-  | NetworkGroupLinkFormStateEmpty
-  | NetworkGroupLinkFormStateError;
-
-export interface NetworkGroupLinkFormStateIdle {
-  type: 'idle';
-  selectOptions: Option[];
-}
-
-export interface NetworkGroupLinkFormStateLoading {
-  type: 'loading';
-}
-
-export interface NetworkGroupLinkFormStateLinking {
-  type: 'linking';
-  selectOptions: Option[];
-}
-
-export interface NetworkGroupLinkFormStateError {
-  type: 'error';
-}
-
-export interface NetworkGroupLinkFormStateEmpty {
-  type: 'empty';
-  networkGroupDashboardUrl: string;
-}
-
 export type NetworkGroupListState =
-  | NetworkGroupListStateLoaded
-  | NetworkGroupListStateUnlinking
   | NetworkGroupListStateLoading
-  | NetworkGroupListStateError;
-
-export interface NetworkGroupListStateLoaded {
-  type: 'loaded';
-  linkedNetworkGroupList: NetworkGroup[];
-}
-
-export interface NetworkGroupListStateUnlinking {
-  type: 'unlinking';
-  linkedNetworkGroupList: NetworkGroup[];
-}
+  | NetworkGroupListStateError
+  | NetworkGroupListStateUnsupported
+  | NetworkGroupListStateLoaded;
 
 export interface NetworkGroupListStateLoading {
   type: 'loading';
@@ -53,6 +13,49 @@ export interface NetworkGroupListStateLoading {
 
 export interface NetworkGroupListStateError {
   type: 'error';
+}
+
+export interface NetworkGroupListStateUnsupported {
+  type: 'unsupported';
+  addonMigrationScreenUrl: string;
+}
+
+export interface NetworkGroupListStateLoaded {
+  type: 'loaded';
+  linkFormState: NetworkGroupLinkFormState;
+  listState: NetworkGroupLinkedListState;
+}
+
+export type NetworkGroupLinkFormState =
+  | NetworkGroupLinkFormStateIdle
+  | NetworkGroupLinkFormStateLinking
+  | NetworkGroupLinkFormStateEmpty;
+
+export interface NetworkGroupLinkFormStateIdle {
+  type: 'idle';
+  selectOptions: Option[];
+}
+
+export interface NetworkGroupLinkFormStateLinking {
+  type: 'linking';
+  selectOptions: Option[];
+}
+
+export interface NetworkGroupLinkFormStateEmpty {
+  type: 'empty';
+  networkGroupDashboardUrl: string;
+}
+
+export type NetworkGroupLinkedListState = NetworkGroupLinkedListStateLoaded | NetworkGroupLinkedListStateUnlinking;
+
+export interface NetworkGroupLinkedListStateLoaded {
+  type: 'loaded';
+  linkedNetworkGroupList: NetworkGroup[];
+}
+
+export interface NetworkGroupLinkedListStateUnlinking {
+  type: 'unlinking';
+  linkedNetworkGroupList: NetworkGroup[];
 }
 
 export interface NetworkGroup {

--- a/src/lib/cc-api-client.js
+++ b/src/lib/cc-api-client.js
@@ -1,5 +1,12 @@
 import { CcApiClient } from '@clevercloud/client/cc-api-client.js';
+// FIXME: the import-x/resovler plugin needs to be configured to use `browser` export condition
+// eslint-disable-next-line import-x/no-unresolved
+import { LocalStorageStore } from '@clevercloud/client/cc-api-local-storage-store.js';
 import { CcApiErrorEvent } from './send-to-api.events.js';
+
+/**
+ * @typedef {Omit<ConstructorParameters<typeof CcApiClient>[0], 'hooks'>} CcApiClientConfigWithoutHooks
+ */
 
 /** @import { ApiConfig, ApiTokenConfig } from './send-to-api.types.js' */
 
@@ -99,6 +106,7 @@ export function getCcApiClientWithToken(apiTokenConfig) {
         },
         baseUrl: apiTokenConfig.API_HOST,
         defaultRequestConfig: { cors: true },
+        resourceIdResolverStore: new LocalStorageStore(`cc-client-cache-${cacheKey}`),
       }),
     );
   }
@@ -109,7 +117,7 @@ export function getCcApiClientWithToken(apiTokenConfig) {
 /**
  * Create a CcApiClient with an onError hook that dispatches CcApiErrorEvent.
  *
- * @param {object} config - CcApiClient configuration
+ * @param {CcApiClientConfigWithoutHooks} config - CcApiClient configuration
  * @returns {CcApiClient}
  */
 function createClient(config) {

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -1399,6 +1399,11 @@ export const translations = {
   'cc-network-group-list.unlink.dialog.unlink-btn': `Confirm and unlink`,
   'cc-network-group-list.unlink.error': `Something went wrong while unlinking the Network Group`,
   'cc-network-group-list.unlink.success': `The Network Group has been unlinked successfully`,
+  'cc-network-group-list.unsupported-notice.heading': `Migrate to paid plan`,
+  'cc-network-group-list.unsupported-notice.message': /** @param {{addonMigrationScreenUrl: string}} _ */ ({
+    addonMigrationScreenUrl,
+  }) =>
+    sanitize`Add-ons on a dev plan do not support Network Groups. <cc-link href="${addonMigrationScreenUrl}">Migrate to a paid plan</cc-link> to use this feature.`,
   //#endregion
   //#region cc-network-group-member-card
   'cc-network-group-member-card.deleted-member.badge': `Resource deleted`,

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -1410,6 +1410,11 @@ export const translations = {
   'cc-network-group-list.unlink.dialog.unlink-btn': `Confirmer et dissocier`,
   'cc-network-group-list.unlink.error': `Une erreur est survenue pendant la dissociation du Network Group`,
   'cc-network-group-list.unlink.success': `La dissociation du Network Group a bien été effectuée`,
+  'cc-network-group-list.unsupported-notice.heading': `Migrez vers un plan payant`,
+  'cc-network-group-list.unsupported-notice.message': /** @param {{addonMigrationScreenUrl: string}} _ */ ({
+    addonMigrationScreenUrl,
+  }) =>
+    sanitize`Les Network Groups ne sont pas disponibles pour les add-ons avec un plan dev. <cc-link href="${addonMigrationScreenUrl}">Migrez vers un plan payant</cc-link> pour profiter de cette fonctionnalité.`,
   //#endregion
   //#region cc-network-group-member-card
   'cc-network-group-member-card.deleted-member.badge': `Ressource supprimée`,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,7 @@
     /* Modules */
     "module": "nodenext" /* Specify what module code is generated. */,
     "moduleDetection": "force" /* Make TypeScript treat every file as a module even if it does not have any imports or export (see https://www.totaltypescript.com/cannot-redeclare-block-scoped-variable) */,
+    "customConditions": ["browser"],
     /* JavaScript Support */
     "allowJs": true /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */,
     "checkJs": true /* Enable error reporting in type-checked JavaScript files. */,

--- a/web-test-runner.config.js
+++ b/web-test-runner.config.js
@@ -22,7 +22,7 @@ export default {
     return logMessage != null && !logsToExclude.includes(logMessage);
   },
   nodeResolve: {
-    exportConditions: ['production', 'default'],
+    exportConditions: ['production', 'default', 'browser'],
   },
   browsers: [
     chromeLauncher({


### PR DESCRIPTION
## What does this PR do?

- For add-ons on a dev plan, Network Groups are unsupported so we show a notice inviting people to migrate to a paid plan.
- Why don't we show specific notice for other "unsupported" add-ons (operators, materia, etc.) ?
  - the console won't show the Network Groups tab for such add-ons,
  - If users reach the route by entering the URL manually:
    -  worst case scenario it doesn't break stuff it's just useless to add a Network Group to such resources,
    -  the API should not allow any interaction (right now it might, but should be fixed someday).

## How to review?

- Check the new story,
- Check `demo-smart` with the `Network Group (add-on with dev plan)` context button,
- 1 reviewer should be enough for this one.