### PR TITLE
refactor(metrics): migrate metrics tiles and logsmap to cc-api-client

### DIFF
--- a/demo-smart/index.html
+++ b/demo-smart/index.html
@@ -659,6 +659,7 @@
             <ul class="def-list">
               <li><a class="definition-link" href="?definition=cc-grafana-info.smart">cc-grafana-info</a></li>
               <li><a class="definition-link" href="?definition=cc-tile-status-codes.smart">cc-tile-status-codes</a></li>
+              <li><a class="definition-link" href="?definition=cc-tile-requests.smart">cc-tile-requests</a></li>
               <li><a class="definition-link" href="?definition=cc-tile-metrics.smart">cc-tile-metrics</a></li>
             </ul>
           </div>

--- a/demo-smart/index.html
+++ b/demo-smart/index.html
@@ -324,6 +324,11 @@
         width: 20em;
       }
 
+      cc-logsmap {
+        width: 50em;
+        height: 30em;
+      }
+
       .visually-hidden {
         position: absolute;
         width: 1px;
@@ -661,6 +666,7 @@
               <li><a class="definition-link" href="?definition=cc-tile-status-codes.smart">cc-tile-status-codes</a></li>
               <li><a class="definition-link" href="?definition=cc-tile-requests.smart">cc-tile-requests</a></li>
               <li><a class="definition-link" href="?definition=cc-tile-metrics.smart">cc-tile-metrics</a></li>
+              <li><a class="definition-link" href="?definition=cc-logsmap.smart">cc-logsmap</a></li>
             </ul>
           </div>
 
@@ -895,6 +901,14 @@
                   data-context='{"ownerId":"orga_540caeb6-521c-4a19-a955-efe6da35d142","appId":"app_f2f99229-4aba-42ef-bcb1-d69e8a443cd1","consoleGrafanaLink":"https://console.clever-cloud.com","grafanaBaseLink":"https://grafana.services.clever-cloud.com/"}'
                 >
                   <span class="ctx-label">CPU Load Bench</span>
+                  <span class="ctx-subtitle">ownerId, appId</span>
+                </button>
+                <button
+                  class="ctx-btn"
+                  title="ownerId, appId"
+                  data-context='{"ownerId":"orga_540caeb6-521c-4a19-a955-efe6da35d142","appId":"app_46ec6a5c-1512-401f-ad40-1864ad5050f0","consoleGrafanaLink":"https://console.clever-cloud.com","grafanaBaseLink":"https://grafana.services.clever-cloud.com/","type":"app","logsUrlPattern":"/organisations/orga_540caeb6-521c-4a19-a955-efe6da35d142/applications/:id/logs"}'
+                >
+                  <span class="ctx-label">App Access logs</span>
                   <span class="ctx-subtitle">ownerId, appId</span>
                 </button>
               </div>

--- a/rollup/rollup-common.js
+++ b/rollup/rollup-common.js
@@ -76,6 +76,7 @@ export function minifyStylesheet(stylesheet) {
 export function getMainFiles() {
   const mainFilesPatterns = [
     `${SOURCE_DIR}/components/**/*.js`,
+    `${SOURCE_DIR}/lib/cc-api-client.js`,
     `${SOURCE_DIR}/lib/i18n/i18n.js`,
     `${SOURCE_DIR}/lib/smart/smart-manager.js`,
     `${SOURCE_DIR}/translations/*.js`,

--- a/src/components/cc-logsmap/cc-logsmap.smart.js
+++ b/src/components/cc-logsmap/cc-logsmap.smart.js
@@ -1,0 +1,216 @@
+import { GetHeatMapCommand } from '@clevercloud/client/cc-api-commands/metrics/get-heat-map-command.js';
+import { StreamRequestsCommand } from '@clevercloud/client/cc-api-commands/metrics/stream-requests-command.js';
+import { getCcApiClientWithOAuth } from '../../lib/cc-api-client.js';
+import { defineSmartComponent } from '../../lib/smart/define-smart-component.js';
+import '../cc-smart-container/cc-smart-container.js';
+import './cc-logsmap.js';
+
+/**
+ * @import { CcLogsmap } from './cc-logsmap.js'
+ * @import { HeatmapPoint, MapModeType } from '../common.types.js'
+ * @import { ApiConfig } from '../../lib/send-to-api.types.js'
+ * @import { OnContextUpdateArgs, UpdateComponentCallback } from '../../lib/smart/smart-component.types.js'
+ * @import { RequestsStream } from '@clevercloud/client/cc-api-commands/metrics/stream-requests-command.js'
+ * @import { CcApiClient } from '@clevercloud/client/cc-api-client.js'
+ */
+
+// Spread the dots of a live batch over this duration so they don't all blink at once.
+const POINTS_SPREAD_DURATION = 3000;
+// How long a live dot stays on the map before fading out (outlives the spread so dots don't vanish mid-batch).
+const POINTS_DELAY = POINTS_SPREAD_DURATION + 2000;
+
+// The heat map aggregates requests into hourly buckets, so its response is byte-identical for the rest of the current
+// hour. We cache it until the next hour boundary, plus this margin to let the just-completed bucket be fully ingested
+// before we read it.
+const HEATMAP_CACHE_INGESTION_MARGIN = 2 * 60 * 1000;
+
+defineSmartComponent({
+  selector: 'cc-logsmap',
+  params: {
+    apiConfig: { type: Object },
+    ownerId: { type: String },
+    appId: { type: String, optional: true },
+  },
+  /**
+   * @param {OnContextUpdateArgs<CcLogsmap>} args
+   */
+  onContextUpdate({ component, context, onEvent, updateComponent, signal }) {
+    const { apiConfig, ownerId, appId } = context;
+
+    const controller = new LogsmapController({ apiConfig, ownerId, appId, component, updateComponent });
+
+    signal.onabort = () => {
+      controller.stop();
+    };
+
+    // The user can toggle the map mode from the component itself, so we react to the change and (re)load accordingly.
+    onEvent('cc-logsmap-mode-change', (mode) => {
+      controller.loadMode(mode);
+    });
+
+    controller.loadMode(component.mode);
+  },
+});
+
+/**
+ * Drives a `<cc-logsmap>`:
+ * * in `heatmap` mode, it fetches the heat map once with `GetHeatMapCommand`,
+ * * in `points` mode, it opens a live SSE stream with `StreamRequestsCommand` and adds blinking dots as batches arrive.
+ *
+ * A generation counter guards every async callback so that stale loads (mode switched or controller stopped in the
+ * meantime) are ignored.
+ */
+class LogsmapController {
+  /**
+   * @param {object} _
+   * @param {ApiConfig} _.apiConfig
+   * @param {string} _.ownerId
+   * @param {string} [_.appId]
+   * @param {CcLogsmap} _.component
+   * @param {UpdateComponentCallback<CcLogsmap>} _.updateComponent
+   */
+  constructor({ apiConfig, ownerId, appId, component, updateComponent }) {
+    /** @type {CcApiClient} */
+    this._client = getCcApiClientWithOAuth(apiConfig);
+    this._ownerId = ownerId;
+    this._appId = appId;
+    this._component = component;
+    this._updateComponent = updateComponent;
+
+    /** @type {RequestsStream|null} */
+    this._stream = null;
+    /** @type {AbortController|null} */
+    this._heatmapAbortController = null;
+    /** @type {number} */
+    this._generation = 0;
+    this._stopped = false;
+  }
+
+  /**
+   * Cancels the current load (live stream or heat map fetch) and invalidates its async callbacks.
+   * @param {MapModeType} [mode]
+   */
+  loadMode(mode) {
+    this._cancel();
+
+    if (this._stopped) {
+      return;
+    }
+
+    if (mode === 'heatmap') {
+      this._loadHeatmap();
+    } else {
+      this._openPointsStream();
+    }
+  }
+
+  stop() {
+    this._stopped = true;
+    this._cancel();
+  }
+
+  _cancel() {
+    // Invalidate every in-flight callback captured with the previous generation.
+    this._generation++;
+
+    this._stream?.close();
+    this._stream = null;
+
+    this._heatmapAbortController?.abort();
+    this._heatmapAbortController = null;
+  }
+
+  _loadHeatmap() {
+    const generation = this._generation;
+    this._heatmapAbortController = new AbortController();
+
+    this._updateComponent('error', false);
+    this._updateComponent('loading', true);
+    // Drop the previous result: a stale empty array would make `<cc-map>` show its "no points" message while loading.
+    this._updateComponent('heatmapPoints', null);
+
+    this._client
+      .send(new GetHeatMapCommand({ ownerId: this._ownerId, applicationId: this._appId }), {
+        signal: this._heatmapAbortController.signal,
+        cache: { ttl: getHeatmapCacheTtl() },
+      })
+      .then(
+        /** @param {Array<HeatmapPoint>} heatmapPoints */ (heatmapPoints) => {
+          if (generation !== this._generation) {
+            return;
+          }
+          this._updateComponent('heatmapPoints', heatmapPoints);
+          this._updateComponent('loading', false);
+        },
+      )
+      .catch((error) => {
+        if (generation !== this._generation) {
+          return;
+        }
+        console.error(error);
+        this._updateComponent('error', true);
+        this._updateComponent('loading', false);
+      });
+  }
+
+  _openPointsStream() {
+    const generation = this._generation;
+
+    this._updateComponent('error', false);
+    this._updateComponent('loading', true);
+
+    this._client
+      .stream(new StreamRequestsCommand({ ownerId: this._ownerId, applicationId: this._appId }))
+      .then((stream) => {
+        // Mode switched or controller stopped while the stream was being created.
+        if (generation !== this._generation) {
+          stream.close();
+          return null;
+        }
+
+        this._stream = stream;
+
+        stream.onOpen(() => {
+          if (generation === this._generation) {
+            this._updateComponent('loading', false);
+          }
+        });
+
+        stream.onRequests((locations) => {
+          this._component.addPoints(
+            locations.map((location) => ({
+              lat: location.lat,
+              lon: location.lon,
+              count: location.count,
+              tooltip: location.city,
+              delay: POINTS_DELAY,
+            })),
+            { spreadDuration: POINTS_SPREAD_DURATION },
+          );
+        });
+
+        return stream.start();
+      })
+      .catch((error) => {
+        if (generation !== this._generation) {
+          return;
+        }
+        console.error(error);
+        this._updateComponent('error', true);
+        this._updateComponent('loading', false);
+      });
+  }
+}
+
+/**
+ * Computes the heat map cache TTL (in ms) so the cached response expires shortly after the next hour boundary, once
+ * the just-completed hourly bucket has had time to be ingested.
+ *
+ * @returns {number}
+ */
+function getHeatmapCacheTtl() {
+  const now = Date.now();
+  const nextHourBoundary = new Date(now);
+  nextHourBoundary.setHours(nextHourBoundary.getHours() + 1, 0, 0, 0);
+  return nextHourBoundary.getTime() - now + HEATMAP_CACHE_INGESTION_MARGIN;
+}

--- a/src/components/cc-logsmap/cc-logsmap.smart.md
+++ b/src/components/cc-logsmap/cc-logsmap.smart.md
@@ -1,0 +1,84 @@
+---
+kind: '🛠 Maps/<cc-logsmap>'
+title: '💡 Smart'
+---
+# 💡 Smart `<cc-logsmap>`
+
+## ℹ️ Details
+
+<table>
+  <tr><td><strong>Component    </strong> <td><a href="🛠-maps-cc-logsmap--default-story"><code>&lt;cc-logsmap&gt;</code></a>
+  <tr><td><strong>Selector     </strong> <td><code>cc-logsmap</code>
+  <tr><td><strong>Requires auth</strong> <td>Yes
+</table>
+
+## ⚙️ Params
+
+| Name        | Type        | Details                                                |
+|-------------|-------------|--------------------------------------------------------|
+| `apiConfig` | `ApiConfig` | Object with API configuration (target host, tokens...) |
+| `ownerId`   | `String`    | UUID prefixed with `user_` or `orga_`                  |
+| `appId`     | `String`    | UUID prefixed with `app_` (optional)                   |
+
+```ts
+interface ApiConfig {
+  API_HOST: String,
+  API_OAUTH_TOKEN: String,
+  API_OAUTH_TOKEN_SECRET: String,
+  OAUTH_CONSUMER_KEY: String,
+  OAUTH_CONSUMER_SECRET: String,
+}
+```
+
+## 🌐 API endpoints
+
+The endpoint used depends on the map `mode`:
+
+| Method | URL                                                     | Cache                   | Mode      |
+|--------|---------------------------------------------------------|-------------------------|-----------|
+| `GET`  | `/v4/stats/organisations/{ownerId}/requests`            | Until next hour + 2 min | `heatmap` |
+| `GET`  | `/v4/stats/organisations/{ownerId}/requests-live` (SSE) | None                    | `points`  |
+
+The heat map response is byte-identical for the rest of the current hour, so it is cached until the next hour boundary plus a 2-minute margin (to absorb ingestion lag of the just-completed bucket).
+
+* In `heatmap` mode, the heat map is fetched once with `GetHeatMapCommand`.
+* In `points` mode, a live SSE stream is opened with `StreamRequestsCommand` and blinking dots are added as request batches arrive.
+
+## ⬇️️ Examples
+
+### Whole organization
+
+If you only specify an `ownerId` and no `appId`, the data represent the whole organization.
+
+```html
+<cc-smart-container context='{
+  "apiConfig": {
+    "API_HOST": "",
+    "API_OAUTH_TOKEN": "",
+    "API_OAUTH_TOKEN_SECRET": "",
+    "OAUTH_CONSUMER_KEY": "",
+    "OAUTH_CONSUMER_SECRET": "",
+  },
+  "ownerId": ""
+}'>
+  <cc-logsmap orga-name="ACME Corp"></cc-logsmap>
+</cc-smart-container>
+```
+
+### Application only
+
+```html
+<cc-smart-container context='{
+  "apiConfig": {
+    "API_HOST": "",
+    "API_OAUTH_TOKEN": "",
+    "API_OAUTH_TOKEN_SECRET": "",
+    "OAUTH_CONSUMER_KEY": "",
+    "OAUTH_CONSUMER_SECRET": "",
+  },
+  "ownerId": "",
+  "appId": ""
+}'>
+  <cc-logsmap app-name="My Awesome Java App (PROD)"></cc-logsmap>
+</cc-smart-container>
+```

--- a/src/components/cc-tile-metrics/cc-tile-metrics.smart.js
+++ b/src/components/cc-tile-metrics/cc-tile-metrics.smart.js
@@ -1,5 +1,6 @@
-import { getOrganisationApplicationMetrics } from '@clevercloud/client/esm/api/v4/resources.js';
+import { GetMetricsCommand } from '@clevercloud/client/cc-api-commands/metrics/get-metrics-command.js';
 import { getGrafanaOrganisation } from '@clevercloud/client/esm/api/v4/saas.js';
+import { getCcApiClientWithOAuth } from '../../lib/cc-api-client.js';
 import { sendToApi } from '../../lib/send-to-api.js';
 import { defineSmartComponent } from '../../lib/smart/define-smart-component.js';
 import '../cc-smart-container/cc-smart-container.js';
@@ -7,7 +8,7 @@ import './cc-tile-metrics.js';
 
 /**
  * @import { CcTileMetrics } from './cc-tile-metrics.js'
- * @import { RawMetric, MetricsData, Metric } from './cc-tile-metrics.types.js'
+ * @import { MetricsData, Metric } from './cc-tile-metrics.types.js'
  * @import { ApiConfig } from '../../lib/send-to-api.types.js'
  * @import { OnContextUpdateArgs } from '../../lib/smart/smart-component.types.js'
  */
@@ -70,39 +71,25 @@ defineSmartComponent({
  * @param {AbortSignal} parameters.signal
  * @returns {Promise<MetricsData>}
  */
-function fetchMetrics({ apiConfig, ownerId, appId, signal }) {
-  return getOrganisationApplicationMetrics({
-    ownerId,
-    resourceId: appId,
-    interval: 'P1D',
-    span: 'PT1H',
-    // @ts-expect-error FIXME: the client expects a string, which makes sense since it's using this as a query param. We should fix this but we need to check how the string is supposed to be formatted (separator, etc.)
-    only: ['cpu', 'mem'],
-  })
-    .then(sendToApi({ apiConfig, signal }))
-    .then(
-      /** @param {RawMetric[]} metrics */ (metrics) => {
-        const cpuMetrics = extractMetric(metrics, 'cpu');
-        const memMetrics = extractMetric(metrics, 'mem');
-        return { cpuMetrics, memMetrics };
-      },
-    );
-}
+async function fetchMetrics({ apiConfig, ownerId, appId, signal }) {
+  const client = getCcApiClientWithOAuth(apiConfig);
 
-/**
- * @param {RawMetric[]} metrics
- * @param {string} name
- * @returns {Metric[]}
- */
-function extractMetric(metrics, name) {
-  const metric = metrics?.find((m) => m.name === name)?.data ?? [];
-  return metric.map(({ timestamp, value }) => {
-    return {
-      // API returns timestamps in microseconds
-      timestamp: timestamp / 1000,
-      value: parseFloat(value),
-    };
-  });
+  const metrics = await client.send(
+    new GetMetricsCommand({
+      ownerId,
+      applicationId: appId,
+      interval: 'P1D',
+      span: 'PT1H',
+      metrics: ['cpu', 'mem'],
+      timestampUnit: 'ms',
+    }),
+    { signal },
+  );
+
+  return {
+    cpuMetrics: metrics.cpu ?? [],
+    memMetrics: metrics.mem ?? [],
+  };
 }
 
 /**

--- a/src/components/cc-tile-metrics/cc-tile-metrics.smart.md
+++ b/src/components/cc-tile-metrics/cc-tile-metrics.smart.md
@@ -35,10 +35,10 @@ interface ApiConfig {
 
 ## 🌐 API endpoints
 
-| Method | URL                                                                                                          | Cache   |
-|--------|--------------------------------------------------------------------------------------------------------------|---------|
-| `GET`  | `/v4/metrics/organisations/{ownerId}/resources/{appId}/metrics?interval="P1D"&span="PT1H"&only=cpu&only=mem` | Default |
-| `GET`  | `/v4/saas/grafana/{ownerId}`                                                                                 | Default |
+| Method | URL                                                                                                        | Cache   |
+|--------|------------------------------------------------------------------------------------------------------------|---------|
+| `GET`  | `/v4/stats/organisations/{ownerId}/resources/{appId}/metrics?interval="P1D"&span="PT1H"&only=cpu&only=mem` | Default |
+| `GET`  | `/v4/saas/grafana/{ownerId}`                                                                               | Default |
 
 
 

--- a/src/components/cc-tile-metrics/cc-tile-metrics.types.d.ts
+++ b/src/components/cc-tile-metrics/cc-tile-metrics.types.d.ts
@@ -1,3 +1,5 @@
+import type { MetricData } from '@clevercloud/client/cc-api-commands/metrics/metrics.types.js';
+
 export type TileMetricsMetricsState =
   | TileMetricsMetricsStateLoading
   | TileMetricsMetricsStateError
@@ -21,12 +23,7 @@ export interface TileMetricsMetricsStateEmpty {
   type: 'empty';
 }
 
-export interface Metric {
-  // Timestamp in ms
-  timestamp: number;
-  // Value is a percentage (e.g: 14.02)
-  value: number;
-}
+export type Metric = MetricData;
 
 export interface MetricsData {
   cpuMetrics: Metric[];

--- a/src/components/cc-tile-requests/cc-tile-requests.smart.js
+++ b/src/components/cc-tile-requests/cc-tile-requests.smart.js
@@ -1,0 +1,65 @@
+import { GetStatusCodeDistributionCommand } from '@clevercloud/client/cc-api-commands/metrics/get-status-code-distribution-command.js';
+import { getCcApiClientWithOAuth } from '../../lib/cc-api-client.js';
+import { defineSmartComponent } from '../../lib/smart/define-smart-component.js';
+import '../cc-smart-container/cc-smart-container.js';
+import './cc-tile-requests.js';
+
+/**
+ * @import { CcTileRequests } from './cc-tile-requests.js'
+ * @import { RequestsData } from './cc-tile-requests.types.js'
+ * @import { ApiConfig } from '../../lib/send-to-api.types.js'
+ * @import { OnContextUpdateArgs } from '../../lib/smart/smart-component.types.js'
+ */
+
+defineSmartComponent({
+  selector: 'cc-tile-requests',
+  params: {
+    apiConfig: { type: Object },
+    ownerId: { type: String },
+    appId: { type: String, optional: true },
+  },
+  /**
+   * @param {OnContextUpdateArgs<CcTileRequests>} args
+   */
+  onContextUpdate({ context, updateComponent, signal }) {
+    const { apiConfig, ownerId, appId } = context;
+
+    updateComponent('state', { type: 'loading' });
+
+    fetchRequests({ apiConfig, signal, ownerId, appId })
+      .then((data) => {
+        updateComponent('state', { type: 'loaded', data });
+      })
+      .catch((error) => {
+        console.log(error);
+        updateComponent('state', { type: 'error' });
+      });
+  },
+});
+
+/**
+ * @param {Object} settings
+ * @param {ApiConfig} settings.apiConfig
+ * @param {AbortSignal} settings.signal
+ * @param {string} settings.ownerId
+ * @param {string} settings.appId
+ * @return {Promise<Array<RequestsData>>}
+ */
+async function fetchRequests({ apiConfig, signal, ownerId, appId }) {
+  const to = new Date();
+  to.setHours(to.getHours() - 1, 0, 0, 0);
+
+  const data = await getCcApiClientWithOAuth(apiConfig).send(
+    new GetStatusCodeDistributionCommand({
+      ownerId,
+      applicationId: appId,
+      to,
+    }),
+    { signal },
+  );
+
+  return data.byDate.map((entry) => {
+    const time = new Date(entry.date).getTime();
+    return [time, time + 1000 * 60 * 60 - 1, entry.total];
+  });
+}

--- a/src/components/cc-tile-requests/cc-tile-requests.smart.md
+++ b/src/components/cc-tile-requests/cc-tile-requests.smart.md
@@ -1,0 +1,76 @@
+---
+kind: '🛠 Overview/<cc-tile-requests>'
+title: '💡 Smart'
+---
+# 💡 Smart `<cc-tile-requests>`
+
+## ℹ️ Details
+
+<table>
+  <tr><td><strong>Component    </strong> <td><a href="🛠-overview-cc-tile-requests--default-story"><code>&lt;cc-tile-requests&gt;</code></a>
+  <tr><td><strong>Selector     </strong> <td><code>cc-tile-requests</code>
+  <tr><td><strong>Requires auth</strong> <td>Yes
+</table>
+
+### ⚙️ Params
+
+| Name                 | Type        | Details                                                |
+|----------------------|-------------|--------------------------------------------------------|
+| `apiConfig`          | `ApiConfig` | Object with API configuration (target host, tokens...) |
+| `ownerId`            | `String`    | UUID prefixed with `user_` or `orga_`                  |
+| `appId`              | `String`    | UUID prefixed with `app_`                              |
+
+```ts
+interface ApiConfig {
+  API_HOST: String,
+  API_OAUTH_TOKEN: String,
+  API_OAUTH_TOKEN_SECRET: String,
+  OAUTH_CONSUMER_KEY: String,
+  OAUTH_CONSUMER_SECRET: String,
+}
+```
+
+## 🌐 API endpoints
+
+| Method | URL                                               | Cache   |
+|--------|---------------------------------------------------|---------|
+| `GET`  | `/v4/stats/organisations/{ownerId}/http-requests` | Default |
+
+## ⬇️️ Examples
+
+### Whole organization
+
+If you only specify a `ownerId` and no `appId`, the data represent the whole organization.
+
+```html
+<cc-smart-container context='{
+  "apiConfig": {
+    "API_HOST": "",
+    "API_OAUTH_TOKEN": "",
+    "API_OAUTH_TOKEN_SECRET": "",
+    "OAUTH_CONSUMER_KEY": "",
+    "OAUTH_CONSUMER_SECRET": "",
+  },
+  "ownerId": ""
+}'>
+  <cc-tile-requests></cc-tile-requests>
+</cc-smart-container>
+```
+
+### Application only
+
+```html
+<cc-smart-container context='{
+  "apiConfig": {
+    "API_HOST": "",
+    "API_OAUTH_TOKEN": "",
+    "API_OAUTH_TOKEN_SECRET": "",
+    "OAUTH_CONSUMER_KEY": "",
+    "OAUTH_CONSUMER_SECRET": "",
+  },
+  "ownerId": "",
+  "appId": ""
+}'>
+    <cc-tile-requests></cc-tile-requests>
+</cc-smart-container>
+```

--- a/src/components/cc-tile-status-codes/cc-tile-status-codes.smart.js
+++ b/src/components/cc-tile-status-codes/cc-tile-status-codes.smart.js
@@ -1,8 +1,5 @@
-import { getStatusCodesFromWarp10 } from '@clevercloud/client/esm/access-logs.js';
-import { getWarp10AccessLogsToken } from '@clevercloud/client/esm/api/v2/warp-10.js';
-import { THIRTY_SECONDS } from '@clevercloud/client/esm/request.fetch-with-timeout.js';
-import { ONE_DAY } from '@clevercloud/client/esm/with-cache.js';
-import { sendToApi, sendToWarp } from '../../lib/send-to-api.js';
+import { GetStatusCodeDistributionCommand } from '@clevercloud/client/cc-api-commands/metrics/get-status-code-distribution-command.js';
+import { getCcApiClientWithOAuth } from '../../lib/cc-api-client.js';
 import { defineSmartComponent } from '../../lib/smart/define-smart-component.js';
 import '../cc-smart-container/cc-smart-container.js';
 import './cc-tile-status-codes.js';
@@ -10,7 +7,7 @@ import './cc-tile-status-codes.js';
 /**
  * @import { CcTileStatusCodes } from './cc-tile-status-codes.js'
  * @import { StatusCodesData } from './cc-tile-status-codes.types.js'
- * @import { ApiConfig, Warp10ApiConfig } from '../../lib/send-to-api.types.js'
+ * @import { ApiConfig } from '../../lib/send-to-api.types.js'
  * @import { OnContextUpdateArgs } from '../../lib/smart/smart-component.types.js'
  */
 
@@ -42,25 +39,21 @@ defineSmartComponent({
 
 /**
  * @param {Object} settings
- * @param {ApiConfig & Warp10ApiConfig} settings.apiConfig
+ * @param {ApiConfig} settings.apiConfig
  * @param {AbortSignal} settings.signal
  * @param {string} settings.ownerId
  * @param {string} settings.appId
  * @return {Promise<StatusCodesData>}
  */
 async function fetchStatusCodes({ apiConfig, signal, ownerId, appId }) {
-  const warpToken = await getWarp10AccessLogsToken({ orgaId: ownerId }).then(
-    sendToApi({ apiConfig, signal, cacheDelay: ONE_DAY }),
+  const data = await getCcApiClientWithOAuth(apiConfig).send(
+    new GetStatusCodeDistributionCommand({
+      ownerId,
+      applicationId: appId,
+      excludeNonStandardStatusCodes: true,
+    }),
+    { signal },
   );
-  return getStatusCodesFromWarp10({ warpToken, ownerId, appId })
-    .then(sendToWarp({ apiConfig, signal, timeout: THIRTY_SECONDS }))
-    .then((/** @type {Record<string, string>} */ data) => {
-      for (const statusCode in data) {
-        const statusCodeNumber = parseInt(statusCode);
-        if (statusCodeNumber < 100) {
-          delete data[statusCode];
-        }
-      }
-      return data;
-    });
+
+  return data.byStatusCode.statuses;
 }

--- a/src/components/cc-tile-status-codes/cc-tile-status-codes.smart.md
+++ b/src/components/cc-tile-status-codes/cc-tile-status-codes.smart.md
@@ -12,19 +12,17 @@ title: '💡 Smart'
   <tr><td><strong>Requires auth</strong> <td>Yes
 </table>
 
-## ⚙️ Params
+### ⚙️ Params
 
-<table>
-  <tr><th>Name                   <th>Type                   <th>Details                                                     <th>Default
-  <tr><td><code>apiConfig</code> <td><code>ApiConfig</code> <td>Object with API configuration (target host, tokens...)      <td>
-  <tr><td><code>ownerId</code>   <td><code>String</code>    <td>UUID prefixed with <code>user_</code> or <code>orga_</code> <td>
-  <tr><td><code>appId</code>     <td><code>String</code>    <td>UUID prefixed with <code>app_</code> (optional)             <td>
-</table>
+| Name                 | Type        | Details                                                |
+|----------------------|-------------|--------------------------------------------------------|
+| `apiConfig`          | `ApiConfig` | Object with API configuration (target host, tokens...) |
+| `ownerId`            | `String`    | UUID prefixed with `user_` or `orga_`                  |
+| `appId`              | `String`    | UUID prefixed with `app_`                              |
 
-```js
+```ts
 interface ApiConfig {
   API_HOST: String,
-  WARP_10_HOST: String,
   API_OAUTH_TOKEN: String,
   API_OAUTH_TOKEN_SECRET: String,
   OAUTH_CONSUMER_KEY: String,
@@ -34,17 +32,9 @@ interface ApiConfig {
 
 ## 🌐 API endpoints
 
-<table>
-  <tr><th>Method <th>URL                                                 <th>Cache?
-  <tr><td>GET    <td><code>/v2/w10tokens/accessLogs/read/{orgaId}</code> <td>1 day
-</table>
-
-## 🌐 Warp10 macros
-
-<table>
-  <tr><th>Method <th>Macro                                               <th>Cache?
-  <tr><td>GET    <td><code>@clevercloud/accessLogs_status_code_v1</code> <td>30 seconds
-</table>
+| Method | URL                                                   | Cache   |
+|--------|-------------------------------------------------------|---------|
+| `GET`  | `/v4/stats/organisations/{ownerId}/http-status-codes` | Default |
 
 ## ⬇️️ Examples
 
@@ -56,7 +46,6 @@ If you only specify a `ownerId` and no `appId`, the data represent the whole org
 <cc-smart-container context='{
   "apiConfig": {
     "API_HOST": "",
-    "WARP_10_HOST": ""
     "API_OAUTH_TOKEN": "",
     "API_OAUTH_TOKEN_SECRET": "",
     "OAUTH_CONSUMER_KEY": "",
@@ -74,7 +63,6 @@ If you only specify a `ownerId` and no `appId`, the data represent the whole org
 <cc-smart-container context='{
   "apiConfig": {
     "API_HOST": "",
-    "WARP_10_HOST": ""
     "API_OAUTH_TOKEN": "",
     "API_OAUTH_TOKEN_SECRET": "",
     "OAUTH_CONSUMER_KEY": "",

--- a/src/lib/send-to-api.js
+++ b/src/lib/send-to-api.js
@@ -1,6 +1,5 @@
 import { addOauthHeader } from '@clevercloud/client/esm/oauth.js';
 import { prefixUrl } from '@clevercloud/client/esm/prefix-url.js';
-import { execWarpscript } from '@clevercloud/client/esm/request-warp10.fetch.js';
 import { request } from '@clevercloud/client/esm/request.fetch.js';
 import { withCache } from '@clevercloud/client/esm/with-cache.js';
 import { withOptions } from '@clevercloud/client/esm/with-options.js';
@@ -10,7 +9,6 @@ import { CcApiErrorEvent } from './send-to-api.events.js';
 // See: https://github.com/microsoft/TypeScript/issues/60908/
 /**
  * @typedef {import('./send-to-api.types.js').ApiConfig} ApiConfig
- * @typedef {import('./send-to-api.types.js').Warp10ApiConfig} Warp10ApiConfig
  */
 
 /**
@@ -38,31 +36,6 @@ export function sendToApi({ apiConfig, signal, cacheDelay, timeout }) {
             window.dispatchEvent(new CcApiErrorEvent(error));
             throw error;
           })
-      );
-    });
-  };
-}
-
-/**
- * @param {Object} settings
- * @param {Warp10ApiConfig} settings.apiConfig
- * @param {AbortSignal} [settings.signal]
- * @param {number} [settings.cacheDelay]
- * @param {number} [settings.timeout]
- * @return {(requestParams: Object) => Promise<any>}
- */
-export function sendToWarp({ apiConfig, signal, cacheDelay, timeout }) {
-  return (requestParams) => {
-    const cacheParams = { ...apiConfig, ...requestParams };
-    return withCache(cacheParams, cacheDelay, () => {
-      const { WARP_10_HOST } = apiConfig;
-      return (
-        Promise.resolve(requestParams)
-          // @ts-expect-error FIXME: will become irrelevant when we switch to the new client and fixing it seems to lead to many fixes in places everywhere sendToApi is used
-          .then(prefixUrl(WARP_10_HOST))
-          .then(withOptions({ signal, timeout }))
-          // @ts-expect-error FIXME: will become irrelevant when we switch to the new client and fixing it seems to lead to many fixes in places everywhere sendToApi is used
-          .then(execWarpscript)
       );
     });
   };

--- a/src/lib/send-to-api.types.d.ts
+++ b/src/lib/send-to-api.types.d.ts
@@ -6,14 +6,6 @@ export interface ApiConfig {
   OAUTH_CONSUMER_SECRET: string;
 }
 
-export interface Warp10ApiConfig {
-  WARP_10_HOST: string;
-  API_OAUTH_TOKEN: string;
-  API_OAUTH_TOKEN_SECRET: string;
-  OAUTH_CONSUMER_KEY: string;
-  OAUTH_CONSUMER_SECRET: string;
-}
-
 export interface AuthBridgeConfig {
   AUTH_BRIDGE_HOST: string;
   API_OAUTH_TOKEN: string;

--- a/src/stories/lib/smart-auth-plugin.js
+++ b/src/stories/lib/smart-auth-plugin.js
@@ -17,20 +17,13 @@ export const injectAuthForSmartComponentsPlugin = {
     const isSandboxIndex = id.includes('/sandbox/index.js');
 
     if (isSmartStory || isDemoSmartIndex || isSandboxIndex) {
-      const {
-        WARP_10_HOST,
-        API_HOST,
-        API_OAUTH_TOKEN,
-        API_OAUTH_TOKEN_SECRET,
-        OAUTH_CONSUMER_KEY,
-        OAUTH_CONSUMER_SECRET,
-      } = process.env;
+      const { API_HOST, API_OAUTH_TOKEN, API_OAUTH_TOKEN_SECRET, OAUTH_CONSUMER_KEY, OAUTH_CONSUMER_SECRET } =
+        process.env;
 
       // language=JavaScript
       code += `
         updateRootContext({
           apiConfig: {
-            WARP_10_HOST: '${WARP_10_HOST}',
             API_HOST: '${API_HOST}',
             API_OAUTH_TOKEN: '${API_OAUTH_TOKEN}',
             API_OAUTH_TOKEN_SECRET: '${API_OAUTH_TOKEN_SECRET}',


### PR DESCRIPTION
## Context

Continues the migration away from the legacy `@clevercloud/client` Warp 10 access path
toward the new typed `cc-api-client`. Once every consumer of `sendToWarp` is gone, we can
drop the Warpscript plumbing and the `WARP_10_HOST` config surface, which is what this
branch achieves for the metrics tiles and the logs map.

## Changes

- `cc-tile-metrics`: smart binding now uses `GetMetricsCommand`. The new response is
  already keyed by metric name with normalized timestamps, so the local `extractMetric`
  helper and the `RawMetric` type are gone. Doc fixed from `/v4/metrics/...` to
  `/v4/stats/...` to match the endpoint.
- `cc-tile-status-codes`: replaces the two-step Warp 10 token + Warpscript exec with a
  single `GetStatusCodeDistributionCommand`. Client-side filtering of non-standard codes
  is dropped — the new client exposes `excludeNonStandardStatusCodes`.
- `cc-tile-requests`: adds the smart binding it never had, backed by
  `GetStatusCodeDistributionCommand`, so it can be wired into the demo and console
  without going through Warpscript.
- `cc-logsmap`: adds a smart binding using `GetRequestsCommand` for `heatmap` mode and
  `StreamRequestsCommand` for the live `points` mode.
- `send-to-api`: removes `sendToWarp`, the `Warp10ApiConfig` type, and the
  `WARP_10_HOST` plumbing in the storybook auth plugin. The API config surface now only
  carries what is actually used.
- Build: `cc-api-client.js` is added as a rollup main entry so consumers can import it
  without pulling in a specific component chunk.

### Implementation notes

For `cc-logsmap` heatmap mode, the response is byte-identical within an hour-aligned
bucket, so the current hour is cached until the next hour boundary plus a 2-minute
margin — same cadence the previous Warpscript query had, but expressed at the client
level instead of inside the script.

For `cc-tile-status-codes`, dropping the local filter changes a subtle behavior: codes
outside the standard ranges used to be silently dropped after fetch. The new flag
asks the client to omit them upstream, so the tile shows exactly what the client returns.

## How to review

1. Start with `src/lib/send-to-api.js` and the storybook plugin to confirm nothing else
   in the tree still references `sendToWarp` / `WARP_10_HOST`.
2. Then walk the four `*.smart.js` files in this order:
   `cc-tile-metrics` → `cc-tile-status-codes` → `cc-tile-requests` → `cc-logsmap`.
   Each one is independent; reading them in that order matches increasing complexity
   (single command → two commands + streaming).
3. The `.smart.md` docs next to each component were updated in lockstep — worth a pass
   to check the example payloads match the new command outputs.
4. Local smoke test: run the storybook smart demos for the four components against a
   real account and confirm the tiles render the same data as on `master`.

**1-2 approvals** from anyone on the team.