### PR TITLE
chore: bump `@clevercloud/client` to `12.3.1`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "25.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@clevercloud/client": "^12.3.0",
+        "@clevercloud/client": "^12.3.1",
         "@lit-labs/motion": "^1.0.7",
         "@lit-labs/virtualizer": "^2.0.14",
         "@shoelace-style/shoelace": "^2.18.0",
@@ -1965,9 +1965,9 @@
       "dev": true
     },
     "node_modules/@clevercloud/client": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@clevercloud/client/-/client-12.3.0.tgz",
-      "integrity": "sha512-V4PcfXnZiC9oHKrBVb9RLrNcnS92SHBkPaQgQEe8gDtkDqTpDFVcvpoagiED9ODIWdKcs/vTMk5MqEwwWlH/vA==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@clevercloud/client/-/client-12.3.1.tgz",
+      "integrity": "sha512-ahc/otEB/Cg81+qrLbx5NC+Q+W6YCrGEIShFrVtzfsy47tQu8dXj8kGHHi0KsmzUgPqzgbORVh5yU+dkSuwf/g==",
       "license": "Apache-2.0",
       "dependencies": {
         "component-emitter": "^1.3.0",
@@ -21929,9 +21929,9 @@
       "dev": true
     },
     "@clevercloud/client": {
-      "version": "12.3.0",
-      "resolved": "https://registry.npmjs.org/@clevercloud/client/-/client-12.3.0.tgz",
-      "integrity": "sha512-V4PcfXnZiC9oHKrBVb9RLrNcnS92SHBkPaQgQEe8gDtkDqTpDFVcvpoagiED9ODIWdKcs/vTMk5MqEwwWlH/vA==",
+      "version": "12.3.1",
+      "resolved": "https://registry.npmjs.org/@clevercloud/client/-/client-12.3.1.tgz",
+      "integrity": "sha512-ahc/otEB/Cg81+qrLbx5NC+Q+W6YCrGEIShFrVtzfsy47tQu8dXj8kGHHi0KsmzUgPqzgbORVh5yU+dkSuwf/g==",
       "requires": {
         "component-emitter": "^1.3.0",
         "fetch-event-stream": "^0.1.6"

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "typecheck:stats": "node tasks/typechecking-stats.js"
   },
   "dependencies": {
-    "@clevercloud/client": "^12.3.0",
+    "@clevercloud/client": "^12.3.1",
     "@lit-labs/motion": "^1.0.7",
     "@lit-labs/virtualizer": "^2.0.14",
     "@shoelace-style/shoelace": "^2.18.0",


### PR DESCRIPTION
## What does this PR do?

Network Group screens fail to load if the user has at least one  ftp application. This is fixed in the latest version of `@clevercloud/client`

## How to review?

- No reviews necessary