### PR TITLE
feat(cc-addon-admin): emit cc-addon-tags-was-changed after tags save

### DIFF
--- a/src/components/cc-addon-admin/cc-addon-admin.events.js
+++ b/src/components/cc-addon-admin/cc-addon-admin.events.js
@@ -70,3 +70,16 @@ export class CcAddonNameWasChangedEvent extends CcEvent {
     super(CcAddonNameWasChangedEvent.TYPE, detail);
   }
 }
+
+/**
+ * Dispatched when an add-on's tags have been changed successfully.
+ * @extends {CcEvent<{id: string, tags: Array<string>}>}
+ */
+export class CcAddonTagsWasChangedEvent extends CcEvent {
+  static TYPE = 'cc-addon-tags-was-changed';
+
+  /** @param {{ id: string, tags: Array<string> }} detail */
+  constructor(detail) {
+    super(CcAddonTagsWasChangedEvent.TYPE, detail);
+  }
+}

--- a/src/components/cc-addon-admin/cc-addon-admin.smart.js
+++ b/src/components/cc-addon-admin/cc-addon-admin.smart.js
@@ -10,7 +10,11 @@ import { notifyError, notifySuccess } from '../../lib/notifications.js';
 import { sendToApi } from '../../lib/send-to-api.js';
 import { defineSmartComponent } from '../../lib/smart/define-smart-component.js';
 import '../cc-smart-container/cc-smart-container.js';
-import { CcAddonNameWasChangedEvent, CcAddonWasDeletedEvent } from './cc-addon-admin.events.js';
+import {
+  CcAddonNameWasChangedEvent,
+  CcAddonTagsWasChangedEvent,
+  CcAddonWasDeletedEvent,
+} from './cc-addon-admin.events.js';
 import './cc-addon-admin.js';
 
 /**
@@ -85,6 +89,7 @@ defineSmartComponent({
         .onUpdateTags({ ownerId, addonId, tags })
         .then(() => {
           notifySuccess(i18n('cc-addon-admin.update-tags.success'));
+          component.dispatchEvent(new CcAddonTagsWasChangedEvent({ id: addonId, tags }));
           updateComponent('state', (state) => ({
             ...state,
             type: 'loaded',

--- a/src/components/cc-addon-admin/cc-addon-admin.smart.md
+++ b/src/components/cc-addon-admin/cc-addon-admin.smart.md
@@ -14,10 +14,11 @@ title: '💡 Smart'
 
 ## 👋️ Events fired
 
-| Name                         | Payload                       | Details                                                                                                                             |
-| ---------------------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `cc-addon-was-deleted`       | `{ id: string, name: string}` | Fired when the add-on has been deleted successfully.<br/>Should be used to redirect to another page                                 |
-| `cc-addon-name-was-changed`  | `{ id: string, name: string}` | Fired when the add-on name has been changed successfully.<br/>Should be used to refresh the menu                                    |
+| Name                         | Payload                          | Details                                                                                                                             |
+| ---------------------------- | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `cc-addon-was-deleted`       | `{ id: string, name: string}`    | Fired when the add-on has been deleted successfully.<br/>Should be used to redirect to another page                                 |
+| `cc-addon-name-was-changed`  | `{ id: string, name: string}`    | Fired when the add-on name has been changed successfully.<br/>Should be used to refresh the menu                                    |
+| `cc-addon-tags-was-changed`  | `{ id: string, tags: string[] }` | Fired when the add-on tags have been changed successfully.<br/>Should be used to refresh tag-driven views (e.g. the sidebar)        |
 
 ## ⚙️ Params
 

--- a/src/lib/events-map.types.d.ts
+++ b/src/lib/events-map.types.d.ts
@@ -4,6 +4,7 @@ import {
   CcAddonNameChangeEvent,
   CcAddonNameWasChangedEvent,
   CcAddonTagsChangeEvent,
+  CcAddonTagsWasChangedEvent,
   CcAddonWasDeletedEvent,
 } from '../components/cc-addon-admin/cc-addon-admin.events.js';
 import {
@@ -225,6 +226,7 @@ declare global {
     'cc-addon-rebuild': CcAddonRebuildEvent;
     'cc-addon-restart': CcAddonRestartEvent;
     'cc-addon-tags-change': CcAddonTagsChangeEvent;
+    'cc-addon-tags-was-changed': CcAddonTagsWasChangedEvent;
     'cc-addon-version-change': CcAddonVersionChangeEvent;
     'cc-addon-was-deleted': CcAddonWasDeletedEvent;
     'cc-api-error': CcApiErrorEvent;


### PR DESCRIPTION
## Context

The new console sidebar groups apps and add-ons into `project:` sections driven by **tags**, which only live on `/v2/summary` — so a tag edit must trigger a full summary refresh.

For **apps** the console owns the save and refreshes right after the PUT resolves. For **add-ons**, `cc-addon-admin`'s own smart saves the tags but — unlike the name field — emitted no post-save success event. The console only saw the input intent (`cc-addon-tags-change`) and worked around it with a fragile `setTimeout(…, 1000)`:

- save **fails** → console refetches the **old** tags, sidebar stays stale
- save **> 1 s** → same stale outcome
- save **< 1 s** → needless wait

## Proposal

Add a `cc-addon-tags-was-changed` event, dispatched by the smart **only after the tag save resolves successfully**, mirroring the existing `cc-addon-name-was-changed` flow:

- payload `{ id, tags }` (consistent with `cc-addon-name-was-changed`'s `{ id, name }`)
- not emitted on error → the error keeps going through `notifyError`, as for the name field
- the input intent event `cc-addon-tags-change` is unchanged

### Files

- `cc-addon-admin.events.js` — new `CcAddonTagsWasChangedEvent`
- `cc-addon-admin.smart.js` — dispatch in the tags-save `.then()`
- `lib/events-map.types.d.ts` — regenerated (`pnpm components:events-map-generate`)
- `cc-addon-admin.smart.md` — added to the "Events fired" table

### Design decisions

- **Payload `{ id, tags }`** rather than `{ tags }`: mirrors `cc-addon-name-was-changed` for consistency across the component's post-save events.
- **No tests added**, intentionally aligned with the reference flow: `cc-addon-name-was-changed` has no test, and the repo has no harness for testing smart components against a mocked API. The event fires only from the smart, so neither the stories nor the dumb component can exercise it.