### PR TITLE
fix(cc-search-bar): add tabindex to sections and widen dialog

### DIFF
--- a/src/components/cc-search-bar/cc-search-bar.js
+++ b/src/components/cc-search-bar/cc-search-bar.js
@@ -125,7 +125,9 @@ export class CcSearchBar extends LitElement {
         <div class="search-bar">
           ${this._renderSearchInput()}
           ${hasItems
-            ? html`<div class="sections">${filteredSections.map((section) => this._renderSection(section))}</div>`
+            ? html`<div class="sections" tabindex="-1">
+                ${filteredSections.map((section) => this._renderSection(section))}
+              </div>`
             : this._renderEmpty()}
         </div>
       </cc-dialog>
@@ -216,6 +218,10 @@ export class CcSearchBar extends LitElement {
       css`
         :host {
           display: contents;
+        }
+
+        cc-dialog {
+          --cc-dialog-width: 45em;
         }
 
         cc-dialog::part(dialog) {


### PR DESCRIPTION
# What does this PR do?

- Widens the cc-search-bar dialog from 38em (the cc-dialog default) to 45em via the --cc-dialog-width custom property.
- Adds tabindex="-1" to the scrollable .sections container so it can be focused and scrolled with the keyboard without entering the tab order.

# How to review?

- Check the commits,
- Check the preview
- 1 reviewer should be enough.