### PR TITLE
refactor(cc-logs): migrate log virtualizer from @lit-labs to @tanstack

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,8 @@
     "@lit-labs/motion": "^1.0.7",
     "@lit-labs/virtualizer": "^2.0.14",
     "@shoelace-style/shoelace": "^2.18.0",
+    "@tanstack/lit-virtual": "^3.13.29",
+    "@tanstack/virtual-core": "^3.17.0",
     "ansi-regex": "^6.0.1",
     "chart.js": "^3.5.0",
     "chartjs-plugin-datalabels": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,12 @@ importers:
       '@shoelace-style/shoelace':
         specifier: ^2.18.0
         version: 2.20.1(@floating-ui/utils@0.2.11)(@types/react@19.2.14)
+      '@tanstack/lit-virtual':
+        specifier: ^3.13.29
+        version: 3.13.29(lit@3.3.3)
+      '@tanstack/virtual-core':
+        specifier: ^3.17.0
+        version: 3.17.0
       ansi-regex:
         specifier: ^6.0.1
         version: 6.2.2
@@ -53,22 +59,22 @@ importers:
         version: 3.1049.0
       '@babel/core':
         specifier: ^7.14.0
-        version: 7.29.0
+        version: 7.29.0(supports-color@8.1.1)
       '@babel/eslint-parser':
         specifier: ^7.28.0
-        version: 7.28.6(@babel/core@7.29.0)(eslint@9.39.4(jiti@1.21.7))
+        version: 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))
       '@babel/plugin-syntax-import-attributes':
         specifier: ^7.27.1
-        version: 7.28.6(@babel/core@7.29.0)
+        version: 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))
       '@babel/preset-react':
         specifier: ^7.13.13
-        version: 7.28.5(@babel/core@7.29.0)
+        version: 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))
       '@bundled-es-modules/chai':
         specifier: ^4.2.2
         version: 4.3.7
       '@clevercloud/eslint-config':
         specifier: ^1.0.1
-        version: 1.1.0(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+        version: 1.1.0(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
       '@clevercloud/reglage':
         specifier: ^0.0.6
         version: 0.0.6(zod@4.4.3)
@@ -83,7 +89,7 @@ importers:
         version: 0.9.9
       '@eslint/compat':
         specifier: ^1.2.0
-        version: 1.4.1(eslint@9.39.4(jiti@1.21.7))
+        version: 1.4.1(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))
       '@eslint/js':
         specifier: ^9.8.0
         version: 9.39.4
@@ -92,13 +98,13 @@ importers:
         version: 7.1.1
       '@html-eslint/eslint-plugin':
         specifier: ^0.41.0
-        version: 0.41.0(eslint@9.39.4(jiti@1.21.7))
+        version: 0.41.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))
       '@octokit/rest':
         specifier: ^22.0.0
         version: 22.0.1
       '@open-wc/dev-server-hmr':
         specifier: ^0.1.3
-        version: 0.1.4
+        version: 0.1.4(supports-color@8.1.1)
       '@open-wc/testing':
         specifier: ^4.0.0
         version: 4.0.0
@@ -164,7 +170,7 @@ importers:
         version: 1.0.8(rollup@2.80.0)
       '@web/test-runner':
         specifier: ^0.19.0
-        version: 0.19.0
+        version: 0.19.0(supports-color@8.1.1)
       '@web/test-runner-chrome':
         specifier: ^0.17.0
         version: 0.17.0
@@ -182,7 +188,7 @@ importers:
         version: 0.10.0
       babel-loader:
         specifier: ^8.2.2
-        version: 8.4.1(@babel/core@7.29.0)(webpack@5.106.2(clean-css@5.3.3)(esbuild@0.12.29)(postcss@8.5.15))
+        version: 8.4.1(@babel/core@7.29.0(supports-color@8.1.1))(webpack@5.106.2(clean-css@5.3.3)(esbuild@0.12.29)(postcss@8.5.15))
       babel-plugin-inline-svg:
         specifier: ^1.2.0
         version: 1.2.0
@@ -209,25 +215,25 @@ importers:
         version: 0.12.29
       eslint:
         specifier: ^9.32.0
-        version: 9.39.4(jiti@1.21.7)
+        version: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
       eslint-config-prettier:
         specifier: ^9.1.0
-        version: 9.1.2(eslint@9.39.4(jiti@1.21.7))
+        version: 9.1.2(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))
       eslint-plugin-import:
         specifier: ^2.31.0
-        version: 2.32.0(eslint@9.39.4(jiti@1.21.7))
+        version: 2.32.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))
       eslint-plugin-lit:
         specifier: ^1.15.0
-        version: 1.15.0(eslint@9.39.4(jiti@1.21.7))
+        version: 1.15.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))
       eslint-plugin-lit-a11y:
         specifier: ^4.1.4
-        version: 4.1.4(eslint@9.39.4(jiti@1.21.7))
+        version: 4.1.4(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))
       eslint-plugin-n:
         specifier: ^17.13.0
-        version: 17.24.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+        version: 17.24.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(typescript@5.9.3)
       eslint-plugin-wc:
         specifier: ^2.2.0
-        version: 2.2.1(eslint@9.39.4(jiti@1.21.7))
+        version: 2.2.1(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))
       github-markdown-css:
         specifier: ^4.0.0
         version: 4.0.0
@@ -296,7 +302,7 @@ importers:
         version: 2.80.0
       rollup-plugin-babel:
         specifier: ^4.4.0
-        version: 4.4.0(@babel/core@7.29.0)(rollup@2.80.0)
+        version: 4.4.0(@babel/core@7.29.0(supports-color@8.1.1))(rollup@2.80.0)
       rollup-plugin-clear:
         specifier: ^2.0.7
         version: 2.0.7
@@ -317,19 +323,19 @@ importers:
         version: 10.4.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       stylelint:
         specifier: ^16.10.0
-        version: 16.26.1(typescript@5.9.3)
+        version: 16.26.1(supports-color@8.1.1)(typescript@5.9.3)
       stylelint-config-standard:
         specifier: ^36.0.0
-        version: 36.0.1(stylelint@16.26.1(typescript@5.9.3))
+        version: 36.0.1(stylelint@16.26.1(supports-color@8.1.1)(typescript@5.9.3))
       stylelint-no-unsupported-browser-features:
         specifier: ^8.0.4
-        version: 8.1.1(stylelint@16.26.1(typescript@5.9.3))
+        version: 8.1.1(stylelint@16.26.1(supports-color@8.1.1)(typescript@5.9.3))
       stylelint-order:
         specifier: ^6.0.4
-        version: 6.0.4(stylelint@16.26.1(typescript@5.9.3))
+        version: 6.0.4(stylelint@16.26.1(supports-color@8.1.1)(typescript@5.9.3))
       superagent:
         specifier: ^6.1.0
-        version: 6.1.0
+        version: 6.1.0(supports-color@8.1.1)
       svgo:
         specifier: ^1.3.2
         version: 1.3.2
@@ -1803,6 +1809,14 @@ packages:
     peerDependencies:
       lit: ^2.0.0 || ^3.0.0
       storybook: ^10.4.0
+
+  '@tanstack/lit-virtual@3.13.29':
+    resolution: {integrity: sha512-fnFZ2cFcOEskbLIzNwPgN1sZ9R4xxG3wWsD8WnHRbKlUZUs9qs1lyYiakXaIHHpKedYNbhmYaP9iYYGoXwYSYQ==}
+    peerDependencies:
+      lit: ^3.1.0
+
+  '@tanstack/virtual-core@3.17.0':
+    resolution: {integrity: sha512-gOxY/hFkPh/XQYhnThBHzkbkX3Ed+z/iushyz+R+JAr213aXxUDgQoTgTdrDpBSRsjFM73P/KfUyWmaF9WHMkQ==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -6453,16 +6467,16 @@ snapshots:
 
   '@babel/compat-data@7.29.3': {}
 
-  '@babel/core@7.29.0':
+  '@babel/core@7.29.0(supports-color@8.1.1)':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
       '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))
       '@babel/helpers': 7.29.2
       '@babel/parser': 7.29.3
       '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
@@ -6473,11 +6487,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/eslint-parser@7.28.6(@babel/core@7.29.0)(eslint@9.39.4(jiti@1.21.7))':
+  '@babel/eslint-parser@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
-      eslint: 9.39.4(jiti@1.21.7)
+      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
       eslint-visitor-keys: 2.1.0
       semver: 6.3.1
 
@@ -6501,15 +6515,15 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.29.3(@babel/core@7.29.0)':
+  '@babel/helper-create-class-features-plugin@7.29.3(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -6518,24 +6532,24 @@ snapshots:
 
   '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-imports@7.28.6':
     dependencies:
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-module-imports': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -6545,18 +6559,18 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.28.6': {}
 
-  '@babel/helper-replace-supers@7.28.6(@babel/core@7.29.0)':
+  '@babel/helper-replace-supers@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     dependencies:
-      '@babel/traverse': 7.29.0
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -6576,102 +6590,102 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
-  '@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.29.0)':
+  '@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0)':
+  '@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0(supports-color@8.1.1))
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-syntax-decorators': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-decorators': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-decorators@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-decorators@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-import-assertions@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-import-assertions@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.0)':
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-react-display-name@7.28.0(@babel/core@7.29.0)':
+  '@babel/plugin-transform-react-display-name@7.28.0(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-react-jsx-development@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-react-jsx-development@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0)':
+  '@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-module-imports': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-react-pure-annotations@7.27.1(@babel/core@7.29.0)':
+  '@babel/plugin-transform-react-pure-annotations@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/preset-react@7.28.5(@babel/core@7.29.0)':
+  '@babel/preset-react@7.28.5(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-transform-react-display-name': 7.28.0(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-pure-annotations': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-display-name': 7.28.0(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-react-pure-annotations': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/register@7.29.3(@babel/core@7.29.0)':
+  '@babel/register@7.29.3(@babel/core@7.29.0(supports-color@8.1.1))':
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       clone-deep: 4.0.1
       find-cache-dir: 2.1.0
       make-dir: 2.1.0
@@ -6686,7 +6700,7 @@ snapshots:
       '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
 
-  '@babel/traverse@7.29.0':
+  '@babel/traverse@7.29.0(supports-color@8.1.1)':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
@@ -6723,12 +6737,12 @@ snapshots:
       eventsource: 4.1.0
       fetch-event-stream: 0.1.6
 
-  '@clevercloud/eslint-config@1.1.0(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)':
+  '@clevercloud/eslint-config@1.1.0(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
     dependencies:
       '@eslint/js': 9.39.4
-      eslint: 9.39.4(jiti@1.21.7)
-      eslint-plugin-import-x: 4.16.2(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@1.21.7))
-      eslint-plugin-n: 17.24.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
+      eslint-plugin-import-x: 4.16.2(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(supports-color@8.1.1)
+      eslint-plugin-n: 17.24.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(typescript@5.9.3)
     transitivePeerDependencies:
       - '@typescript-eslint/utils'
       - eslint-import-resolver-node
@@ -6997,20 +7011,20 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@1.21.7))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))':
     dependencies:
-      eslint: 9.39.4(jiti@1.21.7)
+      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/compat@1.4.1(eslint@9.39.4(jiti@1.21.7))':
+  '@eslint/compat@1.4.1(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))':
     dependencies:
       '@eslint/core': 0.17.0
     optionalDependencies:
-      eslint: 9.39.4(jiti@1.21.7)
+      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
 
-  '@eslint/config-array@0.21.2':
+  '@eslint/config-array@0.21.2(supports-color@8.1.1)':
     dependencies:
       '@eslint/object-schema': 2.1.7
       debug: 4.4.3(supports-color@8.1.1)
@@ -7030,7 +7044,7 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.3.5':
+  '@eslint/eslintrc@3.3.5(supports-color@8.1.1)':
     dependencies:
       ajv: 6.15.0
       debug: 4.4.3(supports-color@8.1.1)
@@ -7079,13 +7093,13 @@ snapshots:
 
   '@hapi/bourne@3.0.0': {}
 
-  '@html-eslint/eslint-plugin@0.41.0(eslint@9.39.4(jiti@1.21.7))':
+  '@html-eslint/eslint-plugin@0.41.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))':
     dependencies:
       '@eslint/plugin-kit': 0.3.5
       '@html-eslint/parser': 0.41.0
       '@html-eslint/template-parser': 0.41.0
       '@html-eslint/template-syntax-parser': 0.41.0
-      eslint: 9.39.4(jiti@1.21.7)
+      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
 
   '@html-eslint/parser@0.41.0':
     dependencies:
@@ -7270,13 +7284,13 @@ snapshots:
 
   '@open-wc/dedupe-mixin@2.0.1': {}
 
-  '@open-wc/dev-server-hmr@0.1.4':
+  '@open-wc/dev-server-hmr@0.1.4(supports-color@8.1.1)':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.0)
-      '@babel/plugin-syntax-import-assertions': 7.28.6(@babel/core@7.29.0)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.0)
-      '@web/dev-server-core': 0.4.1
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-import-assertions': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.0(supports-color@8.1.1))
+      '@web/dev-server-core': 0.4.1(supports-color@8.1.1)
       '@web/dev-server-hmr': 0.1.12
       picomatch: 2.3.2
     transitivePeerDependencies:
@@ -7756,6 +7770,13 @@ snapshots:
       tiny-invariant: 1.3.3
       ts-dedent: 2.2.0
 
+  '@tanstack/lit-virtual@3.13.29(lit@3.3.3)':
+    dependencies:
+      '@tanstack/virtual-core': 3.17.0
+      lit: 3.3.3
+
+  '@tanstack/virtual-core@3.17.0': {}
+
   '@testing-library/dom@10.4.1':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -8134,9 +8155,9 @@ snapshots:
       get-stream: 6.0.1
       is-stream: 2.0.1
       isbinaryfile: 4.0.10
-      koa: 2.16.4
+      koa: 2.16.4(supports-color@8.1.1)
       koa-etag: 4.0.0
-      koa-send: 5.0.1
+      koa-send: 5.0.1(supports-color@8.1.1)
       koa-static: 5.0.0
       lru-cache: 6.0.0
       mime-types: 2.1.35
@@ -8148,7 +8169,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@web/dev-server-core@0.4.1':
+  '@web/dev-server-core@0.4.1(supports-color@8.1.1)':
     dependencies:
       '@types/koa': 2.15.1
       '@types/ws': 7.4.7
@@ -8159,9 +8180,9 @@ snapshots:
       get-stream: 6.0.1
       is-stream: 2.0.1
       isbinaryfile: 5.0.7
-      koa: 2.16.4
+      koa: 2.16.4(supports-color@8.1.1)
       koa-etag: 4.0.0
-      koa-send: 5.0.1
+      koa-send: 5.0.1(supports-color@8.1.1)
       koa-static: 5.0.0
       lru-cache: 6.0.0
       mime-types: 2.1.35
@@ -8184,9 +8205,9 @@ snapshots:
       get-stream: 6.0.1
       is-stream: 2.0.1
       isbinaryfile: 5.0.7
-      koa: 2.16.4
+      koa: 2.16.4(supports-color@8.1.1)
       koa-etag: 4.0.0
-      koa-send: 5.0.1
+      koa-send: 5.0.1(supports-color@8.1.1)
       koa-static: 5.0.0
       lru-cache: 8.0.5
       mime-types: 2.1.35
@@ -8200,7 +8221,7 @@ snapshots:
 
   '@web/dev-server-hmr@0.1.12':
     dependencies:
-      '@web/dev-server-core': 0.4.1
+      '@web/dev-server-core': 0.4.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -8247,7 +8268,7 @@ snapshots:
       internal-ip: 6.2.0
       nanocolors: 0.2.13
       open: 8.4.2
-      portfinder: 1.0.38
+      portfinder: 1.0.38(supports-color@8.1.1)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -8373,7 +8394,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@web/test-runner@0.19.0':
+  '@web/test-runner@0.19.0(supports-color@8.1.1)':
     dependencies:
       '@web/browser-logs': 0.4.1
       '@web/config-loader': 0.3.3
@@ -8389,7 +8410,7 @@ snapshots:
       diff: 5.2.2
       globby: 11.1.0
       nanocolors: 0.2.13
-      portfinder: 1.0.38
+      portfinder: 1.0.38(supports-color@8.1.1)
       source-map: 0.7.6
     transitivePeerDependencies:
       - bare-abort-controller
@@ -8684,9 +8705,9 @@ snapshots:
       esutils: 2.0.3
       js-tokens: 3.0.2
 
-  babel-loader@8.4.1(@babel/core@7.29.0)(webpack@5.106.2(clean-css@5.3.3)(esbuild@0.12.29)(postcss@8.5.15)):
+  babel-loader@8.4.1(@babel/core@7.29.0(supports-color@8.1.1))(webpack@5.106.2(clean-css@5.3.3)(esbuild@0.12.29)(postcss@8.5.15)):
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       find-cache-dir: 3.3.2
       loader-utils: 2.0.4
       make-dir: 3.1.0
@@ -9577,14 +9598,14 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-compat-utils@0.5.1(eslint@9.39.4(jiti@1.21.7)):
+  eslint-compat-utils@0.5.1(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1)):
     dependencies:
-      eslint: 9.39.4(jiti@1.21.7)
+      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
       semver: 7.8.0
 
-  eslint-config-prettier@9.1.2(eslint@9.39.4(jiti@1.21.7)):
+  eslint-config-prettier@9.1.2(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1)):
     dependencies:
-      eslint: 9.39.4(jiti@1.21.7)
+      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
 
   eslint-import-context@0.1.9(unrs-resolver@1.12.2):
     dependencies:
@@ -9601,29 +9622,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@1.21.7)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      eslint: 9.39.4(jiti@1.21.7)
+      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
       eslint-import-resolver-node: 0.3.10
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-es-x@7.8.0(eslint@9.39.4(jiti@1.21.7)):
+  eslint-plugin-es-x@7.8.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@1.21.7))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))
       '@eslint-community/regexpp': 4.12.2
-      eslint: 9.39.4(jiti@1.21.7)
-      eslint-compat-utils: 0.5.1(eslint@9.39.4(jiti@1.21.7))
+      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
+      eslint-compat-utils: 0.5.1(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))
 
-  eslint-plugin-import-x@4.16.2(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@1.21.7)):
+  eslint-plugin-import-x@4.16.2(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       '@package-json/types': 0.0.12
       '@typescript-eslint/types': 8.59.4
       comment-parser: 1.4.6
       debug: 4.4.3(supports-color@8.1.1)
-      eslint: 9.39.4(jiti@1.21.7)
+      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
       eslint-import-context: 0.1.9(unrs-resolver@1.12.2)
       is-glob: 4.0.3
       minimatch: 10.2.5
@@ -9635,7 +9656,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@1.21.7)):
+  eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -9644,9 +9665,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.39.4(jiti@1.21.7)
+      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@1.21.7))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))
       hasown: 2.0.3
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -9662,34 +9683,34 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-lit-a11y@4.1.4(eslint@9.39.4(jiti@1.21.7)):
+  eslint-plugin-lit-a11y@4.1.4(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1)):
     dependencies:
       '@thepassle/axobject-query': 4.0.0
       aria-query: 5.3.2
       axe-core: 4.4.3
       dom5: 3.0.1
       emoji-regex: 10.6.0
-      eslint: 9.39.4(jiti@1.21.7)
-      eslint-plugin-lit: 1.15.0(eslint@9.39.4(jiti@1.21.7))
+      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
+      eslint-plugin-lit: 1.15.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))
       eslint-rule-extender: 0.0.1
       language-tags: 1.0.9
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 6.0.1
       requireindex: 1.2.0
 
-  eslint-plugin-lit@1.15.0(eslint@9.39.4(jiti@1.21.7)):
+  eslint-plugin-lit@1.15.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1)):
     dependencies:
-      eslint: 9.39.4(jiti@1.21.7)
+      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
       parse5: 6.0.1
       parse5-htmlparser2-tree-adapter: 6.0.1
       requireindex: 1.2.0
 
-  eslint-plugin-n@17.24.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3):
+  eslint-plugin-n@17.24.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(typescript@5.9.3):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@1.21.7))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))
       enhanced-resolve: 5.21.5
-      eslint: 9.39.4(jiti@1.21.7)
-      eslint-plugin-es-x: 7.8.0(eslint@9.39.4(jiti@1.21.7))
+      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
+      eslint-plugin-es-x: 7.8.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))
       get-tsconfig: 4.14.0
       globals: 15.15.0
       globrex: 0.1.2
@@ -9699,9 +9720,9 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  eslint-plugin-wc@2.2.1(eslint@9.39.4(jiti@1.21.7)):
+  eslint-plugin-wc@2.2.1(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1)):
     dependencies:
-      eslint: 9.39.4(jiti@1.21.7)
+      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
       is-valid-element-name: 1.0.0
       js-levenshtein-esm: 1.2.0
 
@@ -9723,14 +9744,14 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.39.4(jiti@1.21.7):
+  eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@1.21.7))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.2
+      '@eslint/config-array': 0.21.2(supports-color@8.1.1)
       '@eslint/config-helpers': 0.4.2
       '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.5
+      '@eslint/eslintrc': 3.3.5(supports-color@8.1.1)
       '@eslint/js': 9.39.4
       '@eslint/plugin-kit': 0.4.1
       '@humanfs/node': 0.16.8
@@ -10266,12 +10287,12 @@ snapshots:
 
   i18n-extract@0.6.7:
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.29.0)
-      '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.29.0)
-      '@babel/register': 7.29.3(@babel/core@7.29.0)
-      '@babel/traverse': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/register': 7.29.3(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/traverse': 7.29.0(supports-color@8.1.1)
       gettext-parser: 3.1.1
       glob: 7.2.3
     transitivePeerDependencies:
@@ -10632,7 +10653,7 @@ snapshots:
     dependencies:
       etag: 1.8.1
 
-  koa-send@5.0.1:
+  koa-send@5.0.1(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       http-errors: 1.8.1
@@ -10643,11 +10664,11 @@ snapshots:
   koa-static@5.0.0:
     dependencies:
       debug: 3.2.7
-      koa-send: 5.0.1
+      koa-send: 5.0.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  koa@2.16.4:
+  koa@2.16.4(supports-color@8.1.1):
     dependencies:
       accepts: 1.3.8
       cache-content-type: 1.0.1
@@ -11435,7 +11456,7 @@ snapshots:
 
   pngjs@7.0.0: {}
 
-  portfinder@1.0.38:
+  portfinder@1.0.38(supports-color@8.1.1):
     dependencies:
       async: 3.2.6
       debug: 4.4.3(supports-color@8.1.1)
@@ -11715,9 +11736,9 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
-  rollup-plugin-babel@4.4.0(@babel/core@7.29.0)(rollup@2.80.0):
+  rollup-plugin-babel@4.4.0(@babel/core@7.29.0(supports-color@8.1.1))(rollup@2.80.0):
     dependencies:
-      '@babel/core': 7.29.0
+      '@babel/core': 7.29.0(supports-color@8.1.1)
       '@babel/helper-module-imports': 7.28.6
       rollup: 2.80.0
       rollup-pluginutils: 2.8.2
@@ -12098,29 +12119,29 @@ snapshots:
 
   strnum@2.3.0: {}
 
-  stylelint-config-recommended@14.0.1(stylelint@16.26.1(typescript@5.9.3)):
+  stylelint-config-recommended@14.0.1(stylelint@16.26.1(supports-color@8.1.1)(typescript@5.9.3)):
     dependencies:
-      stylelint: 16.26.1(typescript@5.9.3)
+      stylelint: 16.26.1(supports-color@8.1.1)(typescript@5.9.3)
 
-  stylelint-config-standard@36.0.1(stylelint@16.26.1(typescript@5.9.3)):
+  stylelint-config-standard@36.0.1(stylelint@16.26.1(supports-color@8.1.1)(typescript@5.9.3)):
     dependencies:
-      stylelint: 16.26.1(typescript@5.9.3)
-      stylelint-config-recommended: 14.0.1(stylelint@16.26.1(typescript@5.9.3))
+      stylelint: 16.26.1(supports-color@8.1.1)(typescript@5.9.3)
+      stylelint-config-recommended: 14.0.1(stylelint@16.26.1(supports-color@8.1.1)(typescript@5.9.3))
 
-  stylelint-no-unsupported-browser-features@8.1.1(stylelint@16.26.1(typescript@5.9.3)):
+  stylelint-no-unsupported-browser-features@8.1.1(stylelint@16.26.1(supports-color@8.1.1)(typescript@5.9.3)):
     dependencies:
       browserslist: 4.28.2
       doiuse: 6.0.6
       postcss: 8.5.15
-      stylelint: 16.26.1(typescript@5.9.3)
+      stylelint: 16.26.1(supports-color@8.1.1)(typescript@5.9.3)
 
-  stylelint-order@6.0.4(stylelint@16.26.1(typescript@5.9.3)):
+  stylelint-order@6.0.4(stylelint@16.26.1(supports-color@8.1.1)(typescript@5.9.3)):
     dependencies:
       postcss: 8.5.15
       postcss-sorting: 8.0.2(postcss@8.5.15)
-      stylelint: 16.26.1(typescript@5.9.3)
+      stylelint: 16.26.1(supports-color@8.1.1)(typescript@5.9.3)
 
-  stylelint@16.26.1(typescript@5.9.3):
+  stylelint@16.26.1(supports-color@8.1.1)(typescript@5.9.3):
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-syntax-patches-for-csstree': 1.1.4(css-tree@3.2.1)
@@ -12165,7 +12186,7 @@ snapshots:
       - supports-color
       - typescript
 
-  superagent@6.1.0:
+  superagent@6.1.0(supports-color@8.1.1):
     dependencies:
       component-emitter: 1.3.1
       cookiejar: 2.1.4

--- a/sandbox/cc-logs-app-runtime/cc-logs-app-runtime-sandbox.js
+++ b/sandbox/cc-logs-app-runtime/cc-logs-app-runtime-sandbox.js
@@ -79,7 +79,7 @@ class CcLogsAppRuntimeSandbox extends LitElement {
 
       <div class="main">
         <cc-smart-container ${ref(this._smartContainerRef)}>
-          <cc-logs-app-runtime-beta class="cc-logs-app-runtime"></cc-logs-app-runtime-beta>
+          <cc-logs-app-runtime-beta class="cc-logs-app-runtime" limit="10000"></cc-logs-app-runtime-beta>
         </cc-smart-container>
       </div>
     `;

--- a/sandbox/cc-logs/cc-logs-sandbox.js
+++ b/sandbox/cc-logs/cc-logs-sandbox.js
@@ -159,6 +159,10 @@ class CcLogsSandbox extends LitElement {
     this._logsRef.value.appendLogs([this._newLog()]);
   }
 
+  _onAddManyClick() {
+    this._logsRef.value.appendLogs(Array.from({ length: 1000 }, () => this._newLog()));
+  }
+
   _onClearClick() {
     this._clear();
   }
@@ -268,6 +272,9 @@ class CcLogsSandbox extends LitElement {
         ></cc-button>
         <cc-button @cc-click=${this._onAddClick} ?primary=${true} ?outlined=${true} .icon=${addIcon}
           >Add one log
+        </cc-button>
+        <cc-button @cc-click=${this._onAddManyClick} ?primary=${true} ?outlined=${true} .icon=${addIcon}
+          >Add +1000 logs
         </cc-button>
         <cc-button @cc-click=${this._onClearClick} ?danger=${true} ?outlined=${true} .icon=${clearIcon}
           >Clear

--- a/src/components/cc-logs/cc-logs.follow.test.js
+++ b/src/components/cc-logs/cc-logs.follow.test.js
@@ -1,0 +1,174 @@
+import { expect, fixture, nextFrame } from '@open-wc/testing';
+import { html } from 'lit';
+import './cc-logs.js';
+
+/** @param {number} length @param {number} offset */
+function generateLogs(length, offset = 0) {
+  return Array.from({ length }, (_, i) => {
+    const id = offset + i;
+    return {
+      id: `log-${id}`,
+      date: new Date(1600000000000 + id * 1000),
+      message: `Message ${id} lorem ipsum dolor sit amet`,
+      metadata: [{ name: 'instance', value: `instance-${id % 4}` }],
+    };
+  });
+}
+
+/** @param {number} ms */
+function wait(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** @param {import('./cc-logs.js').CcLogs} el */
+function snap(el) {
+  const c = el.shadowRoot.querySelector('.logs_container');
+  const v = el._getVirtualizer();
+  return {
+    follow: el.follow,
+    scrollTop: Math.round(c.scrollTop),
+    distToBottom: Math.round(v.getTotalSize() - c.clientHeight - c.scrollTop),
+  };
+}
+
+describe('cc-logs native follow', function () {
+  // The "ResizeObserver loop completed with undelivered notifications" warning is benign and already filtered by the
+  // project's web-test-runner config; swallow it here so it doesn't fail these strict, churn-heavy tests.
+  before(function () {
+    const original = window.onerror;
+    window.onerror = function (message, ...rest) {
+      if (typeof message === 'string' && message.includes('ResizeObserver loop')) {
+        return true;
+      }
+      return original ? original.call(this, message, ...rest) : false;
+    };
+  });
+
+  it('follows the initial big append', async function () {
+    const el = await fixture(html`<cc-logs-beta follow style="display:block; height:300px;"></cc-logs-beta>`);
+    await el.updateComplete;
+    el.appendLogs(generateLogs(2000));
+    for (let i = 0; i < 8; i++) {
+      await nextFrame();
+    }
+    const s = snap(el);
+    expect(s.follow, 'follow stays on').to.equal(true);
+    expect(s.scrollTop, 'pinned to bottom').to.be.greaterThan(0);
+    expect(s.distToBottom, 'at bottom').to.be.lessThan(8);
+  });
+
+  it('keeps following through a throttled stream then silence', async function () {
+    const el = await fixture(html`<cc-logs-beta follow style="display:block; height:300px;"></cc-logs-beta>`);
+    await el.updateComplete;
+    const transitions = [];
+    el.addEventListener('cc-logs-follow-change', (e) => transitions.push(e.detail));
+    for (let b = 0; b < 25; b++) {
+      el.appendLogs(generateLogs(200, b * 200));
+      await nextFrame();
+    }
+    await wait(300);
+    await nextFrame();
+    const s = snap(el);
+    expect(s.follow, `follow stayed on (transitions=${transitions})`).to.equal(true);
+    expect(s.distToBottom).to.be.lessThan(8);
+  });
+
+  it('unfollows on user scroll-up and re-follows at the bottom', async function () {
+    const el = await fixture(html`<cc-logs-beta follow style="display:block; height:300px;"></cc-logs-beta>`);
+    await el.updateComplete;
+    el.appendLogs(generateLogs(2000));
+    for (let i = 0; i < 8; i++) {
+      await nextFrame();
+    }
+    const c = el.shadowRoot.querySelector('.logs_container');
+
+    // User scrolls up.
+    c.scrollTop = 100;
+    c.dispatchEvent(new Event('scroll'));
+    await nextFrame();
+    expect(el.follow, 'unfollowed after scroll-up').to.equal(false);
+
+    // New logs arrive: view must NOT jump to bottom.
+    el.appendLogs(generateLogs(200, 2000));
+    for (let i = 0; i < 4; i++) {
+      await nextFrame();
+    }
+    expect(el.follow, 'stays unfollowed while reading history').to.equal(false);
+    expect(c.scrollTop, 'view stayed up').to.be.lessThan(2000);
+
+    // User scrolls back to the bottom.
+    c.scrollTop = c.scrollHeight;
+    c.dispatchEvent(new Event('scroll'));
+    await nextFrame();
+    expect(el.follow, 're-followed at bottom').to.equal(true);
+  });
+
+  it('lets the user break out of follow with a wheel-up during fast streaming', async function () {
+    const el = await fixture(html`<cc-logs-beta follow style="display:block; height:300px;"></cc-logs-beta>`);
+    await el.updateComplete;
+    const c = el.shadowRoot.querySelector('.logs_container');
+
+    // Logs stream in on every frame (so the virtualizer keeps re-pinning to the bottom and its `scrollState` stays
+    // busy). Mid-stream, the user flicks the wheel up to read history — this must break out of follow even though a
+    // programmatic scroll is in flight, and the following appends must not re-pin the view under them.
+    for (let b = 0; b < 12; b++) {
+      el.appendLogs(generateLogs(200, b * 200));
+      if (b === 6) {
+        c.scrollTop = 100;
+        c.dispatchEvent(new WheelEvent('wheel', { deltaY: -100, bubbles: true }));
+      }
+      await nextFrame();
+    }
+
+    expect(el.follow, 'wheel-up unfollowed during streaming').to.equal(false);
+    expect(c.scrollTop, 'view was not re-pinned to the bottom').to.be.lessThan(2000);
+  });
+
+  it('keeps following once the list is capped at the limit (front-trim)', async function () {
+    const el = await fixture(
+      html`<cc-logs-beta follow limit="500" style="display:block; height:300px;"></cc-logs-beta>`,
+    );
+    await el.updateComplete;
+    // Stream well past the limit so front-trim kicks in repeatedly.
+    for (let b = 0; b < 15; b++) {
+      el.appendLogs(generateLogs(200, b * 200));
+      await wait(20);
+    }
+    for (let i = 0; i < 6; i++) {
+      await nextFrame();
+    }
+    const s = snap(el);
+    expect(el._logsCtrl.listLength, 'capped at limit').to.equal(500);
+    expect(s.follow, 'still following at limit').to.equal(true);
+    expect(s.distToBottom, 'still pinned to bottom').to.be.lessThan(8);
+  });
+
+  it('skips the costly size-cache realign while following at the limit', async function () {
+    const el = await fixture(
+      html`<cc-logs-beta follow limit="500" style="display:block; height:300px;"></cc-logs-beta>`,
+    );
+    await el.updateComplete;
+    // Fill past the limit so front-trim is now happening on every append.
+    for (let b = 0; b < 5; b++) {
+      el.appendLogs(generateLogs(200, b * 200));
+      await wait(20);
+    }
+    for (let i = 0; i < 6; i++) {
+      await nextFrame();
+    }
+    expect(el._logsCtrl.listLength, 'capped at limit').to.equal(500);
+    expect(el.follow, 'following').to.equal(true);
+
+    // The realign shift is the only thing that ever REPLACES the virtualizer's `itemSizeCache` Map (the virtualizer
+    // itself only mutates it in place). While following, the shift+recompute is skipped — the dominant per-append cost
+    // at a large limit — because the re-measured bottom window keeps heights correct on its own.
+    const cacheRef = el._getVirtualizer().itemSizeCache;
+    el.appendLogs(generateLogs(200, 1000));
+    for (let i = 0; i < 6; i++) {
+      await nextFrame();
+    }
+
+    expect(el.follow, 'still following after another front-trim').to.equal(true);
+    expect(el._getVirtualizer().itemSizeCache, 'the size-cache Map is not rebuilt while following').to.equal(cacheRef);
+  });
+});

--- a/src/components/cc-logs/cc-logs.inspect.test.js
+++ b/src/components/cc-logs/cc-logs.inspect.test.js
@@ -1,0 +1,80 @@
+import { expect, fixture, nextFrame } from '@open-wc/testing';
+import { html } from 'lit';
+import './cc-logs.js';
+
+/** @param {number} length @param {number} offset */
+function generateLogs(length, offset = 0) {
+  return Array.from({ length }, (_, i) => {
+    const id = offset + i;
+    return {
+      id: `log-${id}`,
+      date: new Date(1600000000000 + id * 1000),
+      // One log in ten carries a marker so a message filter keeps a spread-out subset.
+      message: id % 10 === 0 ? `Message ${id} TARGET lorem ipsum` : `Message ${id} lorem ipsum`,
+      metadata: [],
+    };
+  });
+}
+
+/** @param {number} ms */
+function wait(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe('cc-logs inspect scroll', function () {
+  // The "ResizeObserver loop completed with undelivered notifications" warning is benign; swallow it so it doesn't
+  // fail these strict, churn-heavy tests.
+  before(function () {
+    const original = window.onerror;
+    window.onerror = function (message, ...rest) {
+      if (typeof message === 'string' && message.includes('ResizeObserver loop')) {
+        return true;
+      }
+      return original ? original.call(this, message, ...rest) : false;
+    };
+  });
+
+  it('scrolls the inspected log into view once the host clears the message filter', async function () {
+    const el = await fixture(
+      html`<cc-logs-beta message-filter="TARGET" style="display:block; height:300px;"></cc-logs-beta>`,
+    );
+    await el.updateComplete;
+    el.appendLogs(generateLogs(200));
+    for (let i = 0; i < 6; i++) {
+      await nextFrame();
+    }
+
+    // Real hosts (cc-logs-*-runtime) clear the message filter when a log is inspected.
+    el.addEventListener('cc-log-inspect', () => {
+      el.messageFilter = '';
+    });
+
+    // Select a TARGET log far from the top: filtered index 10 maps to full-list index 100.
+    el._logsCtrl.toggleSelection(10);
+    await el.updateComplete;
+
+    el._onInspectLogButtonClick();
+    // Let the filter-clearing update land and the virtualizer's scroll reconcile converge.
+    for (let i = 0; i < 10; i++) {
+      await nextFrame();
+    }
+    await wait(50);
+    await nextFrame();
+
+    const c = el.shadowRoot.querySelector('.logs_container');
+    const row = el.shadowRoot.querySelector('.log[data-index="100"]');
+
+    // The inspected log (full-list index 100, not the filtered index 10) is the one rendered and brought into view.
+    expect(row, 'the inspected log is rendered').to.not.equal(null);
+
+    const cRect = c.getBoundingClientRect();
+    const rRect = row.getBoundingClientRect();
+    // It is within the viewport...
+    expect(rRect.top, 'inspected row below container top').to.be.greaterThan(cRect.top - 5);
+    expect(rRect.bottom, 'inspected row above container bottom').to.be.lessThan(cRect.bottom + 5);
+    // ...and roughly centered, not pinned to an edge.
+    const rowCenter = rRect.top + rRect.height / 2;
+    const containerCenter = cRect.top + cRect.height / 2;
+    expect(Math.abs(rowCenter - containerCenter), 'inspected row roughly centered').to.be.lessThan(cRect.height / 2);
+  });
+});

--- a/src/components/cc-logs/cc-logs.js
+++ b/src/components/cc-logs/cc-logs.js
@@ -1,4 +1,4 @@
-import '@lit-labs/virtualizer';
+import { VirtualizerController } from '@tanstack/lit-virtual';
 import { css, html, LitElement, unsafeCSS } from 'lit';
 import { classMap } from 'lit/directives/class-map.js';
 import { join } from 'lit/directives/join.js';
@@ -13,6 +13,7 @@ import { ansiStyles, ansiToLit, stripAnsi } from '../../lib/ansi/ansi.js';
 import defaultPalette from '../../lib/ansi/palettes/default.js';
 import { copyToClipboard, prepareLinesOfCodeForClipboard } from '../../lib/clipboard.js';
 import { hasClass } from '../../lib/dom.js';
+import { focusBySelector } from '../../lib/focus-helper.js';
 import { notifySuccess } from '../../lib/notifications.js';
 import { isStringEmpty, truncateString } from '../../lib/utils.js';
 import { i18n } from '../../translations/translation.js';
@@ -25,6 +26,28 @@ import { CcLogInspectEvent, CcLogsFollowChangeEvent } from './cc-logs.events.js'
 import { DateDisplayer } from './date-displayer.js';
 import { LogsController } from './logs-controller.js';
 import { LogsInputController } from './logs-input-controller.js';
+
+// The estimated height (in pixels) of a single log line.
+// This is only used by the virtualizer for logs that are not in the DOM yet (their real size is measured once rendered).
+const ESTIMATED_LOG_LINE_HEIGHT = 21;
+
+// How many extra logs the virtualizer renders above and below the viewport to smooth out scrolling.
+const VIRTUALIZER_OVERSCAN = 10;
+
+// The maximum distance (in pixels) from the bottom of the scroll container under which we consider the user is at the
+// bottom of the logs and the follow should be (re)activated. It absorbs sub-pixel rounding from dynamic measurement.
+const FOLLOW_SCROLL_THRESHOLD = 8;
+
+// How long (in milliseconds) auto-follow stays suppressed after a user interaction that must not be interrupted by a
+// fresh append re-pinning the view (selecting or dragging logs).
+const FOLLOW_SUPPRESS_MS = 150;
+
+// The `@tanstack/virtual-core` internals cc-logs reaches into that are NOT part of the public API: they are declared
+// `private` in the library's types, which is why they are accessed by string key. Every access is funnelled through
+// `_isVirtualizerScrolling()` / `_forceVirtualizerRemeasure()` so a library upgrade has a single audit point, and
+// `cc-logs.virtualizer-contract.test.js` asserts these fields still exist so an incompatible upgrade fails in CI
+// instead of silently breaking follow detection and overlap realignment. Verified against @tanstack/virtual-core 3.x.
+export const VIRTUALIZER_PRIVATE_FIELDS = ['scrollState', 'pendingMin', 'itemSizeCacheVersion'];
 
 /** @type {MetadataRendering} The default metadata renderer */
 const DEFAULT_METADATA_RENDERING = {
@@ -47,40 +70,12 @@ const DEFAULT_PALETTE_STYLE = ansiPaletteStyle(
 );
 
 /**
- * A function that can be disabled during an amount of time.
- */
-class TemporaryFunctionDisabler {
-  /**
-   * @param {() => any} callback
-   * @param {number} timeout
-   */
-  constructor(callback, timeout) {
-    this._callback = callback;
-    this._timeout = timeout;
-    this._timestamp = 0;
-  }
-
-  disable() {
-    this._timestamp = new Date().getTime();
-  }
-
-  call() {
-    const timeSinceDisabled = new Date().getTime() - this._timestamp;
-
-    if (timeSinceDisabled > this._timeout) {
-      return this._callback();
-    }
-  }
-}
-
-/**
  * @import { Log, Metadata, MetadataFilter, MetadataRenderer, MetadataRendering, LogMessageFilterMode } from './cc-logs.types.js'
  * @import { DateDisplay } from './date-display.types.js'
  * @import { AnsiPalette } from '../../lib/ansi/ansi.types.js'
  * @import { Timezone } from '../../lib/date/date.types.js'
- * @import { RangeChangedEvent, VisibilityChangedEvent } from '@lit-labs/virtualizer/events.js'
- * @import { LitVirtualizer as Virtualizer } from '@lit-labs/virtualizer/LitVirtualizer.js'
- * @import { TemplateResult, PropertyValues } from 'lit'
+ * @import { Virtualizer } from '@tanstack/virtual-core'
+ * @import { PropertyValues } from 'lit'
  * @import { EventWithTarget, GenericEventWithTarget } from '../../lib/events.types.js'
  * @import { Ref } from 'lit/directives/ref.js'
  */
@@ -99,7 +94,7 @@ class TemporaryFunctionDisabler {
  *
  * The component gives the ability to:
  *
- * * Display a huge amount of logs by using a <a href="https://github.com/lit/lit/tree/main/packages/labs/virtualizer">scroll virtualizer</a>.
+ * * Display a huge amount of logs by using a <a href="https://tanstack.com/virtual">scroll virtualizer</a>.
  * * Limit the amount of logs to be displayed.
  * * Filter the logs by metadata.
  * * Wrap the long lines.
@@ -283,9 +278,11 @@ export class CcLogs extends LitElement {
     /** @type {boolean} Whereas the focused index is in the DOM. */
     this._focusedIndexIsInDom = false;
 
-    // This function synchronizes the follow property according to the actual scroll position.
-    // This function can also be disabled during a small amount of time.
-    this._followSynchronizer = new TemporaryFunctionDisabler(() => this._synchronizeFollow(), 150);
+    /**
+     * @type {number} Timestamp (ms) until which auto-follow derivation is suppressed. Set while the user is selecting
+     * or dragging so a fresh append cannot silently re-pin the view to the bottom under them.
+     */
+    this._followSuppressedAt = 0;
 
     /** @type {LogsInputController} */
     this._inputCtrl = new LogsInputController(this);
@@ -293,8 +290,26 @@ export class CcLogs extends LitElement {
     /** @type {LogsController} */
     this._logsCtrl = new LogsController(this);
 
-    /** @type {Ref<Virtualizer>} A reference to the logs' container. */
+    /** @type {Ref<HTMLDivElement>} A reference to the scrollable logs' container. */
     this._logsRef = createRef();
+
+    // workaround for https://github.com/lit/lit/issues/3619
+    this._measureElement = this._measureElement.bind(this);
+
+    /** @type {number} The height in pixel of the horizontal scroll bar. */
+    this._horizontalScrollbarHeight = 0;
+
+    /**
+     * @type {VirtualizerController<HTMLDivElement, HTMLElement>} The virtualizer rendering only the visible logs.
+     * Its `count` and `paddingEnd` options are kept in sync within `willUpdate()`.
+     */
+    this._virtualizerController = new VirtualizerController(this, this._buildVirtualizerOptions());
+
+    // A trailing controller that keeps the view pinned to the bottom while following. It is registered AFTER the
+    // virtualizer controller on purpose: the virtualizer restores/anchors the scroll position in its own `hostUpdated`,
+    // so we must re-pin to the end after that, otherwise our scroll would be undone. `anchorTo: 'end'` then holds the
+    // pin through the asynchronous re-measurement of the freshly appended logs.
+    this.addController({ hostUpdated: () => this._pinToBottomIfFollowing() });
 
     /** @type {DateDisplayer} */
     this._dateDisplayer = this._resolveDateDisplayer();
@@ -302,8 +317,14 @@ export class CcLogs extends LitElement {
     /** @type {{last: number, first: number}} The range of visible logs in the virtualizer. */
     this._visibleRange = { first: -1, last: -1 };
 
-    /** @type {number} The height in pixel of the horizontal scroll bar. */
-    this._horizontalScrollbarHeight = 0;
+    /** @type {Log|null} A log we must scroll into view (and center) on the next update, set by the inspect action. */
+    this._logToScrollIntoView = null;
+
+    /**
+     * @type {string|null} Signature (rendered log ids + wrap mode) of the rows measured during the last `updated()`.
+     * Used to skip the re-measure loop when the rendered content did not change.
+     */
+    this._lastMeasureSignature = null;
 
     // workaround for https://github.com/lit/lit/issues/3619
     this._onMouseDownGutter = this._onMouseDownGutter.bind(this);
@@ -318,8 +339,6 @@ export class CcLogs extends LitElement {
    * @param {Array<Log>} logs The logs to append
    */
   appendLogs(logs) {
-    // We disable the follow modifier to prevent next visibilityChanged events to change the actual follow property.
-    this._followSynchronizer.disable();
     this._logsCtrl.append(logs);
   }
 
@@ -334,7 +353,11 @@ export class CcLogs extends LitElement {
    * Forces scroll to the bottom
    */
   scrollToBottom() {
+    // Explicit user/host intent: clear any follow suppression and re-pin to the end. `followOnAppend` then keeps the
+    // view glued to the bottom for the subsequent appends (kept in sync with `follow` in `willUpdate()`).
+    this._followSuppressedAt = 0;
     this._setFollow(true);
+    this._getVirtualizer().scrollToEnd({ behavior: 'auto' });
   }
 
   // endregion
@@ -342,6 +365,117 @@ export class CcLogs extends LitElement {
   _resolveDateDisplayer() {
     return new DateDisplayer(this.dateDisplay, this.timezone);
   }
+
+  // region Virtualizer
+
+  /**
+   * Builds the options for the TanStack virtualizer.
+   *
+   * This is only used to create the virtualizer. The dynamic options (`count` and `paddingEnd`) are then kept in sync
+   * through `setOptions()` on each update (see `willUpdate()`).
+   *
+   * @return {import('@tanstack/virtual-core').PartialKeys<import('@tanstack/virtual-core').VirtualizerOptions<HTMLDivElement, HTMLElement>, 'observeElementRect' | 'observeElementOffset' | 'scrollToFn'>}
+   */
+  _buildVirtualizerOptions() {
+    return {
+      getScrollElement: () => this._logsRef.value,
+      count: this._logsCtrl.listLength,
+      estimateSize: () => ESTIMATED_LOG_LINE_HEIGHT,
+      // We deliberately key the virtualizer's caches by index (the default) and NOT by log id.
+      // Keying by id makes the `itemSizeCache` and `elementsCache` grow by one entry for every log that ever scrolls
+      // into view (they are only pruned for disconnected elements, but our line elements are reused and stay
+      // connected). With an endless stream of logs this is an unbounded memory leak that eventually crashes the tab.
+      // Keying by index bounds both caches to the number of logs (the `limit`). The visible lines are kept measured
+      // correctly by the re-measure loop in `updated()`.
+      overscan: VIRTUALIZER_OVERSCAN,
+      // `anchorTo: 'end'` makes the virtualizer keep the view pinned to the bottom while logs are (re)measured: when a
+      // line settles to a height different from the estimate, it adjusts the scroll offset to absorb the change instead
+      // of letting the bottom drift. This is what makes following stable through the measurement churn of a big append —
+      // we only have to scroll to the end once (see `_pinToBottomIfFollowing()`) and the virtualizer holds it there.
+      anchorTo: 'end',
+      // Tolerance for considering the view "at the end" (must match the follow detection threshold).
+      scrollEndThreshold: FOLLOW_SCROLL_THRESHOLD,
+      // Adds some space at the bottom so the last log is not hidden behind the horizontal scrollbar.
+      paddingEnd: this._horizontalScrollbarHeight,
+      measureElement: (element, _entry, instance) => {
+        // Measure the real rendered height of a log line.
+        // We guard against a 0 height: a `ResizeObserver` notification can report a 0 height transiently when an
+        // element is being detached or reused (which happens a lot when logs are appended by buckets). Caching a 0
+        // would make several lines share the same vertical offset and overlap. We keep the row's last measured
+        // height when we have one (so an already-measured row does not shrink to the estimate for a frame), and
+        // fall back to the estimate only for a row that has never been measured.
+        const height = Math.round(element.getBoundingClientRect().height);
+        if (height > 0) {
+          return height;
+        }
+        const index = Number(element.dataset.index);
+        return instance.itemSizeCache.get(index) ?? ESTIMATED_LOG_LINE_HEIGHT;
+      },
+      onChange: (virtualizer) => this._onVirtualizerChange(virtualizer),
+    };
+  }
+
+  /**
+   * @return {Virtualizer<HTMLDivElement, HTMLElement>}
+   */
+  _getVirtualizer() {
+    return this._virtualizerController.getVirtualizer();
+  }
+
+  /**
+   * @param {Virtualizer<HTMLDivElement, HTMLElement>} virtualizer
+   * @return {boolean} Whether the virtualizer is currently driving (or reconciling) a programmatic scroll. Reads the
+   * private `scrollState` internal — see `VIRTUALIZER_PRIVATE_FIELDS`.
+   */
+  _isVirtualizerScrolling(virtualizer) {
+    return virtualizer['scrollState'] != null;
+  }
+
+  /**
+   * Forces the virtualizer to recompute its memoized measurements from index 0, after we mutated its `itemSizeCache`
+   * directly (clear or shift). Without this it would keep its stale, now-misaligned measurements.
+   *
+   * Reaches into the private `pendingMin` and `itemSizeCacheVersion` internals (and resets the public
+   * `measurementsCache`) — see `VIRTUALIZER_PRIVATE_FIELDS`.
+   *
+   * @param {Virtualizer<HTMLDivElement, HTMLElement>} virtualizer
+   */
+  _forceVirtualizerRemeasure(virtualizer) {
+    virtualizer.measurementsCache = [];
+    virtualizer['pendingMin'] = 0;
+    virtualizer['itemSizeCacheVersion']++;
+  }
+
+  /**
+   * Wired as the `ref` callback of every rendered log line.
+   *
+   * It registers the element with the virtualizer so it can measure its real height (logs have variable heights,
+   * especially when wrapping lines). The virtualizer reads the line index from the `data-index` attribute.
+   *
+   * @param {Element} [element]
+   */
+  _measureElement(element) {
+    this._getVirtualizer().measureElement(element == null ? null : /** @type {HTMLElement} */ (element));
+  }
+
+  /**
+   * Focuses the select button of the log at the given index.
+   *
+   * The element may not be in the DOM yet: after asking the virtualizer to scroll to it, we may need to wait for the
+   * next render(s) before being able to focus it.
+   *
+   * @param {number} logIndex
+   * @param {number} [remainingAttempts]
+   */
+  _focusLogButton(logIndex, remainingAttempts = 10) {
+    focusBySelector(this._logsRef.value, `.log[data-index="${logIndex}"] .select_button`, () => {
+      if (remainingAttempts > 0) {
+        requestAnimationFrame(() => this._focusLogButton(logIndex, remainingAttempts - 1));
+      }
+    });
+  }
+
+  // endregion
 
   /**
    * Calculates the new drag index according to the given direction and given offset.
@@ -360,15 +494,51 @@ export class CcLogs extends LitElement {
     throw new Error(`Illegal argument. direction ${direction} is not valid`);
   }
 
+  /** Suppresses auto-follow derivation for a short window (see `FOLLOW_SUPPRESS_MS`). */
+  _suppressFollow() {
+    this._followSuppressedAt = Date.now();
+  }
+
+  /** @return {boolean} Whether auto-follow derivation is currently suppressed. */
+  _isFollowSuppressed() {
+    return Date.now() - this._followSuppressedAt < FOLLOW_SUPPRESS_MS;
+  }
+
   /**
-   * Synchronizes the `follow` property according to the actual scroll position.
+   * @param {HTMLDivElement} container The scrollable logs container.
+   * @param {Virtualizer<HTMLDivElement, HTMLElement>} virtualizer
+   * @return {boolean} Whether the view is scrolled to the bottom, within `FOLLOW_SCROLL_THRESHOLD`.
    *
-   * If the scroll position shows the last line of log, the follow is activated.
-   * Otherwise, the follow is deactivated.
-   * An event is dispatched when the follow state changes.
+   * We measure against the virtualizer's `getTotalSize()` rather than the DOM `container.scrollHeight` because the DOM
+   * height (`.logs_inner`) is only refreshed on the next lit render, so it can lag behind a programmatic scroll and
+   * report a stale, larger value. `getTotalSize()` stays consistent with `scrollTop`.
    */
-  _synchronizeFollow() {
-    this._setFollow(this._visibleRange.last === Math.max(0, this._logsCtrl.listLength - 1));
+  _isAtBottom(container, virtualizer) {
+    const distanceToBottom = virtualizer.getTotalSize() - container.clientHeight - container.scrollTop;
+    return distanceToBottom <= FOLLOW_SCROLL_THRESHOLD;
+  }
+
+  /**
+   * Derives the `follow` property from the actual scroll position: the component follows when the view is at the bottom.
+   *
+   * With `anchorTo: 'end'`, the virtualizer keeps the view glued to the bottom across measurement churn and its own
+   * programmatic scrolls, so the only thing that moves the view away from the end is a genuine user scroll-up. That
+   * makes "at the end" a reliable proxy for "following": we no longer need to guess whether a scroll was the user's.
+   */
+  _syncFollow() {
+    const container = this._logsRef.value;
+    if (container == null || this._isFollowSuppressed() || this._logsCtrl.listLength === 0) {
+      return;
+    }
+    const virtualizer = this._getVirtualizer();
+    // Ignore scrolls that the virtualizer itself is driving: it is non-null while a programmatic scroll or its reconcile
+    // loop is in flight (e.g. `_pinToBottomIfFollowing()` pinning to a growing bottom). During that window the scroll
+    // event can fire with a `scrollTop` that momentarily lags the just-grown `getTotalSize()`, which would read as "not
+    // at the bottom" and wrongly unfollow. Only a user scroll happens with no programmatic scroll pending.
+    if (this._isVirtualizerScrolling(virtualizer)) {
+      return;
+    }
+    this._setFollow(this._isAtBottom(container, virtualizer));
   }
 
   /**
@@ -417,6 +587,144 @@ export class CcLogs extends LitElement {
       : `${metadataRendering.showName ? `${metadata.name}: ` : ''}${metadata.value}`;
   }
 
+  /**
+   * Keeps the virtualizer's index-keyed size cache aligned with the logs list.
+   *
+   * The virtualizer caches each rendered log's measured height in a `Map` keyed by index (we deliberately key by index
+   * and not by log id to bound memory — see `_buildVirtualizerOptions()`). When logs are trimmed off the front (FIFO
+   * once `limit` is reached), every surviving log's index decreases, but this cache does not follow on its own: the
+   * trim+append at the limit keeps `count` constant and the index edge keys unchanged, so the virtualizer's built-in
+   * edge-key-change detection never fires. The stale cached heights then apply to the wrong logs, which positions lines
+   * with the wrong height and makes them overlap (most visible with `wrap-lines` and multi-line logs, when scrolling up
+   * into a trimmed region).
+   *
+   * We therefore reach into the virtualizer internals (same defensive pattern as the `measureElement` 0-height guard)
+   * and either drop the cache (on a full rebuild: filter change / clear) or shift every cached index down by the
+   * front-trim count. We then force the memoized measurements to be recomputed from the start.
+   */
+  _realignVirtualizerSizeCache() {
+    const { rebuilt, frontTrim } = this._logsCtrl.consumeIndexSpaceChange();
+
+    const virtualizer = this._getVirtualizer();
+
+    if (rebuilt) {
+      // Full rebuild (filter change / clear): indices map to entirely different logs, drop the whole cache.
+      virtualizer.itemSizeCache.clear();
+    } else if (frontTrim > 0 && !this.follow) {
+      // FIFO front-trim shifted every surviving log's index down by `frontTrim`. Shift each measured height down by the
+      // same amount so it stays attached to the same log; cached indices that fall below 0 belonged to trimmed logs and
+      // are dropped. We only need this while the user is scrolled up reading history: the region they can scroll into
+      // must stay correctly positioned.
+      //
+      // While following the tail we deliberately SKIP this (see the `else` below). It is the dominant per-append cost at
+      // a large `limit` — both this O(cache size) shift and the O(count) recompute it forces — and it is unnecessary:
+      // only the bottom window is rendered while following, and it is re-measured at its (constant) indices on every
+      // update (see the loop in `updated()`), so its heights are always correct and the cache never accumulates the
+      // off-screen history that the shift exists to keep aligned. Skipping the shift is also what keeps the cache
+      // bounded to the visible window instead of letting it grow towards `limit`.
+      /** @type {Map<number, number>} */
+      const shiftedCache = new Map();
+      for (const [index, size] of virtualizer.itemSizeCache) {
+        const shiftedIndex = Number(index) - frontTrim;
+        if (shiftedIndex >= 0) {
+          shiftedCache.set(shiftedIndex, size);
+        }
+      }
+      virtualizer.itemSizeCache = shiftedCache;
+    } else {
+      // Nothing changed, or we are following the tail and the bottom window is kept correct by the per-update
+      // re-measure: nothing to realign.
+      return;
+    }
+
+    // Force the virtualizer to recompute its positions from the realigned cache.
+    this._forceVirtualizerRemeasure(virtualizer);
+  }
+
+  /**
+   * Keeps the view pinned to the bottom while `follow` is on.
+   *
+   * Runs in a trailing `ReactiveController.hostUpdated()` (registered after the virtualizer controller) so the scroll
+   * to the end is applied after the virtualizer's own post-update scroll anchoring, not before it (which would undo it).
+   * A single scroll to the end per update is enough: `anchorTo: 'end'` then keeps the view glued to the bottom while the
+   * freshly appended logs are measured. We skip it when already at the bottom to avoid redundant scrolls.
+   */
+  _pinToBottomIfFollowing() {
+    const container = this._logsRef.value;
+    if (!this.follow || container == null || this._logsCtrl.listLength === 0) {
+      return;
+    }
+    const virtualizer = this._getVirtualizer();
+    if (!this._isAtBottom(container, virtualizer)) {
+      virtualizer.scrollToEnd({ behavior: 'auto' });
+    }
+  }
+
+  /**
+   * This is called by the virtualizer whenever its state changes (scroll, resize, measurement).
+   *
+   * It replaces the `visibilityChanged` and `rangeChanged` events of the previous virtualizer:
+   *
+   * * It keeps track of the first and last visible logs (used for keyboard navigation).
+   * * It detects when the focused log leaves the DOM (when user scrolls far from it) so we don't lose the focus.
+   *
+   * @param {Virtualizer<HTMLDivElement, HTMLElement>} virtualizer
+   */
+  _onVirtualizerChange(virtualizer) {
+    // We deliberately do NOT re-derive `follow` here. `onChange` fires mid-append — after the total size has grown but
+    // before `followOnAppend` has pinned to the new bottom (that happens in the virtualizer's post-update step) — so the
+    // view is transiently "not at the bottom" and we would wrongly unfollow. `follow` is derived from real scroll events
+    // only (see `_onScroll`); `anchorTo: 'end'` guarantees every programmatic scroll settles at the bottom, so those
+    // scroll events only ever confirm following.
+
+    // `range` is the visible range (without overscan): this is the equivalent of the old `visibilityChanged` event.
+    const range = virtualizer.range;
+    this._visibleRange = range == null ? { first: -1, last: -1 } : { first: range.startIndex, last: range.endIndex };
+
+    // The virtual items are the rendered ones (visible range + overscan): this is the equivalent of the old
+    // `rangeChanged` event. We use it to detect when the focused log is removed from the DOM.
+    const renderedItems = virtualizer.getVirtualItems();
+    const renderedRange =
+      renderedItems.length > 0
+        ? { first: renderedItems[0].index, last: renderedItems[renderedItems.length - 1].index }
+        : { first: -1, last: -1 };
+    this._focusedIndexIsInDom = this._logsCtrl.isFocusedIndexInRange(renderedRange);
+    if (!this._focusedIndexIsInDom && this.shadowRoot?.activeElement != null) {
+      this._logsRef.value?.focus();
+    }
+  }
+
+  /**
+   * This event handler is called whenever the logs' container is scrolled (by the user or programmatically).
+   *
+   * It re-derives the `follow` property from the new scroll position. Because `anchorTo: 'end'` keeps the view pinned
+   * to the bottom for every programmatic scroll, a scroll that ends away from the bottom is necessarily the user's, so
+   * we can safely read the position synchronously here (no debounce, no scroll-direction guessing).
+   */
+  _onScroll() {
+    this._syncFollow();
+  }
+
+  /**
+   * This event handler is called whenever the user scrolls the logs' container with the wheel.
+   *
+   * It forces unfollowing on a scroll-up. We cannot rely on `_onScroll`/`_syncFollow` alone for this: during fast
+   * streaming `_pinToBottomIfFollowing()` re-pins to the bottom on almost every append, so the virtualizer's
+   * `scrollState` is almost always non-null and `_syncFollow()` bails out (to avoid unfollowing on the virtualizer's
+   * own programmatic scrolls). That would make it impossible to scroll away from the bottom while logs pour in. The
+   * `wheel` event is an unambiguous signal of user intent that does not go through the virtualizer, so we use it to
+   * break out of follow regardless of any programmatic scroll in flight. We also suppress auto-follow derivation for a
+   * short window so the next append cannot immediately re-pin the view under the user.
+   *
+   * @param {WheelEvent} e
+   */
+  _onWheel(e) {
+    if (e.deltaY < 0 && this.follow) {
+      this._suppressFollow();
+      this._setFollow(false);
+    }
+  }
+
   // region Focus logic
 
   /**
@@ -457,23 +765,11 @@ export class CcLogs extends LitElement {
       this._logsRef.value.focus();
     } else {
       // Scroll to the element to focus.
-      this._logsRef.value.element(logIndex)?.scrollIntoView({ block: 'nearest' });
+      this._getVirtualizer().scrollToIndex(logIndex, { align: 'auto' });
 
       // The element we want to focus may not be in the DOM yet.
       // We may need to wait for the virtualizer to redo its layout before being able to focus the element.
-      const tryToFocus = () => {
-        const element = /** @type {HTMLElement} */ (
-          this._logsRef.value.querySelector(`.log[data-index="${logIndex}"] .select_button`)
-        );
-        if (element != null) {
-          element.focus();
-          return true;
-        }
-        return false;
-      };
-      if (!tryToFocus()) {
-        this._logsRef.value.layoutComplete.then(tryToFocus);
-      }
+      this._focusLogButton(logIndex);
     }
   }
 
@@ -520,21 +816,6 @@ export class CcLogs extends LitElement {
       this._logsCtrl.extendSelection(this._logsCtrl.listLength - 1, 'replace');
     } else {
       this._logsCtrl.focus(this._logsCtrl.listLength - 1);
-    }
-  }
-
-  /**
-   * This event handler is called whenever the virtualizer adds child elements to the DOM, or removes child elements from the DOM.
-   *
-   * It helps in detecting when the focused button is removed from the DOM, which is when user scrolls far from the focused button.
-   * When the focused button is removed from the DOM, the focus is lost which is something we want to avoid.
-   * Instead, we move to focus on the logs container, and we store the index of the lost button (so that we know where we were when user plays with arrow keys).
-   * @param {RangeChangedEvent} e
-   */
-  _onRangeChanged(e) {
-    this._focusedIndexIsInDom = this._logsCtrl.isFocusedIndexInRange({ first: e.first, last: e.last });
-    if (!this._focusedIndexIsInDom && this.shadowRoot.activeElement != null) {
-      this._logsRef.value.focus();
     }
   }
 
@@ -598,7 +879,7 @@ export class CcLogs extends LitElement {
     }
 
     if (direction === 'up' || direction === 'down') {
-      this._logsRef.value.element(newIndex)?.scrollIntoView({ block: 'nearest' });
+      this._getVirtualizer().scrollToIndex(newIndex, { align: 'auto' });
     }
 
     this._draggedLogIndex = newIndex;
@@ -673,7 +954,7 @@ export class CcLogs extends LitElement {
    * It forces follow to stop.
    */
   _onSelectionChanged() {
-    this._followSynchronizer.disable();
+    this._suppressFollow();
     this._setFollow(false);
   }
 
@@ -741,44 +1022,13 @@ export class CcLogs extends LitElement {
     }
 
     const selectedLog = this._logsCtrl.getSelectedLogs()[0];
-    const logIndex = this._logsCtrl.getFirstSelectedLogIndex();
     this.dispatchEvent(new CcLogInspectEvent(selectedLog));
 
-    this._logsRef.value.layoutComplete.then(() => {
-      this._logsRef.value.element(logIndex)?.scrollIntoView({ block: 'center' });
-    });
-  }
-
-  // endregion
-
-  // region Follow logic
-
-  /**
-   * When logs are appended very fast, the visibilityChanged event is fired very often.
-   * We need to listen to the wheel event to force unfollowing.
-   *
-   * @param {WheelEvent} e
-   */
-  _onWheel(e) {
-    if (e.deltaY < 0) {
-      // When wheel up is detected, this means that the user wants to unfollow.
-      // We disable the follow modifier to prevent next visibilityChanged events to go against the user decision.
-      this._followSynchronizer.disable();
-      this._setFollow(false);
-    }
-  }
-
-  /**
-   * This event handler is called whenever the visible items in the logs container viewport change.
-   *
-   * It synchronizes the `follow` property according to the scroll position.
-   * It also keeps track of the first and last visible elements needed for keyboard navigation.
-   *
-   * @param {VisibilityChangedEvent} e
-   */
-  _onVisibilityChanged(e) {
-    this._visibleRange = { first: e.first, last: e.last };
-    this._followSynchronizer.call();
+    // Inspecting makes the host clear the message filter, which rebuilds the displayed list asynchronously (the new
+    // `message-filter` only reaches us on a later update). We therefore cannot scroll now: we remember the inspected
+    // log and scroll to it once that filter-clearing update has landed (see `updated()`), reading its index from the
+    // list that is actually displayed at that point.
+    this._logToScrollIntoView = selectedLog;
   }
 
   // endregion
@@ -810,70 +1060,94 @@ export class CcLogs extends LitElement {
         metadata: this.metadataFilter,
       };
     }
+
+    // Keep the dynamic virtualizer options in sync with the current state.
+    // We spread the existing options to preserve the ones set by the controller (observers, scroll function, the
+    // `onChange` wrapper that triggers re-renders…).
+    const virtualizer = this._getVirtualizer();
+    virtualizer.setOptions({
+      ...virtualizer.options,
+      count: this._logsCtrl.listLength,
+      paddingEnd: this._horizontalScrollbarHeight,
+    });
+
+    // Realign the index-keyed size cache with the (possibly trimmed) list before `render()` reads the measurements.
+    this._realignVirtualizerSizeCache();
   }
 
   /**
-   * @param {PropertyValues<CcLogs>} _changedProperties
+   * @param {PropertyValues<CcLogs>} changedProperties
    */
-  updated(_changedProperties) {
+  updated(changedProperties) {
+    const virtualizer = this._getVirtualizer();
+
+    // Deferred scroll requested by the inspect action: now that the message filter has been cleared (by the host) and
+    // the displayed list rebuilt, scroll the inspected log into the center. We read its index from the list that is
+    // actually displayed now, so it is correct whether or not a filter was active when inspect was clicked.
+    if (this._logToScrollIntoView != null && changedProperties.has('messageFilter')) {
+      const logIndex = this._logsCtrl.getList().indexOf(this._logToScrollIntoView);
+      this._logToScrollIntoView = null;
+      if (logIndex >= 0) {
+        virtualizer.scrollToIndex(logIndex, { align: 'center' });
+      }
+    }
+
     if (this._logsRef.value != null) {
       this._horizontalScrollbarHeight = this.wrapLines
         ? 0
         : this._logsRef.value.offsetHeight - this._logsRef.value.clientHeight;
+
+      // Re-measure the rendered log lines, but only when the rendered content changed since the last measure.
+      // We render the lines with a positional `map()` (and not a keyed `repeat()`, which is corrupted by the
+      // virtualizer's re-entrant updates while scrolling). With positional rendering, a line element is reused for a
+      // different log when the visible window moves, so the `ref` measuring callback is not called again, and we must
+      // (re)measure here. But `updated()` also fires for changes that leave the rendered rows untouched (follow toggles,
+      // selection, scrollbar-height state, measurement-settle re-renders); re-measuring every row then is pure wasted
+      // layout (a forced reflow per row). We therefore skip the loop unless the rendered logs or the wrap mode changed.
+      // Height changes we skip this way (e.g. a viewport resize) are still caught by the `ResizeObserver` the
+      // virtualizer keeps on each rendered element (registered by the `ref` measuring callback on mount).
+      const renderedLogs = this._logsCtrl.getList();
+      const measureSignature = `${this.wrapLines}|${virtualizer
+        .getVirtualItems()
+        .map((virtualItem) => renderedLogs[virtualItem.index]?.id)
+        .join(',')}`;
+      if (measureSignature !== this._lastMeasureSignature) {
+        this._lastMeasureSignature = measureSignature;
+        for (const logElement of this._logsRef.value.querySelectorAll('.log')) {
+          virtualizer.measureElement(/** @type {HTMLElement} */ (logElement));
+        }
+      }
     }
+
+    // The actual pin-to-bottom while following is done in `_pinToBottomIfFollowing()`, registered as a trailing
+    // controller so it runs after the virtualizer has restored/anchored its own scroll position.
   }
 
   render() {
-    const layout =
-      this.follow && this._logsCtrl.listLength > 0
-        ? {
-            pin: {
-              index: this._logsCtrl.listLength - 1,
-              block: 'start',
-            },
-          }
-        : null;
-
-    /**
-     * @param {Log} log
-     * @return {string}
-     */
-    function keyFunction(log) {
-      return log?.id;
-    }
-
-    /**
-     * @param {Log} log
-     * @param {number} index
-     * @return {TemplateResult}
-     */
-    const renderItem = (log, index) => {
-      if (log == null) {
-        return null;
-      }
-      return this._renderLog(log, index);
-    };
+    const virtualizer = this._getVirtualizer();
+    const virtualItems = virtualizer.getVirtualItems();
+    const logs = this._logsCtrl.getList();
 
     return html`
-      <div class="wrapper" style="--last-log-margin: ${this._horizontalScrollbarHeight}px">
-        <lit-virtualizer
+      <div class="wrapper">
+        <div
           ${ref(this._logsRef)}
           class="logs_container"
           tabindex="0"
-          .items=${this._logsCtrl.getList().slice()}
-          ?scroller=${true}
-          .keyFunction=${keyFunction}
-          .renderItem=${renderItem}
-          .layout=${layout}
           @click=${this._inputCtrl.onClick}
           @keydown=${this._inputCtrl.onKeyDown}
           @keyup=${this._inputCtrl.onKeyUp}
           @copy=${this._onCopy}
           @focus=${this._onFocusLogsContainer}
-          @visibilityChanged=${this._onVisibilityChanged}
-          @rangeChanged=${this._onRangeChanged}
+          @scroll=${this._onScroll}
           @wheel=${this._onWheel}
-        ></lit-virtualizer>
+        >
+          <div class="logs_inner" style="height: ${virtualizer.getTotalSize()}px;">
+            <div class="logs_window" style="transform: translateY(${virtualItems[0]?.start ?? 0}px);">
+              ${virtualItems.map((virtualItem) => this._renderLog(logs[virtualItem.index], virtualItem))}
+            </div>
+          </div>
+        </div>
         ${!this._logsCtrl.isSelectionEmpty()
           ? html` <div class="floating_buttons">
               <cc-button .icon=${iconCopy} @cc-click=${this._onCopySelectionToClipboard}>
@@ -896,9 +1170,14 @@ export class CcLogs extends LitElement {
    * Renders a single line of log.
    *
    * @param {Log} log
-   * @param {number} index
+   * @param {import('@tanstack/virtual-core').VirtualItem} virtualItem
    */
-  _renderLog(log, index) {
+  _renderLog(log, virtualItem) {
+    if (log == null) {
+      return null;
+    }
+
+    const index = virtualItem.index;
     const wrap = this.wrapLines;
     const dateDisplayer = this._dateDisplayer;
 
@@ -908,8 +1187,12 @@ export class CcLogs extends LitElement {
       : i18n('cc-logs.select-button.label', { index: index + 1 });
 
     /* eslint-disable lit-a11y/click-events-have-key-events */
+    // The row is rendered in normal flow inside `.logs_window` (which is translated to the first rendered row's
+    // offset). We deliberately do NOT position each row with its own `translateY`: stacking the rows in flow makes it
+    // impossible for two rows to overlap, even when a row's height has not been measured yet (it falls back to the
+    // estimate). The virtualizer still measures each row (via `data-index`) to keep the scroll size accurate.
     return html`
-      <p class="log ${classMap({ selected })}" data-index="${index}">
+      <p class="log ${classMap({ selected, wrap })}" data-index="${index}" ${ref(this._measureElement)}>
         <span class="gutter" @mousedown=${this._onMouseDownGutter} @click=${this._inputCtrl.onClickLog}>
           <button
             class="select_button"
@@ -1025,6 +1308,21 @@ export class CcLogs extends LitElement {
           flex: 1;
           font-family: var(--cc-ff-monospace, monospace);
           font-size: var(--font-size);
+          overflow: auto;
+        }
+
+        .logs_inner {
+          position: relative;
+          width: 100%;
+        }
+
+        /* The window holds the currently rendered rows. It is translated to the first rendered row's offset; the rows
+           themselves are laid out in normal flow inside it so they can never overlap (see _renderLog). */
+        .logs_window {
+          left: 0;
+          position: absolute;
+          top: 0;
+          width: 100%;
         }
 
         .log {
@@ -1032,11 +1330,19 @@ export class CcLogs extends LitElement {
           display: flex;
           gap: 0.5em;
           margin: 0;
-          width: 100%;
+          /* When lines are not wrapped, the line grows to fit its content so it can be scrolled horizontally,
+             while still being at least as wide as the viewport (so hover/selection backgrounds span the full width). */
+          min-width: 100%;
+          width: max-content;
 
           /* We don't need em here. At least with px we avoid strange blinking effect. */
           --spacing: 2px;
           --gutter-size: 1.5em;
+        }
+
+        /* When lines are wrapped, the line is constrained to the viewport width so its content wraps. */
+        .log.wrap {
+          width: 100%;
         }
 
         .log:hover {
@@ -1045,10 +1351,6 @@ export class CcLogs extends LitElement {
 
         .log.selected {
           background-color: var(--cc-color-ansi-background-selected);
-        }
-
-        .log:last-of-type {
-          margin-bottom: var(--last-log-margin);
         }
 
         .date,

--- a/src/components/cc-logs/cc-logs.stories.js
+++ b/src/components/cc-logs/cc-logs.stories.js
@@ -20,6 +20,13 @@ export default {
 const conf = {
   component: 'cc-logs-beta',
   beta: true,
+  // The component relies on a virtualizer and therefore needs a bounded height to define its scroll viewport.
+  // language=CSS
+  css: `
+    cc-logs-beta {
+      height: 300px;
+    }
+  `,
 };
 
 export const defaultStory = makeStory(conf, {

--- a/src/components/cc-logs/cc-logs.virtualizer-contract.test.js
+++ b/src/components/cc-logs/cc-logs.virtualizer-contract.test.js
@@ -1,0 +1,40 @@
+import { expect, fixture } from '@open-wc/testing';
+import { html } from 'lit';
+import { VIRTUALIZER_PRIVATE_FIELDS } from './cc-logs.js';
+
+// cc-logs reaches into a few `@tanstack/virtual-core` internals (to detect user vs programmatic scrolls and to realign
+// the index-keyed size cache after a FIFO front-trim). Some of those are declared `private` in the library's types and
+// are accessed by string key. If an upgrade renames any of them, those reach-ins silently turn into no-ops — breaking
+// follow detection and reintroducing overlapping lines, with no error. This suite pins that contract so an
+// incompatible upgrade fails here in CI instead.
+describe('cc-logs @tanstack/virtual-core internal contract', function () {
+  it('still exposes the internals cc-logs depends on', async function () {
+    const el = await fixture(html`<cc-logs-beta style="display:block; height:300px;"></cc-logs-beta>`);
+    await el.updateComplete;
+    const virtualizer = el._getVirtualizer();
+
+    // Private internals accessed by string key (see `VIRTUALIZER_PRIVATE_FIELDS` in cc-logs.js). They are all
+    // initialised in the virtualizer constructor, so a rename makes the `in` check fail.
+    for (const field of VIRTUALIZER_PRIVATE_FIELDS) {
+      expect(field in virtualizer, `virtualizer still exposes the private internal "${field}"`).to.equal(true);
+    }
+
+    // Public-but-internal-contract fields we mutate directly during the cache realign.
+    expect(virtualizer.itemSizeCache, 'itemSizeCache is a Map').to.be.instanceOf(Map);
+    expect(Array.isArray(virtualizer.measurementsCache), 'measurementsCache is an Array').to.equal(true);
+
+    // Methods cc-logs calls to drive scrolling and measurement.
+    for (const method of [
+      'scrollToIndex',
+      'scrollToEnd',
+      'getTotalSize',
+      'getVirtualItems',
+      'measureElement',
+      'range',
+    ]) {
+      const value = virtualizer[method];
+      // `range` is an accessor returning an object/null; the rest are methods.
+      expect(value, `virtualizer.${method} exists`).to.not.equal(undefined);
+    }
+  });
+});

--- a/src/components/cc-logs/logs-controller.js
+++ b/src/components/cc-logs/logs-controller.js
@@ -33,6 +33,16 @@ export class LogsController {
     this._selectionLast = null;
     /** @type {number|null} The index of the focused log. */
     this._focusedIndex = null;
+    /**
+     * @type {number} The number of logs trimmed off the front of the filtered list since the last
+     * `consumeIndexSpaceChange()` call. Accumulated because several appends can be batched into a single render.
+     */
+    this._pendingFrontTrim = 0;
+    /**
+     * @type {boolean} Whether the filtered list was rebuilt from scratch (filter change / clear) since the last
+     * `consumeIndexSpaceChange()` call. When `true`, indices no longer map to the same logs at all.
+     */
+    this._pendingRebuild = false;
   }
 
   /**
@@ -88,8 +98,27 @@ export class LogsController {
     this._logs = [];
     this._logsFiltered = [];
     this._selection.clear();
+    this._pendingRebuild = true;
     this._updateList();
     this.clearFocus();
+  }
+
+  /**
+   * Reports — and resets — how the filtered list's index space changed since the last call.
+   *
+   * The virtualizer caches each rendered log's measured height in a map keyed by index.
+   * When logs are trimmed off the front (FIFO once `limit` is reached), every surviving log's index
+   * decreases, but the index-keyed size cache does not follow, so cached heights end up applying to the wrong logs
+   * (causing overlapping lines). The host uses this information to realign that cache.
+   *
+   * @return {{ rebuilt: boolean, frontTrim: number }} `rebuilt` when the whole list changed (filter / clear) and the
+   * cache should be dropped; `frontTrim` the number of logs removed from the front, by which cached indices must shift.
+   */
+  consumeIndexSpaceChange() {
+    const change = { rebuilt: this._pendingRebuild, frontTrim: this._pendingFrontTrim };
+    this._pendingRebuild = false;
+    this._pendingFrontTrim = 0;
+    return change;
   }
 
   // region selection
@@ -207,17 +236,6 @@ export class LogsController {
     return this._logs.filter((log) => this._selection.has(log));
   }
 
-  /**
-   * @return {number} The index of the first selected log, or `-1` if no log is selected.
-   */
-  getFirstSelectedLogIndex() {
-    if (this._selection.size === 0) {
-      return -1;
-    }
-    const firstSelectedLog = this._selection.values().next().value;
-    return this._logs.findIndex((log) => firstSelectedLog === log);
-  }
-
   // endregion
 
   // region focus
@@ -315,6 +333,9 @@ export class LogsController {
     this._logs.push(...logsToAdd);
 
     if (forceFilter) {
+      // The filtered list is rebuilt from scratch: indices no longer map to the same logs, so the size cache must be
+      // dropped entirely rather than shifted.
+      this._pendingRebuild = true;
       this._logsFiltered = [];
 
       this._logs.forEach((log) => {
@@ -333,6 +354,9 @@ export class LogsController {
       const logsToRemoveFiltered = logsToRemove.filter(this._filterCallback);
       // No need to filter the logs we want to keep
       this._logsFiltered.splice(0, logsToRemoveFiltered.length);
+      // Front-trimming shifts every surviving log's index down: record it so the host can realign the virtualizer's
+      // index-keyed size cache (see `consumeIndexSpaceChange()`).
+      this._pendingFrontTrim += logsToRemoveFiltered.length;
       // Only need to filter the new logs
       const logsToAddFiltered = logsToAdd.filter(this._filterCallback);
 
@@ -340,7 +364,7 @@ export class LogsController {
 
       // Handle focused log
       if (this._focusedIndex != null && logsToRemoveFiltered.length > 0) {
-        if (this._focusedIndex > logsToRemoveFiltered.length) {
+        if (this._focusedIndex >= logsToRemoveFiltered.length) {
           this.focus(this._focusedIndex - logsToRemoveFiltered.length);
         } else {
           this.clearFocus();

--- a/src/components/cc-logs/logs-controller.test.js
+++ b/src/components/cc-logs/logs-controller.test.js
@@ -196,6 +196,88 @@ describe('', () => {
     });
   });
 
+  describe('consumeIndexSpaceChange', () => {
+    it('should report no change at startup', () => {
+      expect(logsCtrl.consumeIndexSpaceChange()).to.deep.equal({ rebuilt: false, frontTrim: 0 });
+    });
+
+    it('should report no front trim when appending below the limit', () => {
+      logsCtrl.limit = 10;
+      appendLogs(4);
+
+      expect(logsCtrl.consumeIndexSpaceChange()).to.deep.equal({ rebuilt: false, frontTrim: 0 });
+    });
+
+    it('should report the number of logs trimmed off the front when the limit is reached', () => {
+      logsCtrl.limit = 6;
+      appendLogs(4);
+      logsCtrl.consumeIndexSpaceChange();
+
+      appendLogs(4);
+
+      // 4 + 4 = 8 logs, limit 6 -> 2 logs trimmed off the front
+      expect(logsCtrl.consumeIndexSpaceChange()).to.deep.equal({ rebuilt: false, frontTrim: 2 });
+    });
+
+    it('should accumulate the front trim across several appends until consumed', () => {
+      logsCtrl.limit = 6;
+      appendLogs(6);
+      logsCtrl.consumeIndexSpaceChange();
+
+      appendLogs(2);
+      appendLogs(3);
+
+      // 2 + 3 = 5 logs appended over a full list -> 5 logs trimmed off the front
+      expect(logsCtrl.consumeIndexSpaceChange()).to.deep.equal({ rebuilt: false, frontTrim: 5 });
+    });
+
+    it('should only count trimmed logs that pass the active filter', () => {
+      logsCtrl.limit = 6;
+      logsCtrl.filter = {
+        message: { value: 'Message 0000', type: 'strict' },
+        metadata: [],
+      };
+      // Matching logs are 00000..00009 (their message contains "Message 0000").
+      appendLogs(6);
+      logsCtrl.consumeIndexSpaceChange();
+
+      // Appending 4 more trims the 4 oldest full-list logs (00000..00003), all of which pass the filter.
+      appendLogs(4);
+
+      expect(logsCtrl.consumeIndexSpaceChange().frontTrim).to.equal(4);
+    });
+
+    it('should reset the accumulated change once consumed', () => {
+      logsCtrl.limit = 6;
+      appendLogs(6);
+      appendLogs(2);
+      logsCtrl.consumeIndexSpaceChange();
+
+      expect(logsCtrl.consumeIndexSpaceChange()).to.deep.equal({ rebuilt: false, frontTrim: 0 });
+    });
+
+    it('should report a rebuild when the filter changes', () => {
+      appendLogs(6);
+      logsCtrl.consumeIndexSpaceChange();
+
+      logsCtrl.filter = {
+        message: { value: 'Message', type: 'strict' },
+        metadata: [],
+      };
+
+      expect(logsCtrl.consumeIndexSpaceChange().rebuilt).to.equal(true);
+    });
+
+    it('should report a rebuild when cleared', () => {
+      appendLogs(6);
+      logsCtrl.consumeIndexSpaceChange();
+
+      logsCtrl.clear();
+
+      expect(logsCtrl.consumeIndexSpaceChange().rebuilt).to.equal(true);
+    });
+  });
+
   describe('filter', () => {
     describe('with metadata filter', () => {
       it('should be applied when setting new filter on metadata', () => {

--- a/src/components/cc-logs/logs-input-controller.js
+++ b/src/components/cc-logs/logs-input-controller.js
@@ -184,15 +184,19 @@ export class LogsInputController {
       // Find the log right under the mouse if 'inside',
       // or on the same y position if 'left' or 'right'.
       const elementsPath = this._getElementsFromPoint(e, position, distance);
-      const log = /** @type {HTMLElement} */ (
+      const log = /** @type {HTMLElement | undefined} */ (
         elementsPath.find((element) => element instanceof HTMLElement && hasClass(element, 'log'))
       );
 
-      const logIndex = Number(log.dataset.index);
-      // No need to trigger this._host.onDrag if it's the same index
-      if (this._dragIndex !== logIndex) {
-        this._host._onDrag({ logIndex }, isFirstDrag);
-        this._dragIndex = logIndex;
+      // The cursor may be over an element that is not a log (e.g. a gap between rows),
+      // in which case there is no log to drag onto.
+      if (log != null) {
+        const logIndex = Number(log.dataset.index);
+        // No need to trigger this._host.onDrag if it's the same index
+        if (this._dragIndex !== logIndex) {
+          this._host._onDrag({ logIndex }, isFirstDrag);
+          this._dragIndex = logIndex;
+        }
       }
     }
 


### PR DESCRIPTION
## Context

`cc-logs` virtualizes an effectively unbounded, continuously-streaming log list. It was built
on `@lit-labs/virtualizer`, which is experimental and behaves poorly under a sustained append
load — it has been the source of a string of recurring bugs: a Firefox-only ResizeObserver
memory leak, overlapping log lines, and duplicate-key crashes from its keyed rendering.

On top of that, "follow the bottom" was hand-rolled on raw scroll geometry. During a streaming
burst the virtualizer's own programmatic re-pinning scrolls were indistinguishable from a user
scrolling up, so `follow` flickered off mid-append and fired spurious `cc-logs-follow-change`
events.

## Changes

- Migrate the virtualizer from `@lit-labs/virtualizer` to `@tanstack/lit-virtual`, which is
  actively maintained and exposes the low-level control (explicit element measurement, manual
  cache and rendering management) needed to keep memory bounded and avoid the streaming bugs.
- Drive "follow" from the virtualizer's native bottom-anchoring (`anchorTo: 'end'`) instead of
  inferring it from scroll deltas. A single `scrollToEnd()` per append does the pinning, and
  `follow` is derived only when `scrollState` confirms no programmatic scroll is in flight —
  giving an exact user-vs-virtualizer discriminator where the old heuristic only approximated.
- Add `cc-logs.follow.test.js` and `logs-controller.test.js` covering empty-list append,
  throttled streaming, user scroll-up / re-follow, and at-limit front-trim.
- Add a bulk "Add +1000 logs" sandbox button to make the streaming / bottom-pinning paths
  easy to trigger by hand.

### Implementation notes

The list is rendered with **flow rendering** (rows in document flow, not absolutely positioned
in a translated window) so concurrent reconciles can no longer overlap two rows.

Rows are **index-keyed**, not id-keyed: under `@tanstack/virtual` 3.17 id-keying leaks unbounded
size/element caches over an endless stream. The cost is that FIFO front-trimming (once `limit`
is reached) shifts every surviving log's index down while the index-keyed size cache does not
follow, so cached heights would apply to the wrong rows. `LogsController.consumeIndexSpaceChange()`
reports the per-render front-trim count (and full-rebuild flag on filter/clear) so the host can
realign that cache instead of dropping it.

## How to review

1. Start with `bdc8c8d1` (the bare migration) then read the three follow-up commits in order —
   each commit message explains the specific failure mode it addresses.
2. Read `src/components/cc-logs/cc-logs.js` (the virtualizer wiring + follow derivation) and
   `logs-controller.js` (the `consumeIndexSpaceChange()` index-space accounting).
3. Run the new tests: `cc-logs.follow.test.js` and `logs-controller.test.js`.
4. Exercise it by hand in the sandbox: stream with the new "Add +1000 logs" button, scroll up
   mid-stream and confirm follow turns off cleanly, then scroll back to the bottom to re-follow.
   Check Firefox memory stays bounded over a long stream.

**1 approval** from a front-end reviewer.