### PR TITLE
fix(cc-domain-management): include path prefix in delete and mark-as-primary buttons a11y-name

### DIFF
--- a/src/components/cc-domain-management/cc-domain-management.js
+++ b/src/components/cc-domain-management/cc-domain-management.js
@@ -669,7 +669,9 @@ export class CcDomainManagement extends LitElement {
                   outlined
                   ?disabled=${isMarkingPrimaryDisabled && domainItemStateType !== 'marking-primary'}
                   ?waiting="${domainItemStateType === 'marking-primary'}"
-                  a11y-name="${i18n('cc-domain-management.list.btn.primary.a11y-name', { domain: hostWithWildcard })}"
+                  a11y-name="${i18n('cc-domain-management.list.btn.primary.a11y-name', {
+                    domain: hostWithWildcard + pathPrefix,
+                  })}"
                   .icon=${iconPrimary}
                   hide-text
                   circle
@@ -685,7 +687,9 @@ export class CcDomainManagement extends LitElement {
             outlined
             ?disabled="${domainItemStateType === 'marking-primary'}"
             ?waiting="${domainItemStateType === 'deleting'}"
-            a11y-name="${i18n('cc-domain-management.list.btn.delete.a11y-name', { domain: hostWithWildcard })}"
+            a11y-name="${i18n('cc-domain-management.list.btn.delete.a11y-name', {
+              domain: hostWithWildcard + pathPrefix,
+            })}"
             .icon=${iconDelete}
             hide-text
             circle


### PR DESCRIPTION
#1621

# What does this PR do?
  
  - Includes the path prefix in the accessible name of the `delete` and `mark as primary` buttons in
  `cc-domain-management`.
  
# How to review?

  - Check the commit,
  - Check the [preview](https://clever-components-preview.cellar-c2.services.clever-cloud.com/fix/cc-domain-management/delete-btn-a11y-name/index.html?path=/story/%F0%9F%9B%A0-domains-cc-domain-management--default-story)
  - 1 reviewer should be enough.
