### PR TITLE
fix(cellar-client): restore content-length for cellar s3 uploads

### DIFF
--- a/tasks/cellar-client.js
+++ b/tasks/cellar-client.js
@@ -24,6 +24,12 @@ export class CellarClient {
       endpoint: `https://${CELLAR_HOST}`,
       credentials: { accessKeyId, secretAccessKey },
       region: 'REGION',
+      // Cellar (S3-compatible) requires Content-Length. AWS SDK v3 (>=3.729)
+      // enables flexible checksums by default, which makes PutObject use aws-chunked
+      // trailing-checksum encoding for streams and omit Content-Length -> 411.
+      // WHEN_REQUIRED disables the default checksum so Content-Length is restored.
+      requestChecksumCalculation: 'WHEN_REQUIRED',
+      responseChecksumValidation: 'WHEN_REQUIRED',
     });
   }
 


### PR DESCRIPTION
## Context

`pnpm run preview:publish` (and the GitHub CI preview job) fails uploading to Clever Cloud's Cellar bucket `clever-components-preview` with:

```
MissingContentLength: UnknownError   (httpStatusCode: 411)
Code: 'MissingContentLength'
```

- `package.json` declares `@aws-sdk/client-s3: ^3.29.0`, but it now resolves to **3.1049.0**.
- Since AWS SDK v3 **>=3.729**, flexible checksums are **on by default** (`requestChecksumCalculation: "WHEN_SUPPORTED"`).
- For `PutObject` with a **stream body** (the `sync()` path uses `fs.createReadStream`), this triggers `aws-chunked` trailing-checksum encoding, which drops `Content-Length` in favor of chunked transfer encoding.
- Cellar (S3-compatible) requires `Content-Length` and rejects the request with `411`.

## Proposal

Set `requestChecksumCalculation` and `responseChecksumValidation` to `WHEN_REQUIRED` on the shared `S3Client` in `tasks/cellar-client.js`. AWS documents this as the way to disable automatic checksum headers for third-party S3-compatible services; the SDK then restores a normal `Content-Length` (computed from the `fs.ReadStream` path for files, inline for string bodies).

This `S3Client` is shared by all preview and CDN tasks, so the fix also covers `cdn-preview:*` and `cdn-release:*`.

### Design decisions

- Minimal config-only fix — no explicit `ContentLength` plumbing and no SDK version pin/downgrade.
- `DeleteObject` (singular) has no body, so it needs no checksum and is unaffected.

## How to test

Requires Cellar credentials (run via `op run`):

1. `op run -- node tasks/preview.js publish` — uploads `storybook-static/`, the manifest and index without the 411 error.
2. `op run -- node tasks/preview.js list` and `op run -- node tasks/preview.js get <branch>` — read paths still work.