### PR TITLE
fix(cc-plan-picker): prevent detail icon from shrinking when description wraps

### DIFF
--- a/src/components/cc-plan-picker/cc-plan-picker.js
+++ b/src/components/cc-plan-picker/cc-plan-picker.js
@@ -233,7 +233,7 @@ export class CcPlanPicker extends CcFormControlElement {
       <ul part="option-footer">
         ${details.map((detail) => {
           return html`<li part="option-footer--detail">
-            <cc-icon .icon="${detail.icon}" size="md"></cc-icon>
+            <cc-icon .icon="${detail.icon}" size="md" part="option-footer--detail-icon"></cc-icon>
             <span>${detail.value}</span>
           </li>`;
         })}
@@ -318,6 +318,10 @@ export class CcPlanPicker extends CcFormControlElement {
           align-items: center;
           column-gap: 0.5em;
           display: inline-flex;
+        }
+
+        ::part(option-footer--detail-icon) {
+          flex: 0 0 auto;
         }
         /* endregion */
       `,

--- a/src/stories/fixtures/plans.js
+++ b/src/stories/fixtures/plans.js
@@ -19,7 +19,7 @@ export const DEFAULT_PLANS = [
         value: 'Shared memory',
       },
       {
-        value: '1 vCPUs',
+        value: '1 shared vCPU with burstable performance',
         icon: iconCpu,
       },
     ],


### PR DESCRIPTION
## Context

In `cc-plan-picker`, each option-footer detail row is a flex row (`display: inline-flex`) containing a leading `cc-icon` and a description `<span>`. When the description wraps to multiple lines, the icon shrinks (flex item default `flex-shrink: 1`) and gets distorted.

## Fix

Expose the detail icon as a CSS part (`option-footer--detail-icon`) and set `flex: 0 0 auto` so it keeps its intrinsic size regardless of how the description wraps.

## How to test

Check the `cc-plan-picker` stories in Storybook (`defaultStory` / `readonly`): the `DEV` plan now ships long, wrapping detail descriptions — the leading icons stay full-size and undistorted.

> Only one reviewer is required for this PR.
