### PR TITLE
ci(manage-visual-tests): prevent reporting if no components are impacted

### DIFF
--- a/.github/workflows/manage-visual-tests.yml
+++ b/.github/workflows/manage-visual-tests.yml
@@ -210,7 +210,7 @@ jobs:
           LAST_ACTUAL_UPDATE: ${{ needs.run-visual-tests.outputs.last-actual-update-utc }}
 
       - name: '[Run] Generate HTML report'
-        if: ${{ steps.merge-results-and-generate-report.outputs.nb-of-impacted-components }} > 0
+        if: steps.merge-results-and-generate-report.outputs.nb-of-impacted-components > 0
         run: node ./tasks/visual-tests/generate-visual-tests-html-report.js
 
       # Expected outputs:


### PR DESCRIPTION
## What does this PR do?

- To check if visual test report needs to be generated, we checked if the number of impacted components was > than 0.
- The issue is that in GitHub actions, action output is always a string, and GitHub does automatic coercion but only if it sees that you're trying to compare a string with a number,
- Since we were using interpolation outside the comparison, GitHub was not coercing the string value and the result was always truthy, as explained in the warning we got in the logs:  

> .github/workflows/manage-visual-tests.yml (Line: 213, Col: 13): Conditional expression contains literal text outside replacement tokens.  This will cause the expression to always evaluate to truthy.  Did you mean to put the entire expression inside ${{ }}?

## How to review?

- Check the code,
- Let the CI do its job,
- This PR can be automerged (no impact on prod, no security considerations, and the CI will validate the bug is gone by itself).