### PR TITLE
feat(cc-logs): add clear button with clear-and-continue overflow option

### DIFF
--- a/src/components/cc-logs-addon-runtime/cc-logs-addon-runtime.js
+++ b/src/components/cc-logs-addon-runtime/cc-logs-addon-runtime.js
@@ -152,6 +152,7 @@ export class CcLogsAddonRuntime extends LitElement {
       class="progress"
       .state=${state}
       limit=${this.limit}
+      clearable
     ></cc-logs-loading-progress-beta>`;
   }
 

--- a/src/components/cc-logs-addon-runtime/cc-logs-addon-runtime.smart.js
+++ b/src/components/cc-logs-addon-runtime/cc-logs-addon-runtime.smart.js
@@ -55,8 +55,19 @@ defineSmartComponent({
       controller.resume();
     });
 
+    onEvent('cc-logs-loading-clear', () => {
+      controller.clearLogs();
+      component.clear();
+    });
+
     onEvent('cc-logs-loading-overflow-accept', () => {
       controller.acceptOverflow();
+    });
+
+    onEvent('cc-logs-loading-overflow-clear-and-continue', () => {
+      controller.clearLogs();
+      controller.resume();
+      component.clear();
     });
 
     onEvent('cc-logs-loading-overflow-discard', () => {

--- a/src/components/cc-logs-app-access/cc-logs-app-access.js
+++ b/src/components/cc-logs-app-access/cc-logs-app-access.js
@@ -223,6 +223,7 @@ export class CcLogsAppAccess extends LitElement {
       class="progress"
       .state=${state}
       limit=${this.limit}
+      clearable
     ></cc-logs-loading-progress-beta>`;
   }
 

--- a/src/components/cc-logs-app-access/cc-logs-app-access.smart.js
+++ b/src/components/cc-logs-app-access/cc-logs-app-access.smart.js
@@ -55,8 +55,19 @@ defineSmartComponent({
       controller.resume();
     });
 
+    onEvent('cc-logs-loading-clear', () => {
+      controller.clearLogs();
+      component.clear();
+    });
+
     onEvent('cc-logs-loading-overflow-accept', () => {
       controller.acceptOverflow();
+    });
+
+    onEvent('cc-logs-loading-overflow-clear-and-continue', () => {
+      controller.clearLogs();
+      controller.resume();
+      component.clear();
     });
 
     onEvent('cc-logs-loading-overflow-discard', () => {

--- a/src/components/cc-logs-app-runtime/cc-logs-app-runtime.js
+++ b/src/components/cc-logs-app-runtime/cc-logs-app-runtime.js
@@ -219,6 +219,7 @@ export class CcLogsAppRuntime extends LitElement {
       class="progress"
       .state=${state}
       limit=${this.limit}
+      clearable
     ></cc-logs-loading-progress-beta>`;
   }
 

--- a/src/components/cc-logs-app-runtime/cc-logs-app-runtime.smart.js
+++ b/src/components/cc-logs-app-runtime/cc-logs-app-runtime.smart.js
@@ -70,8 +70,19 @@ defineSmartComponent({
       controller.resume();
     });
 
+    onEvent('cc-logs-loading-clear', () => {
+      controller.clearLogs();
+      component.clear();
+    });
+
     onEvent('cc-logs-loading-overflow-accept', () => {
       controller.acceptOverflow();
+    });
+
+    onEvent('cc-logs-loading-overflow-clear-and-continue', () => {
+      controller.clearLogs();
+      controller.resume();
+      component.clear();
     });
 
     onEvent('cc-logs-loading-overflow-discard', () => {

--- a/src/components/cc-logs-loading-progress/cc-logs-loading-progress.events.js
+++ b/src/components/cc-logs-loading-progress/cc-logs-loading-progress.events.js
@@ -47,3 +47,27 @@ export class CcLogsLoadingOverflowDiscardEvent extends CcEvent {
     super(CcLogsLoadingOverflowDiscardEvent.TYPE);
   }
 }
+
+/**
+ * Dispatched when clearing of the logs is requested.
+ * @extends {CcEvent}
+ */
+export class CcLogsLoadingClearEvent extends CcEvent {
+  static TYPE = 'cc-logs-loading-clear';
+
+  constructor() {
+    super(CcLogsLoadingClearEvent.TYPE);
+  }
+}
+
+/**
+ * Dispatched when clearing of the logs and continuing the overflow is requested.
+ * @extends {CcEvent}
+ */
+export class CcLogsLoadingOverflowClearAndContinueEvent extends CcEvent {
+  static TYPE = 'cc-logs-loading-overflow-clear-and-continue';
+
+  constructor() {
+    super(CcLogsLoadingOverflowClearAndContinueEvent.TYPE);
+  }
+}

--- a/src/components/cc-logs-loading-progress/cc-logs-loading-progress.js
+++ b/src/components/cc-logs-loading-progress/cc-logs-loading-progress.js
@@ -2,6 +2,7 @@ import { css, html, LitElement } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import {
   iconRemixInformationFill as iconInfo,
+  iconRemixEraserLine,
   iconRemixPauseLine,
   iconRemixPlayLine,
   iconRemixAlertFill as iconWarning,
@@ -10,7 +11,9 @@ import { i18n } from '../../translations/translation.js';
 import '../cc-button/cc-button.js';
 import '../cc-icon/cc-icon.js';
 import {
+  CcLogsLoadingClearEvent,
   CcLogsLoadingOverflowAcceptEvent,
+  CcLogsLoadingOverflowClearAndContinueEvent,
   CcLogsLoadingOverflowDiscardEvent,
   CcLogsLoadingPauseEvent,
   CcLogsLoadingResumeEvent,
@@ -28,6 +31,7 @@ import {
 export class CcLogsLoadingProgress extends LitElement {
   static get properties() {
     return {
+      clearable: { type: Boolean },
       limit: { type: Number },
       state: { type: Object },
     };
@@ -35,6 +39,9 @@ export class CcLogsLoadingProgress extends LitElement {
 
   constructor() {
     super();
+
+    /** @type {boolean} Whether to display the clear button. */
+    this.clearable = false;
 
     /** @type {LogsLoadingProgressState} The state of the component */
     this.state = {
@@ -79,6 +86,14 @@ export class CcLogsLoadingProgress extends LitElement {
     this.dispatchEvent(new CcLogsLoadingOverflowAcceptEvent());
   }
 
+  _onClear() {
+    this.dispatchEvent(new CcLogsLoadingClearEvent());
+  }
+
+  _onClearAndContinue() {
+    this.dispatchEvent(new CcLogsLoadingOverflowClearAndContinueEvent());
+  }
+
   _onDiscardOverflow() {
     this.dispatchEvent(new CcLogsLoadingOverflowDiscardEvent());
   }
@@ -100,7 +115,7 @@ export class CcLogsLoadingProgress extends LitElement {
     return html`
       <div class="wrapper ${classMap({ warning: shouldAskForOverflowDecision })}">
         <div class="content inline">
-          ${this._renderPlayPauseButton()}
+          ${this._renderPlayPauseButton()}${this._renderClearButton()}
           ${
             shouldAskForOverflowDecision
               ? html`
@@ -111,6 +126,9 @@ export class CcLogsLoadingProgress extends LitElement {
                       <div class="overflow-buttons">
                         <cc-button link @cc-click=${this._onAcceptOverflow}>
                           ${i18n('cc-logs-loading-progress.overflow.accept')}
+                        </cc-button>
+                        <cc-button link @cc-click=${this._onClearAndContinue}>
+                          ${i18n('cc-logs-loading-progress.overflow.clear-and-continue')}
                         </cc-button>
                         <cc-button link @cc-click=${this._onDiscardOverflow}>
                           ${i18n('cc-logs-loading-progress.overflow.discard')}
@@ -152,6 +170,21 @@ export class CcLogsLoadingProgress extends LitElement {
         }
       </div>
     </div>`;
+  }
+
+  _renderClearButton() {
+    if (!this.clearable) {
+      return null;
+    }
+
+    return html`
+      <cc-button
+        .icon=${iconRemixEraserLine}
+        hide-text
+        a11y-name=${i18n('cc-logs-loading-progress.control.clear')}
+        @cc-click=${this._onClear}
+      ></cc-button>
+    `;
   }
 
   _renderPlayPauseButton() {

--- a/src/components/cc-logs-loading-progress/cc-logs-loading-progress.stories.js
+++ b/src/components/cc-logs-loading-progress/cc-logs-loading-progress.stories.js
@@ -186,3 +186,74 @@ export const completedWithOverflowing = makeStory(conf, {
     },
   ],
 });
+
+export const withClearable = makeStory(conf, {
+  /** @type {Array<Partial<CcLogsLoadingProgress>>} */
+  items: [
+    {
+      clearable: true,
+      state: {
+        type: 'running',
+        value: 500,
+        percent: 5,
+        overflowing: false,
+      },
+      limit: 1000,
+    },
+    {
+      clearable: true,
+      state: {
+        type: 'running',
+        value: 500,
+        overflowing: false,
+      },
+      limit: 1000,
+    },
+    {
+      clearable: true,
+      state: {
+        type: 'paused',
+        value: 580,
+        percent: 5.8,
+        overflowing: false,
+      },
+      limit: 1000,
+    },
+    {
+      clearable: true,
+      state: {
+        type: 'paused',
+        value: 580,
+        overflowing: false,
+      },
+      limit: 1000,
+    },
+    {
+      clearable: true,
+      state: {
+        type: 'running',
+        value: 1500,
+        overflowing: true,
+      },
+      limit: 1000,
+    },
+    {
+      clearable: true,
+      state: {
+        type: 'overflowLimitReached',
+        value: 990,
+      },
+      limit: 1000,
+    },
+    {
+      clearable: true,
+      state: {
+        type: 'running',
+        value: 0,
+        percent: 0,
+        overflowing: false,
+      },
+      limit: 1000,
+    },
+  ],
+});

--- a/src/lib/events-map.types.d.ts
+++ b/src/lib/events-map.types.d.ts
@@ -114,7 +114,9 @@ import { CcLogsOptionsChangeEvent } from '../components/cc-logs-control/cc-logs-
 import { CcLogsDateRangeSelectionChangeEvent } from '../components/cc-logs-date-range-selector/cc-logs-date-range-selector.events.js';
 import { CcLogsInstancesSelectionChangeEvent } from '../components/cc-logs-instances/cc-logs-instances.events.js';
 import {
+  CcLogsLoadingClearEvent,
   CcLogsLoadingOverflowAcceptEvent,
+  CcLogsLoadingOverflowClearAndContinueEvent,
   CcLogsLoadingOverflowDiscardEvent,
   CcLogsLoadingPauseEvent,
   CcLogsLoadingResumeEvent,
@@ -310,7 +312,9 @@ declare global {
     'cc-logs-date-range-selection-change': CcLogsDateRangeSelectionChangeEvent;
     'cc-logs-follow-change': CcLogsFollowChangeEvent;
     'cc-logs-instances-selection-change': CcLogsInstancesSelectionChangeEvent;
+    'cc-logs-loading-clear': CcLogsLoadingClearEvent;
     'cc-logs-loading-overflow-accept': CcLogsLoadingOverflowAcceptEvent;
+    'cc-logs-loading-overflow-clear-and-continue': CcLogsLoadingOverflowClearAndContinueEvent;
     'cc-logs-loading-overflow-discard': CcLogsLoadingOverflowDiscardEvent;
     'cc-logs-loading-pause': CcLogsLoadingPauseEvent;
     'cc-logs-loading-resume': CcLogsLoadingResumeEvent;

--- a/src/lib/logs/logs-progress.js
+++ b/src/lib/logs/logs-progress.js
@@ -26,6 +26,16 @@ export class LogsProgress {
     this._overflowWasNotified = false;
   }
 
+  resetProgress() {
+    this._value = 0;
+    this._lastLogDate = null;
+    this._overflowWasNotified = false;
+    // live mode has no percent (unbounded time range)
+    if (!this._isLive) {
+      this._percent = 0;
+    }
+  }
+
   /**
    * @param {DateRange} dateRange
    */

--- a/src/lib/logs/logs-stream.js
+++ b/src/lib/logs/logs-stream.js
@@ -156,6 +156,33 @@ export class LogsStream {
   }
 
   /**
+   * Clears the logs and resets progress without stopping the stream.
+   * When paused (by user or overflow), the stream stays paused after clearing.
+   * This method has no effect if the current state is not `running` or `paused`.
+   */
+  clearLogs() {
+    if (this.#streamState.type !== 'running' && this.#streamState.type !== 'paused') {
+      return;
+    }
+
+    const wasPaused = this.#streamState.type === 'paused';
+
+    this.#logsBuffer.clear();
+    this.#progress.resetProgress();
+
+    if (wasPaused) {
+      this._updateStreamState({
+        type: 'paused',
+        reason: 'user',
+        progress: this.#progress.getProgress(),
+        overflowing: this.#progress.isOverflowing(),
+      });
+    } else {
+      this._updateStreamState(this.#buildRunningState());
+    }
+  }
+
+  /**
    * Discard overflow by stopping the stream.
    * This method has no effect if the current state is not paused with the `overflow` reason.
    */

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -1337,9 +1337,11 @@ export const translations = {
   'cc-logs-instances.stopping.header': `Stopping instances`,
   //#endregion
   //#region cc-logs-loading-progress
+  'cc-logs-loading-progress.control.clear': `Clear logs`,
   'cc-logs-loading-progress.control.pause': `Pause`,
   'cc-logs-loading-progress.control.resume': `Resume`,
   'cc-logs-loading-progress.overflow.accept': `Continue`,
+  'cc-logs-loading-progress.overflow.clear-and-continue': `Clear and continue`,
   'cc-logs-loading-progress.overflow.discard': `Stop`,
   'cc-logs-loading-progress.overflow.info': /** @param {{limit: number}} _ */ ({ limit }) =>
     `Only the last ${formatNumber(lang, limit)} logs are displayed`,

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -1348,9 +1348,11 @@ export const translations = {
   'cc-logs-instances.stopping.header': `Instances arrêtées`,
   //#endregion
   //#region cc-logs-loading-progress
+  'cc-logs-loading-progress.control.clear': `Effacer les logs`,
   'cc-logs-loading-progress.control.pause': `Mettre en pause`,
   'cc-logs-loading-progress.control.resume': `Reprendre`,
   'cc-logs-loading-progress.overflow.accept': `Continuer`,
+  'cc-logs-loading-progress.overflow.clear-and-continue': `Effacer et continuer`,
   'cc-logs-loading-progress.overflow.discard': `Arrêter`,
   'cc-logs-loading-progress.overflow.info': /** @param {{limit: number}} _ */ ({ limit }) =>
     `Seuls les ${formatNumber(lang, limit)} derniers logs sont affichés.`,

--- a/test/logs/logs-progress.test.js
+++ b/test/logs/logs-progress.test.js
@@ -179,6 +179,70 @@ describe('logs-progress', () => {
     });
   });
 
+  describe('resetProgress() method', () => {
+    it('should reset value to 0', () => {
+      const logsProgress = new LogsProgress(10);
+      logsProgress.start({ since: new Date().toISOString() });
+      logsProgress.progress(generateLogs(5));
+
+      logsProgress.resetProgress();
+
+      expect(logsProgress.getProgress().value).to.eq(0);
+    });
+
+    it('should reset lastLogDate to null', () => {
+      const logsProgress = new LogsProgress(10);
+      logsProgress.start({ since: new Date().toISOString() });
+      logsProgress.progress(generateLogs(5));
+
+      logsProgress.resetProgress();
+
+      expect(logsProgress.getLastLogDate()).to.eq(null);
+    });
+
+    it('should allow overflow watermark to trigger again', () => {
+      const logsProgress = new LogsProgress(10);
+      logsProgress.start({ since: new Date().toISOString() });
+      logsProgress.progress(generateLogs(10));
+
+      logsProgress.resetProgress();
+      const watermarkReached = logsProgress.progress(generateLogs(10));
+
+      expect(watermarkReached).to.eq(true);
+    });
+
+    it('should reset percent to 0 when not live', () => {
+      const now = new Date();
+      const logsProgress = new LogsProgress(10);
+      logsProgress.start({ since: now.toISOString(), until: date(now, 1000).toISOString() });
+      logsProgress.progress([{ date: date(now, 500) }]);
+
+      logsProgress.resetProgress();
+
+      expect(logsProgress.getProgress().percent).to.eq(0);
+    });
+
+    it('should not add percent when live', () => {
+      const logsProgress = new LogsProgress(10);
+      logsProgress.start({ since: new Date().toISOString() });
+      logsProgress.progress(generateLogs(5));
+
+      logsProgress.resetProgress();
+
+      expect(logsProgress.getProgress().percent).to.eq(undefined);
+    });
+
+    it('should mark progress as empty', () => {
+      const logsProgress = new LogsProgress(10);
+      logsProgress.start({ since: new Date().toISOString() });
+      logsProgress.progress(generateLogs(5));
+
+      logsProgress.resetProgress();
+
+      expect(logsProgress.isEmpty()).to.eq(true);
+    });
+  });
+
   describe('getProgress() method', () => {
     describe('with live range', () => {
       it('should have undefined percentage', () => {

--- a/test/logs/logs-stream.test.js
+++ b/test/logs/logs-stream.test.js
@@ -438,6 +438,110 @@ describe('logs-stream', () => {
     });
   });
 
+  describe('clearLogs() method', () => {
+    it('should reset progress and stay running when running', async () => {
+      const logsStream = new FakeLogsStream();
+      logsStream.openLogsStream({ since: new Date().toISOString() });
+      await fakeLogsReceived(logsStream, 5);
+      await sleep(BUFFER_TIMEOUT);
+      logsStream.resetSpies();
+
+      logsStream.clearLogs();
+
+      expect(logsStream.spies.updateStreamState.callCount).to.eql(1);
+      expect(logsStream.spies.updateStreamState.firstCall.args[0]).to.eql({
+        type: 'running',
+        progress: { value: 0 },
+        overflowing: false,
+      });
+    });
+
+    it('should reset progress and stay paused when paused by user', async () => {
+      const logsStream = new FakeLogsStream();
+      logsStream.openLogsStream({ since: new Date().toISOString() });
+      await fakeLogsReceived(logsStream, 5);
+      await sleep(BUFFER_TIMEOUT);
+      logsStream.pause();
+      logsStream.resetSpies();
+
+      logsStream.clearLogs();
+
+      expect(logsStream.spies.updateStreamState.callCount).to.eql(1);
+      expect(logsStream.spies.updateStreamState.firstCall.args[0]).to.eql({
+        type: 'paused',
+        reason: 'user',
+        progress: { value: 0 },
+        overflowing: false,
+      });
+    });
+
+    it('should not resume SSE when paused by user', async () => {
+      const logsStream = new FakeLogsStream();
+      logsStream.openLogsStream({ since: new Date().toISOString() });
+      await fakeLogsReceived(logsStream, 5);
+      await sleep(BUFFER_TIMEOUT);
+      logsStream.pause();
+      logsStream.resetSpies();
+
+      logsStream.clearLogs();
+
+      expect(logsStream.sseSpies.resume.callCount).to.eql(0);
+    });
+
+    it('should reset progress and stay paused when paused by overflow', async () => {
+      const logsStream = new FakeLogsStream();
+      logsStream.openLogsStream({ since: new Date().toISOString() });
+      await fakeLogsReceived(logsStream);
+      await fakeLogsReceived(logsStream, LIMIT);
+      await sleep(BUFFER_TIMEOUT);
+      logsStream.resetSpies();
+
+      logsStream.clearLogs();
+
+      expect(logsStream.spies.updateStreamState.callCount).to.eql(1);
+      expect(logsStream.spies.updateStreamState.firstCall.args[0]).to.eql({
+        type: 'paused',
+        reason: 'user',
+        progress: { value: 0 },
+        overflowing: false,
+      });
+    });
+
+    it('should not resume SSE when paused by overflow', async () => {
+      const logsStream = new FakeLogsStream();
+      logsStream.openLogsStream({ since: new Date().toISOString() });
+      await fakeLogsReceived(logsStream);
+      await fakeLogsReceived(logsStream, LIMIT);
+      await sleep(BUFFER_TIMEOUT);
+      logsStream.resetSpies();
+
+      logsStream.clearLogs();
+
+      expect(logsStream.sseSpies.resume.callCount).to.eql(0);
+    });
+
+    it('should do nothing when idle', () => {
+      const logsStream = new FakeLogsStream();
+      logsStream.resetSpies();
+
+      logsStream.clearLogs();
+
+      expect(logsStream.spies.updateStreamState.callCount).to.eql(0);
+    });
+
+    it('should do nothing when completed', async () => {
+      const logsStream = new FakeLogsStream();
+      logsStream.openLogsStream({ since: new Date().toISOString(), until: new Date().toISOString() });
+      await fakeLogsReceived(logsStream);
+      await logsStream.sseFakeApi.end();
+      logsStream.resetSpies();
+
+      logsStream.clearLogs();
+
+      expect(logsStream.spies.updateStreamState.callCount).to.eql(0);
+    });
+  });
+
   describe('when no logs is received since a long time', () => {
     it('should set waiting state if no logs was received at all', async () => {
       const logsStream = new FakeLogsStream(50);


### PR DESCRIPTION
Closes #1467

## Summary

- Add an opt-in `clearable` property to `cc-logs-loading-progress-beta` that renders an eraser icon button next to play/pause
- Wire the `cc-logs-loading-clear` event through all three smart controllers (`cc-logs-app-runtime`, `cc-logs-addon-runtime`, `cc-logs-app-access`)
- Add `clearLogs()` to `LogsStream` and `resetProgress()` to `LogsProgress` to clear displayed logs and reset counters without disconnecting the SSE stream
- The clear button is shown in all modes (live and cold logs)
- During an overflow pause, clearing does NOT resume the stream — a new "Clear and continue" option is available in the overflow dialog alongside "Continue" and "Stop"

## Behavior

| State | Clear action |
|---|---|
| Running | Reset progress to 0, clear buffer, clear display |
| Paused (user) | Reset progress to 0, clear buffer, clear display, stay paused |
| Paused (overflow) | Reset progress to 0, clear buffer, clear display, stay paused (transition to user pause) |
| Completed / Idle | No effect |

### Overflow dialog options

| Option | Action |
|---|---|
| Continue | Resume stream (existing) |
| Clear and continue | Clear logs + resume stream (new) |
| Stop | Discard overflow, stop stream (existing) |

## Review

- [`<cc-logs-loading-progress-beta>`](https://clever-components-preview.cellar-c2.services.clever-cloud.com/clear-logs/index.html?path=/story/%F0%9F%9A%A7-beta-%F0%9F%9B%A0-logs-cc-logs-loading-progress-beta--with-clearable)
- [`<cc-logs-app-runtime-beta>`](https://clever-components-preview.cellar-c2.services.clever-cloud.com/clear-logs/index.html?path=/story/%F0%9F%9A%A7-beta-%F0%9F%9B%A0-logs-app-cc-logs-app-runtime-beta--default-story)
  - same for app access logs and add-on logs
- [next-console](https://next-console.cleverapps.io/organisations/orga_540caeb6-521c-4a19-a955-efe6da35d142/applications/app_457bd0d5-23c5-48c3-93bc-881ab5e4492c/logs)