### PR TITLE
ci(browserslist-db): automate monthly update

### DIFF
--- a/.github/actions/pr-creation/action.yml
+++ b/.github/actions/pr-creation/action.yml
@@ -1,0 +1,50 @@
+name: Pull request creation
+
+inputs:
+  ci-token:
+    description: 'GitHub PAT used to push the branch and open the PR (so that downstream workflows are triggered).'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: '[Configure] git profile'
+      shell: bash
+      run: |
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+    - name: '[Versioning] Create branch'
+      id: branch
+      shell: bash
+      run: |
+        BRANCH_NAME=chore/update-browserslist-db-$(date -u +%Y-%m)
+        git checkout -b "$BRANCH_NAME"
+        echo "name=$BRANCH_NAME" >> "$GITHUB_OUTPUT"
+    - name: '[Versioning] Add'
+      shell: bash
+      run: git add package-lock.json
+    - name: '[Versioning] Commit'
+      shell: bash
+      run: |
+        git commit -m "chore(deps): update browserslist-db"
+    - name: '[Versioning] Push'
+      shell: bash
+      run: git push --set-upstream origin HEAD
+    - name: '[Versioning] Create PR'
+      id: create-pr
+      shell: bash
+      run: node ./.github/scripts/manage-pull-request.js create
+      env:
+        GITHUB_TOKEN: ${{ inputs.ci-token }}
+        TITLE: 'chore(deps): update browserslist-db'
+        HEAD: ${{ steps.branch.outputs.name }}
+        BASE: master
+        BODY: |
+          Automated monthly update of browserslist-db (`npx update-browserslist-db@latest`).
+    - name: '[Versioning] Assign reviewers'
+      shell: bash
+      run: node ./.github/scripts/manage-pull-request.js assign-reviewers
+      env:
+        GITHUB_TOKEN: ${{ inputs.ci-token }}
+        PR_NUMBER: ${{ steps.create-pr.outputs.pr_number }}

--- a/.github/reviewers.json
+++ b/.github/reviewers.json
@@ -1,0 +1,1 @@
+["hsablonniere", "Galimede", "florian-sanders-cc", "roberttran-cc", "pdesoyres-cc", "HeleneAmouzou", "clara-layus-cc"]

--- a/.github/scripts/manage-comment.js
+++ b/.github/scripts/manage-comment.js
@@ -1,5 +1,6 @@
 import { Octokit } from '@octokit/rest';
 import { readFile } from 'node:fs/promises';
+import { validateEnv } from './validate-env.js';
 
 /**
  * @typedef {import('@octokit/rest').RestEndpointMethodTypes} RestEndpointMethodTypes
@@ -218,10 +219,10 @@ Variable descriptions:
    * @type {Record<typeof ACTIONS[number], string[]>}
    */
   #actionConfig = {
-    create: ['GITHUB_TOKEN', 'GITHUB_REPOSITORY', 'PR_NUMBER', 'MESSAGE_OR_FILE'],
-    edit: ['GITHUB_TOKEN', 'GITHUB_REPOSITORY', 'PR_NUMBER', 'MARKER', 'MESSAGE_OR_FILE'],
+    create: ['GITHUB_TOKEN', 'GITHUB_REPOSITORY', 'PR_NUMBER'],
+    edit: ['GITHUB_TOKEN', 'GITHUB_REPOSITORY', 'PR_NUMBER', 'MARKER'],
     delete: ['GITHUB_TOKEN', 'GITHUB_REPOSITORY', 'PR_NUMBER', 'MARKER'],
-    'create-or-edit': ['GITHUB_TOKEN', 'GITHUB_REPOSITORY', 'PR_NUMBER', 'MARKER', 'MESSAGE_OR_FILE'],
+    'create-or-edit': ['GITHUB_TOKEN', 'GITHUB_REPOSITORY', 'PR_NUMBER', 'MARKER'],
   };
 
   /**
@@ -230,19 +231,11 @@ Variable descriptions:
    * @returns {string[]} Array of validation errors
    */
   #validateEnvironment(action) {
-    const errors = [];
     const requiredEnvVars = this.#actionConfig[action];
-
-    // Validate required environment variables
-    for (const envVar of requiredEnvVars) {
-      if (envVar === 'MESSAGE_OR_FILE') {
-        // Special case: either MESSAGE or MESSAGE_FILE_PATH is required
-        if (!process.env.MESSAGE && !process.env.MESSAGE_FILE_PATH) {
-          errors.push('MESSAGE or MESSAGE_FILE_PATH is required for this action');
-        }
-      } else if (!process.env[envVar]) {
-        errors.push(`${envVar} is required`);
-      }
+    const errors = validateEnv(requiredEnvVars);
+    // Special case: either MESSAGE or MESSAGE_FILE_PATH is required
+    if (action !== 'delete' && !process.env.MESSAGE && !process.env.MESSAGE_FILE_PATH) {
+      errors.push('MESSAGE or MESSAGE_FILE_PATH is required for this action');
     }
 
     return errors;

--- a/.github/scripts/manage-pull-request.js
+++ b/.github/scripts/manage-pull-request.js
@@ -1,0 +1,313 @@
+import { Octokit } from '@octokit/rest';
+import { appendFile, readFile } from 'node:fs/promises';
+
+/**
+ * @typedef {import('@octokit/rest').RestEndpointMethodTypes} RestEndpointMethodTypes
+ */
+
+const ACTIONS = /** @type {const} */ (['create', 'assign-reviewers']);
+
+/**
+ * GitHub Client for creating pull requests
+ */
+class GithubPullRequestClient {
+  /**
+   * @param {string} token - GitHub API token
+   */
+  constructor(token) {
+    this.octokit = new Octokit({ auth: token });
+  }
+
+  /**
+   * Create a new pull request
+   * @param {string} owner - Repository owner
+   * @param {string} repo - Repository name
+   * @param {string} title - Pull request title
+   * @param {string} head - Source branch
+   * @param {string} base - Target branch
+   * @param {string} [body] - Pull request body (optional)
+   * @returns {Promise<RestEndpointMethodTypes["pulls"]["create"]["response"]["data"]>}
+   */
+  async createPullRequest(owner, repo, title, head, base, body) {
+    try {
+      const response = await this.octokit.rest.pulls.create({
+        owner,
+        repo,
+        title,
+        head,
+        base,
+        body,
+      });
+      console.log(`✓ Created PR #${response.data.number} at ${response.data.html_url}`);
+      return response.data;
+    } catch (err) {
+      console.error('✗ Error creating pull request:', err instanceof Error ? err.message : 'unknown');
+      process.exit(1);
+    }
+  }
+
+  /**
+   * Request reviews on a pull request
+   * @param {string} owner - Repository owner
+   * @param {string} repo - Repository name
+   * @param {number} prNumber - Pull request number
+   * @param {string[]} reviewers - GitHub handles to request reviews from
+   */
+  async assignReviewers(owner, repo, prNumber, reviewers) {
+    try {
+      const response = await this.octokit.rest.pulls.requestReviewers({
+        owner,
+        repo,
+        // eslint-disable-next-line camelcase
+        pull_number: prNumber,
+        reviewers,
+      });
+      console.log(`✓ Requested review from ${reviewers.join(', ')} on ${owner}/${repo}#${prNumber}`);
+      return response.data;
+    } catch (err) {
+      console.error('✗ Error requesting reviewers:', err instanceof Error ? err.message : 'unknown');
+      process.exit(1);
+    }
+  }
+}
+
+/**
+ * Command-line interface manager for GitHub pull request operations
+ */
+class PullRequestActionManager {
+  constructor() {
+    this.client = null;
+  }
+
+  /**
+   * @param {string} action
+   * @returns {action is typeof ACTIONS[number]}
+   */
+  isValidAction(action) {
+    return ACTIONS.includes(/** @type {typeof ACTIONS[number]} */ (action));
+  }
+
+  printUsage() {
+    console.log(`
+Usage: node manage-pull-request.js <action>
+
+Actions:
+  create            Create a new pull request
+  assign-reviewers  Request reviews on an existing pull request
+
+Environment variables by action:
+
+  create:
+    Required: GITHUB_TOKEN, GITHUB_REPOSITORY, TITLE, HEAD, BASE
+    Optional: BODY or BODY_FILE_PATH (PR body)
+
+  assign-reviewers:
+    Required: GITHUB_TOKEN, GITHUB_REPOSITORY, PR_NUMBER
+    Optional: REVIEWERS (comma-separated, overrides the file) or
+              REVIEWERS_FILE_PATH (JSON array of handles,
+              defaults to .github/reviewers.json)
+
+Variable descriptions:
+  GITHUB_TOKEN        GitHub API token
+  GITHUB_REPOSITORY   Repository in format owner/repo
+  TITLE               Pull request title
+  HEAD                Source branch (the branch with changes)
+  BASE                Target branch (where to merge into)
+  BODY                Pull request body as string
+  BODY_FILE_PATH      Path to file containing pull request body
+  PR_NUMBER           Pull request number
+  REVIEWERS           Comma-separated list of GitHub handles (overrides file)
+  REVIEWERS_FILE_PATH Path to a JSON file containing an array of handles
+`);
+  }
+
+  async getMessageBody() {
+    if (process.env.BODY_FILE_PATH) {
+      try {
+        return await readFile(process.env.BODY_FILE_PATH, { encoding: 'utf-8' });
+      } catch (error) {
+        console.error('✗ Error reading message file:', error instanceof Error ? error.message : 'unknown');
+        process.exit(1);
+      }
+    }
+    return process.env.BODY;
+  }
+
+  /**
+   * Resolve the list of reviewers.
+   * Priority: REVIEWERS env (comma-separated) overrides the JSON file.
+   * The file defaults to .github/reviewers.json and must contain a JSON array of handles.
+   * @returns {Promise<string[]>}
+   */
+  async getReviewers() {
+    if (process.env.REVIEWERS) {
+      return this.#parseReviewers(process.env.REVIEWERS);
+    }
+    const filePath = process.env.REVIEWERS_FILE_PATH ?? '.github/reviewers.json';
+    try {
+      const parsed = JSON.parse(await readFile(filePath, { encoding: 'utf-8' }));
+      if (!Array.isArray(parsed)) {
+        throw new Error(`${filePath} must contain a JSON array of GitHub handles`);
+      }
+      return parsed.map((handle) => String(handle).trim()).filter(Boolean);
+    } catch (error) {
+      console.error('✗ Error reading reviewers file:', error instanceof Error ? error.message : 'unknown');
+      process.exit(1);
+    }
+  }
+
+  /**
+   * Configuration mapping actions to their required environment variables
+   * @type {Record<typeof ACTIONS[number], string[]>}
+   */
+  #actionConfig = {
+    create: ['GITHUB_TOKEN', 'GITHUB_REPOSITORY', 'TITLE', 'HEAD', 'BASE'],
+    'assign-reviewers': ['GITHUB_TOKEN', 'GITHUB_REPOSITORY', 'PR_NUMBER'],
+  };
+
+  /**
+   * Validate environment variables for the given action
+   * @param {typeof ACTIONS[number]} action
+   * @returns {string[]} Array of validation errors
+   */
+  #validateEnvironment(action) {
+    const errors = [];
+    const requiredEnvVars = this.#actionConfig[action];
+
+    for (const envVar of requiredEnvVars) {
+      if (!process.env[envVar]) {
+        errors.push(`${envVar} is required`);
+      }
+    }
+
+    return errors;
+  }
+
+  /**
+   * @param {string} value
+   * @returns {string[]}
+   */
+  #parseReviewers(value) {
+    return value
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+  }
+
+  /**
+   * Retrieve and parse input values from environment variables
+   * @param {typeof ACTIONS[number]} action
+   */
+  async #getInputsFromEnvironment(action) {
+    const [owner, repo] = process.env.GITHUB_REPOSITORY.split('/');
+
+    if (action === 'create') {
+      const body = await this.getMessageBody();
+      return {
+        owner,
+        repo,
+        title: process.env.TITLE,
+        head: process.env.HEAD,
+        base: process.env.BASE,
+        body,
+      };
+    }
+
+    const reviewers = await this.getReviewers();
+    if (reviewers.length === 0) {
+      console.error('✗ No reviewers resolved (set the REVIEWERS env var or populate the reviewers file)');
+      process.exit(1);
+    }
+    return {
+      owner,
+      repo,
+      prNumber: Number(process.env.PR_NUMBER),
+      reviewers,
+    };
+  }
+
+  /** @param {typeof ACTIONS[number]} action */
+  async validateAndGetInputs(action) {
+    const errors = this.#validateEnvironment(action);
+
+    if (errors.length > 0) {
+      console.error('Environment validation errors:');
+      errors.forEach((error) => console.error(`  - ${error}`));
+      console.error('\nRun with no arguments to see usage information.');
+      process.exit(1);
+    }
+
+    return await this.#getInputsFromEnvironment(action);
+  }
+
+  /**
+   * Write key/value pairs to the GitHub Actions step output file, if available.
+   * @param {Record<string, string | number>} outputs
+   */
+  async #writeStepOutputs(outputs) {
+    if (!process.env.GITHUB_OUTPUT) {
+      return;
+    }
+    const lines = Object.entries(outputs)
+      .map(([key, value]) => `${key}=${value}\n`)
+      .join('');
+    try {
+      await appendFile(process.env.GITHUB_OUTPUT, lines);
+    } catch (err) {
+      console.error('✗ Error writing step outputs:', err instanceof Error ? err.message : 'unknown');
+      process.exit(1);
+    }
+  }
+
+  /** @param {typeof ACTIONS[number]} action */
+  async executeAction(action) {
+    const inputs = await this.validateAndGetInputs(action);
+    this.client = new GithubPullRequestClient(process.env.GITHUB_TOKEN);
+
+    switch (action) {
+      case 'create': {
+        const { owner, repo, title, head, base, body } = inputs;
+        const pr = await this.client.createPullRequest(owner, repo, title, head, base, body);
+        await this.#writeStepOutputs({
+          // eslint-disable-next-line camelcase
+          pr_number: pr.number,
+          // eslint-disable-next-line camelcase
+          pr_url: pr.html_url,
+        });
+        break;
+      }
+
+      case 'assign-reviewers': {
+        const { owner, repo, prNumber, reviewers } = inputs;
+        await this.client.assignReviewers(owner, repo, prNumber, reviewers);
+        break;
+      }
+    }
+  }
+}
+
+async function main() {
+  const action = process.argv[2];
+  const manager = new PullRequestActionManager();
+
+  if (!action) {
+    console.error('Error: No action specified');
+    manager.printUsage();
+    process.exit(1);
+  }
+
+  if (!manager.isValidAction(action)) {
+    console.error(`Error: Invalid action "${action}"`);
+    manager.printUsage();
+    process.exit(1);
+  }
+
+  try {
+    await manager.executeAction(action);
+  } catch (error) {
+    console.error('✗ Unexpected error:', error instanceof Error ? error.message : 'unknown');
+    process.exit(1);
+  }
+}
+
+main();

--- a/.github/scripts/manage-pull-request.js
+++ b/.github/scripts/manage-pull-request.js
@@ -1,8 +1,9 @@
 import { Octokit } from '@octokit/rest';
 import { appendFile, readFile } from 'node:fs/promises';
+import { validateEnv } from './validate-env.js';
 
 /**
- * @typedef {import('@octokit/rest').RestEndpointMethodTypes} RestEndpointMethodTypes
+ * @import { RestEndpointMethodTypes } from '@octokit/rest'
  */
 
 const ACTIONS = /** @type {const} */ (['create', 'assign-reviewers']);
@@ -171,16 +172,8 @@ Variable descriptions:
    * @returns {string[]} Array of validation errors
    */
   #validateEnvironment(action) {
-    const errors = [];
     const requiredEnvVars = this.#actionConfig[action];
-
-    for (const envVar of requiredEnvVars) {
-      if (!process.env[envVar]) {
-        errors.push(`${envVar} is required`);
-      }
-    }
-
-    return errors;
+    return validateEnv(requiredEnvVars);
   }
 
   /**

--- a/.github/scripts/validate-env.js
+++ b/.github/scripts/validate-env.js
@@ -1,0 +1,13 @@
+/**
+ * @param {string[]} variables Array of environment variables to check
+ * @returns {string[]} Array of errors
+ */
+export function validateEnv(variables) {
+  const errors = [];
+  for (const envVar of variables) {
+    if (!process.env[envVar]) {
+      errors.push(`${envVar} is required`);
+    }
+  }
+  return errors;
+}

--- a/.github/workflows/browserslist-database-update.yml
+++ b/.github/workflows/browserslist-database-update.yml
@@ -1,0 +1,65 @@
+name: Browserslist Database Update
+
+on:
+  schedule:
+    - cron: '0 0 1 * *'
+
+  workflow_dispatch:
+
+concurrency:
+  group: browserslist-db-update
+  cancel-in-progress: false
+
+jobs:
+  update-browserslist:
+    runs-on: ubuntu-latest
+    steps:
+      - name: '[Prepare] Checkout'
+        uses: actions/checkout@v5
+        with:
+          token: ${{ secrets.CI_TOKEN }}
+      - name: '[Prepare] Setup Node.js'
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: 'package.json'
+          cache: 'npm'
+      - name: '[Prepare] Install dependencies'
+        run: npm ci
+
+      - name: '[Update] browserslist database'
+        run: npx update-browserslist-db@latest
+
+      - name: '[Check] Detect package-lock.json changes'
+        id: check
+        run: |
+          if git diff --quiet -- package-lock.json; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: '[Check] No changes detected'
+        if: steps.check.outputs.has_changes == 'false'
+        run: echo "browserslist-db is already up to date"
+      - name: '[Check] Display detected changes'
+        if: steps.check.outputs.has_changes == 'true'
+        run: |
+          echo "Changes detected in package-lock.json:"
+          git diff --stat -- package-lock.json
+
+      - name: '[Check] Detect existing remote branch'
+        id: branch
+        if: steps.check.outputs.has_changes == 'true'
+        run: |
+          BRANCH_NAME=chore/update-browserslist-db-$(date -u +%Y-%m)
+          if git ls-remote --exit-code --heads origin "$BRANCH_NAME" >/dev/null 2>&1; then
+            echo "::notice::Remote branch $BRANCH_NAME already exists — skipping PR creation."
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: 'Create Pull Request'
+        if: steps.check.outputs.has_changes == 'true' && steps.branch.outputs.exists == 'false'
+        uses: ./.github/actions/pr-creation
+        with:
+          ci-token: ${{ secrets.CI_TOKEN }}


### PR DESCRIPTION
## What does this PR do?

Fixes #1655

- Introduces a new workflow to monthly update the browserslist database,
- Adds on `yml` file to describe the workflow,
- Adds a `manage-pull-request.js` script with `create` and `assign-reviewers` actions,
- Adds `reviewers.json` file with the list of reviewers to add to the PR.

## NOTES

### About the issue 

In the [issue](https://github.com/CleverCloud/clever-components/issues/1655) it was suggested to use a ready-made action (`peter-evans/create-pull-request`) to create a PR, but I have decided to match what we already did for managing comment and handle it without a third party action.

### Multiple uses of `if` condition

I have try several ways to refactor the workflow to simplify all the uses of `if` by grouping the steps together, but I decided to leave it as is because I thought it is more convenient to see all the steps in detail in case one of them doesn't work. Feel free to question/challenge this decision, maybe there is one way of doing I did not thought of.

### Reviewers

I decided to put all possible reviewers in a separate `json` file that could be updated when needed. Claude suggested another solution that would be to do a `reviewer team` on GitHub. I did not know which solution could be the best, I chose the `json` one because I thought it could be reused in another case on the repository.

### Test

To test the workflow, I have copy the `clever-components` repository on my account and started the action directly from GitHub and it all worked. The repo in private, but if needed I could pass it in public so reviewers could tested it. That does however require a few changes to the workflow file to adapt to the repository. 


## How to review?

- Check the commit.

2 or 3 reviewers should be enough.
