### PR TITLE
refactor(cc-cellar-explorer): drop cellarProxyUrl smart context property

### DIFF
--- a/sandbox/cc-cellar-explorer/cc-cellar-explorer-sandbox.js
+++ b/sandbox/cc-cellar-explorer/cc-cellar-explorer-sandbox.js
@@ -37,7 +37,6 @@ class CcCellarExplorerSandbox extends LitElement {
 
   render() {
     const context = {
-      cellarProxyUrl: 'http://localhost:8082',
       ownerId: 'orga_540caeb6-521c-4a19-a955-efe6da35d142',
       addonId: this._addonId,
     };

--- a/src/components/cc-cellar-explorer/cc-cellar-explorer.smart.js
+++ b/src/components/cc-cellar-explorer/cc-cellar-explorer.smart.js
@@ -23,7 +23,6 @@ defineSmartComponent({
   selector: 'cc-cellar-explorer-beta',
   params: {
     apiConfig: { type: Object },
-    cellarProxyUrl: { type: String },
     ownerId: { type: String },
     addonId: { type: String },
   },

--- a/src/components/cc-cellar-explorer/cc-cellar-explorer.smart.md
+++ b/src/components/cc-cellar-explorer/cc-cellar-explorer.smart.md
@@ -17,7 +17,6 @@ title: '💡 Smart'
 | Name              | Type        | Details                                  | Default |
 |-------------------|-------------|------------------------------------------|---------|
 | `apiConfig`       | `ApiConfig` | Object with API configuration            |         |
-| `cellarProxyUrl`  | `String`    | URL of the Cellar proxy backend          |         |
 | `ownerId`         | `String`    | ID of the owner (organization or user)   |         |
 | `addonId`         | `String`    | ID of the Cellar addon                   |         |
 
@@ -34,20 +33,19 @@ interface ApiConfig {
 
 ## 🌐 API endpoints
 
-### Clever Cloud API
+| Method   | URL                                                                                                               | Cache?  |
+|----------|-------------------------------------------------------------------------------------------------------------------|---------|
+| `GET`    | `/v2/organisations/{ownerId}/addons/{addonId}`                                                                    | Default |
+| `GET`    | `/v4/cellar/organisations/{ownerId}/cellar/{realAddonId}/buckets`                                                 | Default |
+| `POST`   | `/v4/cellar/organisations/{ownerId}/cellar/{realAddonId}/buckets`                                                 | Default |
+| `GET`    | `/v4/cellar/organisations/{ownerId}/cellar/{realAddonId}/buckets/{bucketName}`                                    | Default |
+| `DELETE` | `/v4/cellar/organisations/{ownerId}/cellar/{realAddonId}/buckets/{bucketName}`                                    | Default |
+| `GET`    | `/v4/cellar/organisations/{ownerId}/cellar/{realAddonId}/buckets/{bucketName}/objects`                            | Default |
+| `GET`    | `/v4/cellar/organisations/{ownerId}/cellar/{realAddonId}/buckets/{bucketName}/objects/{objectKey}`                | Default |
+| `DELETE` | `/v4/cellar/organisations/{ownerId}/cellar/{realAddonId}/buckets/{bucketName}/objects/{objectKey}`                | Default |
+| `POST`   | `/v4/cellar/organisations/{ownerId}/cellar/{realAddonId}/buckets/{bucketName}/objects/download-url`               | Default |
+| `POST`   | `/v4/cellar/organisations/{ownerId}/cellar/{realAddonId}/buckets/{bucketName}/objects/{objectName}/presigned-url` | Default |
 
-| Method | URL                                                | Cache?  |
-|--------|----------------------------------------------------|---------|
-| `GET`  | `/v2/organisations/{ownerId}/addons/{addonId}/env` | Default |
-
-### Cellar Proxy API (via `cellarProxyUrl`)
-
-| Method | URL                      | Cache?  |
-|--------|--------------------------|---------|
-| `POST` | `/cellar/bucket/_list`   | Default |
-| `POST` | `/cellar/bucket/_create` | Default |
-| `POST` | `/cellar/bucket/_get`    | Default |
-| `POST` | `/cellar/bucket/_delete` | Default |
 
 ## ⬇️️ Examples
 
@@ -60,7 +58,6 @@ interface ApiConfig {
     "OAUTH_CONSUMER_KEY": "...",
     "OAUTH_CONSUMER_SECRET": "..."
   },
-  "cellarProxyUrl": "https://file-explorer-proxy.services.clever-cloud.com",
   "ownerId": "orga_...",
   "addonId": "addon_..."
 }'>


### PR DESCRIPTION
## Context

`cc-cellar-explorer` originally talked to a separate Cellar proxy backend (`cellarProxyUrl`) for
bucket and object operations. Those operations are now exposed directly on the Clever Cloud v4
cellar API, so the proxy URL is dead weight in the smart context — every consumer would have to
pass a value that no code path actually reads.

## Changes

- Remove `cellarProxyUrl` from the smart component's context definition.
- Drop the corresponding entry from the sandbox harness so it stops advertising a parameter that
  is no longer wired up.
- Refresh `cc-cellar-explorer.smart.md` to describe the v4 cellar endpoints actually used and
  remove the "Cellar Proxy API" section.

## How to review

1. Start with `src/components/cc-cellar-explorer/cc-cellar-explorer.smart.js` — the context shape
   change is the load-bearing edit.
2. Cross-check `cc-cellar-explorer.smart.md` against the endpoints the component actually calls
   to confirm the documented table is accurate.
3. Run the sandbox (`cc-cellar-explorer`) locally to verify bucket/object listing still works
   without the proxy URL.