### PR TITLE
Refactor/design token

### DIFF
--- a/docs/getting-started/design-tokens.md
+++ b/docs/getting-started/design-tokens.md
@@ -116,10 +116,12 @@ As our design tokens only exist (for now) as CSS values, keys will be listed as 
 
 ### Border radius decisions
 
-| Key                          | Default value  |
-|:-----------------------------|:---------------|
-| `--cc-border-radius-default` | `0.25em`       |
-| `--cc-border-radius-small`   | `0.15em`       |
+| Key                         | Default value  |
+|:----------------------------|:---------------|
+| `--cc-border-radius-xs`     | `0.15em`       |
+| `--cc-border-radius-small`  | `0.25em`       |
+| `--cc-border-radius-medium` | `0.375em`      |
+| `--cc-border-radius-large`  | `0.5em`        |
 
 ### Spacing decisions
 

--- a/docs/getting-started/design-tokens.md
+++ b/docs/getting-started/design-tokens.md
@@ -143,12 +143,14 @@ These tokens are meant to be used for spacing values such as `padding`, `gap` an
 
 ### Form decisions
 
-| Key                          | Default value |
-|:-----------------------------|:--------------|
-| `--cc-form-controls-gap`     | `2em`         |
-| `--cc-form-controls-indent`  | `34px`        |
-| `--cc-form-label-gap`        | `0.35em`      |
-| `--cc-form-label-gap-inline` | `0.75em`      |
+| Key                                 | Default value |
+|:------------------------------------|:--------------|
+| `--cc-form-controls-gap`            | `2em`         |
+| `--cc-form-controls-indent`         | `34px`        |
+| `--cc-form-label-gap`               | `0.35em`      |
+| `--cc-form-label-gap-inline`        | `0.75em`      |
+| `--cc-form-required-font-style`     | `italic`      |
+| `--cc-form-required-text-transform` | `lowercase`   |
 
 ### Miscellaneous
 

--- a/docs/getting-started/design-tokens.md
+++ b/docs/getting-started/design-tokens.md
@@ -121,6 +121,24 @@ As our design tokens only exist (for now) as CSS values, keys will be listed as 
 | `--cc-border-radius-default` | `0.25em`       |
 | `--cc-border-radius-small`   | `0.15em`       |
 
+### Spacing decisions
+
+These tokens are meant to be used for spacing values such as `padding`, `gap` and `margin`.
+
+| Key                | Default value |
+|:-------------------|:--------------|
+| `--cc-spacing-0`   | `0.125em`     |
+| `--cc-spacing-1`   | `0.25em`      |
+| `--cc-spacing-2`   | `0.35em`      |
+| `--cc-spacing-3`   | `0.5em`       |
+| `--cc-spacing-4`   | `0.75em`      |
+| `--cc-spacing-5`   | `1em`         |
+| `--cc-spacing-6`   | `1.25em`      |
+| `--cc-spacing-7`   | `1.5em`       |
+| `--cc-spacing-8`   | `2em`         |
+| `--cc-spacing-9`   | `2.5em`       |
+| `--cc-spacing-10`  | `3em`         |
+
 ### Form decisions
 
 | Key                          | Default value |

--- a/sandbox/index.html
+++ b/sandbox/index.html
@@ -58,7 +58,7 @@
         display: block;
         background-color: #eee;
         padding: 0.25em 0.5em;
-        border-radius: var(--cc-border-radius-default, 0.25em);
+        border-radius: var(--cc-border-radius-small, 0.25em);
       }
 
       .sandboxes-list a:hover {

--- a/src/components/cc-addon-admin/cc-addon-admin.js
+++ b/src/components/cc-addon-admin/cc-addon-admin.js
@@ -281,7 +281,7 @@ export class CcAddonAdmin extends LitElement {
 
         .one-line-form cc-input-text {
           flex: 1 1 10em;
-          margin-right: 0.5em;
+          margin-right: var(--cc-spacing-3, 0.5em);
         }
 
         .one-line-form cc-button {
@@ -297,14 +297,14 @@ export class CcAddonAdmin extends LitElement {
           border-radius: var(--cc-border-radius-default, 0.25em);
           box-shadow: 2px 4px 8px 0 rgb(0 0 0 / 12%);
           box-sizing: border-box;
-          padding: 4em;
+          padding: var(--cc-spacing-10, 3em);
           width: min(38em, 80%);
         }
 
         /* stylelint-disable-next-line media-feature-range-notation */
         @media screen and (max-width: 38em) {
           dialog {
-            padding: 1em;
+            padding: var(--cc-spacing-5, 1em);
           }
         }
 
@@ -325,7 +325,7 @@ export class CcAddonAdmin extends LitElement {
           border-radius: var(--cc-border-radius-default, 0.25em);
           color: var(--cc-color-text-weak);
           cursor: pointer;
-          padding: 0.5em;
+          padding: var(--cc-spacing-3, 0.5em);
           position: absolute;
           right: 1.5em;
           top: 1.5em;
@@ -354,12 +354,12 @@ export class CcAddonAdmin extends LitElement {
           border-bottom: solid 1px var(--cc-color-border-neutral-weak);
           color: var(--cc-color-text-primary-strongest);
           font-weight: bold;
-          margin-bottom: 1.25em;
-          padding-bottom: 1.25em;
+          margin-bottom: var(--cc-spacing-6, 1.25em);
+          padding-bottom: var(--cc-spacing-6, 1.25em);
         }
 
         .dialog-desc {
-          margin-bottom: 1.25em;
+          margin-bottom: var(--cc-spacing-6, 1.25em);
         }
 
         .dialog-form {
@@ -369,9 +369,9 @@ export class CcAddonAdmin extends LitElement {
         .dialog-form__actions {
           display: flex;
           flex-wrap: wrap;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
           justify-content: end;
-          margin-top: 3.75em;
+          margin-top: var(--cc-spacing-10, 3em);
         }
 
         /* stylelint-disable-next-line media-feature-range-notation */
@@ -379,7 +379,7 @@ export class CcAddonAdmin extends LitElement {
           .dialog-form__actions {
             display: grid;
             justify-content: stretch;
-            margin-top: 2em;
+            margin-top: var(--cc-spacing-8, 2em);
           }
         }
       `,

--- a/src/components/cc-addon-admin/cc-addon-admin.js
+++ b/src/components/cc-addon-admin/cc-addon-admin.js
@@ -294,7 +294,7 @@ export class CcAddonAdmin extends LitElement {
 
         dialog {
           border: none;
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           box-shadow: 2px 4px 8px 0 rgb(0 0 0 / 12%);
           box-sizing: border-box;
           padding: var(--cc-spacing-10, 3em);
@@ -322,7 +322,7 @@ export class CcAddonAdmin extends LitElement {
         .dialog-close {
           background: none;
           border: none;
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           color: var(--cc-color-text-weak);
           cursor: pointer;
           padding: var(--cc-spacing-3, 0.5em);

--- a/src/components/cc-addon-backups/cc-addon-backups.js
+++ b/src/components/cc-addon-backups/cc-addon-backups.js
@@ -462,7 +462,7 @@ export class CcAddonBackups extends LitElement {
 
         .backup-icon,
         .backup-text {
-          margin-right: 0.5em;
+          margin-right: var(--cc-spacing-3, 0.5em);
         }
 
         .backup-icon {
@@ -478,7 +478,7 @@ export class CcAddonBackups extends LitElement {
         }
 
         .backup-text cc-link {
-          margin-right: 0.5em;
+          margin-right: var(--cc-spacing-3, 0.5em);
         }
 
         [title] {
@@ -492,7 +492,7 @@ export class CcAddonBackups extends LitElement {
         }
 
         cc-button[link] {
-          margin-right: 0.5em;
+          margin-right: var(--cc-spacing-3, 0.5em);
           vertical-align: baseline;
         }
 

--- a/src/components/cc-addon-credentials-content/cc-addon-credentials-content.js
+++ b/src/components/cc-addon-credentials-content/cc-addon-credentials-content.js
@@ -295,8 +295,8 @@ export class CcAddonCredentialsContent extends LitElement {
           align-items: baseline;
           display: flex;
           flex-wrap: wrap;
-          gap: 0.5em;
-          padding-block: 1em;
+          gap: var(--cc-spacing-3, 0.5em);
+          padding-block: var(--cc-spacing-5, 1em);
         }
 
         .credential--align-center {
@@ -318,7 +318,7 @@ export class CcAddonCredentialsContent extends LitElement {
           display: flex;
           flex: 1 1 21em;
           flex-wrap: wrap;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         cc-input-text {

--- a/src/components/cc-addon-header/cc-addon-header.js
+++ b/src/components/cc-addon-header/cc-addon-header.js
@@ -280,7 +280,7 @@ export class CcAddonHeader extends LitElement {
         .logo {
           align-self: flex-start;
           background-color: var(--cc-color-bg-neutral-alt);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           height: 3.25em;
           overflow: hidden;
           width: 3.25em;

--- a/src/components/cc-addon-header/cc-addon-header.js
+++ b/src/components/cc-addon-header/cc-addon-header.js
@@ -258,7 +258,7 @@ export class CcAddonHeader extends LitElement {
         .main {
           display: grid;
           flex-wrap: wrap;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
           grid-auto-flow: column;
           justify-content: space-between;
           min-width: 0;
@@ -273,7 +273,7 @@ export class CcAddonHeader extends LitElement {
         .addon-information {
           display: flex;
           flex: 1 1 0;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
           min-width: 0;
         }
 
@@ -298,7 +298,7 @@ export class CcAddonHeader extends LitElement {
           align-items: center;
           display: flex;
           flex-wrap: wrap;
-          gap: 0.5em 0.75em;
+          gap: var(--cc-spacing-3, 0.5em) var(--cc-spacing-4, 0.75em);
         }
 
         .details__name {
@@ -309,7 +309,7 @@ export class CcAddonHeader extends LitElement {
         .details__id {
           align-items: center;
           display: flex;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           min-width: 0;
         }
 
@@ -325,7 +325,7 @@ export class CcAddonHeader extends LitElement {
           align-items: center;
           display: flex;
           flex-wrap: wrap;
-          gap: 0.75em;
+          gap: var(--cc-spacing-4, 0.75em);
         }
 
         .actions cc-link,
@@ -367,7 +367,7 @@ export class CcAddonHeader extends LitElement {
           display: flex;
           flex-wrap: wrap;
           font-size: 0.9em;
-          gap: 0.57em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .messages {
@@ -376,7 +376,7 @@ export class CcAddonHeader extends LitElement {
           flex-wrap: wrap;
           font-size: 0.9em;
           font-style: italic;
-          gap: 0.57em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .messages cc-link,

--- a/src/components/cc-addon-info/cc-addon-info.js
+++ b/src/components/cc-addon-info/cc-addon-info.js
@@ -548,8 +548,8 @@ export class CcAddonInfo extends LitElement {
           align-items: flex-start;
           display: flex;
           flex-wrap: wrap;
-          gap: 0.5em;
-          padding-block: 1em;
+          gap: var(--cc-spacing-3, 0.5em);
+          padding-block: var(--cc-spacing-5, 1em);
         }
 
         .section:focus-visible {
@@ -587,13 +587,13 @@ export class CcAddonInfo extends LitElement {
           display: flex;
           flex: 1 1 21em;
           flex-wrap: wrap;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .version__content {
           align-items: center;
           display: flex;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         .version__content__version {
@@ -604,7 +604,7 @@ export class CcAddonInfo extends LitElement {
           border: solid 1px var(--cc-color-border-neutral, #bfbfbf);
           border-radius: var(--cc-border-radius-default, 0.25em);
           font-weight: bold;
-          padding: 0.12em 0.4em;
+          padding: var(--cc-spacing-0, 0.125em) var(--cc-spacing-2, 0.35em);
         }
 
         .billing__container {
@@ -620,23 +620,23 @@ export class CcAddonInfo extends LitElement {
         }
 
         .linked-services__content {
-          gap: 0.75em;
+          gap: var(--cc-spacing-4, 0.75em);
         }
 
         .linked-services__content ul {
-          column-gap: 1.5em;
+          column-gap: var(--cc-spacing-7, 1.5em);
           display: flex;
           flex-wrap: wrap;
           list-style: none;
           margin: 0;
           padding: 0;
-          row-gap: 0.5em;
+          row-gap: var(--cc-spacing-3, 0.5em);
         }
 
         .linked-service__li {
           align-items: center;
           display: flex;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .linked-service__li cc-img {
@@ -648,34 +648,34 @@ export class CcAddonInfo extends LitElement {
         .features__content {
           display: flex;
           flex-wrap: wrap;
-          gap: 0.75em 1.5em;
+          gap: var(--cc-spacing-4, 0.75em) var(--cc-spacing-7, 1.5em);
         }
 
         .features__content__item {
           align-items: center;
           display: flex;
           flex-wrap: wrap;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .dialog-desc {
-          margin-bottom: 1.25em;
+          margin-bottom: var(--cc-spacing-6, 1.25em);
         }
 
         .dialog-form {
           align-items: baseline;
           display: flex;
           flex-wrap: wrap;
-          gap: 0.5em 1em;
+          gap: var(--cc-spacing-3, 0.5em) var(--cc-spacing-5, 1em);
         }
 
         .dialog-form__version-from {
           display: flex;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         .dialog-form cc-select {
-          column-gap: 1em;
+          column-gap: var(--cc-spacing-5, 1em);
           flex: 1 1 auto;
         }
 

--- a/src/components/cc-addon-info/cc-addon-info.js
+++ b/src/components/cc-addon-info/cc-addon-info.js
@@ -602,7 +602,7 @@ export class CcAddonInfo extends LitElement {
 
         .data-decoration {
           border: solid 1px var(--cc-color-border-neutral, #bfbfbf);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           font-weight: bold;
           padding: var(--cc-spacing-0, 0.125em) var(--cc-spacing-2, 0.35em);
         }
@@ -640,7 +640,7 @@ export class CcAddonInfo extends LitElement {
         }
 
         .linked-service__li cc-img {
-          border-radius: 0.19em;
+          border-radius: var(--cc-border-radius-xs, 0.15em);
           height: 1.5em;
           width: 1.5em;
         }

--- a/src/components/cc-addon-linked-apps/cc-addon-linked-apps.js
+++ b/src/components/cc-addon-linked-apps/cc-addon-linked-apps.js
@@ -140,7 +140,7 @@ export class CcAddonLinkedApps extends LitElement {
           align-items: center;
           display: flex;
           flex-wrap: wrap;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .empty-msg {

--- a/src/components/cc-addon-linked-apps/cc-addon-linked-apps.js
+++ b/src/components/cc-addon-linked-apps/cc-addon-linked-apps.js
@@ -131,7 +131,7 @@ export class CcAddonLinkedApps extends LitElement {
         }
 
         cc-link::part(img) {
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           height: 1.6em;
           width: 1.6em;
         }

--- a/src/components/cc-addon-option-form/cc-addon-option-form.js
+++ b/src/components/cc-addon-option-form/cc-addon-option-form.js
@@ -94,7 +94,7 @@ export class CcAddonOptionForm extends LitElement {
 
         .content {
           display: grid;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         .button-bar {
@@ -108,7 +108,7 @@ export class CcAddonOptionForm extends LitElement {
 
         .option-warning {
           display: grid;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           grid-template-columns: min-content 1fr;
           text-align: left;
         }

--- a/src/components/cc-addon-option/cc-addon-option.js
+++ b/src/components/cc-addon-option/cc-addon-option.js
@@ -79,7 +79,7 @@ export class CcAddonOption extends LitElement {
       css`
         :host {
           background-color: var(--cc-color-bg-default, #fff);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           display: grid;
           grid-gap: 1em;
           grid-template-columns: min-content 1fr;
@@ -112,7 +112,7 @@ export class CcAddonOption extends LitElement {
         }
 
         .logo {
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           height: 1.6em;
           width: 1.6em;
         }

--- a/src/components/cc-addon-option/cc-addon-option.js
+++ b/src/components/cc-addon-option/cc-addon-option.js
@@ -83,7 +83,7 @@ export class CcAddonOption extends LitElement {
           display: grid;
           grid-gap: 1em;
           grid-template-columns: min-content 1fr;
-          padding: 1em;
+          padding: var(--cc-spacing-5, 1em);
         }
 
         ::slotted(.option-warning) {
@@ -124,7 +124,7 @@ export class CcAddonOption extends LitElement {
 
         cc-toggle {
           justify-self: end;
-          margin-top: 0.5em;
+          margin-top: var(--cc-spacing-3, 0.5em);
         }
 
         :host([enabled]) cc-toggle {

--- a/src/components/cc-ansi-palette/cc-ansi-palette.js
+++ b/src/components/cc-ansi-palette/cc-ansi-palette.js
@@ -127,7 +127,7 @@ export class CcAnsiPalette extends LitElement {
         .top,
         .hover,
         .selected {
-          padding: 0.2em;
+          padding: var(--cc-spacing-1, 0.25em);
         }
 
         .title {
@@ -152,14 +152,14 @@ export class CcAnsiPalette extends LitElement {
           display: grid;
           grid-column-gap: 0.5em;
           grid-template-columns: 1fr min-content min-content 1fr;
-          padding-bottom: 1em;
-          padding-top: 1em;
+          padding-bottom: var(--cc-spacing-5, 1em);
+          padding-top: var(--cc-spacing-5, 1em);
         }
 
         .color-line {
           align-items: center;
           display: flex;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .palette-squares {
@@ -178,7 +178,7 @@ export class CcAnsiPalette extends LitElement {
         .color {
           align-items: center;
           display: inline-flex;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
           justify-content: center;
         }
 
@@ -193,7 +193,7 @@ export class CcAnsiPalette extends LitElement {
         .ratio {
           align-items: center;
           display: inline-flex;
-          gap: 0.3em;
+          gap: var(--cc-spacing-1, 0.25em);
           justify-content: center;
         }
 
@@ -206,7 +206,7 @@ export class CcAnsiPalette extends LitElement {
         }
 
         cc-input-text {
-          margin-top: 1em;
+          margin-top: var(--cc-spacing-5, 1em);
           max-height: 200px;
           overflow: auto;
         }

--- a/src/components/cc-article-card/cc-article-card.js
+++ b/src/components/cc-article-card/cc-article-card.js
@@ -74,7 +74,7 @@ export class CcArticleCard extends LitElement {
         :host {
           background-color: var(--cc-color-bg-default, #fff);
           border: 1px solid var(--cc-color-border-neutral, #aaa);
-          border-radius: var(--cc-border-radius-small, 0.25em);
+          border-radius: var(--cc-border-radius-medium, 0.375em);
           box-sizing: border-box;
           display: grid;
           gap: var(--cc-spacing-5, 1em);

--- a/src/components/cc-article-card/cc-article-card.js
+++ b/src/components/cc-article-card/cc-article-card.js
@@ -74,7 +74,7 @@ export class CcArticleCard extends LitElement {
         :host {
           background-color: var(--cc-color-bg-default, #fff);
           border: 1px solid var(--cc-color-border-neutral, #aaa);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           box-sizing: border-box;
           display: grid;
           gap: var(--cc-spacing-5, 1em);

--- a/src/components/cc-article-card/cc-article-card.js
+++ b/src/components/cc-article-card/cc-article-card.js
@@ -77,11 +77,11 @@ export class CcArticleCard extends LitElement {
           border-radius: var(--cc-border-radius-default, 0.25em);
           box-sizing: border-box;
           display: grid;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
           grid-template-columns: 1fr;
           grid-template-rows: min-content min-content 1fr min-content;
           overflow: hidden;
-          padding: 1em;
+          padding: var(--cc-spacing-5, 1em);
         }
 
         .image {
@@ -89,7 +89,7 @@ export class CcArticleCard extends LitElement {
           display: block;
           height: 8em;
           justify-self: stretch;
-          margin: -1em -1em 0;
+          margin: calc(var(--cc-spacing-5, 1em) * -1) calc(var(--cc-spacing-5, 1em) * -1) 0;
         }
 
         .title {

--- a/src/components/cc-article-list/cc-article-list.js
+++ b/src/components/cc-article-list/cc-article-list.js
@@ -59,7 +59,7 @@ export class CcArticleList extends LitElement {
 
         .article-container {
           display: grid;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
           grid-template-columns: repeat(auto-fit, minmax(20em, 1fr));
         }
       `,

--- a/src/components/cc-badge/cc-badge.js
+++ b/src/components/cc-badge/cc-badge.js
@@ -93,9 +93,9 @@ export class CcBadge extends LitElement {
           border-radius: var(--border-radius, 1em);
           display: flex;
           font-size: 0.8em;
-          gap: 0.3em;
+          gap: var(--cc-spacing-1, 0.25em);
           justify-content: var(--cc-badge-justify-content, center);
-          padding: 0.2em 0.8em;
+          padding: var(--cc-spacing-1, 0.25em) var(--cc-spacing-4, 0.75em);
         }
 
         /* skeleton is more important */

--- a/src/components/cc-block-details/cc-block-details.js
+++ b/src/components/cc-block-details/cc-block-details.js
@@ -80,20 +80,20 @@ export class CcBlockDetails extends LitElement {
         }
 
         .btn-wrapper {
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-large, 0.5em);
           grid-area: button;
         }
 
         :host([is-open]) .btn-wrapper {
           background-color: var(--cc-color-bg-default, #fff);
-          border-radius: var(--cc-border-radius-default, 0.25em) var(--cc-border-radius-default, 0.25em) 0 0;
+          border-radius: var(--cc-border-radius-large, 0.5em) var(--cc-border-radius-large, 0.5em) 0 0;
         }
 
         .button {
           align-items: center;
           background-color: transparent;
           border: solid 1px transparent;
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-large, 0.5em);
           display: flex;
           font-family: inherit;
           font-size: 1em;
@@ -126,7 +126,7 @@ export class CcBlockDetails extends LitElement {
 
         .content {
           background-color: var(--cc-color-bg-default, #fff);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-large, 0.5em);
           box-sizing: border-box;
           display: none;
           grid-area: content;

--- a/src/components/cc-block-details/cc-block-details.js
+++ b/src/components/cc-block-details/cc-block-details.js
@@ -97,7 +97,7 @@ export class CcBlockDetails extends LitElement {
           display: flex;
           font-family: inherit;
           font-size: 1em;
-          padding: 0.25em 0.6em 0.35em;
+          padding: var(--cc-spacing-1, 0.25em) var(--cc-spacing-3, 0.5em) var(--cc-spacing-2, 0.35em);
           position: relative;
           z-index: 1;
         }
@@ -112,7 +112,7 @@ export class CcBlockDetails extends LitElement {
         }
 
         .button cc-icon {
-          margin-left: 0.1em;
+          margin-left: var(--cc-spacing-0, 0.125em);
           transition: all 0.3s;
         }
 
@@ -130,7 +130,7 @@ export class CcBlockDetails extends LitElement {
           box-sizing: border-box;
           display: none;
           grid-area: content;
-          padding: 1em;
+          padding: var(--cc-spacing-8, 2em);
           width: 100%;
         }
 
@@ -147,7 +147,7 @@ export class CcBlockDetails extends LitElement {
         .links {
           align-items: center;
           display: flex;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           grid-area: links;
           justify-self: end;
         }
@@ -155,7 +155,7 @@ export class CcBlockDetails extends LitElement {
         @container (max-width: 34em) {
           .links {
             justify-self: unset;
-            margin-block-start: 0.5em;
+            margin-block-start: var(--cc-spacing-3, 0.5em);
           }
         }
 
@@ -164,7 +164,7 @@ export class CcBlockDetails extends LitElement {
           color: var(--cc-color-text-primary-highlight, blue);
           display: flex;
           flex-direction: row;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
       `,
     ];

--- a/src/components/cc-block-section/cc-block-section.js
+++ b/src/components/cc-block-section/cc-block-section.js
@@ -51,8 +51,8 @@ export class CcBlockSection extends LitElement {
 
         :host(:not(:first-of-type)) {
           border-top: 1px solid var(--cc-color-border-neutral-weak, #eee);
-          margin-top: 1em;
-          padding-top: 2em;
+          margin-top: var(--cc-spacing-5, 1em);
+          padding-top: var(--cc-spacing-8, 2em);
         }
 
         ::slotted([slot='title']) {
@@ -66,12 +66,12 @@ export class CcBlockSection extends LitElement {
         .section {
           display: flex;
           flex-wrap: wrap;
-          margin: -0.5em -1.5em;
+          margin: calc(var(--cc-spacing-3, 0.5em) * -1) calc(var(--cc-spacing-7, 1.5em) * -1);
         }
 
         ::slotted([slot='info']),
         .main {
-          margin: 0.5em 1.5em;
+          margin: var(--cc-spacing-3, 0.5em) var(--cc-spacing-7, 1.5em);
         }
 
         ::slotted([slot='info']) {

--- a/src/components/cc-block/cc-block.js
+++ b/src/components/cc-block/cc-block.js
@@ -157,7 +157,7 @@ export class CcBlock extends LitElement {
         :host {
           background-color: var(--cc-color-bg-default, #fff);
           border: 1px solid var(--cc-color-border-neutral, #aaa);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-large, 0.5em);
           box-sizing: border-box;
           display: block;
           overflow: hidden;
@@ -243,7 +243,7 @@ export class CcBlock extends LitElement {
 
         .header-img,
         ::slotted([slot='header-icon']) {
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           height: 1.5em;
           width: 1.5em;
         }

--- a/src/components/cc-block/cc-block.js
+++ b/src/components/cc-block/cc-block.js
@@ -166,8 +166,8 @@ export class CcBlock extends LitElement {
 
         .container {
           display: grid;
-          gap: 0.5em;
-          padding-block: 1em;
+          gap: var(--cc-spacing-3, 0.5em);
+          padding-block: var(--cc-spacing-5, 1em);
 
           --left-space: 1em;
         }
@@ -210,7 +210,7 @@ export class CcBlock extends LitElement {
           align-items: center;
           color: var(--cc-color-text-primary-strongest);
           display: none;
-          padding: 1em 1em 1em var(--left-space);
+          padding: var(--cc-spacing-5, 1em) var(--cc-spacing-5, 1em) var(--cc-spacing-5, 1em) var(--left-space);
         }
 
         .container[header-is-slotted] .header,
@@ -219,7 +219,7 @@ export class CcBlock extends LitElement {
         .container[header-icon-is-slotted] .header {
           display: flex;
           flex-wrap: wrap;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .container[header-is-slotted],
@@ -229,7 +229,7 @@ export class CcBlock extends LitElement {
         }
 
         ::slotted([slot='header']) {
-          padding: 1em 1em 1em var(--left-space);
+          padding: var(--cc-spacing-5, 1em) var(--cc-spacing-5, 1em) var(--cc-spacing-5, 1em) var(--left-space);
         }
 
         .header-icon {
@@ -272,7 +272,7 @@ export class CcBlock extends LitElement {
           font-family: inherit;
           font-size: 1em;
           justify-content: space-between;
-          padding: 0 1em 0 0;
+          padding: 0 var(--cc-spacing-8, 2em) 0 0;
           text-align: start;
         }
 
@@ -298,12 +298,12 @@ export class CcBlock extends LitElement {
 
         .content {
           display: none;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         ::slotted([slot='content']) {
           padding-left: var(--left-space);
-          padding-right: 1em;
+          padding-right: var(--cc-spacing-5, 1em);
         }
 
         .container[content-is-slotted] .content,
@@ -311,14 +311,14 @@ export class CcBlock extends LitElement {
         .container[content-body-is-slotted] .content,
         .container[content-footer-is-slotted] .content {
           display: grid;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         .content-header,
         .content-body,
         .content-footer {
           display: none;
-          padding: 0 1em 0 var(--left-space);
+          padding: 0 var(--cc-spacing-5, 1em) 0 var(--left-space);
         }
 
         .container[content-header-is-slotted] .content-header,
@@ -328,18 +328,18 @@ export class CcBlock extends LitElement {
         }
 
         .content-body {
-          margin-block: -0.5em;
-          padding-block: 0.5em;
+          margin-block: calc(var(--cc-spacing-3, 0.5em) * -1);
+          padding-block: var(--cc-spacing-3, 0.5em);
         }
 
         slot[name='content-body'] {
           display: grid;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         #content-and-footer {
           display: grid;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         #content-and-footer.hidden {
@@ -356,10 +356,10 @@ export class CcBlock extends LitElement {
           box-shadow: inset 0 6px 6px -6px rgb(0 0 0 / 40%);
           display: none;
           flex-wrap: wrap;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
           /* TODO doc */
           justify-content: flex-end;
-          padding: 0.5em 1em;
+          padding: var(--cc-spacing-3, 0.5em) var(--cc-spacing-5, 1em);
         }
 
         .footer-left {
@@ -390,7 +390,7 @@ export class CcBlock extends LitElement {
         }
 
         ::slotted([slot='footer']) {
-          padding: 0.5em 1em;
+          padding: var(--cc-spacing-3, 0.5em) var(--cc-spacing-5, 1em);
         }
 
         /* endregion */

--- a/src/components/cc-breadcrumbs/cc-breadcrumbs.js
+++ b/src/components/cc-breadcrumbs/cc-breadcrumbs.js
@@ -118,7 +118,7 @@ export class CcBreadcrumbs extends LitElement {
         .item-wrapper {
           align-items: center;
           display: flex;
-          gap: 0.2em;
+          gap: var(--cc-spacing-1, 0.25em);
           min-width: 0;
         }
 

--- a/src/components/cc-button/cc-button.js
+++ b/src/components/cc-button/cc-button.js
@@ -40,7 +40,6 @@ import { CcClickEvent } from '../common.events.js';
  * @cssdisplay inline-block
  *
  * @slot - The content of the button (text or HTML). If you want an image, please look at the `image` attribute.
- * @cssprop {BorderRadius} --cc-button-border-radius - Sets the value of the border radius CSS property (defaults: `0.15em`).
  * @cssprop {FontWeight} --cc-button-font-weight - Sets the value of the font weight CSS property (defaults: `bold`).
  * @cssprop {TextTransform} --cc-button-text-transform - Sets the value of the text transform CSS property (defaults: `uppercase`).
  */
@@ -354,7 +353,7 @@ export class CcButton extends LitElement {
         .btn {
           background-color: var(--cc-color-bg-default, #fff);
           border: 1px solid #000;
-          border-radius: var(--cc-button-border-radius, 0.15em);
+          border-radius: var(--cc-border-radius-medium, 0.375em);
           cursor: pointer;
           font-weight: var(--cc-button-font-weight, bold);
           min-height: 2em;
@@ -654,7 +653,7 @@ export class CcButton extends LitElement {
 
         .cc-link:focus {
           background-color: var(--cc-color-bg-default, #fff);
-          border-radius: 0.1em;
+          border-radius: var(--cc-border-radius-medium, 0.375em);
           outline: var(--cc-focus-outline, #000 solid 2px);
           outline-offset: var(--cc-focus-outline-offset, 2px);
         }

--- a/src/components/cc-button/cc-button.js
+++ b/src/components/cc-button/cc-button.js
@@ -359,7 +359,7 @@ export class CcButton extends LitElement {
           font-weight: var(--cc-button-font-weight, bold);
           min-height: 2em;
           overflow: hidden;
-          padding: 0 0.5em;
+          padding: 0 var(--cc-spacing-3, 0.5em);
           /* used to absolutely position the <progress> */
           position: relative;
           text-transform: var(--cc-button-text-transform, uppercase);
@@ -466,7 +466,7 @@ export class CcButton extends LitElement {
         .text-wrapper {
           align-items: center;
           display: grid;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           grid-template-columns: min-content 1fr;
           height: 100%;
           justify-content: center;

--- a/src/components/cc-cellar-bucket-list/cc-cellar-bucket-list.js
+++ b/src/components/cc-cellar-bucket-list/cc-cellar-bucket-list.js
@@ -543,7 +543,7 @@ export class CcCellarBucketList extends LitElement {
         .wrapper {
           background-color: var(--cc-color-bg-default, #fff);
           border: 1px solid var(--cc-color-border-neutral, #aaa);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           box-sizing: border-box;
           display: flex;
           flex-direction: column;
@@ -605,7 +605,7 @@ export class CcCellarBucketList extends LitElement {
 
         .list {
           border: 1px solid var(--cc-color-border-neutral-weak, #aaa);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           flex: 1;
           min-height: 0;
         }
@@ -620,7 +620,7 @@ export class CcCellarBucketList extends LitElement {
           align-content: center;
           align-items: center;
           border: 1px solid var(--cc-color-border-neutral, #aaa);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           color: var(--cc-color-text-primary-strongest, #000);
           display: flex;
           flex-direction: column;

--- a/src/components/cc-cellar-bucket-list/cc-cellar-bucket-list.js
+++ b/src/components/cc-cellar-bucket-list/cc-cellar-bucket-list.js
@@ -543,7 +543,7 @@ export class CcCellarBucketList extends LitElement {
         .wrapper {
           background-color: var(--cc-color-bg-default, #fff);
           border: 1px solid var(--cc-color-border-neutral, #aaa);
-          border-radius: var(--cc-border-radius-small, 0.25em);
+          border-radius: var(--cc-border-radius-medium, 0.375em);
           box-sizing: border-box;
           display: flex;
           flex-direction: column;
@@ -605,7 +605,7 @@ export class CcCellarBucketList extends LitElement {
 
         .list {
           border: 1px solid var(--cc-color-border-neutral-weak, #aaa);
-          border-radius: var(--cc-border-radius-small, 0.25em);
+          border-radius: var(--cc-border-radius-medium, 0.375em);
           flex: 1;
           min-height: 0;
         }

--- a/src/components/cc-cellar-bucket-list/cc-cellar-bucket-list.js
+++ b/src/components/cc-cellar-bucket-list/cc-cellar-bucket-list.js
@@ -547,23 +547,23 @@ export class CcCellarBucketList extends LitElement {
           box-sizing: border-box;
           display: flex;
           flex-direction: column;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
           height: 100%;
-          padding: 1em;
+          padding: var(--cc-spacing-5, 1em);
         }
 
         .list-heading {
           align-items: center;
           display: flex;
           flex-wrap: wrap;
-          gap: 1em;
-          margin-bottom: 1em;
+          gap: var(--cc-spacing-5, 1em);
+          margin-bottom: var(--cc-spacing-5, 1em);
         }
 
         .list-heading--left {
           align-items: center;
           display: flex;
-          gap: 0.2em;
+          gap: var(--cc-spacing-1, 0.25em);
         }
 
         .list-heading--title {
@@ -580,7 +580,7 @@ export class CcCellarBucketList extends LitElement {
           align-items: center;
           display: flex;
           flex: 1 1 auto;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           justify-content: end;
         }
 
@@ -588,7 +588,7 @@ export class CcCellarBucketList extends LitElement {
           align-items: center;
           display: inline-flex;
           flex: 1;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           max-width: 28em;
         }
 
@@ -600,7 +600,7 @@ export class CcCellarBucketList extends LitElement {
           align-items: center;
           display: flex;
           justify-content: center;
-          padding: 1em;
+          padding: var(--cc-spacing-5, 1em);
         }
 
         .list {
@@ -624,8 +624,8 @@ export class CcCellarBucketList extends LitElement {
           color: var(--cc-color-text-primary-strongest, #000);
           display: flex;
           flex-direction: column;
-          gap: 1em;
-          padding: 1em;
+          gap: var(--cc-spacing-5, 1em);
+          padding: var(--cc-spacing-5, 1em);
         }
 
         .details-wrapper .details-icon-wrapper cc-icon {
@@ -644,15 +644,15 @@ export class CcCellarBucketList extends LitElement {
           border-bottom: 1px solid var(--cc-color-border-primary-weak, #aaa);
           display: flex;
           font-weight: bold;
-          margin-bottom: 1em;
-          margin-top: 2em;
-          padding-bottom: 0.5em;
+          margin-bottom: var(--cc-spacing-5, 1em);
+          margin-top: var(--cc-spacing-8, 2em);
+          padding-bottom: var(--cc-spacing-3, 0.5em);
         }
 
         .details-wrapper .details-actions {
           display: flex;
           flex-direction: column;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .details-wrapper .details-overview-list {
@@ -664,22 +664,22 @@ export class CcCellarBucketList extends LitElement {
         .details-wrapper .details-overview-list dt {
           font-size: 0.94em;
           font-weight: bold;
-          margin-bottom: 0.25em;
+          margin-bottom: var(--cc-spacing-1, 0.25em);
         }
 
         .details-wrapper .details-overview-list dd {
           font-size: 0.94em;
-          margin: 0 0 1em;
+          margin: 0 0 var(--cc-spacing-5, 1em);
         }
 
         .bucket-name-help {
           font-size: 1em;
-          padding-left: 1em;
+          padding-left: var(--cc-spacing-5, 1em);
         }
 
         .bucket-name-help li {
           margin: 0;
-          padding: 0.3em;
+          padding: var(--cc-spacing-1, 0.25em);
         }
       `,
     ];

--- a/src/components/cc-cellar-object-list/cc-cellar-object-list.js
+++ b/src/components/cc-cellar-object-list/cc-cellar-object-list.js
@@ -611,7 +611,7 @@ export class CcCellarObjectList extends LitElement {
         .wrapper {
           background-color: var(--cc-color-bg-default, #fff);
           border: 1px solid var(--cc-color-border-neutral, #aaa);
-          border-radius: var(--cc-border-radius-small, 0.25em);
+          border-radius: var(--cc-border-radius-medium, 0.375em);
           box-sizing: border-box;
           display: flex;
           flex-direction: column;
@@ -675,7 +675,7 @@ export class CcCellarObjectList extends LitElement {
 
         .list {
           border: 1px solid var(--cc-color-border-neutral-weak, #aaa);
-          border-radius: var(--cc-border-radius-small, 0.25em);
+          border-radius: var(--cc-border-radius-medium, 0.375em);
           flex: 1;
           min-height: 0;
         }

--- a/src/components/cc-cellar-object-list/cc-cellar-object-list.js
+++ b/src/components/cc-cellar-object-list/cc-cellar-object-list.js
@@ -611,7 +611,7 @@ export class CcCellarObjectList extends LitElement {
         .wrapper {
           background-color: var(--cc-color-bg-default, #fff);
           border: 1px solid var(--cc-color-border-neutral, #aaa);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           box-sizing: border-box;
           display: flex;
           flex-direction: column;
@@ -675,7 +675,7 @@ export class CcCellarObjectList extends LitElement {
 
         .list {
           border: 1px solid var(--cc-color-border-neutral-weak, #aaa);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           flex: 1;
           min-height: 0;
         }
@@ -699,7 +699,7 @@ export class CcCellarObjectList extends LitElement {
           align-content: center;
           align-items: center;
           border: 1px solid var(--cc-color-border-neutral, #aaa);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           color: var(--cc-color-text-primary-strongest, #000);
           display: flex;
           flex-direction: column;

--- a/src/components/cc-cellar-object-list/cc-cellar-object-list.js
+++ b/src/components/cc-cellar-object-list/cc-cellar-object-list.js
@@ -615,23 +615,23 @@ export class CcCellarObjectList extends LitElement {
           box-sizing: border-box;
           display: flex;
           flex-direction: column;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
           height: 100%;
-          padding: 1em;
+          padding: var(--cc-spacing-5, 1em);
         }
 
         .list-heading {
           align-items: center;
           display: flex;
           flex-wrap: wrap;
-          gap: 1em;
-          margin-bottom: 1em;
+          gap: var(--cc-spacing-5, 1em);
+          margin-bottom: var(--cc-spacing-5, 1em);
         }
 
         .list-heading--left {
           align-items: center;
           display: flex;
-          gap: 0.2em;
+          gap: var(--cc-spacing-1, 0.25em);
         }
 
         .list-heading--title {
@@ -644,7 +644,7 @@ export class CcCellarObjectList extends LitElement {
           align-items: center;
           display: flex;
           flex: 1 1 auto;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           justify-content: end;
         }
 
@@ -652,7 +652,7 @@ export class CcCellarObjectList extends LitElement {
           align-items: center;
           display: inline-flex;
           flex: 1;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           max-width: 28em;
         }
 
@@ -663,14 +663,14 @@ export class CcCellarObjectList extends LitElement {
         .path-wrapper {
           align-items: center;
           display: flex;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         .empty-list {
           align-items: center;
           display: flex;
           justify-content: center;
-          padding: 1em;
+          padding: var(--cc-spacing-5, 1em);
         }
 
         .list {
@@ -682,7 +682,7 @@ export class CcCellarObjectList extends LitElement {
 
         .pagination {
           align-items: center;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         .details-wrapper {
@@ -703,8 +703,8 @@ export class CcCellarObjectList extends LitElement {
           color: var(--cc-color-text-primary-strongest, #000);
           display: flex;
           flex-direction: column;
-          gap: 1em;
-          padding: 1em;
+          gap: var(--cc-spacing-5, 1em);
+          padding: var(--cc-spacing-5, 1em);
         }
 
         .details-wrapper .details-icon-wrapper cc-icon {
@@ -723,15 +723,15 @@ export class CcCellarObjectList extends LitElement {
           border-bottom: 1px solid var(--cc-color-border-primary-weak, #aaa);
           display: flex;
           font-weight: bold;
-          margin-bottom: 1em;
-          margin-top: 2em;
-          padding-bottom: 0.5em;
+          margin-bottom: var(--cc-spacing-5, 1em);
+          margin-top: var(--cc-spacing-8, 2em);
+          padding-bottom: var(--cc-spacing-3, 0.5em);
         }
 
         .details-wrapper .details-actions {
           display: flex;
           flex-direction: column;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .details-wrapper .details-overview-list {
@@ -743,15 +743,15 @@ export class CcCellarObjectList extends LitElement {
         .details-wrapper .details-overview-list dt {
           font-size: 0.94em;
           font-weight: bold;
-          margin-bottom: 0.25em;
+          margin-bottom: var(--cc-spacing-1, 0.25em);
         }
 
         .details-wrapper .details-overview-list dd {
           align-items: center;
           display: flex;
           font-size: 0.94em;
-          gap: 0.5em;
-          margin: 0 0 1em;
+          gap: var(--cc-spacing-3, 0.5em);
+          margin: 0 0 var(--cc-spacing-5, 1em);
         }
       `,
     ];

--- a/src/components/cc-clipboard/cc-clipboard.js
+++ b/src/components/cc-clipboard/cc-clipboard.js
@@ -94,7 +94,7 @@ export class CcClipboard extends LitElement {
         button {
           background: transparent;
           border: none;
-          border-radius: var(--cc-border-radius-xs, 0.15em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           color: var(--cc-clipboard-color, var(--cc-color-text-default, #000));
           cursor: pointer;
           display: block;

--- a/src/components/cc-clipboard/cc-clipboard.js
+++ b/src/components/cc-clipboard/cc-clipboard.js
@@ -94,7 +94,7 @@ export class CcClipboard extends LitElement {
         button {
           background: transparent;
           border: none;
-          border-radius: var(--cc-border-radius-small, 0.15em);
+          border-radius: var(--cc-border-radius-xs, 0.15em);
           color: var(--cc-clipboard-color, var(--cc-color-text-default, #000));
           cursor: pointer;
           display: block;

--- a/src/components/cc-code/cc-code.js
+++ b/src/components/cc-code/cc-code.js
@@ -79,8 +79,8 @@ export class CcCode extends LitElement {
           border-radius: var(--cc-border-radius-default, 0.25em);
           display: flex;
           font-family: var(--cc-ff-monospace), serif;
-          gap: 0.5em;
-          padding: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
+          padding: var(--cc-spacing-3, 0.5em);
           word-break: break-all;
         }
 
@@ -93,7 +93,7 @@ export class CcCode extends LitElement {
           font-size: calc(1em); /* Force font size to 14px */
           line-height: 1.5;
           overflow-x: auto;
-          padding-left: 0.25em;
+          padding-left: var(--cc-spacing-1, 0.25em);
           white-space: pre;
         }
       `,

--- a/src/components/cc-code/cc-code.js
+++ b/src/components/cc-code/cc-code.js
@@ -76,7 +76,7 @@ export class CcCode extends LitElement {
           align-items: start;
           background-color: var(--cc-color-bg-neutral);
           border: 1px solid var(--cc-color-border-neutral, #bfbfbf);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           display: flex;
           font-family: var(--cc-ff-monospace), serif;
           gap: var(--cc-spacing-3, 0.5em);

--- a/src/components/cc-dialog-confirm-actions/cc-dialog-confirm-actions.js
+++ b/src/components/cc-dialog-confirm-actions/cc-dialog-confirm-actions.js
@@ -79,7 +79,7 @@ export class CcDialogConfirmActions extends LitElement {
         .dialog-actions {
           display: flex;
           flex-wrap: wrap;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
           justify-content: end;
           margin-top: var(--cc-dialog-confirm-actions-margin-top, 2.75em);
         }

--- a/src/components/cc-dialog/cc-dialog.js
+++ b/src/components/cc-dialog/cc-dialog.js
@@ -201,7 +201,7 @@ export class CcDialog extends LitElement {
 
         dialog {
           border: none;
-          border-radius: var(--cc-border-radius-small, 0.25em);
+          border-radius: var(--cc-border-radius-medium, 0.375em);
           box-shadow: 2px 4px 8px 0 rgb(0 0 0 / 12%);
           box-sizing: border-box;
           padding: var(--cc-dialog-padding, var(--default-dialog-padding));

--- a/src/components/cc-dialog/cc-dialog.js
+++ b/src/components/cc-dialog/cc-dialog.js
@@ -265,15 +265,15 @@ export class CcDialog extends LitElement {
           color: var(--cc-color-text-primary-strongest);
           display: flex;
           font-weight: bold;
-          gap: 0.5em;
-          margin-bottom: 1.25em;
-          padding-bottom: 1.25em;
+          gap: var(--cc-spacing-3, 0.5em);
+          margin-bottom: var(--cc-spacing-6, 1.25em);
+          padding-bottom: var(--cc-spacing-6, 1.25em);
         }
 
         .dialog-content-body-wrapper {
           display: flex;
           flex-direction: column;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
       `,
     ];

--- a/src/components/cc-dialog/cc-dialog.js
+++ b/src/components/cc-dialog/cc-dialog.js
@@ -201,7 +201,7 @@ export class CcDialog extends LitElement {
 
         dialog {
           border: none;
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           box-shadow: 2px 4px 8px 0 rgb(0 0 0 / 12%);
           box-sizing: border-box;
           padding: var(--cc-dialog-padding, var(--default-dialog-padding));
@@ -235,7 +235,7 @@ export class CcDialog extends LitElement {
           align-items: center;
           background: none;
           border: none;
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           color: var(--cc-color-text-weak);
           cursor: pointer;
           display: flex;

--- a/src/components/cc-doc-card/cc-doc-card.js
+++ b/src/components/cc-doc-card/cc-doc-card.js
@@ -73,19 +73,19 @@ export class CcDocCard extends LitElement {
           border-radius: var(--cc-border-radius-default, 0.25em);
           box-sizing: border-box;
           display: grid;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
           grid-template-areas:
             'img title'
             'desc desc'
             'link link';
           grid-template-columns: min-content 1fr;
           grid-template-rows: min-content 1fr min-content;
-          padding: 1em;
+          padding: var(--cc-spacing-5, 1em);
         }
 
         .images {
           display: flex;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           grid-area: img;
         }
 

--- a/src/components/cc-doc-card/cc-doc-card.js
+++ b/src/components/cc-doc-card/cc-doc-card.js
@@ -70,7 +70,7 @@ export class CcDocCard extends LitElement {
         :host {
           background-color: var(--cc-color-bg-default, #fff);
           border: 1px solid var(--cc-color-border-neutral, #aaa);
-          border-radius: var(--cc-border-radius-small, 0.25em);
+          border-radius: var(--cc-border-radius-medium, 0.375em);
           box-sizing: border-box;
           display: grid;
           gap: var(--cc-spacing-5, 1em);

--- a/src/components/cc-doc-card/cc-doc-card.js
+++ b/src/components/cc-doc-card/cc-doc-card.js
@@ -70,7 +70,7 @@ export class CcDocCard extends LitElement {
         :host {
           background-color: var(--cc-color-bg-default, #fff);
           border: 1px solid var(--cc-color-border-neutral, #aaa);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           box-sizing: border-box;
           display: grid;
           gap: var(--cc-spacing-5, 1em);
@@ -90,7 +90,7 @@ export class CcDocCard extends LitElement {
         }
 
         cc-img {
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           height: 2em;
           width: 2em;
         }

--- a/src/components/cc-doc-list/cc-doc-list.js
+++ b/src/components/cc-doc-list/cc-doc-list.js
@@ -59,7 +59,7 @@ export class CcDocList extends LitElement {
 
         .doc-wrapper {
           display: grid;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
           grid-template-columns: repeat(auto-fit, minmax(20em, 1fr));
         }
       `,

--- a/src/components/cc-domain-management/cc-domain-management.js
+++ b/src/components/cc-domain-management/cc-domain-management.js
@@ -896,7 +896,7 @@ export class CcDomainManagement extends LitElement {
         .domain {
           align-items: center;
           border: solid 1px var(--cc-color-border-neutral-weak);
-          border-radius: var(--cc-border-radius-small, 0.25em);
+          border-radius: var(--cc-border-radius-medium, 0.375em);
           display: flex;
           flex-wrap: wrap;
           gap: var(--cc-spacing-3, 0.5em) var(--cc-spacing-5, 1em);

--- a/src/components/cc-domain-management/cc-domain-management.js
+++ b/src/components/cc-domain-management/cc-domain-management.js
@@ -813,14 +813,14 @@ export class CcDomainManagement extends LitElement {
         .wrapper {
           display: flex;
           flex-direction: column;
-          gap: 1.5em;
+          gap: var(--cc-spacing-7, 1.5em);
         }
 
         code {
           background-color: var(--cc-color-bg-neutral);
           border-radius: var(--cc-border-radius-default, 0.25em);
           font-family: var(--cc-ff-monospace);
-          padding: 0.15em 0.3em;
+          padding: var(--cc-spacing-0, 0.125em) var(--cc-spacing-1, 0.25em);
           word-break: break-all;
         }
 
@@ -829,7 +829,7 @@ export class CcDomainManagement extends LitElement {
         .fieldgroup {
           display: flex;
           flex-wrap: wrap;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         .fieldgroup__domain {
@@ -844,7 +844,7 @@ export class CcDomainManagement extends LitElement {
         form {
           display: flex;
           flex-direction: column;
-          gap: 1.5em;
+          gap: var(--cc-spacing-7, 1.5em);
           justify-content: flex-end;
         }
 
@@ -855,7 +855,7 @@ export class CcDomainManagement extends LitElement {
         .form-info {
           color: var(--cc-color-text-weak);
           line-height: 1.5;
-          margin-bottom: 1em;
+          margin-bottom: var(--cc-spacing-5, 1em);
         }
 
         .form-info p {
@@ -865,7 +865,7 @@ export class CcDomainManagement extends LitElement {
         .form-info__cleverapps {
           align-items: center;
           display: flex;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .form-info cc-icon {
@@ -875,7 +875,7 @@ export class CcDomainManagement extends LitElement {
         /** we need this because the help message contains a <code> tag that has some extra padding */
 
         [slot='help'] {
-          padding-top: 0.3em;
+          padding-top: var(--cc-spacing-1, 0.25em);
         }
 
         /** #endregion */
@@ -884,12 +884,12 @@ export class CcDomainManagement extends LitElement {
 
         .domain-count {
           font-size: 0.9em;
-          margin-left: 0.2em;
+          margin-left: var(--cc-spacing-1, 0.25em);
         }
 
         .domains {
           display: grid;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
           grid-template-columns: repeat(auto-fit, minmax(min(25em, 100%), 1fr));
         }
 
@@ -899,8 +899,8 @@ export class CcDomainManagement extends LitElement {
           border-radius: var(--cc-border-radius-default);
           display: flex;
           flex-wrap: wrap;
-          gap: 0.5em 1em;
-          padding: 1em;
+          gap: var(--cc-spacing-3, 0.5em) var(--cc-spacing-5, 1em);
+          padding: var(--cc-spacing-5, 1em);
         }
 
         .domain:hover {
@@ -928,7 +928,7 @@ export class CcDomainManagement extends LitElement {
           /** fixes icon alignment that differs depending on the font-family */
 
           font-family: var(--cc-ff-monospace, monospace);
-          padding: 0.3em;
+          padding: var(--cc-spacing-1, 0.25em);
           vertical-align: middle;
         }
 
@@ -943,13 +943,13 @@ export class CcDomainManagement extends LitElement {
         .badges {
           display: flex;
           flex-wrap: wrap;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .badge-content {
           align-items: center;
           display: flex;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .badge-content cc-icon {
@@ -959,7 +959,7 @@ export class CcDomainManagement extends LitElement {
         .actions {
           align-items: center;
           display: flex;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           margin-inline-start: auto;
         }
 
@@ -973,7 +973,7 @@ export class CcDomainManagement extends LitElement {
 
         .http-only-info cc-badge {
           line-height: normal;
-          margin-right: 0.5em;
+          margin-right: var(--cc-spacing-3, 0.5em);
         }
 
         .http-only-info {
@@ -986,7 +986,7 @@ export class CcDomainManagement extends LitElement {
 
         .certif-info {
           display: grid;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           line-height: 1.5;
         }
 
@@ -997,8 +997,8 @@ export class CcDomainManagement extends LitElement {
 
         .dns-info__desc {
           display: grid;
-          gap: 0.5em;
-          margin-bottom: 1em;
+          gap: var(--cc-spacing-3, 0.5em);
+          margin-bottom: var(--cc-spacing-5, 1em);
         }
 
         .dns-info div[slot='info'] {
@@ -1010,13 +1010,13 @@ export class CcDomainManagement extends LitElement {
         .a-records {
           align-content: baseline;
           display: grid;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
           grid-template-columns: repeat(auto-fit, minmax(8em, 1fr));
         }
 
         .dns-info cc-notice[intent='info'] {
-          margin-bottom: 1em;
-          margin-top: 1.5em;
+          margin-bottom: var(--cc-spacing-5, 1em);
+          margin-top: var(--cc-spacing-7, 1.5em);
         }
 
         /** #endregion */
@@ -1024,7 +1024,7 @@ export class CcDomainManagement extends LitElement {
         /** #region dialogs */
 
         cc-dialog cc-notice {
-          margin-bottom: 0.5em;
+          margin-bottom: var(--cc-spacing-3, 0.5em);
         }
 
         cc-dialog p {

--- a/src/components/cc-domain-management/cc-domain-management.js
+++ b/src/components/cc-domain-management/cc-domain-management.js
@@ -818,7 +818,7 @@ export class CcDomainManagement extends LitElement {
 
         code {
           background-color: var(--cc-color-bg-neutral);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           font-family: var(--cc-ff-monospace);
           padding: var(--cc-spacing-0, 0.125em) var(--cc-spacing-1, 0.25em);
           word-break: break-all;
@@ -896,7 +896,7 @@ export class CcDomainManagement extends LitElement {
         .domain {
           align-items: center;
           border: solid 1px var(--cc-color-border-neutral-weak);
-          border-radius: var(--cc-border-radius-default);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           display: flex;
           flex-wrap: wrap;
           gap: var(--cc-spacing-3, 0.5em) var(--cc-spacing-5, 1em);

--- a/src/components/cc-drawer/cc-drawer.js
+++ b/src/components/cc-drawer/cc-drawer.js
@@ -157,7 +157,7 @@ export class CcDrawer extends LitElement {
         dialog {
           background-color: var(--cc-color-bg-default, #fff);
           border: none;
-          border-radius: var(--cc-border-radius-small, 0.25em);
+          border-radius: var(--cc-border-radius-medium, 0.375em);
           box-shadow: 2px 4px 8px 0 rgb(0 0 0 / 12%);
           box-sizing: border-box;
           display: flex;

--- a/src/components/cc-drawer/cc-drawer.js
+++ b/src/components/cc-drawer/cc-drawer.js
@@ -145,7 +145,7 @@ export class CcDrawer extends LitElement {
       css`
         :host {
           --margin: 2em;
-          --padding: 2em;
+          --padding: var(--cc-spacing-8, 2em);
 
           display: none;
         }
@@ -200,7 +200,7 @@ export class CcDrawer extends LitElement {
           display: flex;
           flex-wrap: nowrap;
           margin: var(--padding);
-          padding-bottom: 0.5em;
+          padding-bottom: var(--cc-spacing-3, 0.5em);
         }
 
         .title {

--- a/src/components/cc-drawer/cc-drawer.js
+++ b/src/components/cc-drawer/cc-drawer.js
@@ -157,7 +157,7 @@ export class CcDrawer extends LitElement {
         dialog {
           background-color: var(--cc-color-bg-default, #fff);
           border: none;
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           box-shadow: 2px 4px 8px 0 rgb(0 0 0 / 12%);
           box-sizing: border-box;
           display: flex;
@@ -221,7 +221,7 @@ export class CcDrawer extends LitElement {
         }
 
         .close-button:focus-visible {
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           outline: var(--cc-focus-outline, #000 solid 2px);
           outline-offset: var(--cc-focus-outline-offset, 2px);
         }

--- a/src/components/cc-elasticsearch-info/cc-elasticsearch-info.js
+++ b/src/components/cc-elasticsearch-info/cc-elasticsearch-info.js
@@ -151,7 +151,7 @@ export class CcElasticsearchInfo extends LitElement {
         }
 
         cc-link::part(img) {
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           height: 1.5em;
           width: 1.5em;
         }

--- a/src/components/cc-elasticsearch-info/cc-elasticsearch-info.js
+++ b/src/components/cc-elasticsearch-info/cc-elasticsearch-info.js
@@ -142,7 +142,7 @@ export class CcElasticsearchInfo extends LitElement {
         .link-list {
           display: flex;
           flex-wrap: wrap;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         cc-link {
@@ -158,7 +158,7 @@ export class CcElasticsearchInfo extends LitElement {
 
         cc-icon {
           flex: 0 0 auto;
-          margin-right: 0.5em;
+          margin-right: var(--cc-spacing-3, 0.5em);
         }
 
         /* SKELETON */

--- a/src/components/cc-email-list/cc-email-list.js
+++ b/src/components/cc-email-list/cc-email-list.js
@@ -343,17 +343,17 @@ export class CcEmailList extends LitElement {
           align-items: center;
           display: flex;
           flex-wrap: wrap;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         .address-line.secondary {
-          margin-bottom: 0.8em;
+          margin-bottom: var(--cc-spacing-4, 0.75em);
         }
 
         .address {
           align-items: center;
           display: flex;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         .address.loading {
@@ -378,7 +378,7 @@ export class CcEmailList extends LitElement {
           align-items: center;
           display: flex;
           flex-wrap: wrap;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         /* region FORM */
@@ -387,7 +387,7 @@ export class CcEmailList extends LitElement {
           align-items: start;
           display: flex;
           flex-wrap: wrap;
-          gap: 0 1em;
+          gap: 0 var(--cc-spacing-5, 1em);
           justify-content: flex-end;
         }
 

--- a/src/components/cc-env-var-create/cc-env-var-create.js
+++ b/src/components/cc-env-var-create/cc-env-var-create.js
@@ -182,7 +182,7 @@ export class CcEnvVarCreate extends LitElement {
         .inline-form {
           display: flex;
           flex-wrap: wrap;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .name {
@@ -193,7 +193,7 @@ export class CcEnvVarCreate extends LitElement {
           display: flex;
           flex: 2 1 27em;
           flex-wrap: wrap;
-          gap: 1em 0.5em;
+          gap: var(--cc-spacing-5, 1em) var(--cc-spacing-3, 0.5em);
         }
 
         .value {
@@ -214,7 +214,7 @@ export class CcEnvVarCreate extends LitElement {
         }
 
         cc-notice {
-          margin-top: 1em;
+          margin-top: var(--cc-spacing-5, 1em);
         }
 
         /* i18n error message may contain <code> tags */
@@ -223,7 +223,7 @@ export class CcEnvVarCreate extends LitElement {
           background-color: var(--cc-color-bg-neutral, #eee);
           border-radius: var(--cc-border-radius-default, 0.25em);
           font-family: var(--cc-ff-monospace, monospace);
-          padding: 0.15em 0.3em;
+          padding: var(--cc-spacing-0, 0.125em) var(--cc-spacing-1, 0.25em);
         }
       `,
     ];

--- a/src/components/cc-env-var-create/cc-env-var-create.js
+++ b/src/components/cc-env-var-create/cc-env-var-create.js
@@ -221,7 +221,7 @@ export class CcEnvVarCreate extends LitElement {
 
         cc-notice code {
           background-color: var(--cc-color-bg-neutral, #eee);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           font-family: var(--cc-ff-monospace, monospace);
           padding: var(--cc-spacing-0, 0.125em) var(--cc-spacing-1, 0.25em);
         }

--- a/src/components/cc-env-var-editor-expert/cc-env-var-editor-expert.js
+++ b/src/components/cc-env-var-editor-expert/cc-env-var-editor-expert.js
@@ -190,7 +190,7 @@ export class CcEnvVarEditorExpert extends LitElement {
         cc-notice code,
         .example code {
           background-color: var(--cc-color-bg-neutral, #eee);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           font-family: var(--cc-ff-monospace, monospace);
           padding: var(--cc-spacing-0, 0.125em) var(--cc-spacing-1, 0.25em);
         }

--- a/src/components/cc-env-var-editor-expert/cc-env-var-editor-expert.js
+++ b/src/components/cc-env-var-editor-expert/cc-env-var-editor-expert.js
@@ -177,12 +177,12 @@ export class CcEnvVarEditorExpert extends LitElement {
         .error-list {
           display: grid;
           grid-gap: 0.75em;
-          margin-top: 1em;
+          margin-top: var(--cc-spacing-5, 1em);
         }
 
         .example {
           line-height: 1.5;
-          padding-bottom: 1em;
+          padding-bottom: var(--cc-spacing-5, 1em);
         }
 
         /* i18n error message may contain <code> tags */
@@ -192,7 +192,7 @@ export class CcEnvVarEditorExpert extends LitElement {
           background-color: var(--cc-color-bg-neutral, #eee);
           border-radius: var(--cc-border-radius-default, 0.25em);
           font-family: var(--cc-ff-monospace, monospace);
-          padding: 0.15em 0.3em;
+          padding: var(--cc-spacing-0, 0.125em) var(--cc-spacing-1, 0.25em);
         }
 
         cc-input-text {

--- a/src/components/cc-env-var-editor-json/cc-env-var-editor-json.js
+++ b/src/components/cc-env-var-editor-json/cc-env-var-editor-json.js
@@ -201,7 +201,7 @@ export class CcEnvVarEditorJson extends LitElement {
         cc-notice code,
         .example code {
           background-color: var(--cc-color-bg-neutral, #eee);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           font-family: var(--cc-ff-monospace, monospace);
           padding: var(--cc-spacing-0, 0.125em) var(--cc-spacing-1, 0.25em);
         }

--- a/src/components/cc-env-var-editor-json/cc-env-var-editor-json.js
+++ b/src/components/cc-env-var-editor-json/cc-env-var-editor-json.js
@@ -188,12 +188,12 @@ export class CcEnvVarEditorJson extends LitElement {
         .error-list {
           display: grid;
           grid-gap: 0.75em;
-          margin-top: 1em;
+          margin-top: var(--cc-spacing-5, 1em);
         }
 
         .example {
           line-height: 1.5;
-          padding-bottom: 1em;
+          padding-bottom: var(--cc-spacing-5, 1em);
         }
 
         /* i18n error message may contain <code> tags */
@@ -203,7 +203,7 @@ export class CcEnvVarEditorJson extends LitElement {
           background-color: var(--cc-color-bg-neutral, #eee);
           border-radius: var(--cc-border-radius-default, 0.25em);
           font-family: var(--cc-ff-monospace, monospace);
-          padding: 0.15em 0.3em;
+          padding: var(--cc-spacing-0, 0.125em) var(--cc-spacing-1, 0.25em);
         }
 
         cc-input-text {

--- a/src/components/cc-env-var-editor-simple/cc-env-var-editor-simple.js
+++ b/src/components/cc-env-var-editor-simple/cc-env-var-editor-simple.js
@@ -175,15 +175,15 @@ despite the cc-block padding
 
       cc-env-var-create {
         background-color: var(--cc-color-bg-neutral);
-        margin-bottom: 0.5em;
-        margin-inline: -1em;
-        padding: 1em;
+        margin-bottom: var(--cc-spacing-3, 0.5em);
+        margin-inline: calc(var(--cc-spacing-5, 1em) * -1);
+        padding: var(--cc-spacing-5, 1em);
       }
 
       .message {
         color: var(--cc-color-text-weak);
         font-style: italic;
-        margin: 0.2em;
+        margin: var(--cc-spacing-1, 0.25em);
       }
     `;
   }

--- a/src/components/cc-env-var-form/cc-env-var-form.js
+++ b/src/components/cc-env-var-form/cc-env-var-form.js
@@ -512,7 +512,7 @@ export class CcEnvVarForm extends LitElement {
         .button-bar {
           display: flex;
           flex-wrap: wrap;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         .spacer {
@@ -520,13 +520,13 @@ export class CcEnvVarForm extends LitElement {
         }
 
         .error-container {
-          padding-bottom: 0.5em;
+          padding-bottom: var(--cc-spacing-3, 0.5em);
         }
 
         [slot='footer-right'] cc-link {
           align-items: center;
           display: flex;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
       `,
     ];

--- a/src/components/cc-env-var-input/cc-env-var-input.js
+++ b/src/components/cc-env-var-input/cc-env-var-input.js
@@ -129,7 +129,7 @@ export class CcEnvVarInput extends LitElement {
         .wrapper {
           display: flex;
           flex-wrap: wrap;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .name {
@@ -139,7 +139,7 @@ export class CcEnvVarInput extends LitElement {
           font-family: var(--cc-ff-monospace, monospace);
           font-size: 0.875em;
           line-height: 1.6em;
-          padding-top: 0.35em;
+          padding-top: var(--cc-spacing-2, 0.35em);
           word-break: break-all;
         }
 
@@ -155,7 +155,7 @@ export class CcEnvVarInput extends LitElement {
           display: flex;
           flex: 2 1 27em;
           flex-wrap: wrap;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .value {

--- a/src/components/cc-env-var-linked-services/cc-env-var-linked-services.js
+++ b/src/components/cc-env-var-linked-services/cc-env-var-linked-services.js
@@ -153,7 +153,7 @@ export class CcEnvVarLinkedServices extends LitElement {
         .empty-msg {
           background-color: var(--cc-color-bg-default, #fff);
           border: 1px solid var(--cc-color-border-neutral, #aaa);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           box-sizing: border-box;
           padding: var(--cc-spacing-5, 1em);
         }

--- a/src/components/cc-env-var-linked-services/cc-env-var-linked-services.js
+++ b/src/components/cc-env-var-linked-services/cc-env-var-linked-services.js
@@ -155,7 +155,7 @@ export class CcEnvVarLinkedServices extends LitElement {
           border: 1px solid var(--cc-color-border-neutral, #aaa);
           border-radius: var(--cc-border-radius-default, 0.25em);
           box-sizing: border-box;
-          padding: 1em;
+          padding: var(--cc-spacing-5, 1em);
         }
 
         .loading {
@@ -164,7 +164,7 @@ export class CcEnvVarLinkedServices extends LitElement {
 
         cc-loader {
           height: 1.5em;
-          margin-right: 1em;
+          margin-right: var(--cc-spacing-5, 1em);
           width: 1.5em;
         }
 

--- a/src/components/cc-feature-list/cc-feature-list.js
+++ b/src/components/cc-feature-list/cc-feature-list.js
@@ -193,7 +193,7 @@ export class CcFeatureList extends LitElement {
 
         .feature {
           border: solid 1px var(--cc-color-border-neutral-weak, #e7e7e7);
-          border-radius: var(--cc-border-radius-small, 0.25em);
+          border-radius: var(--cc-border-radius-medium, 0.375em);
           display: flex;
           flex-direction: column;
           gap: var(--cc-spacing-3, 0.5em);

--- a/src/components/cc-feature-list/cc-feature-list.js
+++ b/src/components/cc-feature-list/cc-feature-list.js
@@ -187,8 +187,8 @@ export class CcFeatureList extends LitElement {
         .feature-list {
           display: flex;
           flex-direction: column;
-          gap: 0.5em;
-          margin-top: 1em;
+          gap: var(--cc-spacing-3, 0.5em);
+          margin-top: var(--cc-spacing-5, 1em);
         }
 
         .feature {
@@ -196,8 +196,8 @@ export class CcFeatureList extends LitElement {
           border-radius: var(--cc-border-radius-default);
           display: flex;
           flex-direction: column;
-          gap: 0.6em;
-          padding: 1em;
+          gap: var(--cc-spacing-3, 0.5em);
+          padding: var(--cc-spacing-5, 1em);
         }
 
         .feature .header {
@@ -205,7 +205,7 @@ export class CcFeatureList extends LitElement {
           display: flex;
           flex-direction: row;
           flex-wrap: wrap;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           justify-content: space-between;
         }
 
@@ -213,7 +213,7 @@ export class CcFeatureList extends LitElement {
           display: flex;
           flex-direction: row;
           flex-wrap: wrap;
-          gap: 0.75em;
+          gap: var(--cc-spacing-4, 0.75em);
         }
 
         .feature .title {
@@ -224,7 +224,7 @@ export class CcFeatureList extends LitElement {
           display: flex;
           flex-direction: row;
           flex-wrap: wrap;
-          gap: 0.75em;
+          gap: var(--cc-spacing-4, 0.75em);
         }
       `,
     ];

--- a/src/components/cc-feature-list/cc-feature-list.js
+++ b/src/components/cc-feature-list/cc-feature-list.js
@@ -193,7 +193,7 @@ export class CcFeatureList extends LitElement {
 
         .feature {
           border: solid 1px var(--cc-color-border-neutral-weak, #e7e7e7);
-          border-radius: var(--cc-border-radius-default);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           display: flex;
           flex-direction: column;
           gap: var(--cc-spacing-3, 0.5em);

--- a/src/components/cc-grafana-info/cc-grafana-info.js
+++ b/src/components/cc-grafana-info/cc-grafana-info.js
@@ -231,7 +231,7 @@ export class CcGrafanaInfo extends LitElement {
         }
 
         cc-img {
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           flex: 0 0 auto;
           height: 1.5em;
           margin-right: var(--cc-spacing-3, 0.5em);
@@ -249,7 +249,7 @@ export class CcGrafanaInfo extends LitElement {
         }
 
         .dashboard-screenshot {
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           max-width: 50em;
           width: 100%;
         }

--- a/src/components/cc-grafana-info/cc-grafana-info.js
+++ b/src/components/cc-grafana-info/cc-grafana-info.js
@@ -234,13 +234,13 @@ export class CcGrafanaInfo extends LitElement {
           border-radius: var(--cc-border-radius-default, 0.25em);
           flex: 0 0 auto;
           height: 1.5em;
-          margin-right: 0.5em;
+          margin-right: var(--cc-spacing-3, 0.5em);
           width: 1.5em;
         }
 
         cc-icon {
           flex: 0 0 auto;
-          margin-right: 0.5em;
+          margin-right: var(--cc-spacing-3, 0.5em);
         }
 
         cc-link {
@@ -260,7 +260,7 @@ export class CcGrafanaInfo extends LitElement {
 
         br {
           display: block;
-          margin: 0.5em 0;
+          margin: var(--cc-spacing-3, 0.5em) 0;
         }
       `,
     ];

--- a/src/components/cc-grid/cc-grid.js
+++ b/src/components/cc-grid/cc-grid.js
@@ -661,16 +661,16 @@ export class CcGrid extends LitElement {
           border-bottom: 1px solid var(--cc-color-border-neutral-weak, #ccc);
           display: flex;
           min-width: 0;
-          padding: 0.75em 1.5em;
+          padding: var(--cc-spacing-4, 0.75em) var(--cc-spacing-7, 1.5em);
         }
 
         th {
           background-color: var(--cc-color-bg-neutral-disabled, #ccc);
           display: flex;
           font-weight: normal;
-          gap: 0.5em;
-          padding-bottom: 1em;
-          padding-top: 1em;
+          gap: var(--cc-spacing-3, 0.5em);
+          padding-bottom: var(--cc-spacing-5, 1em);
+          padding-top: var(--cc-spacing-5, 1em);
           position: sticky;
           top: 0;
           white-space: nowrap;
@@ -702,7 +702,7 @@ export class CcGrid extends LitElement {
         .icon-label {
           align-items: center;
           display: flex;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           min-width: 0;
         }
 
@@ -725,7 +725,7 @@ export class CcGrid extends LitElement {
           display: flex;
           font-family: inherit;
           font-size: unset;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           margin: 0;
           padding: 0;
         }

--- a/src/components/cc-grid/cc-grid.js
+++ b/src/components/cc-grid/cc-grid.js
@@ -694,7 +694,7 @@ export class CcGrid extends LitElement {
 
         td:focus[data-focusable='true'],
         th:focus[data-focusable='true'] {
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           outline: var(--cc-focus-outline, #000 solid 2px);
           outline-offset: -2px;
         }
@@ -720,7 +720,7 @@ export class CcGrid extends LitElement {
           align-items: center;
           background: unset;
           border: none;
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           cursor: pointer;
           display: flex;
           font-family: inherit;

--- a/src/components/cc-header-app/cc-header-app.js
+++ b/src/components/cc-header-app/cc-header-app.js
@@ -412,7 +412,7 @@ export class CcHeaderApp extends LitElement {
         .main {
           display: flex;
           flex-wrap: wrap;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         .flavor-logo {
@@ -443,7 +443,7 @@ export class CcHeaderApp extends LitElement {
         .commits {
           display: flex;
           flex-wrap: wrap;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         .name {
@@ -457,7 +457,7 @@ export class CcHeaderApp extends LitElement {
         }
 
         .commit_img {
-          margin-right: 0.2em;
+          margin-right: var(--cc-spacing-1, 0.25em);
         }
 
         .commit_img.git {
@@ -485,7 +485,7 @@ export class CcHeaderApp extends LitElement {
           align-self: center;
           display: flex;
           flex-wrap: wrap;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         cc-button {
@@ -503,7 +503,7 @@ export class CcHeaderApp extends LitElement {
           flex-wrap: wrap;
           font-size: 0.9em;
           font-style: italic;
-          gap: 0.57em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .status-icon {

--- a/src/components/cc-header-app/cc-header-app.js
+++ b/src/components/cc-header-app/cc-header-app.js
@@ -417,7 +417,7 @@ export class CcHeaderApp extends LitElement {
 
         .flavor-logo {
           align-self: flex-start;
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           height: 3.25em;
           overflow: hidden;
           width: 3.25em;

--- a/src/components/cc-header-orga/cc-header-orga.js
+++ b/src/components/cc-header-orga/cc-header-orga.js
@@ -212,7 +212,7 @@ export class CcHeaderOrga extends LitElement {
 
         .logo,
         .initials {
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           flex: 0 0 auto;
           height: 3.25em;
           width: 3.25em;

--- a/src/components/cc-header-orga/cc-header-orga.js
+++ b/src/components/cc-header-orga/cc-header-orga.js
@@ -200,14 +200,14 @@ export class CcHeaderOrga extends LitElement {
           align-items: center;
           display: flex;
           flex-wrap: wrap;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
           justify-content: space-between;
         }
 
         .identity {
           align-items: center;
           display: flex;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         .logo,
@@ -237,13 +237,13 @@ export class CcHeaderOrga extends LitElement {
         .enterprise {
           display: flex;
           flex-direction: column;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .enterprise-row {
           align-items: center;
           display: flex;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .enterprise-row cc-icon {
@@ -255,7 +255,7 @@ export class CcHeaderOrga extends LitElement {
         ::slotted([slot='footer']) {
           background-color: var(--cc-color-bg-neutral);
           border-top: solid 1px var(--cc-color-border-neutral-weak);
-          padding: 0.5em 1em;
+          padding: var(--cc-spacing-3, 0.5em) var(--cc-spacing-5, 1em);
         }
 
         /* SKELETON */

--- a/src/components/cc-heptapod-info/cc-heptapod-info.js
+++ b/src/components/cc-heptapod-info/cc-heptapod-info.js
@@ -130,7 +130,7 @@ export class CcHeptapodInfo extends LitElement {
         .header {
           display: flex;
           flex-wrap: wrap;
-          gap: 0.5em 1em;
+          gap: var(--cc-spacing-3, 0.5em) var(--cc-spacing-5, 1em);
         }
 
         .header-logo {
@@ -147,7 +147,7 @@ export class CcHeptapodInfo extends LitElement {
         .pricing {
           display: flex;
           flex-wrap: wrap;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         .pricing-item {
@@ -165,7 +165,7 @@ export class CcHeptapodInfo extends LitElement {
         .no-statistics {
           color: var(--cc-color-text-weak);
           font-style: italic;
-          margin: 0.2em;
+          margin: var(--cc-spacing-1, 0.25em);
         }
 
         /* SKELETON */

--- a/src/components/cc-homepage-onboarding/cc-homepage-onboarding.js
+++ b/src/components/cc-homepage-onboarding/cc-homepage-onboarding.js
@@ -306,8 +306,8 @@ export class CcHomepageOnboarding extends LitElement {
           align-items: center;
           display: flex;
           flex-direction: column;
-          gap: 2em;
-          padding: 0 3em 1em;
+          gap: var(--cc-spacing-8, 2em);
+          padding: 0 var(--cc-spacing-10, 3em) var(--cc-spacing-5, 1em);
           text-align: center;
         }
 
@@ -319,7 +319,7 @@ export class CcHomepageOnboarding extends LitElement {
           cursor: pointer;
           display: flex;
           justify-content: center;
-          padding: 0.35em;
+          padding: var(--cc-spacing-2, 0.35em);
           position: absolute;
           right: 0.5em;
           top: 0.5em;
@@ -350,7 +350,7 @@ export class CcHomepageOnboarding extends LitElement {
 
         .cards {
           display: grid;
-          gap: 1.3em;
+          gap: var(--cc-spacing-6, 1.25em);
           grid-template-columns: repeat(auto-fit, minmax(10em, 1fr));
           grid-template-rows: repeat(5, auto);
           width: 100%;
@@ -386,10 +386,10 @@ export class CcHomepageOnboarding extends LitElement {
             0 10px 15px -3px #0000001a;
           box-sizing: border-box;
           display: grid;
-          gap: 1.25em;
+          gap: var(--cc-spacing-6, 1.25em);
           grid-row: span 5;
           grid-template-rows: subgrid;
-          padding: 2em;
+          padding: var(--cc-spacing-8, 2em);
           text-align: left;
           transition: box-shadow 0.2s ease-in-out;
         }
@@ -415,7 +415,7 @@ export class CcHomepageOnboarding extends LitElement {
             0 10px 15px -3px #0000001a;
           box-sizing: border-box;
           overflow: hidden;
-          padding: 1em;
+          padding: var(--cc-spacing-5, 1em);
           transition: width 0.5s ease-in-out;
           width: 5em;
         }
@@ -492,7 +492,7 @@ export class CcHomepageOnboarding extends LitElement {
           font-weight: var(--cc-button-font-weight, bold);
           justify-content: center;
           min-height: 2em;
-          padding: 0 0.5em;
+          padding: 0 var(--cc-spacing-3, 0.5em);
           text-decoration: none;
           text-transform: var(--cc-button-text-transform, uppercase);
         }

--- a/src/components/cc-homepage-onboarding/cc-homepage-onboarding.js
+++ b/src/components/cc-homepage-onboarding/cc-homepage-onboarding.js
@@ -315,7 +315,7 @@ export class CcHomepageOnboarding extends LitElement {
           align-items: center;
           background: transparent;
           border: none;
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           cursor: pointer;
           display: flex;
           justify-content: center;
@@ -409,7 +409,7 @@ export class CcHomepageOnboarding extends LitElement {
         }
 
         .icon {
-          border-radius: 0.5em;
+          border-radius: var(--cc-border-radius-large, 0.5em);
           box-shadow:
             0 4px 6px -4px #0000001a,
             0 10px 15px -3px #0000001a;
@@ -484,7 +484,7 @@ export class CcHomepageOnboarding extends LitElement {
           align-items: center;
           background-color: var(--cc-color-bg-default, #fff);
           border: 1px solid #000;
-          border-radius: var(--cc-button-border-radius, 0.15em);
+          border-radius: var(--cc-border-radius-xs, 0.15em);
           box-sizing: border-box;
           color: var(--cc-color-text-primary-strongest, #3569aa);
           cursor: pointer;

--- a/src/components/cc-homepage-template-project/cc-homepage-template-project.js
+++ b/src/components/cc-homepage-template-project/cc-homepage-template-project.js
@@ -86,13 +86,13 @@ export class CcHomepageTemplateProject extends LitElement {
         }
 
         cc-block {
-          padding: 1em;
+          padding: var(--cc-spacing-5, 1em);
         }
 
         .project-list {
           display: flex;
           flex-direction: column;
-          gap: 0.3em;
+          gap: var(--cc-spacing-1, 0.25em);
           list-style: none;
           margin: 0;
           padding: 0;
@@ -102,9 +102,9 @@ export class CcHomepageTemplateProject extends LitElement {
           align-items: center;
           border-radius: var(--cc-border-radius-default, 0.25em);
           display: flex;
-          gap: 1em;
-          margin-inline: 0.2em;
-          padding: 0.6em 0.8em;
+          gap: var(--cc-spacing-5, 1em);
+          margin-inline: var(--cc-spacing-1, 0.25em);
+          padding: var(--cc-spacing-3, 0.5em) var(--cc-spacing-4, 0.75em);
           text-decoration: none;
         }
 
@@ -135,7 +135,7 @@ export class CcHomepageTemplateProject extends LitElement {
           display: flex;
           flex: 1;
           flex-direction: column;
-          gap: 0.15em;
+          gap: var(--cc-spacing-0, 0.125em);
           min-width: 0;
         }
 

--- a/src/components/cc-homepage-template-project/cc-homepage-template-project.js
+++ b/src/components/cc-homepage-template-project/cc-homepage-template-project.js
@@ -100,7 +100,7 @@ export class CcHomepageTemplateProject extends LitElement {
 
         .project-row {
           align-items: center;
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           display: flex;
           gap: var(--cc-spacing-5, 1em);
           margin-inline: var(--cc-spacing-1, 0.25em);

--- a/src/components/cc-homepage-video/cc-homepage-video.js
+++ b/src/components/cc-homepage-video/cc-homepage-video.js
@@ -125,10 +125,10 @@ export class CcHomepageVideo extends LitElement {
           border-radius: var(--cc-border-radius-default, 0.25em);
           box-sizing: border-box;
           display: grid;
-          gap: 2em;
+          gap: var(--cc-spacing-8, 2em);
           grid-template-columns: 1fr auto;
           grid-template-rows: auto 1fr;
-          padding: 2em;
+          padding: var(--cc-spacing-8, 2em);
         }
 
         .header {
@@ -206,7 +206,7 @@ export class CcHomepageVideo extends LitElement {
           box-sizing: border-box;
           color: #fff;
           height: var(--play-icon-size);
-          padding: 0.6em;
+          padding: var(--cc-spacing-3, 0.5em);
           width: var(--play-icon-size);
         }
 

--- a/src/components/cc-homepage-video/cc-homepage-video.js
+++ b/src/components/cc-homepage-video/cc-homepage-video.js
@@ -122,7 +122,7 @@ export class CcHomepageVideo extends LitElement {
 
           background-color: var(--cc-color-bg-default, #fff);
           border: 1px solid var(--cc-color-border-neutral, #aaa);
-          border-radius: var(--cc-border-radius-small, 0.25em);
+          border-radius: var(--cc-border-radius-large, 0.5em);
           box-sizing: border-box;
           display: grid;
           gap: var(--cc-spacing-8, 2em);

--- a/src/components/cc-homepage-video/cc-homepage-video.js
+++ b/src/components/cc-homepage-video/cc-homepage-video.js
@@ -122,7 +122,7 @@ export class CcHomepageVideo extends LitElement {
 
           background-color: var(--cc-color-bg-default, #fff);
           border: 1px solid var(--cc-color-border-neutral, #aaa);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           box-sizing: border-box;
           display: grid;
           gap: var(--cc-spacing-8, 2em);

--- a/src/components/cc-img-comparator/cc-img-comparator.js
+++ b/src/components/cc-img-comparator/cc-img-comparator.js
@@ -88,7 +88,7 @@ export class CcImgComparator extends LitElement {
 
         .img-wrapper {
           align-items: center;
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           display: grid;
           grid-template-areas: 'img';
           height: 100%;

--- a/src/components/cc-img-comparator/cc-img-comparator.js
+++ b/src/components/cc-img-comparator/cc-img-comparator.js
@@ -109,7 +109,7 @@ export class CcImgComparator extends LitElement {
         .heading {
           font-size: 0.9em;
           font-style: italic;
-          padding: 1em;
+          padding: var(--cc-spacing-5, 1em);
           position: absolute;
         }
 
@@ -143,7 +143,7 @@ export class CcImgComparator extends LitElement {
           border: solid 1px var(--cc-color-border-neutral, #bfbfbf);
           border-radius: 50%;
           display: flex;
-          padding: 0.5em;
+          padding: var(--cc-spacing-3, 0.5em);
           position: absolute;
           top: 50%;
           transform: translate(-50%, -50%);

--- a/src/components/cc-img/cc-img.js
+++ b/src/components/cc-img/cc-img.js
@@ -135,7 +135,7 @@ export class CcImg extends LitElement {
         .error-msg {
           font-size: 0.85em;
           overflow: hidden;
-          padding: 0.3em;
+          padding: var(--cc-spacing-1, 0.25em);
           text-align: center;
           text-overflow: ellipsis;
           white-space: nowrap;

--- a/src/components/cc-input-date/cc-input-date.js
+++ b/src/components/cc-input-date/cc-input-date.js
@@ -111,6 +111,8 @@ function dateStateValid(date) {
  *
  * @cssprop {Size} --cc-form-label-gap - The space between the label and the control (defaults: `0.35em`).
  * @cssprop {Size} --cc-form-label-gap-inline - The space between the label and the control when layout is inline (defaults: `0.75em`).
+ * @cssprop {FontStyle} --cc-form-required-font-style - The font-style of the "required" mention next to the label (defaults: `italic`).
+ * @cssprop {TextTransform} --cc-form-required-text-transform - The text-transform of the "required" mention next to the label (defaults: `lowercase`).
  * @cssprop {FontFamily} --cc-input-font-family - The font-family for the input content (defaults: `inherit`).
  * @cssprop {Color} --cc-input-label-color - The color for the input's label (defaults: `inherit`).
  * @cssprop {FontSize} --cc-input-label-font-size - The font-size for the input's label (defaults: `inherit`).
@@ -624,7 +626,8 @@ export class CcInputDate extends CcFormControlElement {
         .required {
           color: var(--cc-color-text-weak, #333);
           font-size: 0.9em;
-          font-variant: small-caps;
+          font-style: var(--cc-form-required-font-style, italic);
+          text-transform: var(--cc-form-required-text-transform, lowercase);
         }
 
         :host([inline]) .required {

--- a/src/components/cc-input-date/cc-input-date.js
+++ b/src/components/cc-input-date/cc-input-date.js
@@ -721,7 +721,7 @@ export class CcInputDate extends CcFormControlElement {
         .ring {
           background: var(--cc-color-bg-default, #fff);
           border: 1px solid var(--cc-color-border-neutral-strong, #aaa);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-medium, 0.375em);
           bottom: 0;
           box-shadow: 0 0 0 0 rgb(255 255 255 / 0%);
           left: 0;

--- a/src/components/cc-input-date/cc-input-date.js
+++ b/src/components/cc-input-date/cc-input-date.js
@@ -601,7 +601,7 @@ export class CcInputDate extends CcFormControlElement {
           align-items: flex-end;
           cursor: pointer;
           display: flex;
-          gap: 2em;
+          gap: var(--cc-spacing-8, 2em);
           justify-content: space-between;
           line-height: 1.25em;
           padding-block-end: var(--cc-form-label-gap, 0.35em);
@@ -634,12 +634,12 @@ export class CcInputDate extends CcFormControlElement {
         slot[name='help']::slotted(*) {
           color: var(--cc-color-text-weak, #333);
           font-size: 0.9em;
-          margin: 0.3em 0 0;
+          margin: var(--cc-spacing-1, 0.25em) 0 0;
         }
 
         .error-container {
           color: var(--cc-color-text-danger);
-          margin: 0.5em 0 0;
+          margin: var(--cc-spacing-3, 0.5em) 0 0;
         }
 
         /* endregion */
@@ -662,7 +662,7 @@ export class CcInputDate extends CcFormControlElement {
           min-width: 0;
           overflow: hidden;
           /* see input to know why 0.15em */
-          padding: 0.15em 0.5em;
+          padding: var(--cc-spacing-0, 0.125em) var(--cc-spacing-3, 0.5em);
         }
 
         /* RESET */
@@ -700,7 +700,7 @@ export class CcInputDate extends CcFormControlElement {
         .help-message {
           color: var(--cc-color-text-weak, #333);
           font-size: 0.9em;
-          margin: 0.3em 0 0;
+          margin: var(--cc-spacing-1, 0.25em) 0 0;
         }
 
         /* STATES */

--- a/src/components/cc-input-number/cc-input-number.js
+++ b/src/components/cc-input-number/cc-input-number.js
@@ -362,7 +362,7 @@ export class CcInputNumber extends CcFormControlElement {
           align-items: flex-end;
           cursor: pointer;
           display: flex;
-          gap: 2em;
+          gap: var(--cc-spacing-8, 2em);
           justify-content: space-between;
           line-height: 1.25em;
           padding-block-end: var(--cc-form-label-gap, 0.35em);
@@ -395,12 +395,12 @@ export class CcInputNumber extends CcFormControlElement {
         slot[name='help']::slotted(*) {
           color: var(--cc-color-text-weak);
           font-size: 0.9em;
-          margin: 0.3em 0 0;
+          margin: var(--cc-spacing-1, 0.25em) 0 0;
         }
 
         .error-container {
           color: var(--cc-color-text-danger);
-          margin: 0.5em 0 0;
+          margin: var(--cc-spacing-3, 0.5em) 0 0;
         }
         /* endregion */
 
@@ -422,7 +422,7 @@ export class CcInputNumber extends CcFormControlElement {
           min-width: 0;
           overflow: hidden;
           /* see input to know why 0.15em */
-          padding: 0.15em 0.5em;
+          padding: var(--cc-spacing-0, 0.125em) var(--cc-spacing-3, 0.5em);
         }
 
         /* RESET */
@@ -565,7 +565,7 @@ export class CcInputNumber extends CcFormControlElement {
           cursor: pointer;
           flex-shrink: 0;
           height: 1.6em;
-          margin: 0.2em;
+          margin: var(--cc-spacing-1, 0.25em);
           width: 1.6em;
           z-index: 2;
         }

--- a/src/components/cc-input-number/cc-input-number.js
+++ b/src/components/cc-input-number/cc-input-number.js
@@ -33,6 +33,8 @@ import { CcInputEvent, CcRequestSubmitEvent } from '../common.events.js';
  *
  * @cssprop {Size} --cc-form-label-gap - The space between the label and the control (defaults: `0.35em`).
  * @cssprop {Size} --cc-form-label-gap-inline - The space between the label and the control when layout is inline (defaults: `0.75em`).
+ * @cssprop {FontStyle} --cc-form-required-font-style - The font-style of the "required" mention next to the label (defaults: `italic`).
+ * @cssprop {TextTransform} --cc-form-required-text-transform - The text-transform of the "required" mention next to the label (defaults: `lowercase`).
  * @cssprop {Align} --cc-input-number-align - Change the alignment of the number present in the input (defaults: `right`).
  * @cssprop {Color} --cc-input-btn-icon-color - The color for the icon within the +/- buttons (defaults: `#595959`).
  * @cssprop {FontFamily} --cc-input-font-family - The font-family for the input content (defaults: `inherit`).
@@ -385,7 +387,8 @@ export class CcInputNumber extends CcFormControlElement {
         .required {
           color: var(--cc-color-text-weak);
           font-size: 0.9em;
-          font-variant: small-caps;
+          font-style: var(--cc-form-required-font-style, italic);
+          text-transform: var(--cc-form-required-text-transform, lowercase);
         }
 
         :host([inline]) .required {

--- a/src/components/cc-input-number/cc-input-number.js
+++ b/src/components/cc-input-number/cc-input-number.js
@@ -495,7 +495,7 @@ export class CcInputNumber extends CcFormControlElement {
         .ring {
           background: var(--cc-color-bg-default, #fff);
           border: 1px solid var(--cc-color-border-neutral-strong, #aaa);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-medium, 0.375em);
           bottom: 0;
           box-shadow: 0 0 0 0 rgb(255 255 255 / 0%);
           left: 0;
@@ -561,7 +561,7 @@ export class CcInputNumber extends CcFormControlElement {
         }
 
         .btn {
-          border-radius: var(--cc-border-radius-small, 0.15em);
+          border-radius: var(--cc-border-radius-medium, 0.375em);
           cursor: pointer;
           flex-shrink: 0;
           height: 1.6em;

--- a/src/components/cc-input-text/cc-input-text.js
+++ b/src/components/cc-input-text/cc-input-text.js
@@ -472,7 +472,7 @@ export class CcInputText extends CcFormControlElement {
           align-items: flex-end;
           cursor: pointer;
           display: flex;
-          gap: 2em;
+          gap: var(--cc-spacing-8, 2em);
           justify-content: space-between;
           line-height: 1.25em;
           padding-block-end: var(--cc-form-label-gap, 0.35em);
@@ -505,12 +505,12 @@ export class CcInputText extends CcFormControlElement {
         slot[name='help']::slotted(*) {
           color: var(--cc-color-text-weak);
           font-size: 0.9em;
-          margin: 0.3em 0 0;
+          margin: var(--cc-spacing-1, 0.25em) 0 0;
         }
 
         .error-container {
           color: var(--cc-color-text-danger);
-          margin: 0.5em 0 0;
+          margin: var(--cc-spacing-3, 0.5em) 0 0;
         }
 
         /* endregion */
@@ -536,7 +536,7 @@ export class CcInputText extends CcFormControlElement {
           min-width: 0;
           overflow: hidden;
           /* see input to know why 0.15em */
-          padding: 0.15em 0.5em;
+          padding: var(--cc-spacing-0, 0.125em) var(--cc-spacing-3, 0.5em);
         }
 
         /* RESET */
@@ -704,8 +704,8 @@ export class CcInputText extends CcFormControlElement {
         .btn,
         .btn-copy {
           flex-shrink: 0;
-          margin: 0.2em 0.2em 0.2em 0;
-          margin-right: 0.15em;
+          margin: var(--cc-spacing-1, 0.25em) var(--cc-spacing-1, 0.25em) var(--cc-spacing-1, 0.25em) 0;
+          margin-right: var(--cc-spacing-0, 0.125em);
           z-index: 2;
         }
 

--- a/src/components/cc-input-text/cc-input-text.js
+++ b/src/components/cc-input-text/cc-input-text.js
@@ -609,9 +609,11 @@ export class CcInputText extends CcFormControlElement {
         .input-underlayer {
           font-family: var(--cc-input-font-family, var(--cc-ff-monospace));
           height: auto;
+          /* Slightly taller than the base 2em to give the (bigger) tags some breathing room between lines. */
+          line-height: 2.3em;
           padding: 0 3px;
           word-break: break-all;
-          word-spacing: 0.5ch;
+          word-spacing: 0.7ch;
         }
 
         .input-underlayer {
@@ -628,8 +630,8 @@ export class CcInputText extends CcFormControlElement {
           --color: var(--cc-color-bg-soft, #eee);
 
           background-color: var(--color);
-          border-radius: var(--cc-border-radius-medium, 0.375em);
-          box-shadow: 0 0 0 2px var(--color);
+          border-radius: var(--cc-border-radius-small, 0.25em);
+          box-shadow: 0 0 0 3px var(--color);
           padding: 1px 0;
         }
 

--- a/src/components/cc-input-text/cc-input-text.js
+++ b/src/components/cc-input-text/cc-input-text.js
@@ -38,6 +38,8 @@ const TAG_SEPARATOR = ' ';
  *
  * @cssprop {Size} --cc-form-label-gap - The space between the label and the control (defaults: `0.35em`).
  * @cssprop {Size} --cc-form-label-gap-inline - The space between the label and the control when layout is inline (defaults: `0.75em`).
+ * @cssprop {FontStyle} --cc-form-required-font-style - The font-style of the "required" mention next to the label (defaults: `italic`).
+ * @cssprop {TextTransform} --cc-form-required-text-transform - The text-transform of the "required" mention next to the label (defaults: `lowercase`).
  * @cssprop {Color} --cc-input-btn-icon-color - The color for the icon within the clipboard/secret button (defaults: `#595959`).
  * @cssprop {FontFamily} --cc-input-font-family - The font-family for the input content (defaults: `inherit` or `--cc-ff-monospace` when using the tags mode).
  * @cssprop {Color} --cc-input-label-color - The color for the input's label (defaults: `inherit`).
@@ -495,7 +497,8 @@ export class CcInputText extends CcFormControlElement {
         .required {
           color: var(--cc-color-text-weak);
           font-size: 0.9em;
-          font-variant: small-caps;
+          font-style: var(--cc-form-required-font-style, italic);
+          text-transform: var(--cc-form-required-text-transform, lowercase);
         }
 
         :host([inline]) .required {

--- a/src/components/cc-input-text/cc-input-text.js
+++ b/src/components/cc-input-text/cc-input-text.js
@@ -625,7 +625,7 @@ export class CcInputText extends CcFormControlElement {
           --color: var(--cc-color-bg-soft, #eee);
 
           background-color: var(--color);
-          border-radius: 3px;
+          border-radius: var(--cc-border-radius-medium, 0.375em);
           box-shadow: 0 0 0 2px var(--color);
           padding: 1px 0;
         }
@@ -635,7 +635,7 @@ export class CcInputText extends CcFormControlElement {
         .ring {
           background: var(--cc-color-bg-default, #fff);
           border: 1px solid var(--cc-color-border-neutral-strong, #aaa);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-medium, 0.375em);
           bottom: 0;
           box-shadow: 0 0 0 0 rgb(255 255 255 / 0%);
           left: 0;
@@ -710,7 +710,7 @@ export class CcInputText extends CcFormControlElement {
         }
 
         .btn {
-          border-radius: var(--cc-border-radius-small, 0.15em);
+          border-radius: var(--cc-border-radius-medium, 0.375em);
           cursor: pointer;
           height: 1.6em;
           width: 1.6em;

--- a/src/components/cc-invoice-table/cc-invoice-table.js
+++ b/src/components/cc-invoice-table/cc-invoice-table.js
@@ -228,7 +228,7 @@ export class CcInvoiceTable extends LitElement {
           align-items: center;
           display: flex;
           flex-wrap: wrap;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         /* endregion */
@@ -237,7 +237,7 @@ export class CcInvoiceTable extends LitElement {
 
         .invoice-list {
           display: grid;
-          gap: 1.5em;
+          gap: var(--cc-spacing-7, 1.5em);
         }
 
         .invoice {
@@ -247,7 +247,7 @@ export class CcInvoiceTable extends LitElement {
 
         .invoice-icon,
         .invoice-text {
-          margin-right: 0.5em;
+          margin-right: var(--cc-spacing-3, 0.5em);
         }
 
         .invoice-icon {
@@ -284,7 +284,7 @@ export class CcInvoiceTable extends LitElement {
 
         th,
         td {
-          padding: 0.5em 1em;
+          padding: var(--cc-spacing-3, 0.5em) var(--cc-spacing-5, 1em);
           text-align: left;
         }
 

--- a/src/components/cc-invoice-table/cc-invoice-table.js
+++ b/src/components/cc-invoice-table/cc-invoice-table.js
@@ -278,7 +278,7 @@ export class CcInvoiceTable extends LitElement {
 
         table {
           border-collapse: collapse;
-          border-radius: 5px;
+          border-radius: var(--cc-border-radius-medium, 0.375em);
           overflow: hidden;
         }
 

--- a/src/components/cc-invoice/cc-invoice.js
+++ b/src/components/cc-invoice/cc-invoice.js
@@ -95,7 +95,7 @@ export class CcInvoice extends LitElement {
 
         [slot='button'] {
           align-self: start;
-          margin-left: 1em;
+          margin-left: var(--cc-spacing-5, 1em);
         }
 
         cc-block {
@@ -113,7 +113,7 @@ export class CcInvoice extends LitElement {
         .info {
           display: flex;
           justify-content: center;
-          margin-bottom: 1em;
+          margin-bottom: var(--cc-spacing-5, 1em);
         }
 
         .frame {

--- a/src/components/cc-kv-explorer/cc-kv-explorer.js
+++ b/src/components/cc-kv-explorer/cc-kv-explorer.js
@@ -1000,7 +1000,7 @@ export class CcKvExplorer extends LitElement {
         .filter-bar {
           align-items: center;
           display: flex;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
           grid-area: top-bar;
         }
 
@@ -1034,9 +1034,9 @@ export class CcKvExplorer extends LitElement {
           background-color: var(--cc-color-bg-neutral);
           border-bottom: 1px solid var(--cc-color-border-neutral-strong);
           display: grid;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           grid-template-columns: 1fr auto auto;
-          padding: 1em;
+          padding: var(--cc-spacing-5, 1em);
         }
 
         .keys-list-empty {
@@ -1051,7 +1051,7 @@ export class CcKvExplorer extends LitElement {
         }
 
         cc-notice {
-          margin: 0.5em;
+          margin: var(--cc-spacing-3, 0.5em);
         }
 
         .detail {
@@ -1086,9 +1086,9 @@ export class CcKvExplorer extends LitElement {
           cursor: pointer;
           display: flex;
           flex: 1;
-          gap: 0.25em;
+          gap: var(--cc-spacing-1, 0.25em);
           min-width: 0;
-          padding: 0.35em;
+          padding: var(--cc-spacing-2, 0.35em);
         }
 
         .key label:hover {
@@ -1122,13 +1122,13 @@ export class CcKvExplorer extends LitElement {
         .detail-add {
           display: flex;
           flex-direction: column;
-          gap: 0.5em;
-          padding: 1em;
+          gap: var(--cc-spacing-3, 0.5em);
+          padding: var(--cc-spacing-5, 1em);
         }
 
         .add-form-header {
           display: grid;
-          gap: 0.35em;
+          gap: var(--cc-spacing-2, 0.35em);
           grid-template-columns: 1fr auto;
         }
 
@@ -1143,9 +1143,9 @@ export class CcKvExplorer extends LitElement {
           background-color: var(--cc-color-bg-neutral);
           border-bottom: 1px solid var(--cc-color-border-neutral-strong);
           display: grid;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           grid-template-columns: auto 1fr auto auto;
-          padding: 1em;
+          padding: var(--cc-spacing-5, 1em);
         }
 
         .edit-header-key-name {
@@ -1156,17 +1156,17 @@ export class CcKvExplorer extends LitElement {
         }
 
         .string-editor {
-          margin: 1em;
+          margin: var(--cc-spacing-5, 1em);
         }
 
         .buttons {
           border-top: 1px solid var(--cc-color-border-neutral);
           display: flex;
           flex-direction: row;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           justify-content: end;
-          margin-top: 1em;
-          padding-top: 1em;
+          margin-top: var(--cc-spacing-5, 1em);
+          padding-top: var(--cc-spacing-5, 1em);
         }
 
         .terminal {

--- a/src/components/cc-kv-explorer/cc-kv-explorer.js
+++ b/src/components/cc-kv-explorer/cc-kv-explorer.js
@@ -1011,7 +1011,7 @@ export class CcKvExplorer extends LitElement {
         .keys {
           background-color: var(--cc-color-bg-default, #fff);
           border: 1px solid var(--cc-color-border-neutral, #aaa);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           display: grid;
           grid-area: keys;
           grid-auto-rows: auto 1fr;
@@ -1057,7 +1057,7 @@ export class CcKvExplorer extends LitElement {
         .detail {
           background-color: var(--cc-color-bg-default, #fff);
           border: 1px solid var(--cc-color-border-neutral, #aaa);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           display: flex;
           flex-direction: column;
           grid-area: detail;
@@ -1171,7 +1171,7 @@ export class CcKvExplorer extends LitElement {
 
         .terminal {
           border: 1px solid var(--cc-color-border-neutral, #aaa);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           grid-area: terminal;
           max-height: 25em;
         }

--- a/src/components/cc-kv-hash-explorer/cc-kv-hash-explorer.js
+++ b/src/components/cc-kv-hash-explorer/cc-kv-hash-explorer.js
@@ -508,10 +508,10 @@ export class CcKvHashExplorer extends LitElement {
           align-items: center;
           border-bottom: 1px solid var(--cc-color-border-neutral-strong);
           display: grid;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           grid-auto-columns: 1fr auto;
           grid-auto-flow: column;
-          padding: 0.5em;
+          padding: var(--cc-spacing-3, 0.5em);
         }
 
         .elements {
@@ -522,17 +522,17 @@ export class CcKvHashExplorer extends LitElement {
         .header {
           align-items: center;
           display: grid;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           grid-auto-columns: 1fr 1fr auto auto auto;
           grid-auto-flow: column;
-          padding: 0.25em 0.5em;
+          padding: 0.25em var(--cc-spacing-3, 0.5em);
           width: 100%;
         }
 
         .element-value {
           align-items: center;
           display: grid;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           grid-template-columns: 1fr auto;
         }
 
@@ -546,7 +546,7 @@ export class CcKvHashExplorer extends LitElement {
         .header {
           background-color: var(--cc-color-bg-neutral-active, #d9d9d9);
           font-weight: bold;
-          padding: 0.5em;
+          padding: var(--cc-spacing-3, 0.5em);
           width: unset;
         }
 
@@ -559,12 +559,12 @@ export class CcKvHashExplorer extends LitElement {
         }
 
         .element-value-input {
-          margin: 0.15em 0;
+          margin: var(--cc-spacing-0, 0.125em) 0;
         }
 
         .element-value-buttons {
           display: flex;
-          gap: 0.35em;
+          gap: var(--cc-spacing-2, 0.35em);
         }
 
         .skeleton {
@@ -579,14 +579,14 @@ export class CcKvHashExplorer extends LitElement {
           flex: 1;
           flex-direction: column;
           justify-content: center;
-          padding: 0.5em;
+          padding: var(--cc-spacing-3, 0.5em);
         }
 
         .add-form {
           border-top: 1px solid var(--cc-color-border-neutral-strong);
           display: flex;
-          gap: 1em;
-          padding: 0.5em;
+          gap: var(--cc-spacing-5, 1em);
+          padding: var(--cc-spacing-3, 0.5em);
         }
 
         .add-form cc-input-text {

--- a/src/components/cc-kv-hash-input/cc-kv-hash-input.js
+++ b/src/components/cc-kv-hash-input/cc-kv-hash-input.js
@@ -258,7 +258,7 @@ export class CcKvHashInput extends CcFormControlElement {
 
         .elements {
           display: grid;
-          gap: 0.35em;
+          gap: var(--cc-spacing-2, 0.35em);
           grid-template-columns: 1fr 1fr auto auto;
         }
 

--- a/src/components/cc-kv-list-explorer/cc-kv-list-explorer.js
+++ b/src/components/cc-kv-list-explorer/cc-kv-list-explorer.js
@@ -492,9 +492,9 @@ export class CcKvListExplorer extends LitElement {
           align-items: center;
           border-bottom: 1px solid var(--cc-color-border-neutral-strong);
           display: grid;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           grid-template-columns: 1fr auto;
-          padding: 0.5em;
+          padding: var(--cc-spacing-3, 0.5em);
         }
 
         .elements {
@@ -505,16 +505,16 @@ export class CcKvListExplorer extends LitElement {
         .header {
           align-items: center;
           display: grid;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           grid-template-columns: 0.25fr 1fr;
-          padding: 0.25em 0.5em;
+          padding: 0.25em var(--cc-spacing-3, 0.5em);
           width: 100%;
         }
 
         .element-value {
           align-items: center;
           display: grid;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           grid-template-columns: 1fr auto;
         }
 
@@ -528,7 +528,7 @@ export class CcKvListExplorer extends LitElement {
         .header {
           background-color: var(--cc-color-bg-neutral-active, #d9d9d9);
           font-weight: bold;
-          padding: 0.5em;
+          padding: var(--cc-spacing-3, 0.5em);
           width: unset;
         }
 
@@ -541,12 +541,12 @@ export class CcKvListExplorer extends LitElement {
         }
 
         .element-value-input {
-          margin: 0.15em 0;
+          margin: var(--cc-spacing-0, 0.125em) 0;
         }
 
         .element-value-buttons {
           display: flex;
-          gap: 0.35em;
+          gap: var(--cc-spacing-2, 0.35em);
         }
 
         .skeleton {
@@ -561,14 +561,14 @@ export class CcKvListExplorer extends LitElement {
           flex: 1;
           flex-direction: column;
           justify-content: center;
-          padding: 0.5em;
+          padding: var(--cc-spacing-3, 0.5em);
         }
 
         .add-form {
           border-top: 1px solid var(--cc-color-border-neutral-strong);
           display: flex;
-          gap: 1em;
-          padding: 0.5em;
+          gap: var(--cc-spacing-5, 1em);
+          padding: var(--cc-spacing-3, 0.5em);
         }
 
         .add-form cc-input-text {

--- a/src/components/cc-kv-list-input/cc-kv-list-input.js
+++ b/src/components/cc-kv-list-input/cc-kv-list-input.js
@@ -231,7 +231,7 @@ export class CcKvListInput extends CcFormControlElement {
 
         .elements {
           display: grid;
-          gap: 0.35em;
+          gap: var(--cc-spacing-2, 0.35em);
           grid-template-columns: 1fr auto auto;
         }
 

--- a/src/components/cc-kv-set-explorer/cc-kv-set-explorer.js
+++ b/src/components/cc-kv-set-explorer/cc-kv-set-explorer.js
@@ -320,9 +320,9 @@ export class CcKvSetExplorer extends LitElement {
           align-items: center;
           border-bottom: 1px solid var(--cc-color-border-neutral-strong);
           display: grid;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           grid-template-columns: 1fr auto;
-          padding: 0.5em;
+          padding: var(--cc-spacing-3, 0.5em);
         }
 
         .elements {
@@ -332,9 +332,9 @@ export class CcKvSetExplorer extends LitElement {
         .element {
           align-items: center;
           display: grid;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           grid-template-columns: 1fr auto;
-          padding: 0.25em 0.5em;
+          padding: 0.25em var(--cc-spacing-3, 0.5em);
           width: 100%;
         }
 
@@ -354,7 +354,7 @@ export class CcKvSetExplorer extends LitElement {
 
         .element-value-buttons {
           display: flex;
-          gap: 0.35em;
+          gap: var(--cc-spacing-2, 0.35em);
         }
 
         .skeleton {
@@ -369,14 +369,14 @@ export class CcKvSetExplorer extends LitElement {
           flex: 1;
           flex-direction: column;
           justify-content: center;
-          padding: 0.5em;
+          padding: var(--cc-spacing-3, 0.5em);
         }
 
         .add-form {
           border-top: 1px solid var(--cc-color-border-neutral-strong);
           display: flex;
-          gap: 1em;
-          padding: 0.5em;
+          gap: var(--cc-spacing-5, 1em);
+          padding: var(--cc-spacing-3, 0.5em);
         }
 
         .add-form cc-input-text {

--- a/src/components/cc-kv-string-editor/cc-kv-string-editor.js
+++ b/src/components/cc-kv-string-editor/cc-kv-string-editor.js
@@ -112,9 +112,9 @@ export class CcKvStringEditor extends LitElement {
 
         .buttons {
           display: flex;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           justify-content: end;
-          margin-top: 1em;
+          margin-top: var(--cc-spacing-5, 1em);
         }
       `,
     ];

--- a/src/components/cc-kv-terminal/cc-kv-terminal.js
+++ b/src/components/cc-kv-terminal/cc-kv-terminal.js
@@ -329,9 +329,9 @@ export class CcKvTerminal extends LitElement {
           border-bottom: 1px solid var(--cc-color-border-neutral-strong);
           display: flex;
           flex-wrap: wrap;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
           justify-content: space-between;
-          padding: 1em;
+          padding: var(--cc-spacing-5, 1em);
         }
 
         .header-warning {
@@ -339,20 +339,20 @@ export class CcKvTerminal extends LitElement {
 
           align-items: center;
           display: flex;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .scroller {
           overflow: auto;
-          padding: 0.5em;
+          padding: var(--cc-spacing-3, 0.5em);
         }
 
         .command {
           align-items: center;
           display: flex;
           font-weight: bold;
-          gap: 0.2em;
-          padding-bottom: 0.2em;
+          gap: var(--cc-spacing-1, 0.25em);
+          padding-bottom: var(--cc-spacing-1, 0.25em);
         }
 
         cc-icon {
@@ -371,13 +371,13 @@ export class CcKvTerminal extends LitElement {
 
         .result.last,
         .command.empty {
-          padding-bottom: 0.5em;
+          padding-bottom: var(--cc-spacing-3, 0.5em);
         }
 
         .prompt {
           align-items: center;
           display: flex;
-          gap: 0.2em;
+          gap: var(--cc-spacing-1, 0.25em);
           position: relative;
         }
 

--- a/src/components/cc-kv-terminal/cc-kv-terminal.js
+++ b/src/components/cc-kv-terminal/cc-kv-terminal.js
@@ -319,7 +319,7 @@ export class CcKvTerminal extends LitElement {
         }
 
         .wrapper:focus-within {
-          border-radius: var(--cc-border-radius-small, 0.15em);
+          border-radius: var(--cc-border-radius-xs, 0.15em);
           outline: var(--cc-focus-outline, #000 solid 2px);
           outline-offset: var(--cc-focus-outline-offset, 2px);
         }

--- a/src/components/cc-link/cc-link.js
+++ b/src/components/cc-link/cc-link.js
@@ -181,7 +181,7 @@ export class CcLink extends LitElement {
         a {
           align-items: center;
           display: inline-flex;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .link-slot {
@@ -193,7 +193,7 @@ export class CcLink extends LitElement {
         a:visited,
         a:active {
           color: var(--cc-color-text-primary-highlight, blue);
-          gap: 0.1em;
+          gap: var(--cc-spacing-0, 0.125em);
           text-decoration: none;
         }
 
@@ -283,12 +283,12 @@ export class CcLink extends LitElement {
           cursor: pointer;
           display: grid;
           font-weight: var(--cc-button-font-weight, bold);
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           grid-template-columns: min-content 1fr;
           height: 100%;
           justify-items: center;
           min-height: 2em;
-          padding: 0 0.5em;
+          padding: 0 var(--cc-spacing-3, 0.5em);
           text-transform: var(--cc-button-text-transform, uppercase);
           width: 100%;
         }

--- a/src/components/cc-link/cc-link.js
+++ b/src/components/cc-link/cc-link.js
@@ -206,7 +206,7 @@ export class CcLink extends LitElement {
 
         .cc-link:focus-within {
           background-color: var(--cc-color-bg-default, #fff);
-          border-radius: var(--cc-border-radius-small, 0.15em);
+          border-radius: var(--cc-border-radius-xs, 0.15em);
           outline: var(--cc-focus-outline, #000 solid 2px);
           outline-offset: var(--cc-focus-outline-offset, 2px);
         }
@@ -278,7 +278,7 @@ export class CcLink extends LitElement {
           align-items: center;
           background-color: var(--cc-color-bg-primary, #3569aaff);
           border: 1px solid var(--cc-color-bg-primary, #3569aaff);
-          border-radius: var(--cc-button-border-radius, 0.15em);
+          border-radius: var(--cc-border-radius-medium, 0.375em);
           box-sizing: border-box;
           cursor: pointer;
           display: grid;

--- a/src/components/cc-logs-addon-runtime/cc-logs-addon-runtime.js
+++ b/src/components/cc-logs-addon-runtime/cc-logs-addon-runtime.js
@@ -272,7 +272,7 @@ export class CcLogsAddonRuntime extends LitElement {
         .wrapper {
           display: grid;
           flex: 1;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           grid-auto-rows: 1fr auto;
         }
 
@@ -280,8 +280,8 @@ export class CcLogsAddonRuntime extends LitElement {
           background-color: var(--cc-color-bg-default, #fff);
           border: 1px solid var(--cc-color-border-neutral, #aaa);
           border-radius: var(--cc-border-radius-default, 0.25em);
-          margin: 1em;
-          padding: 1em;
+          margin: var(--cc-spacing-5, 1em);
+          padding: var(--cc-spacing-5, 1em);
         }
 
         .logs-wrapper {
@@ -296,7 +296,7 @@ export class CcLogsAddonRuntime extends LitElement {
         .logs-header {
           align-items: center;
           display: flex;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
           width: 100%;
         }
 
@@ -321,7 +321,7 @@ export class CcLogsAddonRuntime extends LitElement {
         .overlay-logs-wrapper--loader {
           align-items: center;
           display: flex;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .overlay-logs-wrapper--loader cc-loader {

--- a/src/components/cc-logs-addon-runtime/cc-logs-addon-runtime.js
+++ b/src/components/cc-logs-addon-runtime/cc-logs-addon-runtime.js
@@ -279,7 +279,7 @@ export class CcLogsAddonRuntime extends LitElement {
         .wrapper.fullscreen {
           background-color: var(--cc-color-bg-default, #fff);
           border: 1px solid var(--cc-color-border-neutral, #aaa);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           margin: var(--cc-spacing-5, 1em);
           padding: var(--cc-spacing-5, 1em);
         }

--- a/src/components/cc-logs-app-access/cc-logs-app-access.js
+++ b/src/components/cc-logs-app-access/cc-logs-app-access.js
@@ -352,7 +352,7 @@ export class CcLogsAppAccess extends LitElement {
         .wrapper.fullscreen {
           background-color: var(--cc-color-bg-default);
           border: 1px solid var(--cc-color-border-neutral);
-          border-radius: var(--cc-border-radius-default);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           margin: var(--cc-spacing-5, 1em);
           padding: var(--cc-spacing-5, 1em);
         }

--- a/src/components/cc-logs-app-access/cc-logs-app-access.js
+++ b/src/components/cc-logs-app-access/cc-logs-app-access.js
@@ -345,7 +345,7 @@ export class CcLogsAppAccess extends LitElement {
         .wrapper {
           display: grid;
           flex: 1;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           grid-auto-rows: 1fr auto;
         }
 
@@ -353,8 +353,8 @@ export class CcLogsAppAccess extends LitElement {
           background-color: var(--cc-color-bg-default);
           border: 1px solid var(--cc-color-border-neutral);
           border-radius: var(--cc-border-radius-default);
-          margin: 1em;
-          padding: 1em;
+          margin: var(--cc-spacing-5, 1em);
+          padding: var(--cc-spacing-5, 1em);
         }
 
         .logs-wrapper {
@@ -369,7 +369,7 @@ export class CcLogsAppAccess extends LitElement {
         .logs-header {
           align-items: center;
           display: flex;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
           width: 100%;
         }
 
@@ -395,7 +395,7 @@ export class CcLogsAppAccess extends LitElement {
         .overlay-logs-wrapper--loader {
           align-items: center;
           display: flex;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .overlay-logs-wrapper--loader cc-loader {

--- a/src/components/cc-logs-app-runtime/cc-logs-app-runtime.js
+++ b/src/components/cc-logs-app-runtime/cc-logs-app-runtime.js
@@ -369,7 +369,7 @@ export class CcLogsAppRuntime extends LitElement {
         .wrapper.fullscreen {
           background-color: var(--cc-color-bg-default, #fff);
           border: 1px solid var(--cc-color-border-neutral, #aaa);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           margin: var(--cc-spacing-5, 1em);
           padding: var(--cc-spacing-5, 1em);
         }
@@ -377,7 +377,7 @@ export class CcLogsAppRuntime extends LitElement {
         .instances {
           background-color: var(--cc-color-bg-default, #fff);
           border: 1px solid var(--cc-color-border-neutral, #aaa);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           width: var(--instances-width);
         }
 

--- a/src/components/cc-logs-app-runtime/cc-logs-app-runtime.js
+++ b/src/components/cc-logs-app-runtime/cc-logs-app-runtime.js
@@ -363,15 +363,15 @@ export class CcLogsAppRuntime extends LitElement {
           display: flex;
           flex: 1;
           flex-direction: column;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .wrapper.fullscreen {
           background-color: var(--cc-color-bg-default, #fff);
           border: 1px solid var(--cc-color-border-neutral, #aaa);
           border-radius: var(--cc-border-radius-default, 0.25em);
-          margin: 1em;
-          padding: 1em;
+          margin: var(--cc-spacing-5, 1em);
+          padding: var(--cc-spacing-5, 1em);
         }
 
         .instances {
@@ -395,7 +395,7 @@ export class CcLogsAppRuntime extends LitElement {
         .logs-header {
           align-items: center;
           display: flex;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
           width: 100%;
         }
 
@@ -425,7 +425,7 @@ export class CcLogsAppRuntime extends LitElement {
         .overlay-logs-wrapper--loader {
           align-items: center;
           display: flex;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .overlay-logs-wrapper--loader cc-loader {

--- a/src/components/cc-logs-control/cc-logs-control.js
+++ b/src/components/cc-logs-control/cc-logs-control.js
@@ -465,7 +465,7 @@ export class CcLogsControl extends LitElement {
       css`
         :host {
           display: grid;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           grid-template-rows:
             [header] auto
             [center] 1fr;
@@ -474,13 +474,13 @@ export class CcLogsControl extends LitElement {
         .header {
           align-items: center;
           display: flex;
-          gap: 0.35em;
+          gap: var(--cc-spacing-2, 0.35em);
           justify-content: end;
         }
 
         .center {
           display: flex;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           justify-content: stretch;
           min-height: 0;
         }
@@ -490,7 +490,7 @@ export class CcLogsControl extends LitElement {
         }
 
         .options {
-          margin: 0.5em 0.75em;
+          margin: var(--cc-spacing-3, 0.5em) var(--cc-spacing-4, 0.75em);
           white-space: nowrap;
         }
 
@@ -505,7 +505,7 @@ export class CcLogsControl extends LitElement {
         }
 
         .options-header:not(:first-of-type) {
-          margin-top: 1.85em;
+          margin-top: var(--cc-spacing-8, 2em);
         }
 
         .options-header::after {
@@ -517,8 +517,8 @@ export class CcLogsControl extends LitElement {
         .options-group {
           display: grid;
           grid-template-columns: minmax(max-content, 1fr);
-          margin: 1em 0.75em 0.75em;
-          row-gap: 0.75em;
+          margin: var(--cc-spacing-5, 1em) var(--cc-spacing-4, 0.75em) var(--cc-spacing-4, 0.75em);
+          row-gap: var(--cc-spacing-4, 0.75em);
         }
 
         input[type='checkbox'] {

--- a/src/components/cc-logs-date-range-selector/cc-logs-date-range-selector.js
+++ b/src/components/cc-logs-date-range-selector/cc-logs-date-range-selector.js
@@ -472,7 +472,7 @@ export class CcLogsDateRangeSelector extends LitElement {
         }
 
         .option-button:focus {
-          border-radius: var(--cc-border-radius-small, 0.15em);
+          border-radius: var(--cc-border-radius-xs, 0.15em);
           outline: var(--cc-focus-outline, #000 solid 2px);
           z-index: 3;
         }

--- a/src/components/cc-logs-date-range-selector/cc-logs-date-range-selector.js
+++ b/src/components/cc-logs-date-range-selector/cc-logs-date-range-selector.js
@@ -395,7 +395,7 @@ export class CcLogsDateRangeSelector extends LitElement {
         .wrapper {
           display: flex;
           flex-direction: column;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           height: 100%;
         }
 
@@ -409,7 +409,7 @@ export class CcLogsDateRangeSelector extends LitElement {
           align-items: center;
           display: flex;
           font-size: 1.2em;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         .options-popover-trigger div {
@@ -429,7 +429,7 @@ export class CcLogsDateRangeSelector extends LitElement {
         .options-popover-trigger--with-detail {
           align-items: center;
           display: flex;
-          gap: 0.25em;
+          gap: var(--cc-spacing-1, 0.25em);
         }
 
         .date-range {
@@ -451,8 +451,8 @@ export class CcLogsDateRangeSelector extends LitElement {
           align-items: center;
           border-left: 1px solid var(--cc-color-border-neutral, #000);
           display: flex;
-          margin-left: 1em;
-          padding: 1em;
+          margin-left: var(--cc-spacing-5, 1em);
+          padding: var(--cc-spacing-5, 1em);
         }
 
         .option-button {
@@ -463,11 +463,11 @@ export class CcLogsDateRangeSelector extends LitElement {
           display: grid;
           font-family: inherit;
           font-size: unset;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           grid-template-columns: auto 1fr auto;
           justify-items: start;
           margin: 0;
-          padding: 0.5em;
+          padding: var(--cc-spacing-3, 0.5em);
           white-space: nowrap;
         }
 
@@ -483,17 +483,17 @@ export class CcLogsDateRangeSelector extends LitElement {
         }
 
         .option-button[data-selected='false'] {
-          padding-right: 1.5em;
+          padding-right: var(--cc-spacing-7, 1.5em);
         }
 
         .option-button-current {
-          margin-left: 1em;
+          margin-left: var(--cc-spacing-5, 1em);
         }
 
         .custom-date-range {
           display: flex;
           flex-direction: column;
-          gap: 0.75em;
+          gap: var(--cc-spacing-4, 0.75em);
           min-width: max-content;
         }
 

--- a/src/components/cc-logs-instances/cc-logs-instances.js
+++ b/src/components/cc-logs-instances/cc-logs-instances.js
@@ -568,7 +568,7 @@ export class CcLogsInstances extends LitElement {
         }
 
         .wrapper {
-          padding: 0.5em 0.75em;
+          padding: var(--cc-spacing-3, 0.5em) var(--cc-spacing-4, 0.75em);
         }
 
         .wrapper.wrapper--center {
@@ -584,7 +584,7 @@ export class CcLogsInstances extends LitElement {
         }
 
         .section {
-          margin-bottom: 1em;
+          margin-bottom: var(--cc-spacing-5, 1em);
         }
 
         .section--deploying {
@@ -610,9 +610,9 @@ export class CcLogsInstances extends LitElement {
           background-color: var(--cc-color-bg-neutral, #eee);
           color: var(--cc-color-text-weak, #555);
           display: flex;
-          gap: 0.5em;
-          margin-bottom: 0.5em;
-          padding: 0.5em 0.75em;
+          gap: var(--cc-spacing-3, 0.5em);
+          margin-bottom: var(--cc-spacing-3, 0.5em);
+          padding: var(--cc-spacing-3, 0.5em) var(--cc-spacing-4, 0.75em);
         }
 
         .section-header-icon {
@@ -637,19 +637,19 @@ export class CcLogsInstances extends LitElement {
           display: flex;
           font-family: var(--cc-ff-monospace, monospace);
           font-size: 0.7em;
-          padding: 0.2em;
+          padding: var(--cc-spacing-1, 0.25em);
         }
 
         .section-content {
           display: flex;
           flex-direction: column;
-          padding: 0.25em 0.75em 0.25em 1em;
+          padding: 0.25em var(--cc-spacing-4, 0.75em) 0.25em var(--cc-spacing-5, 1em);
         }
 
         .instances {
           align-items: center;
           display: grid;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           grid-template-columns: max-content max-content;
         }
 
@@ -660,13 +660,13 @@ export class CcLogsInstances extends LitElement {
         .instances.instances--ghost {
           display: flex;
           flex-direction: column;
-          margin-top: 1em;
+          margin-top: var(--cc-spacing-5, 1em);
         }
 
         .instance {
           align-items: center;
           display: flex;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .instance-id {
@@ -685,7 +685,7 @@ export class CcLogsInstances extends LitElement {
           font-size: 0.7em;
           height: 1em;
           justify-content: center;
-          padding: 0.2em;
+          padding: var(--cc-spacing-1, 0.25em);
           width: 1em;
         }
 
@@ -694,25 +694,25 @@ export class CcLogsInstances extends LitElement {
         }
 
         .deployments {
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         .deployment {
           display: flex;
           flex-direction: column;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .deployment-detail {
           align-items: center;
           color: var(--cc-color-text-weak, #555);
           display: grid;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           grid-template-columns: auto 1fr auto;
         }
 
         .deployment .instances {
-          padding-left: 1.5em;
+          padding-left: var(--cc-spacing-7, 1.5em);
         }
 
         cc-icon.deployment-state {
@@ -747,13 +747,13 @@ export class CcLogsInstances extends LitElement {
 
         .empty {
           font-style: italic;
-          padding-left: 0.75em;
+          padding-left: var(--cc-spacing-4, 0.75em);
         }
 
         input[type='checkbox'] {
           height: 1em;
           /* pixel perfect horizontal alignement with the header icon */
-          margin: 0 0 0 0.1em;
+          margin: 0 0 0 var(--cc-spacing-0, 0.125em);
           width: 1em;
         }
       `,

--- a/src/components/cc-logs-instances/cc-logs-instances.js
+++ b/src/components/cc-logs-instances/cc-logs-instances.js
@@ -632,7 +632,7 @@ export class CcLogsInstances extends LitElement {
           align-items: center;
           background-color: var(--cc-color-bg-neutral-readonly, #aaa);
           border: 1px solid var(--cc-color-border-neutral, #aaa);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           color: var(--cc-color-text-weak, #555);
           display: flex;
           font-family: var(--cc-ff-monospace, monospace);

--- a/src/components/cc-logs-loading-progress/cc-logs-loading-progress.js
+++ b/src/components/cc-logs-loading-progress/cc-logs-loading-progress.js
@@ -198,14 +198,14 @@ export class CcLogsLoadingProgress extends LitElement {
           color: var(--cc-color-text-weak);
           display: flex;
           flex-wrap: wrap;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           height: 1.75em;
-          padding: 0.5em;
+          padding: var(--cc-spacing-3, 0.5em);
         }
 
         .overflow-buttons {
           display: flex;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .loading-progress-message {
@@ -215,14 +215,14 @@ export class CcLogsLoadingProgress extends LitElement {
         .notice {
           align-items: center;
           display: flex;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .notice-message {
           align-items: center;
           display: flex;
           flex-wrap: wrap;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .notice cc-icon {

--- a/src/components/cc-logs-loading-progress/cc-logs-loading-progress.js
+++ b/src/components/cc-logs-loading-progress/cc-logs-loading-progress.js
@@ -185,7 +185,7 @@ export class CcLogsLoadingProgress extends LitElement {
         .wrapper {
           background-color: var(--cc-color-bg-default, #fff);
           border: 1px solid var(--cc-color-border-neutral, #aaa);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
         }
 
         .wrapper.warning {

--- a/src/components/cc-logs-message-filter/cc-logs-message-filter.js
+++ b/src/components/cc-logs-message-filter/cc-logs-message-filter.js
@@ -175,7 +175,7 @@ export class CcLogsMessageFilter extends LitElement {
           background: unset;
           background: var(--cc-color-bg-default, #fff);
           border: none;
-          border-radius: var(--cc-border-radius-default, 0.15em);
+          border-radius: var(--cc-border-radius-xs, 0.15em);
           color: var(--cc-color-text-default, #000);
           cursor: pointer;
           display: block;

--- a/src/components/cc-logs-message-filter/cc-logs-message-filter.js
+++ b/src/components/cc-logs-message-filter/cc-logs-message-filter.js
@@ -227,7 +227,7 @@ export class CcLogsMessageFilter extends LitElement {
         .error {
           background: var(--cc-color-bg-default, #fff);
           color: var(--cc-color-text-danger);
-          margin-right: 0.5em;
+          margin-right: var(--cc-spacing-3, 0.5em);
         }
       `,
     ];

--- a/src/components/cc-logs/cc-logs.js
+++ b/src/components/cc-logs/cc-logs.js
@@ -1285,7 +1285,7 @@ export class CcLogs extends LitElement {
         :host {
           background-color: var(--cc-color-bg-default, #fff);
           border: 1px solid var(--cc-color-border-neutral, #aaa);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           display: block;
           overflow: hidden;
 

--- a/src/components/cc-logs/cc-logs.js
+++ b/src/components/cc-logs/cc-logs.js
@@ -1328,7 +1328,7 @@ export class CcLogs extends LitElement {
         .log {
           align-items: center;
           display: flex;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           margin: 0;
           /* When lines are not wrapped, the line grows to fit its content so it can be scrolled horizontally,
              while still being at least as wide as the viewport (so hover/selection backgrounds span the full width). */

--- a/src/components/cc-logsmap/cc-logsmap.js
+++ b/src/components/cc-logsmap/cc-logsmap.js
@@ -199,7 +199,7 @@ export class CcLogsmap extends LitElement {
       :host {
         background-color: var(--cc-color-bg-default, #fff);
         border: 1px solid var(--cc-color-border-neutral, #aaa);
-        border-radius: var(--cc-border-radius-default, 0.25em);
+        border-radius: var(--cc-border-radius-small, 0.25em);
         display: block;
         height: 15em;
         overflow: hidden;

--- a/src/components/cc-logsmap/cc-logsmap.js
+++ b/src/components/cc-logsmap/cc-logsmap.js
@@ -199,7 +199,7 @@ export class CcLogsmap extends LitElement {
       :host {
         background-color: var(--cc-color-bg-default, #fff);
         border: 1px solid var(--cc-color-border-neutral, #aaa);
-        border-radius: var(--cc-border-radius-small, 0.25em);
+        border-radius: var(--cc-border-radius-medium, 0.375em);
         display: block;
         height: 15em;
         overflow: hidden;

--- a/src/components/cc-map/cc-map.js
+++ b/src/components/cc-map/cc-map.js
@@ -428,7 +428,7 @@ export class CcMap extends LitElement {
           align-items: center;
           background-color: var(--cc-color-bg-default, #fff);
           border: 1px solid var(--cc-color-border-neutral, #aaa);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-large, 0.5em);
           box-shadow: 0 0 1em rgb(0 0 0 / 40%);
           display: flex;
           justify-content: center;
@@ -445,7 +445,7 @@ export class CcMap extends LitElement {
           align-items: center;
           background-color: var(--cc-color-bg-default, #fff);
           border: 1px solid #bcc2d1;
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-large, 0.5em);
           box-shadow: 0 0 1em rgb(0 0 0 / 40%);
           display: grid;
           gap: var(--cc-spacing-3, 0.5em);

--- a/src/components/cc-map/cc-map.js
+++ b/src/components/cc-map/cc-map.js
@@ -394,7 +394,7 @@ export class CcMap extends LitElement {
           box-sizing: border-box;
           font-size: 0.9em;
           font-style: italic;
-          padding: 0.45em 1.1em;
+          padding: var(--cc-spacing-3, 0.5em) var(--cc-spacing-5, 1em);
         }
 
         .loader {
@@ -432,7 +432,7 @@ export class CcMap extends LitElement {
           box-shadow: 0 0 1em rgb(0 0 0 / 40%);
           display: flex;
           justify-content: center;
-          padding: 1em;
+          padding: var(--cc-spacing-7, 1.5em);
         }
 
         .cc-map-marker {
@@ -448,9 +448,9 @@ export class CcMap extends LitElement {
           border-radius: var(--cc-border-radius-default, 0.25em);
           box-shadow: 0 0 1em rgb(0 0 0 / 40%);
           display: grid;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           grid-template-columns: min-content 1fr;
-          padding: 1em;
+          padding: var(--cc-spacing-7, 1.5em);
           text-align: center;
         }
 

--- a/src/components/cc-network-group-dashboard/cc-network-group-dashboard.js
+++ b/src/components/cc-network-group-dashboard/cc-network-group-dashboard.js
@@ -185,7 +185,7 @@ export class CcNetworkGroupDashboard extends LitElement {
         :host {
           container-type: inline-size;
           display: grid;
-          gap: 1.5em;
+          gap: var(--cc-spacing-7, 1.5em);
         }
 
         .danger-zone__heading {
@@ -194,7 +194,7 @@ export class CcNetworkGroupDashboard extends LitElement {
 
         .danger-zone__content {
           align-items: baseline;
-          column-gap: 4em;
+          column-gap: var(--cc-spacing-10, 3em);
           display: flex;
           flex-wrap: wrap;
           justify-content: space-between;

--- a/src/components/cc-network-group-list/cc-network-group-list.js
+++ b/src/components/cc-network-group-list/cc-network-group-list.js
@@ -429,7 +429,7 @@ export class CcNetworkGroupList extends LitElement {
 
         .network-group-card {
           border: solid 1px var(--cc-color-border-neutral-weak, #ccc);
-          border-radius: var(--cc-border-radius-small, 0.25em);
+          border-radius: var(--cc-border-radius-medium, 0.375em);
           padding: var(--cc-spacing-5, 1em);
         }
 

--- a/src/components/cc-network-group-list/cc-network-group-list.js
+++ b/src/components/cc-network-group-list/cc-network-group-list.js
@@ -429,7 +429,7 @@ export class CcNetworkGroupList extends LitElement {
 
         .network-group-card {
           border: solid 1px var(--cc-color-border-neutral-weak, #ccc);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           padding: var(--cc-spacing-5, 1em);
         }
 
@@ -450,7 +450,7 @@ export class CcNetworkGroupList extends LitElement {
 
         .network-group-card__header__heading__img {
           background-color: var(--cc-color-bg-neutral-alt);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           height: 1.375em;
           width: 1.375em;
         }

--- a/src/components/cc-network-group-list/cc-network-group-list.js
+++ b/src/components/cc-network-group-list/cc-network-group-list.js
@@ -381,11 +381,11 @@ export class CcNetworkGroupList extends LitElement {
         :host {
           container: host / inline-size;
           display: grid;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         cc-loader {
-          margin-top: 2em;
+          margin-top: var(--cc-spacing-8, 2em);
         }
 
         .intro {
@@ -396,9 +396,9 @@ export class CcNetworkGroupList extends LitElement {
           border: 1px solid var(--cc-color-border-neutral-weak);
           display: grid;
           font-weight: bold;
-          gap: 1.5em;
+          gap: var(--cc-spacing-7, 1.5em);
           justify-items: center;
-          padding: 1em;
+          padding: var(--cc-spacing-5, 1em);
         }
 
         @container host (max-width: 34.375em) {
@@ -411,7 +411,7 @@ export class CcNetworkGroupList extends LitElement {
           align-items: end;
           display: flex;
           flex-wrap: wrap;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         .link-form__select {
@@ -424,28 +424,28 @@ export class CcNetworkGroupList extends LitElement {
 
         .network-group-list {
           display: grid;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         .network-group-card {
           border: solid 1px var(--cc-color-border-neutral-weak, #ccc);
           border-radius: var(--cc-border-radius-default, 0.25em);
-          padding: 1em;
+          padding: var(--cc-spacing-5, 1em);
         }
 
         .network-group-card__header {
           display: flex;
           flex-wrap: wrap;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           justify-content: space-between;
-          margin-bottom: 1em;
+          margin-bottom: var(--cc-spacing-5, 1em);
         }
 
         .network-group-card__header__heading {
           align-items: center;
           display: flex;
           font-weight: bold;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .network-group-card__header__heading__img {
@@ -458,7 +458,7 @@ export class CcNetworkGroupList extends LitElement {
         .network-group-card__id {
           color: var(--cc-color-text-weak);
           font-style: italic;
-          margin-bottom: 1em;
+          margin-bottom: var(--cc-spacing-5, 1em);
         }
 
         .network-group-card__id cc-clipboard {
@@ -468,21 +468,21 @@ export class CcNetworkGroupList extends LitElement {
 
         .peer-list {
           display: grid;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .network-group-card__footer {
           align-items: center;
           display: flex;
           justify-content: space-between;
-          margin-top: 1em;
+          margin-top: var(--cc-spacing-5, 1em);
         }
 
         .network-group-card__footer__link {
           align-items: center;
           color: var(--cc-color-text-primary-highlight);
           display: flex;
-          gap: 0.25em;
+          gap: var(--cc-spacing-1, 0.25em);
         }
 
         cc-dialog p {
@@ -493,7 +493,7 @@ export class CcNetworkGroupList extends LitElement {
           .network-group-card__footer {
             align-items: flex-start;
             flex-direction: column;
-            gap: 1em;
+            gap: var(--cc-spacing-5, 1em);
           }
 
           .unlink-btn {

--- a/src/components/cc-network-group-member-card/cc-network-group-member-card.js
+++ b/src/components/cc-network-group-member-card/cc-network-group-member-card.js
@@ -341,7 +341,7 @@ export class CcNetworkGroupMemberCard extends LitElement {
 
         .member-card {
           border: solid 1px var(--cc-color-border-neutral-weak);
-          border-radius: var(--cc-border-radius-small, 0.25em);
+          border-radius: var(--cc-border-radius-medium, 0.375em);
           container: member-card / inline-size;
           padding: var(--member-card-padding);
         }

--- a/src/components/cc-network-group-member-card/cc-network-group-member-card.js
+++ b/src/components/cc-network-group-member-card/cc-network-group-member-card.js
@@ -334,7 +334,7 @@ export class CcNetworkGroupMemberCard extends LitElement {
     return [
       css`
         :host {
-          --member-card-padding: 1em;
+          --member-card-padding: var(--cc-spacing-5, 1em);
 
           display: block;
         }
@@ -356,7 +356,7 @@ export class CcNetworkGroupMemberCard extends LitElement {
           align-items: center;
           display: flex;
           flex-wrap: wrap;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           justify-content: space-between;
           margin-bottom: var(--member-card-padding);
           margin-inline: calc(var(--member-card-padding) * -1);
@@ -387,7 +387,7 @@ export class CcNetworkGroupMemberCard extends LitElement {
           align-items: center;
           display: flex;
           flex: 1 1 auto;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .identity-logo {
@@ -408,7 +408,7 @@ export class CcNetworkGroupMemberCard extends LitElement {
           align-items: center;
           display: flex;
           flex-wrap: wrap;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .deleted-member-identity-label {
@@ -422,7 +422,7 @@ export class CcNetworkGroupMemberCard extends LitElement {
         .peers-toggle {
           align-items: center;
           display: flex;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .peers-count {
@@ -468,8 +468,8 @@ export class CcNetworkGroupMemberCard extends LitElement {
 
         .peer-list {
           display: grid;
-          gap: 0.5em;
-          margin-block: 1em;
+          gap: var(--cc-spacing-3, 0.5em);
+          margin-block: var(--cc-spacing-5, 1em);
         }
 
         /* endregion */
@@ -480,15 +480,15 @@ export class CcNetworkGroupMemberCard extends LitElement {
           align-items: center;
           display: flex;
           flex-wrap: wrap;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
           justify-content: space-between;
-          margin-top: 1em;
+          margin-top: var(--cc-spacing-5, 1em);
         }
 
         .dashboard-link {
           align-items: center;
           display: flex;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .dashboard-link-icon {
@@ -503,7 +503,7 @@ export class CcNetworkGroupMemberCard extends LitElement {
           align-items: center;
           display: flex;
           flex-wrap: wrap;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         .deleted-member-footer-warning {

--- a/src/components/cc-network-group-member-card/cc-network-group-member-card.js
+++ b/src/components/cc-network-group-member-card/cc-network-group-member-card.js
@@ -341,7 +341,7 @@ export class CcNetworkGroupMemberCard extends LitElement {
 
         .member-card {
           border: solid 1px var(--cc-color-border-neutral-weak);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           container: member-card / inline-size;
           padding: var(--member-card-padding);
         }
@@ -373,7 +373,7 @@ export class CcNetworkGroupMemberCard extends LitElement {
         }
 
         .header-clickable:focus-visible {
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           outline: var(--cc-focus-outline);
           /* Exception to the usual outline offset, since the header spans through the whole header with no padding */
           outline-offset: -2px;
@@ -392,7 +392,7 @@ export class CcNetworkGroupMemberCard extends LitElement {
 
         .identity-logo {
           background-color: var(--cc-color-bg-neutral-alt);
-          border-radius: var(--cc-border-radius-small, 0.15em);
+          border-radius: var(--cc-border-radius-xs, 0.15em);
           flex: 0 0 auto;
           height: 1.5em;
           width: 1.5em;

--- a/src/components/cc-network-group-member-list/cc-network-group-member-list.js
+++ b/src/components/cc-network-group-member-list/cc-network-group-member-list.js
@@ -333,11 +333,11 @@ export class CcNetworkGroupMemberList extends LitElement {
       css`
         :host {
           display: grid;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         .intro {
-          margin: 0 0 1em;
+          margin: 0 0 var(--cc-spacing-5, 1em);
         }
 
         .empty,
@@ -345,9 +345,9 @@ export class CcNetworkGroupMemberList extends LitElement {
           border: 1px solid var(--cc-color-border-neutral-weak);
           display: grid;
           font-weight: bold;
-          gap: 1.5em;
+          gap: var(--cc-spacing-7, 1.5em);
           justify-items: center;
-          padding: 1em;
+          padding: var(--cc-spacing-5, 1em);
         }
 
         .empty:focus-visible {
@@ -357,14 +357,14 @@ export class CcNetworkGroupMemberList extends LitElement {
 
         .member-list {
           display: grid;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .link-form {
           align-items: end;
           display: flex;
           flex-wrap: wrap;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         .link-form__select {

--- a/src/components/cc-network-group-peer-card/cc-network-group-peer-card.js
+++ b/src/components/cc-network-group-peer-card/cc-network-group-peer-card.js
@@ -124,7 +124,7 @@ export class CcNetworkGroupPeerCard extends LitElement {
         .peer-card {
           background-color: var(--cc-color-bg-neutral);
           border: solid 1px var(--cc-color-border-neutral-weak);
-          border-radius: var(--cc-border-radius-default);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           container: peer-card / inline-size;
           display: grid;
           gap: var(--cc-spacing-5, 1em);

--- a/src/components/cc-network-group-peer-card/cc-network-group-peer-card.js
+++ b/src/components/cc-network-group-peer-card/cc-network-group-peer-card.js
@@ -127,15 +127,15 @@ export class CcNetworkGroupPeerCard extends LitElement {
           border-radius: var(--cc-border-radius-default);
           container: peer-card / inline-size;
           display: grid;
-          gap: 1em;
-          padding: 1em;
+          gap: var(--cc-spacing-5, 1em);
+          padding: var(--cc-spacing-5, 1em);
         }
 
         .peer-card__header {
           align-items: center;
           display: flex;
           flex-wrap: wrap;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
           justify-content: space-between;
           line-height: var(--config-link-icon-size);
         }
@@ -147,7 +147,7 @@ export class CcNetworkGroupPeerCard extends LitElement {
         .metadata-list {
           display: flex;
           flex-wrap: wrap;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         @container peer-card (max-width: 35em) {
@@ -158,7 +158,7 @@ export class CcNetworkGroupPeerCard extends LitElement {
 
         .metadata-item {
           display: flex;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           word-break: break-all;
         }
 

--- a/src/components/cc-network-group-peer-card/cc-network-group-peer-card.js
+++ b/src/components/cc-network-group-peer-card/cc-network-group-peer-card.js
@@ -124,7 +124,7 @@ export class CcNetworkGroupPeerCard extends LitElement {
         .peer-card {
           background-color: var(--cc-color-bg-neutral);
           border: solid 1px var(--cc-color-border-neutral-weak);
-          border-radius: var(--cc-border-radius-small, 0.25em);
+          border-radius: var(--cc-border-radius-medium, 0.375em);
           container: peer-card / inline-size;
           display: grid;
           gap: var(--cc-spacing-5, 1em);

--- a/src/components/cc-notice/cc-notice.js
+++ b/src/components/cc-notice/cc-notice.js
@@ -137,8 +137,9 @@ export class CcNotice extends LitElement {
         .wrapper {
           align-items: start;
           border-radius: var(--cc-border-radius-large, 0.5em);
+          /* Horizontal gap (icon <-> text) stays at spacing-4, vertical gap (heading <-> message) is tighter at spacing-3. */
+          column-gap: var(--cc-spacing-4, 0.75em);
           display: grid;
-          gap: var(--cc-spacing-4, 0.75em);
           grid-template-areas:
             'icon heading'
             '.    message';
@@ -147,6 +148,7 @@ export class CcNotice extends LitElement {
           line-height: 1.4;
           padding: var(--cc-spacing-7, 1.5em);
           position: relative;
+          row-gap: var(--cc-spacing-3, 0.5em);
         }
 
         :host([intent='success']) .wrapper {

--- a/src/components/cc-notice/cc-notice.js
+++ b/src/components/cc-notice/cc-notice.js
@@ -138,14 +138,14 @@ export class CcNotice extends LitElement {
           align-items: start;
           border-radius: var(--cc-border-radius-default, 0.25em);
           display: grid;
-          gap: 0.5em;
+          gap: var(--cc-spacing-4, 0.75em);
           grid-template-areas:
             'icon heading'
             '.    message';
           grid-template-columns: auto 1fr;
           grid-template-rows: auto auto;
           line-height: 1.4;
-          padding: 0.75em;
+          padding: var(--cc-spacing-7, 1.5em);
           position: relative;
         }
 
@@ -186,7 +186,7 @@ export class CcNotice extends LitElement {
         }
 
         .wrapper.closeable {
-          padding-right: 2em;
+          padding-right: var(--cc-spacing-8, 2em);
         }
 
         .wrapper.no-icon {

--- a/src/components/cc-notice/cc-notice.js
+++ b/src/components/cc-notice/cc-notice.js
@@ -136,7 +136,7 @@ export class CcNotice extends LitElement {
 
         .wrapper {
           align-items: start;
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-large, 0.5em);
           display: grid;
           gap: var(--cc-spacing-4, 0.75em);
           grid-template-areas:
@@ -233,7 +233,7 @@ export class CcNotice extends LitElement {
 
           background-color: transparent;
           border: none;
-          border-radius: var(--cc-border-radius-small, 0.15em);
+          border-radius: var(--cc-border-radius-large, 0.5em);
           cursor: pointer;
           height: auto;
           padding: 0;

--- a/src/components/cc-oauth-consumer-form/cc-oauth-consumer-form.js
+++ b/src/components/cc-oauth-consumer-form/cc-oauth-consumer-form.js
@@ -570,7 +570,7 @@ export class CcOauthConsumerForm extends LitElement {
 
         .wrapper {
           display: grid;
-          gap: 1.5em;
+          gap: var(--cc-spacing-7, 1.5em);
         }
 
         .description {
@@ -582,7 +582,7 @@ export class CcOauthConsumerForm extends LitElement {
         /* region information */
 
         .info-block {
-          padding-bottom: 1em;
+          padding-bottom: var(--cc-spacing-5, 1em);
         }
 
         .info-title {
@@ -610,18 +610,18 @@ export class CcOauthConsumerForm extends LitElement {
           flex: 1 1 0;
           font-size: 1.1em;
           font-weight: bold;
-          margin-bottom: 0.5em;
+          margin-bottom: var(--cc-spacing-3, 0.5em);
           padding-left: 0;
         }
 
         .rights-container {
           display: grid;
-          gap: 3em;
+          gap: var(--cc-spacing-10, 3em);
           grid-template-columns: 1fr 1fr;
         }
 
         :host([w-lt-750]) .rights-container {
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
           grid-template-columns: 1fr;
         }
 
@@ -630,20 +630,20 @@ export class CcOauthConsumerForm extends LitElement {
           border: none;
           display: flex;
           flex-direction: column;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .error-message {
           color: var(--cc-color-text-danger);
-          margin: 0.5em 0;
+          margin: var(--cc-spacing-3, 0.5em) 0;
         }
 
         .access-rights-section,
         .manage-rights-section {
           display: flex;
           flex-direction: column;
-          gap: 0.5em;
-          margin-left: 1em;
+          gap: var(--cc-spacing-3, 0.5em);
+          margin-left: var(--cc-spacing-5, 1em);
         }
 
         input[type='checkbox']:focus-visible {
@@ -657,9 +657,9 @@ export class CcOauthConsumerForm extends LitElement {
           align-items: center;
           display: flex;
           flex-wrap: wrap;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
           justify-content: end;
-          margin-top: 1em;
+          margin-top: var(--cc-spacing-5, 1em);
         }
 
         :host([w-lt-450]) .oauth-form-buttons {
@@ -678,7 +678,7 @@ export class CcOauthConsumerForm extends LitElement {
 
         .danger-zone-wrapper {
           display: grid;
-          gap: 0.5em 1em;
+          gap: var(--cc-spacing-3, 0.5em) var(--cc-spacing-5, 1em);
           grid-template-areas:
             'title button'
             'description button';

--- a/src/components/cc-oauth-consumer-form/cc-oauth-consumer-form.js
+++ b/src/components/cc-oauth-consumer-form/cc-oauth-consumer-form.js
@@ -600,7 +600,7 @@ export class CcOauthConsumerForm extends LitElement {
         }
 
         .rights-block:focus-visible {
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           outline: var(--cc-focus-outline-error);
           /* Specific case for large areas */
           outline-offset: 8px;

--- a/src/components/cc-oauth-consumer-info/cc-oauth-consumer-info.js
+++ b/src/components/cc-oauth-consumer-info/cc-oauth-consumer-info.js
@@ -244,14 +244,14 @@ export class CcOauthConsumerInfo extends LitElement {
         .wrapper {
           container-type: inline-size;
           display: grid;
-          gap: 1.5em;
+          gap: var(--cc-spacing-7, 1.5em);
         }
 
         /* region Header */
 
         .header-wrapper {
           display: grid;
-          gap: 0.5em 1em;
+          gap: var(--cc-spacing-3, 0.5em) var(--cc-spacing-5, 1em);
           grid-template-areas:
             'logo name link'
             'logo description link';
@@ -315,18 +315,18 @@ export class CcOauthConsumerInfo extends LitElement {
         .access-grid,
         .rights-container {
           display: grid;
-          gap: 3em;
+          gap: var(--cc-spacing-10, 3em);
           grid-template-columns: 1fr 1fr;
         }
 
         :host([w-lt-550]) .access-grid,
         :host([w-lt-550]) .rights-container {
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
           grid-template-columns: 1fr;
         }
 
         .access-grid:first-of-type {
-          margin-bottom: 1em;
+          margin-bottom: var(--cc-spacing-5, 1em);
         }
 
         .access-grid dd {
@@ -340,7 +340,7 @@ export class CcOauthConsumerInfo extends LitElement {
         }
 
         dt {
-          margin-bottom: 0.35em;
+          margin-bottom: var(--cc-spacing-2, 0.35em);
         }
 
         /* end region */
@@ -350,7 +350,7 @@ export class CcOauthConsumerInfo extends LitElement {
         .header-rights {
           display: flex;
           flex-wrap: wrap;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         .auth-title {
@@ -363,7 +363,7 @@ export class CcOauthConsumerInfo extends LitElement {
         .manage-rights {
           align-content: baseline;
           display: grid;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         .rights-title {
@@ -372,13 +372,13 @@ export class CcOauthConsumerInfo extends LitElement {
 
         .rights-section {
           display: grid;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .right {
           align-items: center;
           display: flex;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         /* end region */

--- a/src/components/cc-order-summary/cc-order-summary.js
+++ b/src/components/cc-order-summary/cc-order-summary.js
@@ -147,8 +147,8 @@ export class CcOrderSummary extends LitElement {
         .title {
           color: var(--cc-color-text-weak, #404040);
           font-weight: var(--cc-order-summary-font-weight, 600);
-          margin-block-end: 0.5em;
-          padding-inline: 0.125em;
+          margin-block-end: var(--cc-spacing-3, 0.5em);
+          padding-inline: var(--cc-spacing-0, 0.125em);
         }
 
         .summary {
@@ -157,15 +157,15 @@ export class CcOrderSummary extends LitElement {
           border-radius: var(--cc-border-radius-default, 0.25em);
           display: flex;
           flex-direction: column;
-          padding: 1.5em;
-          row-gap: 2em;
+          padding: var(--cc-spacing-7, 1.5em);
+          row-gap: var(--cc-spacing-8, 2em);
         }
         /* endregion */
 
         /* region elements > header */
         .header {
           display: grid;
-          gap: 0.25em;
+          gap: var(--cc-spacing-1, 0.25em);
           grid-template-columns: 1fr min-content;
         }
 
@@ -180,7 +180,7 @@ export class CcOrderSummary extends LitElement {
         .header--tags {
           display: inline-flex;
           flex-wrap: wrap;
-          gap: 0.25em;
+          gap: var(--cc-spacing-1, 0.25em);
           grid-column: 1 / 2;
           grid-row: 2 / 3;
         }
@@ -199,14 +199,14 @@ export class CcOrderSummary extends LitElement {
 
         .body--item {
           align-items: baseline;
-          column-gap: 0.5em;
+          column-gap: var(--cc-spacing-3, 0.5em);
           display: flex;
         }
 
         .body--item:not(:last-child) {
           border-block-end: 1px dotted var(--cc-color-border-primary-weak, #ccd4dc);
-          margin-block-end: 1em;
-          padding-block-end: 1em;
+          margin-block-end: var(--cc-spacing-5, 1em);
+          padding-block-end: var(--cc-spacing-5, 1em);
         }
 
         .body--label {
@@ -224,8 +224,8 @@ export class CcOrderSummary extends LitElement {
         .details-container {
           display: flex;
           flex-direction: column;
-          padding-inline: 0.5em;
-          row-gap: 0.5em;
+          padding-inline: var(--cc-spacing-3, 0.5em);
+          row-gap: var(--cc-spacing-3, 0.5em);
         }
 
         ::slotted([slot='detail']) {
@@ -235,11 +235,11 @@ export class CcOrderSummary extends LitElement {
         }
 
         ::slotted([slot='detail']:first-child) {
-          margin-block-start: 1.5em;
+          margin-block-start: var(--cc-spacing-7, 1.5em);
         }
 
         ::slotted([slot='detail']:last-child) {
-          margin-block-end: 1.5em;
+          margin-block-end: var(--cc-spacing-7, 1.5em);
         }
         /* endregion */
 
@@ -254,12 +254,12 @@ export class CcOrderSummary extends LitElement {
 
         .btn-submit {
           display: block;
-          margin-block-start: 0.5em;
+          margin-block-start: var(--cc-spacing-3, 0.5em);
         }
 
         .skeleton {
           background-color: var(--cc-color-bg-neutral-active, #d9d9d9);
-          padding-inline: 0.25em;
+          padding-inline: var(--cc-spacing-1, 0.25em);
         }
         /* endregion */
       `,

--- a/src/components/cc-order-summary/cc-order-summary.js
+++ b/src/components/cc-order-summary/cc-order-summary.js
@@ -154,7 +154,7 @@ export class CcOrderSummary extends LitElement {
         .summary {
           background-color: var(--cc-color-bg-neutral, #f5f5f5);
           border: 1px solid var(--cc-color-border-neutral-weak, #e7e7e7);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           display: flex;
           flex-direction: column;
           padding: var(--cc-spacing-7, 1.5em);
@@ -246,7 +246,7 @@ export class CcOrderSummary extends LitElement {
         /* region elements > misc */
         .logo {
           border: 1px solid var(--cc-color-border-neutral-weak, #e7e7e7);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           height: 3em;
           overflow: hidden;
           width: 3em;

--- a/src/components/cc-orga-member-card/cc-orga-member-card.js
+++ b/src/components/cc-orga-member-card/cc-orga-member-card.js
@@ -413,7 +413,7 @@ export class CcOrgaMemberCard extends LitElement {
         .wrapper {
           align-items: center;
           display: grid;
-          gap: 0.8em 1em;
+          gap: var(--cc-spacing-4, 0.75em) var(--cc-spacing-5, 1em);
         }
 
         :host([w-gte-740]) .wrapper {
@@ -452,7 +452,7 @@ export class CcOrgaMemberCard extends LitElement {
         .identity {
           display: flex;
           flex-direction: column;
-          gap: 0.3em;
+          gap: var(--cc-spacing-1, 0.25em);
           grid-area: identity;
           /* makes the email address wrap if needed */
           word-break: break-all;
@@ -461,7 +461,7 @@ export class CcOrgaMemberCard extends LitElement {
         .name {
           display: flex;
           flex-wrap: wrap;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .status {
@@ -475,7 +475,7 @@ export class CcOrgaMemberCard extends LitElement {
 
         .actions {
           display: flex;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           grid-area: actions;
           justify-content: space-evenly;
           min-width: 4em;
@@ -484,7 +484,7 @@ export class CcOrgaMemberCard extends LitElement {
         .status__role-mfa {
           align-items: center;
           display: flex;
-          gap: 0.5em 1em;
+          gap: var(--cc-spacing-3, 0.5em) var(--cc-spacing-5, 1em);
         }
 
         .error-wrapper {
@@ -531,7 +531,7 @@ export class CcOrgaMemberCard extends LitElement {
         }
 
         :host([w-lt-740]) .error {
-          margin-top: 0.5em;
+          margin-top: var(--cc-spacing-3, 0.5em);
         }
         /* endregion */
 

--- a/src/components/cc-orga-member-list/cc-orga-member-list.js
+++ b/src/components/cc-orga-member-list/cc-orga-member-list.js
@@ -530,12 +530,12 @@ export class CcOrgaMemberList extends LitElement {
           align-items: flex-start;
           display: flex;
           flex-wrap: wrap;
-          gap: 1em 1.5em;
+          gap: var(--cc-spacing-5, 1em) var(--cc-spacing-7, 1.5em);
         }
 
         .info {
           font-style: italic;
-          margin: 0.5em 0;
+          margin: var(--cc-spacing-3, 0.5em) 0;
         }
 
         /* 100 is a weird value but this makes the input grow as much as possible
@@ -560,22 +560,22 @@ export class CcOrgaMemberList extends LitElement {
 
         .member-count {
           font-size: 0.9em;
-          margin-left: 0.2em;
+          margin-left: var(--cc-spacing-1, 0.25em);
         }
 
         .member-list {
           display: flex;
           flex-direction: column;
-          gap: 1.5em;
+          gap: var(--cc-spacing-7, 1.5em);
         }
 
         .filters {
           align-items: flex-end;
           display: flex;
           flex-wrap: wrap;
-          gap: 1em 2.5em;
+          gap: var(--cc-spacing-5, 1em) 2.5em;
           justify-content: space-between;
-          margin-bottom: 1em;
+          margin-bottom: var(--cc-spacing-5, 1em);
         }
 
         .filters cc-input-text {
@@ -585,7 +585,7 @@ export class CcOrgaMemberList extends LitElement {
         .filters__mfa {
           align-items: center;
           display: flex;
-          gap: 0.35em;
+          gap: var(--cc-spacing-2, 0.35em);
         }
 
         .filters__mfa input {
@@ -611,7 +611,7 @@ export class CcOrgaMemberList extends LitElement {
           align-items: center;
           display: flex;
           flex-wrap: wrap;
-          gap: 1.5em;
+          gap: var(--cc-spacing-7, 1.5em);
           justify-content: space-between;
         }
 
@@ -623,7 +623,7 @@ export class CcOrgaMemberList extends LitElement {
           display: flex;
           flex: 1 1 21em;
           flex-direction: column;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .leave cc-button {

--- a/src/components/cc-picker-option/cc-picker-option.js
+++ b/src/components/cc-picker-option/cc-picker-option.js
@@ -109,7 +109,7 @@ class CcPickerOption extends LitElement {
 
         /* region body section */
         ::slotted([slot='body']) {
-          padding: 1em 1.25em;
+          padding: var(--cc-spacing-5, 1em) 1.25em;
         }
 
         .body {
@@ -129,7 +129,7 @@ class CcPickerOption extends LitElement {
         ::slotted([slot='footer']) {
           background-color: var(--cc-color-bg-neutral-alt, #e7e7e7);
           font-size: 0.875em;
-          padding: 0.5em 1.25em;
+          padding: var(--cc-spacing-3, 0.5em) 1.25em;
         }
         /* endregion */
 
@@ -138,7 +138,7 @@ class CcPickerOption extends LitElement {
           --cc-icon-color: var(--cc-color-bg-primary, #3569aa);
 
           align-self: start;
-          padding: 0.5em;
+          padding: var(--cc-spacing-3, 0.5em);
         }
 
         .icon-selection-style--radio {
@@ -149,14 +149,14 @@ class CcPickerOption extends LitElement {
           display: flex;
           height: 1lh;
           justify-content: center;
-          padding-block: 1em;
-          padding-inline-start: 1em;
+          padding-block: var(--cc-spacing-5, 1em);
+          padding-inline-start: var(--cc-spacing-5, 1em);
         }
         /* endregion */
 
         /* region selection style radio */
         :host([selection-style='radio']) ::slotted([slot='body']) {
-          padding-inline-start: 0.5em;
+          padding-inline-start: var(--cc-spacing-3, 0.5em);
         }
         /* endregion */
 

--- a/src/components/cc-picker-option/cc-picker-option.js
+++ b/src/components/cc-picker-option/cc-picker-option.js
@@ -83,13 +83,13 @@ class CcPickerOption extends LitElement {
       css`
         /* region global */
         :host {
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           display: inline-flex;
         }
 
         .wrapper {
           border: 2px solid var(--cc-color-border-neutral, #bfbfbf);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           display: flex;
           flex-direction: column;
           line-height: 1.5;

--- a/src/components/cc-picker-option/cc-picker-option.js
+++ b/src/components/cc-picker-option/cc-picker-option.js
@@ -83,13 +83,13 @@ class CcPickerOption extends LitElement {
       css`
         /* region global */
         :host {
-          border-radius: var(--cc-border-radius-small, 0.25em);
+          border-radius: var(--cc-border-radius-medium, 0.375em);
           display: inline-flex;
         }
 
         .wrapper {
           border: 2px solid var(--cc-color-border-neutral, #bfbfbf);
-          border-radius: var(--cc-border-radius-small, 0.25em);
+          border-radius: var(--cc-border-radius-medium, 0.375em);
           display: flex;
           flex-direction: column;
           line-height: 1.5;

--- a/src/components/cc-picker/cc-picker.js
+++ b/src/components/cc-picker/cc-picker.js
@@ -37,6 +37,8 @@ const DEFAULT_ERROR_MESSAGES = {
  *
  * @cssprop {Size} --cc-form-label-gap - The space between the label and the control (defaults: `0.35em`).
  * @cssprop {Size} --cc-form-label-gap-inline - The space between the label and the control when layout is inline (defaults: `0.75em`).
+ * @cssprop {FontStyle} --cc-form-required-font-style - The font-style of the "required" mention next to the label (defaults: `italic`).
+ * @cssprop {TextTransform} --cc-form-required-text-transform - The text-transform of the "required" mention next to the label (defaults: `lowercase`).
  * @cssprop {Color} --cc-input-label-color - The color for the input's label (defaults: `inherit`).
  * @cssprop {FontSize} --cc-input-label-font-size - The font-size for the input's label (defaults: `inherit`).
  * @cssprop {FontWeight} --cc-input-label-font-weight - The font-weight for the input's label (defaults: `normal`).
@@ -314,7 +316,8 @@ export class CcPicker extends CcFormControlElement {
         .required {
           color: var(--cc-color-text-weak, #404040);
           font-size: 0.9em;
-          font-variant: small-caps;
+          font-style: var(--cc-form-required-font-style, italic);
+          text-transform: var(--cc-form-required-text-transform, lowercase);
         }
         /* endregion */
 

--- a/src/components/cc-picker/cc-picker.js
+++ b/src/components/cc-picker/cc-picker.js
@@ -287,7 +287,7 @@ export class CcPicker extends CcFormControlElement {
         }
 
         .fieldset:focus-visible {
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           outline: var(--cc-focus-outline-error);
           outline-offset: 0.5em;
         }

--- a/src/components/cc-picker/cc-picker.js
+++ b/src/components/cc-picker/cc-picker.js
@@ -298,7 +298,7 @@ export class CcPicker extends CcFormControlElement {
           align-items: flex-end;
           cursor: pointer;
           display: flex;
-          gap: 2em;
+          gap: var(--cc-spacing-8, 2em);
           justify-content: space-between;
           margin: 0;
           padding-block-end: var(--cc-form-label-gap, 0.35em);
@@ -322,7 +322,7 @@ export class CcPicker extends CcFormControlElement {
         .tiles {
           display: flex;
           flex-wrap: wrap;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
           grid-area: input;
         }
         /* endregion */
@@ -379,7 +379,7 @@ export class CcPicker extends CcFormControlElement {
         slot[name='help']::slotted(*) {
           color: var(--cc-color-text-weak);
           font-size: 0.9em;
-          margin: 0.3em 0 0;
+          margin: var(--cc-spacing-1, 0.25em) 0 0;
         }
 
         .help-container {
@@ -389,7 +389,7 @@ export class CcPicker extends CcFormControlElement {
         .error-container {
           color: var(--cc-color-text-danger, #be242d);
           grid-area: error;
-          margin: 0.5em 0 0;
+          margin: var(--cc-spacing-3, 0.5em) 0 0;
         }
         /* endregion */
 

--- a/src/components/cc-plan-picker/cc-plan-picker.js
+++ b/src/components/cc-plan-picker/cc-plan-picker.js
@@ -253,7 +253,7 @@ export class CcPlanPicker extends CcFormControlElement {
 
         /* region cc-picker global layout & style */
         .picker-wrapper {
-          column-gap: 0.25em;
+          column-gap: var(--cc-spacing-1, 0.25em);
           display: flex;
         }
 
@@ -261,7 +261,7 @@ export class CcPlanPicker extends CcFormControlElement {
           --cc-icon-color: var(--cc-color-text-primary);
 
           flex: 0 0 auto;
-          padding-block: 0.25em;
+          padding-block: var(--cc-spacing-1, 0.25em);
         }
 
         .picker-wrapper cc-picker {
@@ -284,7 +284,7 @@ export class CcPlanPicker extends CcFormControlElement {
 
         cc-picker::part(tiles) {
           display: grid;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
           grid-template-columns: repeat(auto-fill, minmax(13em, 1fr));
         }
         /* endregion */
@@ -292,7 +292,7 @@ export class CcPlanPicker extends CcFormControlElement {
         /* region cc-picker-option slotted content */
         ::part(option-body) {
           align-items: center;
-          column-gap: 0.375em;
+          column-gap: var(--cc-spacing-2, 0.35em);
           display: inline-flex;
           flex-wrap: wrap;
         }
@@ -311,12 +311,12 @@ export class CcPlanPicker extends CcFormControlElement {
           list-style-type: none;
           margin: 0;
           padding: 0;
-          row-gap: 0.25em;
+          row-gap: var(--cc-spacing-1, 0.25em);
         }
 
         ::part(option-footer--detail) {
           align-items: center;
-          column-gap: 0.5em;
+          column-gap: var(--cc-spacing-3, 0.5em);
           display: inline-flex;
         }
 

--- a/src/components/cc-popover/cc-popover.js
+++ b/src/components/cc-popover/cc-popover.js
@@ -264,7 +264,7 @@ export class CcPopover extends LitElement {
         .content {
           background-color: var(--cc-color-bg-default, #fff);
           border: 1px solid var(--cc-color-border-neutral, #aaa);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           box-shadow:
             0 2px 4px rgb(38 38 38 / 25%),
             0 5px 15px rgb(38 38 38 / 25%);

--- a/src/components/cc-pricing-estimation/cc-pricing-estimation.js
+++ b/src/components/cc-pricing-estimation/cc-pricing-estimation.js
@@ -1024,7 +1024,7 @@ export class CcPricingEstimation extends LitElement {
           --sl-input-border-color: var(--cc-color-border-neutral-weak, #aaa);
           --sl-input-border-color-disabled: var(--cc-color-border-disabled, #eee);
           --sl-input-border-color-focus: var(--cc-color-border-focused, #777);
-          --sl-input-border-radius-medium: var(--cc-border-radius-default, 0.25em);
+          --sl-input-border-radius-medium: var(--cc-border-radius-small, 0.25em);
           --sl-input-color: var(--cc-color-text-default, #000);
           --sl-input-color-hover: var(--cc-pricing-hovered-color, #000);
           --sl-input-font-family: initial;

--- a/src/components/cc-pricing-estimation/cc-pricing-estimation.js
+++ b/src/components/cc-pricing-estimation/cc-pricing-estimation.js
@@ -707,7 +707,7 @@ export class CcPricingEstimation extends LitElement {
       css`
         :host {
           display: block;
-          padding: 2em;
+          padding: var(--cc-spacing-8, 2em);
         }
 
         .skeleton {
@@ -740,7 +740,7 @@ export class CcPricingEstimation extends LitElement {
         .header--toggle {
           align-items: center;
           display: grid;
-          gap: 0 0.5em;
+          gap: 0 var(--cc-spacing-3, 0.5em);
           grid-template-areas:
             'heading counter btn'
             'total total total';
@@ -802,7 +802,7 @@ export class CcPricingEstimation extends LitElement {
         /* region content */
 
         .content {
-          margin-top: 1em;
+          margin-top: var(--cc-spacing-5, 1em);
         }
 
         .content--hidden {
@@ -814,14 +814,14 @@ export class CcPricingEstimation extends LitElement {
         .plan {
           align-items: center;
           border-bottom: solid 1px var(--cc-color-border-neutral-weak, #eee);
-          column-gap: 0.5em;
+          column-gap: var(--cc-spacing-3, 0.5em);
           display: grid;
           grid-template-areas:
             'plan-header plan-delete'
             'plan-features plan-features'
             'plan-price plan-price';
           grid-template-columns: 1fr auto;
-          padding-block: 1em;
+          padding-block: var(--cc-spacing-5, 1em);
         }
 
         .plan__toggle {
@@ -849,7 +849,7 @@ export class CcPricingEstimation extends LitElement {
           box-sizing: border-box;
           cursor: pointer;
           display: grid;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           grid-area: plan-header;
           grid-template-columns: auto 1fr auto;
           /* Remove the summary icon */
@@ -912,15 +912,15 @@ export class CcPricingEstimation extends LitElement {
           display: flex;
           flex-wrap: wrap;
           font-size: 0.9em;
-          gap: 0 0.5em;
+          gap: 0 var(--cc-spacing-3, 0.5em);
           grid-area: plan-features;
           line-height: 1.5;
-          margin-top: 1em;
+          margin-top: var(--cc-spacing-5, 1em);
         }
 
         .plan__features__feature {
           display: flex;
-          gap: 0.2em;
+          gap: var(--cc-spacing-1, 0.25em);
         }
 
         .plan__features__feature dt {
@@ -935,17 +935,17 @@ export class CcPricingEstimation extends LitElement {
           align-items: center;
           color: var(--cc-color-text-default, #000);
           display: grid;
-          gap: 0.5em 0.2em;
+          gap: var(--cc-spacing-3, 0.5em) var(--cc-spacing-1, 0.25em);
           grid-area: plan-price;
           grid-template-columns: 1fr auto 1fr;
           justify-content: space-between;
-          margin-top: 1em;
+          margin-top: var(--cc-spacing-5, 1em);
         }
 
         .plan__price__quantity {
           align-items: center;
           display: flex;
-          gap: 0.1em;
+          gap: var(--cc-spacing-0, 0.125em);
         }
 
         .plan__price__quantity__counter {
@@ -1010,7 +1010,7 @@ export class CcPricingEstimation extends LitElement {
         .form {
           display: flex;
           flex-wrap: wrap;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         /* region cc-pricing-header styles */
@@ -1042,7 +1042,7 @@ export class CcPricingEstimation extends LitElement {
 
         sl-select::part(form-control-label) {
           /* same value as out own inputs */
-          padding-bottom: 0.35em;
+          padding-bottom: var(--cc-spacing-2, 0.35em);
         }
 
         sl-select::part(display-input) {
@@ -1072,7 +1072,7 @@ export class CcPricingEstimation extends LitElement {
 
         sl-option::part(checked-icon) {
           height: 0.7em;
-          margin-right: 0.5em;
+          margin-right: var(--cc-spacing-3, 0.5em);
           width: 0.7em;
         }
 

--- a/src/components/cc-pricing-header/cc-pricing-header.js
+++ b/src/components/cc-pricing-header/cc-pricing-header.js
@@ -212,7 +212,7 @@ export class CcPricingHeader extends LitElement {
         .main {
           display: flex;
           flex-wrap: wrap;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         sl-select {
@@ -242,7 +242,7 @@ export class CcPricingHeader extends LitElement {
 
         sl-select::part(form-control-label) {
           /* same value as out own inputs */
-          padding-bottom: 0.35em;
+          padding-bottom: var(--cc-spacing-2, 0.35em);
         }
 
         sl-select::part(display-input) {
@@ -272,7 +272,7 @@ export class CcPricingHeader extends LitElement {
 
         sl-option::part(checked-icon) {
           height: 0.7em;
-          margin-right: 0.5em;
+          margin-right: var(--cc-spacing-3, 0.5em);
           width: 0.7em;
         }
 
@@ -307,12 +307,12 @@ export class CcPricingHeader extends LitElement {
           --cc-zone-tag-textcolor: var(--cc-color-text-weak, #333);
 
           border-bottom: solid 1px var(--cc-color-border-neutral-weak, transparent);
-          padding: 1em 0.5em;
+          padding: var(--cc-spacing-5, 1em) var(--cc-spacing-3, 0.5em);
         }
 
         sl-option.zone-item::part(checked-icon) {
           align-self: flex-start;
-          margin-top: 0.3em;
+          margin-top: var(--cc-spacing-1, 0.25em);
         }
         /* endregion */
       `,

--- a/src/components/cc-pricing-header/cc-pricing-header.js
+++ b/src/components/cc-pricing-header/cc-pricing-header.js
@@ -224,7 +224,7 @@ export class CcPricingHeader extends LitElement {
           --sl-input-border-color: var(--cc-color-border-neutral-weak, #aaa);
           --sl-input-border-color-disabled: var(--cc-color-border-disabled, #eee);
           --sl-input-border-color-focus: var(--cc-color-border-focused, #777);
-          --sl-input-border-radius-medium: var(--cc-border-radius-default, 0.25em);
+          --sl-input-border-radius-medium: var(--cc-border-radius-small, 0.25em);
           --sl-input-color: var(--cc-color-text-default, #000);
           --sl-input-color-hover: var(--cc-pricing-hovered-color, #000);
           --sl-input-font-family: initial;

--- a/src/components/cc-pricing-page/cc-pricing-page.stories.js
+++ b/src/components/cc-pricing-page/cc-pricing-page.stories.js
@@ -32,7 +32,7 @@ const websiteStyles = `
     --cc-color-border-neutral-strong: #deddee;
     --cc-color-border-neutral-weak: #deddee;
 
-    --cc-border-radius-default: 0;
+    --cc-border-radius-small: 0;
 
     --cc-pricing-estimation-counter-bg: linear-gradient(90deg, #f57461, #cb1c42 50.48%, #a51050);
 

--- a/src/components/cc-pricing-product-consumption/cc-pricing-product-consumption.js
+++ b/src/components/cc-pricing-product-consumption/cc-pricing-product-consumption.js
@@ -639,7 +639,7 @@ export class CcPricingProductConsumption extends LitElement {
         }
 
         .interval-line {
-          --bdrs: var(--cc-border-radius-default, 0.25em);
+          --bdrs: var(--cc-border-radius-small, 0.25em);
         }
 
         .interval,

--- a/src/components/cc-pricing-product-consumption/cc-pricing-product-consumption.js
+++ b/src/components/cc-pricing-product-consumption/cc-pricing-product-consumption.js
@@ -569,7 +569,7 @@ export class CcPricingProductConsumption extends LitElement {
           border-style: solid;
           border-width: 1px 0 0;
           grid-column: 1 / -1;
-          margin: 1em 0;
+          margin: var(--cc-spacing-5, 1em) 0;
           width: 100%;
         }
 
@@ -583,7 +583,7 @@ export class CcPricingProductConsumption extends LitElement {
 
           align-self: center;
           grid-column: section-icon / span 1;
-          margin-right: 1em;
+          margin-right: var(--cc-spacing-5, 1em);
         }
 
         .section-icon.sum-icon {
@@ -604,7 +604,7 @@ export class CcPricingProductConsumption extends LitElement {
         }
 
         .section-title.section-title--subtotal {
-          margin-top: 0.5em;
+          margin-top: var(--cc-spacing-3, 0.5em);
         }
 
         .section-title.section-title--subtotal .section-title-text {
@@ -612,14 +612,14 @@ export class CcPricingProductConsumption extends LitElement {
         }
 
         .section-title-price {
-          margin-left: 1em;
+          margin-left: var(--cc-spacing-5, 1em);
         }
 
         .input-wrapper {
           align-items: end;
           display: flex;
           grid-column: input-wrapper / input-wrapper--end;
-          margin: 1em 0;
+          margin: var(--cc-spacing-5, 1em) 0;
           width: 100%;
         }
 
@@ -631,7 +631,7 @@ export class CcPricingProductConsumption extends LitElement {
         .input-unit {
           --cc-toggle-text-transform: capitalize;
 
-          margin-left: 0.5em;
+          margin-left: var(--cc-spacing-3, 0.5em);
         }
 
         .interval-list {
@@ -646,14 +646,14 @@ export class CcPricingProductConsumption extends LitElement {
         .interval-price,
         .estimated-price {
           align-self: stretch;
-          margin: 0.1em 0;
-          padding-left: 0.5em;
-          padding-top: 0.5em;
+          margin: var(--cc-spacing-0, 0.125em) 0;
+          padding-left: var(--cc-spacing-3, 0.5em);
+          padding-top: var(--cc-spacing-3, 0.5em);
         }
 
         .interval {
-          padding-bottom: 0.5em;
-          padding-right: 0.5em;
+          padding-bottom: var(--cc-spacing-3, 0.5em);
+          padding-right: var(--cc-spacing-3, 0.5em);
         }
 
         .interval-line.highlighted:not(.progressive) .interval {
@@ -698,7 +698,7 @@ export class CcPricingProductConsumption extends LitElement {
 
         .button-bar {
           grid-column: start / end;
-          margin-bottom: 1em;
+          margin-bottom: var(--cc-spacing-5, 1em);
         }
 
         /* endregion */
@@ -732,12 +732,12 @@ export class CcPricingProductConsumption extends LitElement {
         }
 
         .body--big .interval-price {
-          margin-left: 2em;
+          margin-left: var(--cc-spacing-8, 2em);
         }
 
         .body--big .estimated-price {
           grid-column: estimated-price / span 1;
-          margin-left: 2em;
+          margin-left: var(--cc-spacing-8, 2em);
         }
 
         /* endregion */
@@ -767,7 +767,7 @@ export class CcPricingProductConsumption extends LitElement {
         }
 
         .body--small .interval-price {
-          margin-bottom: 1.5em;
+          margin-bottom: var(--cc-spacing-7, 1.5em);
         }
 
         .body--small .estimated-price {
@@ -775,7 +775,7 @@ export class CcPricingProductConsumption extends LitElement {
         }
 
         .body--small .input-wrapper {
-          margin-bottom: 0.5em;
+          margin-bottom: var(--cc-spacing-3, 0.5em);
         }
 
         .section-toggle-btn {
@@ -786,7 +786,7 @@ export class CcPricingProductConsumption extends LitElement {
           display: flex;
           font-size: 1em;
           grid-column: input-wrapper / -1;
-          margin-block: 0.5em;
+          margin-block: var(--cc-spacing-3, 0.5em);
           padding: 0;
         }
 

--- a/src/components/cc-pricing-product/cc-pricing-product.js
+++ b/src/components/cc-pricing-product/cc-pricing-product.js
@@ -491,7 +491,7 @@ export class CcPricingProduct extends LitElement {
         th {
           color: var(--cc-color-text-weak, #333);
           font-weight: bold;
-          padding: 2em 0.5em;
+          padding: var(--cc-spacing-8, 2em) var(--cc-spacing-3, 0.5em);
           text-align: left;
         }
 
@@ -503,12 +503,12 @@ export class CcPricingProduct extends LitElement {
         td {
           color: var(--cc-color-text-default, #000);
           font-weight: 500;
-          padding: 1.5em 0.5em;
+          padding: var(--cc-spacing-7, 1.5em) var(--cc-spacing-3, 0.5em);
           white-space: nowrap;
         }
 
         td.btn-col {
-          padding: 0.25em 1em;
+          padding: 0.25em var(--cc-spacing-5, 1em);
         }
 
         tr:hover td {
@@ -522,7 +522,7 @@ export class CcPricingProduct extends LitElement {
         table em[title] code {
           box-sizing: border-box;
           left: 100%;
-          padding: 0 0.15em;
+          padding: 0 var(--cc-spacing-0, 0.125em);
           position: absolute;
         }
 
@@ -533,7 +533,7 @@ export class CcPricingProduct extends LitElement {
         .plan {
           border-bottom: 1px solid var(--cc-color-border-neutral-weak, #ddd);
           margin: 0;
-          padding: 1em;
+          padding: var(--cc-spacing-5, 1em);
         }
 
         .plan-name {
@@ -541,12 +541,12 @@ export class CcPricingProduct extends LitElement {
           font-size: 1.2em;
           font-weight: bold;
           justify-content: space-between;
-          margin-bottom: 1em;
+          margin-bottom: var(--cc-spacing-5, 1em);
         }
 
         .feature-list {
           display: grid;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
           grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
         }
 

--- a/src/components/cc-product-card/cc-product-card.js
+++ b/src/components/cc-product-card/cc-product-card.js
@@ -85,7 +85,7 @@ export class CcProductCard extends LitElement {
           align-items: center;
           background-color: var(--cc-color-bg-default, #fff);
           border: 2px solid var(--cc-color-border-neutral, #aaa);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           box-sizing: border-box;
           display: grid;
           gap: var(--cc-spacing-1, 0.25em) var(--cc-spacing-3, 0.5em);
@@ -123,7 +123,7 @@ export class CcProductCard extends LitElement {
         /* region grid-items */
 
         cc-img {
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           height: 2em;
           width: 2em;
         }

--- a/src/components/cc-product-card/cc-product-card.js
+++ b/src/components/cc-product-card/cc-product-card.js
@@ -88,14 +88,14 @@ export class CcProductCard extends LitElement {
           border-radius: var(--cc-border-radius-default, 0.25em);
           box-sizing: border-box;
           display: grid;
-          gap: 0.25em 0.5em;
+          gap: var(--cc-spacing-1, 0.25em) var(--cc-spacing-3, 0.5em);
           grid-template-areas:
             'icon name status'
             'description description description';
           grid-template-columns: min-content auto 1fr;
           grid-template-rows: min-content auto;
           height: 100%;
-          padding: 1em;
+          padding: var(--cc-spacing-5, 1em);
           position: relative;
         }
 

--- a/src/components/cc-product-list/cc-product-list.js
+++ b/src/components/cc-product-list/cc-product-list.js
@@ -172,23 +172,23 @@ export class CcProductList extends LitElement {
 
         .category-products {
           display: grid;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
           grid-template-columns: repeat(auto-fill, minmax(20em, 1fr));
         }
 
         .category-title {
           align-items: center;
           color: var(--cc-product-list-category-title-color);
-          column-gap: 0.25em;
+          column-gap: var(--cc-spacing-1, 0.25em);
           display: flex;
-          margin-block-end: 0.5em;
+          margin-block-end: var(--cc-spacing-3, 0.5em);
         }
 
         .category-filter {
           border: none;
           display: flex;
           flex-wrap: wrap;
-          gap: 0.25em;
+          gap: var(--cc-spacing-1, 0.25em);
           padding: 0;
         }
 
@@ -214,15 +214,15 @@ export class CcProductList extends LitElement {
         .search-form {
           display: flex;
           flex-direction: column;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .search-form + .products {
-          margin-block-start: 1.5em;
+          margin-block-start: var(--cc-spacing-7, 1.5em);
         }
 
         .category + .category {
-          margin-block-start: 1.5em;
+          margin-block-start: var(--cc-spacing-7, 1.5em);
         }
       `,
     ];

--- a/src/components/cc-range-selector-option/cc-range-selector-option.js
+++ b/src/components/cc-range-selector-option/cc-range-selector-option.js
@@ -78,7 +78,7 @@ export class CcRangeSelectorOption extends LitElement {
       css`
         /* region global */
         :host {
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           display: inline-flex;
           overflow: hidden;
           width: fit-content;

--- a/src/components/cc-range-selector-option/cc-range-selector-option.js
+++ b/src/components/cc-range-selector-option/cc-range-selector-option.js
@@ -78,7 +78,7 @@ export class CcRangeSelectorOption extends LitElement {
       css`
         /* region global */
         :host {
-          border-radius: var(--cc-border-radius-small, 0.25em);
+          border-radius: var(--cc-border-radius-medium, 0.375em);
           display: inline-flex;
           overflow: hidden;
           width: fit-content;

--- a/src/components/cc-range-selector/cc-range-selector.js
+++ b/src/components/cc-range-selector/cc-range-selector.js
@@ -1240,7 +1240,7 @@ export class CcRangeSelector extends CcFormControlElement {
         /* region option - custom button */
         .btn-custom {
           align-items: stretch;
-          border-radius: var(--cc-border-radius-small, 0.25em);
+          border-radius: var(--cc-border-radius-medium, 0.375em);
           display: inline-flex;
           flex: 1 1 auto;
           user-select: auto;

--- a/src/components/cc-range-selector/cc-range-selector.js
+++ b/src/components/cc-range-selector/cc-range-selector.js
@@ -1140,7 +1140,7 @@ export class CcRangeSelector extends CcFormControlElement {
           align-items: flex-end;
           cursor: pointer;
           display: flex;
-          gap: 2em;
+          gap: var(--cc-spacing-8, 2em);
           justify-content: space-between;
           padding-block-end: var(--cc-form-label-gap, 0.35em);
           width: 100%;
@@ -1164,7 +1164,7 @@ export class CcRangeSelector extends CcFormControlElement {
           display: flex;
           flex-wrap: wrap;
           grid-area: input;
-          row-gap: 1em;
+          row-gap: var(--cc-spacing-5, 1em);
         }
         /* endregion */
 
@@ -1186,7 +1186,7 @@ export class CcRangeSelector extends CcFormControlElement {
           align-items: center;
           color: var(--cc-color-text-weak, #404040);
           display: inline-flex;
-          padding-inline: 0.125em;
+          padding-inline: var(--cc-spacing-0, 0.125em);
           visibility: hidden;
         }
 
@@ -1296,7 +1296,7 @@ export class CcRangeSelector extends CcFormControlElement {
         slot[name='help']::slotted(*) {
           color: var(--cc-color-text-weak, #404040);
           font-size: 0.9em;
-          margin: 0.3em 0 0;
+          margin: var(--cc-spacing-1, 0.25em) 0 0;
         }
 
         .help-container {
@@ -1306,7 +1306,7 @@ export class CcRangeSelector extends CcFormControlElement {
         .error-container {
           color: var(--cc-color-text-danger, #be242d);
           grid-area: error;
-          margin: 0.5em 0 0;
+          margin: var(--cc-spacing-3, 0.5em) 0 0;
         }
         /* endregion */
 

--- a/src/components/cc-range-selector/cc-range-selector.js
+++ b/src/components/cc-range-selector/cc-range-selector.js
@@ -1116,7 +1116,7 @@ export class CcRangeSelector extends CcFormControlElement {
         }
 
         .fieldset:focus-visible {
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           outline: var(--cc-focus-outline);
           outline-offset: 0.5em;
         }
@@ -1237,7 +1237,7 @@ export class CcRangeSelector extends CcFormControlElement {
         /* region option - custom button */
         .btn-custom {
           align-items: stretch;
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           display: inline-flex;
           flex: 1 1 auto;
           user-select: auto;

--- a/src/components/cc-range-selector/cc-range-selector.js
+++ b/src/components/cc-range-selector/cc-range-selector.js
@@ -61,6 +61,8 @@ import { RangeSelectorDraggingController } from './range-selector-dragging-contr
  *
  * @cssprop {Size} --cc-form-label-gap - The space between the label and the control (defaults: `0.35em`).
  * @cssprop {Size} --cc-form-label-gap-inline - The space between the label and the control when layout is inline (defaults: `0.75em`).
+ * @cssprop {FontStyle} --cc-form-required-font-style - The font-style of the "required" mention next to the label (defaults: `italic`).
+ * @cssprop {TextTransform} --cc-form-required-text-transform - The text-transform of the "required" mention next to the label (defaults: `lowercase`).
  * @cssprop {Color} --cc-input-label-color - The color for the input's label (defaults: `inherit`).
  * @cssprop {FontSize} --cc-input-label-font-size - The font-size for the input's label (defaults: `inherit`).
  * @cssprop {FontWeight} --cc-input-label-font-weight - The font-weight for the input's label (defaults: `normal`).
@@ -1155,7 +1157,8 @@ export class CcRangeSelector extends CcFormControlElement {
         .required {
           color: var(--cc-color-text-weak, #404040);
           font-size: 0.9em;
-          font-variant: small-caps;
+          font-style: var(--cc-form-required-font-style, italic);
+          text-transform: var(--cc-form-required-text-transform, lowercase);
         }
         /* endregion */
 

--- a/src/components/cc-search-bar/cc-search-bar.js
+++ b/src/components/cc-search-bar/cc-search-bar.js
@@ -256,7 +256,7 @@ export class CcSearchBar extends LitElement {
         }
 
         cc-dialog::part(dialog) {
-          margin-block: 1em auto;
+          margin-block: var(--cc-spacing-5, 1em) auto;
           overflow: hidden;
         }
 
@@ -273,8 +273,8 @@ export class CcSearchBar extends LitElement {
         .input-wrapper {
           display: flex;
           flex-direction: column;
-          gap: 0.35em;
-          padding: 0.5em 0.5em 1em;
+          gap: var(--cc-spacing-2, 0.35em);
+          padding: var(--cc-spacing-3, 0.5em) var(--cc-spacing-3, 0.5em) var(--cc-spacing-5, 1em);
         }
 
         .input-field {
@@ -300,7 +300,7 @@ export class CcSearchBar extends LitElement {
           flex: 1;
           max-height: calc(100dvh - 16em);
           overflow-y: auto;
-          padding: 0 0.5em;
+          padding: 0 var(--cc-spacing-3, 0.5em);
         }
 
         .empty {
@@ -308,14 +308,14 @@ export class CcSearchBar extends LitElement {
           color: var(--cc-color-text-default, #000);
           display: flex;
           flex-direction: column;
-          gap: 0.5em;
-          padding: 1.5em 1em;
+          gap: var(--cc-spacing-3, 0.5em);
+          padding: var(--cc-spacing-7, 1.5em) var(--cc-spacing-5, 1em);
           text-align: center;
         }
 
         .empty-icon {
           color: var(--cc-color-text-primary-strongest, #000);
-          margin-bottom: 0.25em;
+          margin-bottom: var(--cc-spacing-1, 0.25em);
         }
 
         .empty-title {
@@ -335,16 +335,16 @@ export class CcSearchBar extends LitElement {
           background-color: var(--cc-color-bg-neutral, #f5f5f5);
           border-radius: var(--cc-border-radius-default, 0.25em);
           font-family: var(--cc-ff-monospace, monospace);
-          padding: 0.1em 0.3em;
+          padding: var(--cc-spacing-0, 0.125em) var(--cc-spacing-1, 0.25em);
         }
 
         .section:not(:last-child) {
           border-bottom: solid 1px var(--cc-color-border-neutral-weak, #e7e7e7);
-          padding-bottom: 1em;
+          padding-bottom: var(--cc-spacing-5, 1em);
         }
 
         .section:not(:first-child) {
-          padding-top: 0.5em;
+          padding-top: var(--cc-spacing-3, 0.5em);
         }
 
         .section-header {
@@ -353,10 +353,10 @@ export class CcSearchBar extends LitElement {
           display: flex;
           font-size: 1em;
           font-weight: normal;
-          gap: 0.4em;
+          gap: var(--cc-spacing-2, 0.35em);
           line-height: 1.3;
           margin: 0;
-          padding: 1em 0;
+          padding: var(--cc-spacing-5, 1em) 0;
         }
 
         .section-header-label {
@@ -366,10 +366,10 @@ export class CcSearchBar extends LitElement {
         .section-items {
           display: flex;
           flex-direction: column;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           list-style: none;
           margin: 0;
-          padding: 0.33em 0;
+          padding: var(--cc-spacing-2, 0.35em) 0;
         }
 
         .item {
@@ -378,9 +378,9 @@ export class CcSearchBar extends LitElement {
           color: var(--cc-color-text-default, #000);
           display: flex;
           font-weight: normal;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           letter-spacing: -0.15px;
-          padding: 0.5em;
+          padding: var(--cc-spacing-3, 0.5em);
           text-decoration: none;
         }
 

--- a/src/components/cc-search-bar/cc-search-bar.js
+++ b/src/components/cc-search-bar/cc-search-bar.js
@@ -333,7 +333,7 @@ export class CcSearchBar extends LitElement {
 
         .empty-description code {
           background-color: var(--cc-color-bg-neutral, #f5f5f5);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           font-family: var(--cc-ff-monospace, monospace);
           padding: var(--cc-spacing-0, 0.125em) var(--cc-spacing-1, 0.25em);
         }
@@ -374,7 +374,7 @@ export class CcSearchBar extends LitElement {
 
         .item {
           align-items: center;
-          border-radius: 0.5em;
+          border-radius: var(--cc-border-radius-large, 0.5em);
           color: var(--cc-color-text-default, #000);
           display: flex;
           font-weight: normal;
@@ -389,7 +389,7 @@ export class CcSearchBar extends LitElement {
         }
 
         .item:focus-visible {
-          border-radius: 0.625em;
+          border-radius: var(--cc-border-radius-large, 0.5em);
           outline: var(--cc-focus-outline);
           outline-offset: var(--cc-focus-outline-offset, 2px);
         }

--- a/src/components/cc-select/cc-select.js
+++ b/src/components/cc-select/cc-select.js
@@ -315,7 +315,7 @@ export class CcSelect extends CcFormControlElement {
         select {
           background-color: var(--cc-color-bg-default, #fff);
           border: 1px solid var(--cc-color-border-neutral-strong, #aaa);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-medium, 0.375em);
           box-sizing: border-box;
           grid-area: input;
           height: 2em;

--- a/src/components/cc-select/cc-select.js
+++ b/src/components/cc-select/cc-select.js
@@ -33,6 +33,8 @@ const DEFAULT_ERROR_MESSAGES = {
  *
  * @cssprop {Size} --cc-form-label-gap - The space between the label and the control (defaults: `0.35em`).
  * @cssprop {Size} --cc-form-label-gap-inline - The space between the label and the control when layout is inline (defaults: `0.75em`).
+ * @cssprop {FontStyle} --cc-form-required-font-style - The font-style of the "required" mention next to the label (defaults: `italic`).
+ * @cssprop {TextTransform} --cc-form-required-text-transform - The text-transform of the "required" mention next to the label (defaults: `lowercase`).
  * @cssprop {Color} --cc-select-label-color - The color for the select's label (defaults: `inherit`).
  * @cssprop {FontSize} --cc-select-label-font-size - The font-size for the select's label (defaults: `inherit`).
  * @cssprop {FontWeight} --cc-select-label-font-weight - The font-weight for the select's label (defaults: `normal`).
@@ -275,7 +277,8 @@ export class CcSelect extends CcFormControlElement {
         .required {
           color: var(--cc-color-text-weak);
           font-size: 0.9em;
-          font-variant: small-caps;
+          font-style: var(--cc-form-required-font-style, italic);
+          text-transform: var(--cc-form-required-text-transform, lowercase);
         }
 
         :host([inline]) .required {

--- a/src/components/cc-select/cc-select.js
+++ b/src/components/cc-select/cc-select.js
@@ -252,7 +252,7 @@ export class CcSelect extends CcFormControlElement {
           align-items: flex-end;
           cursor: pointer;
           display: flex;
-          gap: 2em;
+          gap: var(--cc-spacing-8, 2em);
           justify-content: space-between;
           line-height: 1.25em;
           padding-block-end: var(--cc-form-label-gap, 0.35em);
@@ -285,12 +285,12 @@ export class CcSelect extends CcFormControlElement {
         slot[name='help']::slotted(*) {
           color: var(--cc-color-text-weak);
           font-size: 0.9em;
-          margin: 0.3em 0 0;
+          margin: var(--cc-spacing-1, 0.25em) 0 0;
         }
 
         .error-container {
           color: var(--cc-color-text-danger);
-          margin: 0.5em 0 0;
+          margin: var(--cc-spacing-3, 0.5em) 0 0;
         }
         /* endregion */
 
@@ -319,7 +319,7 @@ export class CcSelect extends CcFormControlElement {
           box-sizing: border-box;
           grid-area: input;
           height: 2em;
-          padding: 0 3em 0 0.5em;
+          padding: 0 var(--cc-spacing-10, 3em) 0 var(--cc-spacing-3, 0.5em);
         }
 
         select:hover {

--- a/src/components/cc-ssh-key-list/cc-ssh-key-list.js
+++ b/src/components/cc-ssh-key-list/cc-ssh-key-list.js
@@ -355,7 +355,7 @@ export class CcSshKeyList extends LitElement {
         .create-form {
           display: flex;
           flex-direction: column;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         .create-form__public-key {
@@ -372,7 +372,7 @@ export class CcSshKeyList extends LitElement {
         .key-list {
           display: flex;
           flex-direction: column;
-          gap: 2.5em;
+          gap: var(--cc-spacing-9, 2.5em);
         }
         /* endregion */
 
@@ -380,7 +380,7 @@ export class CcSshKeyList extends LitElement {
 
         .key {
           display: grid;
-          gap: 0.5em 0.75em;
+          gap: var(--cc-spacing-3, 0.5em) var(--cc-spacing-4, 0.75em);
           grid-template-areas:
             'key-icon key-name'
             '. key-form';
@@ -408,7 +408,7 @@ export class CcSshKeyList extends LitElement {
           align-items: center;
           display: flex;
           flex-wrap: wrap;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
           grid-area: key-form;
           justify-content: flex-end;
         }
@@ -423,7 +423,7 @@ export class CcSshKeyList extends LitElement {
           flex-grow: 1;
           font-family: var(--cc-ff-monospace);
           line-height: 1.5;
-          padding: 0.5em 0.75em;
+          padding: var(--cc-spacing-3, 0.5em) var(--cc-spacing-4, 0.75em);
           word-break: break-word;
         }
 
@@ -445,8 +445,8 @@ export class CcSshKeyList extends LitElement {
 
         [slot='info'] {
           display: grid;
-          gap: 1em;
-          margin-top: 1.5em;
+          gap: var(--cc-spacing-5, 1em);
+          margin-top: var(--cc-spacing-7, 1.5em);
         }
 
         [slot='info'] code {
@@ -457,7 +457,7 @@ export class CcSshKeyList extends LitElement {
           font-family: var(--cc-ff-monospace);
           font-size: 0.9em;
           line-height: 2;
-          padding: 0.25em 0.75em;
+          padding: 0.25em var(--cc-spacing-4, 0.75em);
           white-space: pre-wrap;
           word-break: break-all;
         }
@@ -475,7 +475,7 @@ export class CcSshKeyList extends LitElement {
           font-style: italic;
           line-height: 1.5;
           margin-bottom: 0;
-          margin-top: 1em;
+          margin-top: var(--cc-spacing-5, 1em);
         }
 
         /* endregion */
@@ -483,7 +483,7 @@ export class CcSshKeyList extends LitElement {
         [slot='footer-right'] cc-link {
           align-items: center;
           display: flex;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
       `,
     ];

--- a/src/components/cc-ssh-key-list/cc-ssh-key-list.js
+++ b/src/components/cc-ssh-key-list/cc-ssh-key-list.js
@@ -418,7 +418,7 @@ export class CcSshKeyList extends LitElement {
         .key__fingerprint {
           background-color: var(--cc-color-bg-neutral);
           border-inline-start: 5px solid #a6a6a6;
-          border-radius: 0.125em;
+          border-radius: var(--cc-border-radius-xs, 0.15em);
           flex-basis: min(100%, 21.25em);
           flex-grow: 1;
           font-family: var(--cc-ff-monospace);
@@ -452,7 +452,7 @@ export class CcSshKeyList extends LitElement {
         [slot='info'] code {
           background-color: var(--cc-color-bg-neutral);
           border: 1px solid var(--cc-color-border-neutral-weak, #eee);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           display: inline-block;
           font-family: var(--cc-ff-monospace);
           font-size: 0.9em;

--- a/src/components/cc-tcp-redirection-form/cc-tcp-redirection-form.js
+++ b/src/components/cc-tcp-redirection-form/cc-tcp-redirection-form.js
@@ -146,13 +146,13 @@ export class CcTcpRedirectionForm extends LitElement {
         cc-badge {
           /* cc-block title changes the font-size to 1.2em, which makes our badge way too big */
           font-size: 0.8em;
-          margin-left: 0.5em;
+          margin-left: var(--cc-spacing-3, 0.5em);
           vertical-align: middle;
         }
 
         .content {
           display: grid;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         .description {
@@ -161,14 +161,14 @@ export class CcTcpRedirectionForm extends LitElement {
 
         .description p {
           margin: 0;
-          margin-bottom: 1em;
+          margin-bottom: var(--cc-spacing-5, 1em);
         }
 
         .description code {
           background-color: var(--cc-color-bg-neutral);
           border-radius: var(--cc-border-radius-default, 0.25em);
           font-family: var(--cc-ff-monospace);
-          padding: 0.15em 0.3em;
+          padding: var(--cc-spacing-0, 0.125em) var(--cc-spacing-1, 0.25em);
         }
 
         .empty-msg {

--- a/src/components/cc-tcp-redirection-form/cc-tcp-redirection-form.js
+++ b/src/components/cc-tcp-redirection-form/cc-tcp-redirection-form.js
@@ -166,7 +166,7 @@ export class CcTcpRedirectionForm extends LitElement {
 
         .description code {
           background-color: var(--cc-color-bg-neutral);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           font-family: var(--cc-ff-monospace);
           padding: var(--cc-spacing-0, 0.125em) var(--cc-spacing-1, 0.25em);
         }

--- a/src/components/cc-tcp-redirection/cc-tcp-redirection.js
+++ b/src/components/cc-tcp-redirection/cc-tcp-redirection.js
@@ -171,7 +171,7 @@ export class CcTcpRedirection extends LitElement {
         .wrapper {
           display: flex;
           flex-wrap: wrap;
-          gap: 0.8em;
+          gap: var(--cc-spacing-4, 0.75em);
         }
 
         .icon {
@@ -201,7 +201,7 @@ export class CcTcpRedirection extends LitElement {
           display: flex;
           flex: 1 1 0;
           flex-wrap: wrap;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         .text-wrapper {
@@ -217,7 +217,7 @@ export class CcTcpRedirection extends LitElement {
           background-color: var(--cc-color-bg-neutral);
           border-radius: var(--cc-border-radius-default, 0.25em);
           font-family: var(--cc-ff-monospace);
-          padding: 0.15em 0.3em;
+          padding: var(--cc-spacing-0, 0.125em) var(--cc-spacing-1, 0.25em);
         }
 
         .text-addendum:not(.skeleton) {

--- a/src/components/cc-tcp-redirection/cc-tcp-redirection.js
+++ b/src/components/cc-tcp-redirection/cc-tcp-redirection.js
@@ -215,7 +215,7 @@ export class CcTcpRedirection extends LitElement {
 
         .text:not(.skeleton) code {
           background-color: var(--cc-color-bg-neutral);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           font-family: var(--cc-ff-monospace);
           padding: var(--cc-spacing-0, 0.125em) var(--cc-spacing-1, 0.25em);
         }

--- a/src/components/cc-tile-deployments/cc-tile-deployments.js
+++ b/src/components/cc-tile-deployments/cc-tile-deployments.js
@@ -146,7 +146,7 @@ export class CcTileDeployments extends LitElement {
 
         .error-message {
           display: grid;
-          gap: 0.75em;
+          gap: var(--cc-spacing-4, 0.75em);
           grid-template-columns: min-content 1fr;
           text-align: left;
         }

--- a/src/components/cc-tile-instances/cc-tile-instances.js
+++ b/src/components/cc-tile-instances/cc-tile-instances.js
@@ -191,7 +191,7 @@ export class CcTileInstances extends LitElement {
           color: var(--status-color, #000);
           flex: 1 1 0;
           font-size: 1.2em;
-          margin-left: 0.25em;
+          margin-left: var(--cc-spacing-1, 0.25em);
         }
 
         .size-label {
@@ -208,7 +208,7 @@ export class CcTileInstances extends LitElement {
 
         .error-message {
           display: grid;
-          gap: 0.75em;
+          gap: var(--cc-spacing-4, 0.75em);
           grid-template-columns: min-content 1fr;
           text-align: left;
         }

--- a/src/components/cc-tile-metrics/cc-tile-metrics.js
+++ b/src/components/cc-tile-metrics/cc-tile-metrics.js
@@ -453,7 +453,7 @@ export class CcTileMetrics extends LitElement {
           align-items: center;
           /* TODO: Change variable when we have proper border token */
           border: 1px solid var(--cc-color-bg-strong);
-          border-radius: var(--cc-border-radius-small, 0.15em);
+          border-radius: var(--cc-border-radius-large, 0.5em);
           box-shadow: rgb(255 255 255 / 0%) 0 0 0 0;
           box-sizing: border-box;
           display: flex;

--- a/src/components/cc-tile-metrics/cc-tile-metrics.js
+++ b/src/components/cc-tile-metrics/cc-tile-metrics.js
@@ -471,7 +471,7 @@ export class CcTileMetrics extends LitElement {
           align-items: center;
           display: flex;
           font-size: 0.8em;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         /* endregion */
@@ -508,7 +508,7 @@ export class CcTileMetrics extends LitElement {
 
         .tile_body {
           align-items: center;
-          gap: 0 1em;
+          gap: 0 var(--cc-spacing-5, 1em);
           grid-template-areas:
             'icon-cpu chart-cpu percent-cpu'
             '. legend-cpu .'
@@ -565,12 +565,12 @@ export class CcTileMetrics extends LitElement {
           font-size: 0.75em;
           font-style: italic;
           justify-self: center;
-          margin-top: 0.5em;
+          margin-top: var(--cc-spacing-3, 0.5em);
         }
 
         .legend-cpu {
           grid-area: legend-cpu;
-          margin-bottom: 1.25em;
+          margin-bottom: var(--cc-spacing-6, 1.25em);
         }
 
         .legend-mem {
@@ -588,7 +588,7 @@ export class CcTileMetrics extends LitElement {
 
         .tile_docs ul {
           display: flex;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           list-style: none;
           margin: 0;
           padding: 0;
@@ -597,8 +597,8 @@ export class CcTileMetrics extends LitElement {
         .docs-links {
           align-items: flex-end;
           display: flex;
-          gap: 0.5em;
-          margin-top: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
+          margin-top: var(--cc-spacing-3, 0.5em);
         }
 
         /* endregion */
@@ -636,7 +636,7 @@ export class CcTileMetrics extends LitElement {
 
         .error-message {
           display: grid;
-          gap: 0.75em;
+          gap: var(--cc-spacing-4, 0.75em);
           grid-template-columns: min-content 1fr;
           text-align: left;
         }

--- a/src/components/cc-tile-requests/cc-tile-requests.js
+++ b/src/components/cc-tile-requests/cc-tile-requests.js
@@ -298,7 +298,7 @@ export class CcTileRequests extends LitElement {
 
         .docs-toggle {
           font-size: 0.8em;
-          margin: 0 0 0 1em;
+          margin: 0 0 0 var(--cc-spacing-5, 1em);
         }
 
         .docs-toggle.close {
@@ -353,7 +353,7 @@ export class CcTileRequests extends LitElement {
 
         .error-message {
           display: grid;
-          gap: 0.75em;
+          gap: var(--cc-spacing-4, 0.75em);
           grid-template-columns: min-content 1fr;
           text-align: left;
         }

--- a/src/components/cc-tile-scalability/cc-tile-scalability.js
+++ b/src/components/cc-tile-scalability/cc-tile-scalability.js
@@ -142,7 +142,7 @@ export class CcTileScalability extends LitElement {
 
         .error-message {
           display: grid;
-          gap: 0.75em;
+          gap: var(--cc-spacing-4, 0.75em);
           grid-template-columns: min-content 1fr;
           text-align: left;
         }

--- a/src/components/cc-tile-status-codes/cc-tile-status-codes.js
+++ b/src/components/cc-tile-status-codes/cc-tile-status-codes.js
@@ -285,7 +285,7 @@ export class CcTileStatusCodes extends LitElement {
 
         .docs-toggle {
           font-size: 0.8em;
-          margin: 0 0 0 1em;
+          margin: 0 0 0 var(--cc-spacing-5, 1em);
         }
 
         .docs-toggle.close {
@@ -339,7 +339,7 @@ export class CcTileStatusCodes extends LitElement {
 
         .error-message {
           display: grid;
-          gap: 0.75em;
+          gap: var(--cc-spacing-4, 0.75em);
           grid-template-columns: min-content 1fr;
           text-align: left;
         }

--- a/src/components/cc-toast/cc-toast.js
+++ b/src/components/cc-toast/cc-toast.js
@@ -194,7 +194,7 @@ export class CcToast extends LitElement {
           align-items: stretch;
           background-color: var(--toast-color);
           border: 1px solid var(--toast-color);
-          border-radius: var(--cc-border-radius-small, 0.25em);
+          border-radius: var(--cc-border-radius-medium, 0.375em);
           box-shadow:
             0 2px 4px rgb(38 38 38 / 25%),
             0 5px 15px rgb(38 38 38 / 25%);

--- a/src/components/cc-toast/cc-toast.js
+++ b/src/components/cc-toast/cc-toast.js
@@ -255,13 +255,13 @@ export class CcToast extends LitElement {
           display: flex;
           flex: 1 1 auto;
           flex-direction: column;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           justify-content: center;
           padding: var(--padding);
         }
 
         .content p {
-          margin-block: 0.5em;
+          margin-block: var(--cc-spacing-3, 0.5em);
         }
 
         .heading {
@@ -282,8 +282,8 @@ export class CcToast extends LitElement {
           border-radius: var(--cc-border-radius-small, 0.15em);
           cursor: pointer;
           height: auto;
-          margin: 0.25em;
-          padding: 0.2em;
+          margin: var(--cc-spacing-1, 0.25em);
+          padding: var(--cc-spacing-1, 0.25em);
           width: auto;
         }
 

--- a/src/components/cc-toast/cc-toast.js
+++ b/src/components/cc-toast/cc-toast.js
@@ -194,7 +194,7 @@ export class CcToast extends LitElement {
           align-items: stretch;
           background-color: var(--toast-color);
           border: 1px solid var(--toast-color);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           box-shadow:
             0 2px 4px rgb(38 38 38 / 25%),
             0 5px 15px rgb(38 38 38 / 25%);
@@ -279,7 +279,7 @@ export class CcToast extends LitElement {
           align-self: start;
           background-color: transparent;
           border: none;
-          border-radius: var(--cc-border-radius-small, 0.15em);
+          border-radius: var(--cc-border-radius-xs, 0.15em);
           cursor: pointer;
           height: auto;
           margin: var(--cc-spacing-1, 0.25em);

--- a/src/components/cc-toaster/cc-toaster.js
+++ b/src/components/cc-toaster/cc-toaster.js
@@ -288,7 +288,7 @@ export class CcToaster extends LitElement {
           align-items: center;
           display: flex;
           flex-direction: column;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
           pointer-events: none;
         }
 

--- a/src/components/cc-toggle/cc-toggle.js
+++ b/src/components/cc-toggle/cc-toggle.js
@@ -257,9 +257,9 @@ export class CcToggle extends LitElement {
           display: grid;
           font-size: 0.85em;
           font-weight: var(--cc-toggle-font-weight, bold);
-          gap: 0.6em;
+          gap: var(--cc-spacing-3, 0.5em);
           grid-auto-flow: column;
-          padding: 0 0.6em;
+          padding: 0 var(--cc-spacing-3, 0.5em);
           position: relative;
           text-transform: var(--cc-toggle-text-transform, uppercase);
           -moz-user-select: none;

--- a/src/components/cc-toggle/cc-toggle.js
+++ b/src/components/cc-toggle/cc-toggle.js
@@ -33,7 +33,7 @@ import { CcMultiSelectEvent, CcSelectEvent } from '../common.events.js';
  *
  * @cssprop {Size} --cc-form-label-gap - The space between the label and the control (defaults: `0.35em`).
  * @cssprop {Size} --cc-form-label-gap-inline - The space between the label and the control when layout is inline (defaults: `0.75em`).
- * @cssprop {BorderRadius} --cc-toggle-border-radius - Sets the value of the border radius CSS property (defaults: `0.15em`).
+ * @cssprop {BorderRadius} --cc-toggle-border-radius - Sets the value of the border radius CSS property (defaults: `0.25em`).
  * @cssprop {Color} --cc-toggle-color - The main color of the toggle (defaults: `#334252`). It must be defined directly on the element.
  * @cssprop {FontWeight} --cc-toggle-font-weight - Sets the value of the font weight CSS property (defaults: `bold`).
  * @cssprop {Filter} --cc-toggle-img-filter - A CSS filter to apply on images of all choices (defaults: `none`). It must be defined directly on the element.
@@ -221,7 +221,7 @@ export class CcToggle extends LitElement {
 
         .toggle-group {
           background-color: var(--cc-color-bg-default, #fff);
-          border-radius: var(--cc-border-radius-xs, 0.15em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           box-sizing: border-box;
           display: flex;
           height: var(--height);
@@ -247,7 +247,7 @@ export class CcToggle extends LitElement {
         label {
           /* used around the background */
           --space: 2px;
-          --border-radius: var(--cc-toggle-border-radius, 0.15em);
+          --border-radius: var(--cc-toggle-border-radius, var(--cc-border-radius-small, 0.25em));
 
           align-items: center;
           border-color: var(--cc-toggle-color);
@@ -290,7 +290,7 @@ export class CcToggle extends LitElement {
 
         label::before {
           background-color: var(--cc-color-bg);
-          border-radius: var(--cc-border-radius-xs, 0.15em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           bottom: var(--space);
           content: '';
           display: block;

--- a/src/components/cc-toggle/cc-toggle.js
+++ b/src/components/cc-toggle/cc-toggle.js
@@ -221,7 +221,7 @@ export class CcToggle extends LitElement {
 
         .toggle-group {
           background-color: var(--cc-color-bg-default, #fff);
-          border-radius: var(--cc-border-radius-small, 0.15em);
+          border-radius: var(--cc-border-radius-xs, 0.15em);
           box-sizing: border-box;
           display: flex;
           height: var(--height);
@@ -290,7 +290,7 @@ export class CcToggle extends LitElement {
 
         label::before {
           background-color: var(--cc-color-bg);
-          border-radius: var(--cc-border-radius-small, 0.15em);
+          border-radius: var(--cc-border-radius-xs, 0.15em);
           bottom: var(--space);
           content: '';
           display: block;

--- a/src/components/cc-token-api-creation-form/cc-token-api-creation-form.js
+++ b/src/components/cc-token-api-creation-form/cc-token-api-creation-form.js
@@ -733,18 +733,18 @@ export class CcTokenApiCreationForm extends LitElement {
 
         /* FIXME: not great when viewport is reduced + should be handled by the cc-block component itself */
         cc-block {
-          padding-top: 2em;
+          padding-top: var(--cc-spacing-8, 2em);
         }
 
         /* FIXME: not great when viewport is reduced + should be handled by the cc-block component itself */
         cc-block > [slot='content'] {
-          padding-bottom: 1em;
-          padding-inline: 3em;
+          padding-bottom: var(--cc-spacing-5, 1em);
+          padding-inline: var(--cc-spacing-10, 3em);
         }
 
         /* FIXME: not great when viewport is reduced + should be handled by the cc-block component itself */
         [slot='header-title'] {
-          padding-inline: 1.5em;
+          padding-inline: var(--cc-spacing-7, 1.5em);
         }
 
         [slot='link'] {
@@ -758,14 +758,14 @@ export class CcTokenApiCreationForm extends LitElement {
         }
 
         .creation-steps-nav {
-          column-gap: 2em;
+          column-gap: var(--cc-spacing-8, 2em);
           display: flex;
           flex-wrap: wrap;
           list-style: none;
           margin: 0;
-          margin-block: 1em;
+          margin-block: var(--cc-spacing-5, 1em);
           padding: 0;
-          row-gap: 1em;
+          row-gap: var(--cc-spacing-5, 1em);
         }
 
         .creation-steps-nav__step-item {
@@ -776,9 +776,9 @@ export class CcTokenApiCreationForm extends LitElement {
           color: var(--cc-color-text-weak);
           display: flex;
           flex: 1 1 10em;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           line-height: 1.3em;
-          padding-block: 1em;
+          padding-block: var(--cc-spacing-5, 1em);
           position: relative;
           transition: all var(--transition-duration) ease-in-out;
         }
@@ -809,8 +809,8 @@ export class CcTokenApiCreationForm extends LitElement {
         }
 
         cc-expand {
-          margin-inline: -1em;
-          padding: 1em;
+          margin-inline: calc(var(--cc-spacing-5, 1em) * -1);
+          padding: var(--cc-spacing-5, 1em);
           transition: all var(--transition-duration) ease-in-out;
         }
 
@@ -850,13 +850,13 @@ export class CcTokenApiCreationForm extends LitElement {
 
         .form {
           display: grid;
-          gap: 1.5em;
+          gap: var(--cc-spacing-7, 1.5em);
         }
 
         .form__expiration {
           display: flex;
           flex-wrap: wrap;
-          gap: 1.5em;
+          gap: var(--cc-spacing-7, 1.5em);
         }
 
         .form__expiration cc-input-date,
@@ -868,9 +868,9 @@ export class CcTokenApiCreationForm extends LitElement {
           align-items: center;
           display: flex;
           flex-wrap: wrap;
-          gap: 1.5em;
+          gap: var(--cc-spacing-7, 1.5em);
           justify-content: flex-end;
-          margin-top: 1em;
+          margin-top: var(--cc-spacing-5, 1em);
         }
 
         .form__actions__submit-button {
@@ -879,7 +879,7 @@ export class CcTokenApiCreationForm extends LitElement {
 
         .copy-step-wrapper {
           display: grid;
-          gap: 1.5em;
+          gap: var(--cc-spacing-7, 1.5em);
         }
 
         .copy-step-wrapper cc-input-text {
@@ -901,8 +901,8 @@ export class CcTokenApiCreationForm extends LitElement {
           color: var(--cc-color-text-weak);
           cursor: pointer;
           display: flex;
-          gap: 0.5em;
-          padding: 0.25em 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
+          padding: 0.25em var(--cc-spacing-3, 0.5em);
           text-decoration: none;
         }
 

--- a/src/components/cc-token-api-creation-form/cc-token-api-creation-form.js
+++ b/src/components/cc-token-api-creation-form/cc-token-api-creation-form.js
@@ -912,7 +912,7 @@ export class CcTokenApiCreationForm extends LitElement {
         }
 
         .form__actions__link-container__link:focus-visible {
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           outline: var(--cc-focus-outline);
           outline-offset: var(--cc-focus-outline-offset, 2px);
         }

--- a/src/components/cc-token-api-list/cc-token-api-list.js
+++ b/src/components/cc-token-api-list/cc-token-api-list.js
@@ -393,7 +393,7 @@ export class CcTokenApiList extends LitElement {
         .api-token-card {
           align-items: center;
           border: solid 1px var(--cc-color-border-neutral-weak, #e6e6e6);
-          border-radius: var(--cc-border-radius-small, 0.25em);
+          border-radius: var(--cc-border-radius-medium, 0.375em);
           display: grid;
           gap: var(--cc-spacing-3, 0.5em);
           grid-template-columns: [card-start info-start] 1fr [info-end actions-start] max-content [actions-end card-end];

--- a/src/components/cc-token-api-list/cc-token-api-list.js
+++ b/src/components/cc-token-api-list/cc-token-api-list.js
@@ -344,9 +344,9 @@ export class CcTokenApiList extends LitElement {
           border: 1px solid var(--cc-color-border-neutral-weak);
           display: grid;
           font-weight: bold;
-          gap: 1.5em;
+          gap: var(--cc-spacing-7, 1.5em);
           justify-items: center;
-          padding: 1em;
+          padding: var(--cc-spacing-5, 1em);
         }
 
         .empty__no-password {
@@ -354,7 +354,7 @@ export class CcTokenApiList extends LitElement {
           display: flex;
           flex-wrap: wrap;
           font-weight: normal;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         .empty__no-password__message {
@@ -372,12 +372,12 @@ export class CcTokenApiList extends LitElement {
         }
 
         .api-tokens-wrapper {
-          margin-top: 2.5em;
+          margin-top: var(--cc-spacing-9, 2.5em);
         }
 
         .api-tokens-wrapper__list {
           display: grid;
-          gap: 1.5em;
+          gap: var(--cc-spacing-7, 1.5em);
         }
 
         @supports (grid-template-columns: subgrid) {
@@ -395,9 +395,9 @@ export class CcTokenApiList extends LitElement {
           border: solid 1px var(--cc-color-border-neutral-weak, #e6e6e6);
           border-radius: var(--cc-border-radius-default, 0.25em);
           display: grid;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           grid-template-columns: [card-start info-start] 1fr [info-end actions-start] max-content [actions-end card-end];
-          padding: 1em;
+          padding: var(--cc-spacing-5, 1em);
         }
 
         .api-token-card--is-revoking > :not(cc-button),
@@ -422,11 +422,11 @@ export class CcTokenApiList extends LitElement {
 
         .api-token-card__header {
           align-items: center;
-          column-gap: 1em;
+          column-gap: var(--cc-spacing-5, 1em);
           display: flex;
           flex-wrap: wrap;
           grid-column: info-start / info-end;
-          row-gap: 0.5em;
+          row-gap: var(--cc-spacing-3, 0.5em);
         }
 
         .api-token-card__header__name {
@@ -437,7 +437,7 @@ export class CcTokenApiList extends LitElement {
           align-items: flex-start;
           display: flex;
           flex-wrap: wrap;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           grid-column: info-start / info-end;
         }
 
@@ -458,11 +458,11 @@ export class CcTokenApiList extends LitElement {
         }
 
         .api-token-card__info-list {
-          column-gap: 1em;
+          column-gap: var(--cc-spacing-5, 1em);
           display: flex;
           flex-wrap: wrap;
           grid-column: info-start / info-end;
-          row-gap: 0.5em;
+          row-gap: var(--cc-spacing-3, 0.5em);
         }
 
         @supports (grid-template-columns: subgrid) {
@@ -476,12 +476,12 @@ export class CcTokenApiList extends LitElement {
         .api-token-card__info-list__item {
           display: flex;
           flex-wrap: wrap;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         :host([w-lt-730]) .api-token-card__info-list__item {
           display: grid;
-          row-gap: 0.5em;
+          row-gap: var(--cc-spacing-3, 0.5em);
         }
 
         @supports (grid-template-columns: subgrid) {
@@ -499,14 +499,14 @@ export class CcTokenApiList extends LitElement {
 
           align-items: center;
           display: flex;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .api-token-card__info-list__item dd {
           align-items: center;
           display: flex;
           flex-wrap: wrap;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .api-token-card cc-button {
@@ -518,7 +518,7 @@ export class CcTokenApiList extends LitElement {
 
         .api-token-card__actions__update {
           grid-column: actions-start / actions-end;
-          padding: 0.2em;
+          padding: var(--cc-spacing-1, 0.25em);
         }
 
         .api-token-card__actions__update__span {
@@ -527,7 +527,7 @@ export class CcTokenApiList extends LitElement {
           border-radius: var(--cc-border-radius-default, 0.25em);
           color: var(--cc-color-text-weak, #404040);
           display: flex;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .api-token-card__actions__update--disabled {

--- a/src/components/cc-token-api-list/cc-token-api-list.js
+++ b/src/components/cc-token-api-list/cc-token-api-list.js
@@ -393,7 +393,7 @@ export class CcTokenApiList extends LitElement {
         .api-token-card {
           align-items: center;
           border: solid 1px var(--cc-color-border-neutral-weak, #e6e6e6);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           display: grid;
           gap: var(--cc-spacing-3, 0.5em);
           grid-template-columns: [card-start info-start] 1fr [info-end actions-start] max-content [actions-end card-end];
@@ -524,7 +524,7 @@ export class CcTokenApiList extends LitElement {
         .api-token-card__actions__update__span {
           align-items: center;
           align-self: flex-end;
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           color: var(--cc-color-text-weak, #404040);
           display: flex;
           gap: var(--cc-spacing-3, 0.5em);

--- a/src/components/cc-token-api-update-form/cc-token-api-update-form.js
+++ b/src/components/cc-token-api-update-form/cc-token-api-update-form.js
@@ -233,7 +233,7 @@ export class CcTokenApiUpdateForm extends LitElement {
         }
 
         .form__actions__link-container__link:focus-visible {
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           outline: var(--cc-focus-outline);
           outline-offset: var(--cc-focus-outline-offset, 2px);
         }

--- a/src/components/cc-token-api-update-form/cc-token-api-update-form.js
+++ b/src/components/cc-token-api-update-form/cc-token-api-update-form.js
@@ -176,18 +176,18 @@ export class CcTokenApiUpdateForm extends LitElement {
 
         /* FIXME: not great when viewport is reduced + should be handled by the cc-block component itself */
         cc-block {
-          padding-top: 2em;
+          padding-top: var(--cc-spacing-8, 2em);
         }
 
         /* FIXME: not great when viewport is reduced + should be handled by the cc-block component itself */
         cc-block > [slot='content'] {
-          padding-bottom: 2em;
-          padding-inline: 3em;
+          padding-bottom: var(--cc-spacing-8, 2em);
+          padding-inline: var(--cc-spacing-10, 3em);
         }
 
         /* FIXME: not great when viewport is reduced + should be handled by the cc-block component itself */
         [slot='header-title'] {
-          padding-inline: 1.5em;
+          padding-inline: var(--cc-spacing-7, 1.5em);
         }
 
         .intro {
@@ -195,21 +195,21 @@ export class CcTokenApiUpdateForm extends LitElement {
         }
 
         .content-wrapper {
-          margin-top: 1em;
+          margin-top: var(--cc-spacing-5, 1em);
         }
 
         .form {
           display: grid;
-          gap: 1.5em;
+          gap: var(--cc-spacing-7, 1.5em);
         }
 
         .form__actions {
           align-items: center;
           display: flex;
           flex-wrap: wrap;
-          gap: 1.5em;
+          gap: var(--cc-spacing-7, 1.5em);
           justify-content: flex-end;
-          margin-top: 1em;
+          margin-top: var(--cc-spacing-5, 1em);
         }
 
         .form__actions__submit-button {
@@ -227,8 +227,8 @@ export class CcTokenApiUpdateForm extends LitElement {
           color: var(--cc-color-text-weak);
           cursor: pointer;
           display: flex;
-          gap: 0.5em;
-          padding: 0.25em 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
+          padding: 0.25em var(--cc-spacing-3, 0.5em);
           text-decoration: none;
         }
 

--- a/src/components/cc-token-oauth-list/cc-token-oauth-list.js
+++ b/src/components/cc-token-oauth-list/cc-token-oauth-list.js
@@ -205,7 +205,7 @@ export class CcTokenOauthList extends LitElement {
           color: var(--cc-color-text-primary-highlight, blue);
           display: flex;
           flex-direction: row;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         /* Reset default margins and paddings */
@@ -227,7 +227,7 @@ export class CcTokenOauthList extends LitElement {
         .empty {
           border: 1px solid var(--cc-color-border-neutral-weak);
           font-weight: bold;
-          padding: 1em;
+          padding: var(--cc-spacing-5, 1em);
           text-align: center;
         }
 
@@ -238,12 +238,12 @@ export class CcTokenOauthList extends LitElement {
         }
 
         .oauth-token-list-wrapper {
-          margin-top: 2.5em;
+          margin-top: var(--cc-spacing-9, 2.5em);
         }
 
         .oauth-token-list-wrapper__list {
           display: grid;
-          gap: 1.5em;
+          gap: var(--cc-spacing-7, 1.5em);
         }
 
         @supports (grid-template-columns: subgrid) {
@@ -262,7 +262,7 @@ export class CcTokenOauthList extends LitElement {
           border-radius: var(--cc-border-radius-default, 0.25em);
           display: grid;
           grid-template-columns: [card-start info-start] 1fr [info-end actions-start] auto [actions-end card-end];
-          padding: 1em;
+          padding: var(--cc-spacing-5, 1em);
         }
 
         :host([w-lt-730]) .oauth-token-card {
@@ -285,19 +285,19 @@ export class CcTokenOauthList extends LitElement {
           --cc-icon-size: 1.2em;
 
           align-items: center;
-          column-gap: 1em;
+          column-gap: var(--cc-spacing-5, 1em);
           display: flex;
           flex-wrap: wrap;
           grid-column: info-start / info-end;
-          margin-bottom: 1em;
-          row-gap: 0.5em;
+          margin-bottom: var(--cc-spacing-5, 1em);
+          row-gap: var(--cc-spacing-3, 0.5em);
         }
 
         .oauth-token-card__header__logo-name {
           align-items: center;
           display: flex;
           font-weight: bold;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .oauth-token-card__header__logo-name cc-img {
@@ -310,13 +310,13 @@ export class CcTokenOauthList extends LitElement {
 
         .oauth-token-card__info-list {
           display: flex;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
           grid-column: info-start / info-end;
         }
 
         :host([w-lt-730]) .oauth-token-card__info-list {
           display: grid;
-          row-gap: 0.5em;
+          row-gap: var(--cc-spacing-3, 0.5em);
         }
 
         @supports (grid-template-columns: subgrid) {
@@ -327,14 +327,14 @@ export class CcTokenOauthList extends LitElement {
           }
 
           :host([w-lt-730]) .oauth-token-card__info-list {
-            row-gap: 0.5em;
+            row-gap: var(--cc-spacing-3, 0.5em);
           }
         }
 
         .oauth-token-card__info-list__item {
           display: flex;
           flex-wrap: wrap;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         :host([w-lt-995]) .oauth-token-card__info-list__item {
@@ -361,7 +361,7 @@ export class CcTokenOauthList extends LitElement {
 
           align-items: center;
           display: flex;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           line-height: var(--line-height);
         }
 
@@ -369,7 +369,7 @@ export class CcTokenOauthList extends LitElement {
           align-items: center;
           display: flex;
           flex-wrap: wrap;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .oauth-token-card cc-button {

--- a/src/components/cc-token-oauth-list/cc-token-oauth-list.js
+++ b/src/components/cc-token-oauth-list/cc-token-oauth-list.js
@@ -259,7 +259,7 @@ export class CcTokenOauthList extends LitElement {
         .oauth-token-card {
           align-items: center;
           border: solid 1px var(--cc-color-border-neutral-weak, #e6e6e6);
-          border-radius: var(--cc-border-radius-small, 0.25em);
+          border-radius: var(--cc-border-radius-medium, 0.375em);
           display: grid;
           grid-template-columns: [card-start info-start] 1fr [info-end actions-start] auto [actions-end card-end];
           padding: var(--cc-spacing-5, 1em);

--- a/src/components/cc-token-oauth-list/cc-token-oauth-list.js
+++ b/src/components/cc-token-oauth-list/cc-token-oauth-list.js
@@ -259,7 +259,7 @@ export class CcTokenOauthList extends LitElement {
         .oauth-token-card {
           align-items: center;
           border: solid 1px var(--cc-color-border-neutral-weak, #e6e6e6);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           display: grid;
           grid-template-columns: [card-start info-start] 1fr [info-end actions-start] auto [actions-end card-end];
           padding: var(--cc-spacing-5, 1em);
@@ -301,7 +301,7 @@ export class CcTokenOauthList extends LitElement {
         }
 
         .oauth-token-card__header__logo-name cc-img {
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           height: 2em;
           width: 2em;
 

--- a/src/components/cc-token-session-list/cc-token-session-list.js
+++ b/src/components/cc-token-session-list/cc-token-session-list.js
@@ -307,7 +307,7 @@ export class CcTokenSessionList extends LitElement {
       .session-token-card {
         align-items: center;
         border: solid 1px var(--cc-color-border-neutral-weak, #e6e6e6);
-        border-radius: var(--cc-border-radius-small, 0.25em);
+        border-radius: var(--cc-border-radius-medium, 0.375em);
         column-gap: var(--cc-spacing-5, 1em);
         display: grid;
         grid-template-columns: [card-start info-start] 1fr [info-end actions-start] max-content [actions-end card-end];

--- a/src/components/cc-token-session-list/cc-token-session-list.js
+++ b/src/components/cc-token-session-list/cc-token-session-list.js
@@ -307,7 +307,7 @@ export class CcTokenSessionList extends LitElement {
       .session-token-card {
         align-items: center;
         border: solid 1px var(--cc-color-border-neutral-weak, #e6e6e6);
-        border-radius: var(--cc-border-radius-default, 0.25em);
+        border-radius: var(--cc-border-radius-small, 0.25em);
         column-gap: var(--cc-spacing-5, 1em);
         display: grid;
         grid-template-columns: [card-start info-start] 1fr [info-end actions-start] max-content [actions-end card-end];

--- a/src/components/cc-token-session-list/cc-token-session-list.js
+++ b/src/components/cc-token-session-list/cc-token-session-list.js
@@ -282,12 +282,12 @@ export class CcTokenSessionList extends LitElement {
       }
 
       .session-tokens-wrapper {
-        margin-top: 2.5em;
+        margin-top: var(--cc-spacing-9, 2.5em);
       }
 
       .session-tokens-wrapper__list {
         display: grid;
-        gap: 1.5em;
+        gap: var(--cc-spacing-7, 1.5em);
       }
 
       @supports (grid-template-columns: subgrid) {
@@ -308,10 +308,10 @@ export class CcTokenSessionList extends LitElement {
         align-items: center;
         border: solid 1px var(--cc-color-border-neutral-weak, #e6e6e6);
         border-radius: var(--cc-border-radius-default, 0.25em);
-        column-gap: 1em;
+        column-gap: var(--cc-spacing-5, 1em);
         display: grid;
         grid-template-columns: [card-start info-start] 1fr [info-end actions-start] max-content [actions-end card-end];
-        padding: 1em;
+        padding: var(--cc-spacing-5, 1em);
       }
 
       @supports (grid-template-columns: subgrid) {
@@ -326,12 +326,12 @@ export class CcTokenSessionList extends LitElement {
         --cc-icon-size: 1.2em;
 
         align-items: center;
-        column-gap: 1em;
+        column-gap: var(--cc-spacing-5, 1em);
         display: flex;
         flex-wrap: wrap;
         grid-column: info-start / info-end;
-        margin-bottom: 1em;
-        row-gap: 0.5em;
+        margin-bottom: var(--cc-spacing-5, 1em);
+        row-gap: var(--cc-spacing-3, 0.5em);
       }
 
       .session-token-card__header__current-session {
@@ -339,18 +339,18 @@ export class CcTokenSessionList extends LitElement {
         color: var(--cc-color-text-success, #318051);
         display: flex;
         font-weight: bold;
-        gap: 0.5em;
+        gap: var(--cc-spacing-3, 0.5em);
       }
 
       .session-token-card__info-list {
         display: flex;
-        gap: 1em;
+        gap: var(--cc-spacing-5, 1em);
         grid-column: info-start / info-end;
       }
 
       :host([w-lt-730]) .session-token-card__info-list {
         display: grid;
-        row-gap: 0.5em;
+        row-gap: var(--cc-spacing-3, 0.5em);
       }
 
       @supports (grid-template-columns: subgrid) {
@@ -361,14 +361,14 @@ export class CcTokenSessionList extends LitElement {
         }
 
         :host([w-lt-730]) .session-token-card__info-list {
-          row-gap: 0.5em;
+          row-gap: var(--cc-spacing-3, 0.5em);
         }
       }
 
       .session-token-card__info-list__item {
         display: flex;
         flex-wrap: wrap;
-        gap: 0.5em;
+        gap: var(--cc-spacing-3, 0.5em);
       }
 
       @supports (grid-template-columns: subgrid) {
@@ -395,7 +395,7 @@ export class CcTokenSessionList extends LitElement {
 
         align-items: center;
         display: flex;
-        gap: 0.5em;
+        gap: var(--cc-spacing-3, 0.5em);
         line-height: var(--line-height);
       }
 
@@ -403,7 +403,7 @@ export class CcTokenSessionList extends LitElement {
         align-items: center;
         display: flex;
         flex-wrap: wrap;
-        gap: 0.5em;
+        gap: var(--cc-spacing-3, 0.5em);
       }
 
       .session-token-card cc-button {

--- a/src/components/cc-visual-tests-report-entry/cc-visual-tests-report-entry.js
+++ b/src/components/cc-visual-tests-report-entry/cc-visual-tests-report-entry.js
@@ -205,7 +205,7 @@ export class CcVisualTestsReportEntry extends LitElement {
 
         .viewbox {
           border: solid 1px var(--cc-color-border-neutral, #bfbfbf);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           box-sizing: border-box;
           overflow: hidden;
         }
@@ -227,13 +227,13 @@ export class CcVisualTestsReportEntry extends LitElement {
 
         .diff {
           border: solid 1px var(--cc-color-border-neutral, #bfbfbf);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           display: block;
         }
 
         cc-img-comparator {
           border: solid 1px var(--cc-color-border-neutral, #bfbfbf);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           margin-inline: auto;
           max-width: max-content;
           overflow: hidden;

--- a/src/components/cc-visual-tests-report-entry/cc-visual-tests-report-entry.js
+++ b/src/components/cc-visual-tests-report-entry/cc-visual-tests-report-entry.js
@@ -151,7 +151,7 @@ export class CcVisualTestsReportEntry extends LitElement {
       css`
         :host {
           display: grid;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
           grid-template-rows: max-content 1fr;
         }
 
@@ -162,7 +162,7 @@ export class CcVisualTestsReportEntry extends LitElement {
         .header {
           display: flex;
           flex-wrap: wrap;
-          gap: 2em;
+          gap: var(--cc-spacing-8, 2em);
           justify-content: space-between;
         }
 
@@ -176,31 +176,31 @@ export class CcVisualTestsReportEntry extends LitElement {
         }
 
         .main-heading cc-icon {
-          margin-left: 0.5em;
+          margin-left: var(--cc-spacing-3, 0.5em);
         }
 
         .main-heading span {
           align-items: center;
           display: flex;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .heading {
           background-color: var(--cc-color-bg-neutral, #f5f5f5);
           font-weight: bold;
-          padding: 1em;
+          padding: var(--cc-spacing-5, 1em);
         }
 
         .three-way-diff {
           display: grid;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         .three-way-diff__side-by-side {
           box-sizing: border-box;
           display: flex;
           flex-wrap: wrap;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         .viewbox {

--- a/src/components/cc-visual-tests-report-menu/cc-visual-tests-report-menu.js
+++ b/src/components/cc-visual-tests-report-menu/cc-visual-tests-report-menu.js
@@ -312,7 +312,7 @@ export class CcVisualTestsReportMenu extends LitElement {
         .quick-nav a {
           align-items: center;
           background-color: var(--cc-color-bg-primary, #3569aa);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           color: var(--cc-color-text-inverted, #fff);
           display: flex;
           flex: 1 1 0;
@@ -350,7 +350,7 @@ export class CcVisualTestsReportMenu extends LitElement {
         .viewport-browser-list__item__link:focus-visible,
         .btn:focus-visible,
         .quick-nav a:focus {
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           outline: var(--cc-focus-outline, #3569aa solid 2px);
           outline-offset: var(--cc-focus-outline-offset, 2px);
         }
@@ -409,7 +409,7 @@ export class CcVisualTestsReportMenu extends LitElement {
 
         .viewport-browser-list__item__link--active {
           background-color: var(--cc-color-bg-primary, #3569aa);
-          border-radius: var(--cc-border-radius-small, 0.15em);
+          border-radius: var(--cc-border-radius-xs, 0.15em);
           color: var(--cc-color-text-inverted, #fff);
         }
       `,

--- a/src/components/cc-visual-tests-report-menu/cc-visual-tests-report-menu.js
+++ b/src/components/cc-visual-tests-report-menu/cc-visual-tests-report-menu.js
@@ -301,8 +301,8 @@ export class CcVisualTestsReportMenu extends LitElement {
 
         .quick-nav {
           display: flex;
-          gap: 1em;
-          padding: 1em;
+          gap: var(--cc-spacing-5, 1em);
+          padding: var(--cc-spacing-5, 1em);
         }
 
         .quick-nav li {
@@ -316,9 +316,9 @@ export class CcVisualTestsReportMenu extends LitElement {
           color: var(--cc-color-text-inverted, #fff);
           display: flex;
           flex: 1 1 0;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           justify-content: space-between;
-          padding: 0.5em 1em;
+          padding: var(--cc-spacing-3, 0.5em) var(--cc-spacing-5, 1em);
           text-decoration: none;
         }
 
@@ -329,8 +329,8 @@ export class CcVisualTestsReportMenu extends LitElement {
           cursor: pointer;
           display: flex;
           font: inherit;
-          gap: 0.5em;
-          padding: 0.2em 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
+          padding: var(--cc-spacing-1, 0.25em) var(--cc-spacing-3, 0.5em);
           text-align: start;
           width: 100%;
         }
@@ -358,7 +358,7 @@ export class CcVisualTestsReportMenu extends LitElement {
         .component-list {
           display: flex;
           flex-direction: column;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           overflow-x: hidden;
           overflow-y: auto;
           scrollbar-gutter: stable;
@@ -369,19 +369,19 @@ export class CcVisualTestsReportMenu extends LitElement {
         }
 
         .component-list__item__btn {
-          padding: 1em;
+          padding: var(--cc-spacing-5, 1em);
         }
 
         .story-list:not([hidden]) {
           background-color: var(--cc-color-bg-neutral-alt, #e7e7e7);
           display: flex;
           flex-direction: column;
-          padding: 0.5em 1em;
+          padding: var(--cc-spacing-3, 0.5em) var(--cc-spacing-5, 1em);
           transition: background-color 0.3s;
         }
 
         .story-list__item {
-          padding: 0.5em;
+          padding: var(--cc-spacing-3, 0.5em);
         }
 
         .story-list__item:not(:last-of-type) {
@@ -389,7 +389,7 @@ export class CcVisualTestsReportMenu extends LitElement {
         }
 
         .viewport-browser-list {
-          padding: 0.5em 0;
+          padding: var(--cc-spacing-3, 0.5em) 0;
         }
 
         .viewport-browser-list__item__link {
@@ -397,8 +397,8 @@ export class CcVisualTestsReportMenu extends LitElement {
           color: var(--cc-color-text-default, #262626);
           display: flex;
           justify-content: space-between;
-          margin-left: 1.5em;
-          padding: 0.5em;
+          margin-left: var(--cc-spacing-7, 1.5em);
+          padding: var(--cc-spacing-3, 0.5em);
           text-decoration: none;
           text-transform: capitalize;
         }

--- a/src/components/cc-visual-tests-report/cc-visual-tests-report.js
+++ b/src/components/cc-visual-tests-report/cc-visual-tests-report.js
@@ -330,7 +330,7 @@ export class CcVisualTestsReport extends LitElement {
 
         .storybook-link {
           align-items: center;
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           display: flex;
           text-decoration: none;
         }
@@ -390,7 +390,7 @@ export class CcVisualTestsReport extends LitElement {
         .metadata-list__item {
           background-color: var(--color);
           border: var(--bdw) solid var(--color);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           display: flex;
           flex-wrap: wrap;
           font-size: 0.8em;
@@ -415,7 +415,7 @@ export class CcVisualTestsReport extends LitElement {
         .metadata-list__item__value {
           align-items: center;
           background-color: var(--cc-color-bg-default, #fff);
-          border-radius: var(--cc-border-radius-small, 0.15em);
+          border-radius: var(--cc-border-radius-xs, 0.15em);
           color: var(--cc-color-text-primary, #3569aa);
           display: flex;
           flex-wrap: wrap;

--- a/src/components/cc-visual-tests-report/cc-visual-tests-report.js
+++ b/src/components/cc-visual-tests-report/cc-visual-tests-report.js
@@ -296,7 +296,7 @@ export class CcVisualTestsReport extends LitElement {
         .skip-link {
           background-color: #fff;
           left: -9999px;
-          padding: 1em;
+          padding: var(--cc-spacing-5, 1em);
           position: absolute;
           top: 1em;
         }
@@ -319,9 +319,9 @@ export class CcVisualTestsReport extends LitElement {
         header {
           align-items: center;
           display: grid;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
           grid-template-columns: 2em 1fr;
-          padding: 1.5em 1em;
+          padding: var(--cc-spacing-7, 1.5em) var(--cc-spacing-5, 1em);
         }
 
         h1 {
@@ -360,11 +360,11 @@ export class CcVisualTestsReport extends LitElement {
         main {
           box-sizing: border-box;
           display: grid;
-          gap: 2em;
+          gap: var(--cc-spacing-8, 2em);
           grid-template-rows: max-content 1fr;
           overflow-x: hidden;
           overflow-y: auto;
-          padding: 1em;
+          padding: var(--cc-spacing-5, 1em);
           scrollbar-gutter: stable;
         }
 
@@ -374,17 +374,17 @@ export class CcVisualTestsReport extends LitElement {
 
         cc-block-section {
           margin-top: 0;
-          padding-top: 1em;
+          padding-top: var(--cc-spacing-5, 1em);
         }
 
         .metadata-list {
           --bdw: 2px;
           --color: var(--cc-color-bg-primary, #3569aa);
-          --padding: 0.5em;
+          --padding: var(--cc-spacing-3, 0.5em);
 
           display: flex;
           flex-wrap: wrap;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         .metadata-list__item {
@@ -409,7 +409,7 @@ export class CcVisualTestsReport extends LitElement {
           align-items: center;
           color: var(--cc-color-text-inverted, #fff);
           display: flex;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .metadata-list__item__value {
@@ -419,13 +419,13 @@ export class CcVisualTestsReport extends LitElement {
           color: var(--cc-color-text-primary, #3569aa);
           display: flex;
           flex-wrap: wrap;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         cc-datetime-relative {
           border-inline-start: solid 2px var(--cc-color-bg-primary, #3569aa);
           font-style: italic;
-          padding-left: 0.5em;
+          padding-left: var(--cc-spacing-3, 0.5em);
         }
       `,
     ];

--- a/src/components/cc-warning-payment/cc-warning-payment.js
+++ b/src/components/cc-warning-payment/cc-warning-payment.js
@@ -128,12 +128,12 @@ export class CcWarningPayment extends LitElement {
         }
 
         ul {
-          margin: 0.5em 0 0 1.5em;
+          margin: var(--cc-spacing-3, 0.5em) 0 0 var(--cc-spacing-7, 1.5em);
           padding: 0;
         }
 
         li {
-          margin-top: 0.5em;
+          margin-top: var(--cc-spacing-3, 0.5em);
         }
       `,
     ];

--- a/src/components/cc-web-features-tracker/cc-web-features-tracker.js
+++ b/src/components/cc-web-features-tracker/cc-web-features-tracker.js
@@ -414,7 +414,7 @@ export class CcWebFeaturesTracker extends LitElement {
           background: none;
           background-color: var(--cc-color-bg-default, #fff);
           border: solid 1px var(--cc-color-border-neutral);
-          border-radius: var(--cc-border-radius-small, 0.15em);
+          border-radius: var(--cc-border-radius-xs, 0.15em);
           box-shadow: 0 0 0 0 rgb(255 255 255 / 0%);
           cursor: pointer;
           display: flex;

--- a/src/components/cc-web-features-tracker/cc-web-features-tracker.js
+++ b/src/components/cc-web-features-tracker/cc-web-features-tracker.js
@@ -327,7 +327,7 @@ export class CcWebFeaturesTracker extends LitElement {
       css`
         :host {
           display: grid;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         * {
@@ -349,14 +349,14 @@ export class CcWebFeaturesTracker extends LitElement {
 
         .empty {
           border: solid 1px var(--cc-color-border-neutral-weak, #eee);
-          padding: 2em;
+          padding: var(--cc-spacing-8, 2em);
           text-align: center;
         }
 
         .table-controls {
           display: flex;
           flex-wrap: wrap;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
         }
 
         table {
@@ -377,7 +377,7 @@ export class CcWebFeaturesTracker extends LitElement {
         td {
           align-items: center;
           display: grid;
-          padding: 0.5em 1em;
+          padding: var(--cc-spacing-3, 0.5em) var(--cc-spacing-5, 1em);
           text-align: left;
         }
 
@@ -385,7 +385,7 @@ export class CcWebFeaturesTracker extends LitElement {
           background-color: var(--cc-color-bg-neutral-alt, #eee);
           color: var(--cc-color-text-strongest);
           min-width: max-content;
-          padding: 1em;
+          padding: var(--cc-spacing-5, 1em);
         }
 
         tbody th,
@@ -401,13 +401,13 @@ export class CcWebFeaturesTracker extends LitElement {
 
         .feature-name-th {
           display: grid;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .feature-name-th__btn-and-name {
           align-items: center;
           display: flex;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .feature-name-th__btn-and-name__btn {
@@ -418,7 +418,7 @@ export class CcWebFeaturesTracker extends LitElement {
           box-shadow: 0 0 0 0 rgb(255 255 255 / 0%);
           cursor: pointer;
           display: flex;
-          padding: 0.3em;
+          padding: var(--cc-spacing-1, 0.25em);
           transition: box-shadow 75ms ease-in-out;
         }
 
@@ -448,7 +448,7 @@ export class CcWebFeaturesTracker extends LitElement {
         .current-status {
           align-items: center;
           display: grid;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
           text-align: center;
         }
 
@@ -476,7 +476,7 @@ export class CcWebFeaturesTracker extends LitElement {
 
           align-items: center;
           display: flex;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .notice-icon {
@@ -488,13 +488,13 @@ export class CcWebFeaturesTracker extends LitElement {
         }
 
         .row--detailed .browser-support {
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .browser-support p {
           align-items: center;
           display: flex;
-          gap: 0.5em;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .browser-support cc-icon {

--- a/src/components/cc-zone-input/cc-zone-input.js
+++ b/src/components/cc-zone-input/cc-zone-input.js
@@ -349,7 +349,7 @@ export class CcZoneInput extends LitElement {
         }
 
         .zone-list {
-          margin: 0.5em;
+          margin: var(--cc-spacing-3, 0.5em);
         }
 
         .zone-list:not(:hover):focus-within {
@@ -375,7 +375,7 @@ export class CcZoneInput extends LitElement {
           border: 0;
           box-sizing: border-box;
           display: block;
-          margin: -0.5em;
+          margin: calc(var(--cc-spacing-3, 0.5em) * -1);
           outline: none;
         }
 
@@ -384,7 +384,7 @@ export class CcZoneInput extends LitElement {
           border-radius: var(--cc-border-radius-default, 0.25em);
           box-sizing: border-box;
           display: block;
-          padding: 0.5em;
+          padding: var(--cc-spacing-3, 0.5em);
         }
 
         label {

--- a/src/components/cc-zone-input/cc-zone-input.js
+++ b/src/components/cc-zone-input/cc-zone-input.js
@@ -314,7 +314,7 @@ export class CcZoneInput extends LitElement {
         .wrapper {
           background-color: var(--cc-color-bg-default, #fff);
           border: 1px solid var(--cc-color-border-neutral, #aaa);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-medium, 0.375em);
           box-sizing: border-box;
           display: flex;
           height: 100%;
@@ -353,7 +353,7 @@ export class CcZoneInput extends LitElement {
         }
 
         .zone-list:not(:hover):focus-within {
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-medium, 0.375em);
           outline: var(--cc-focus-outline, #000 solid 2px);
           outline-offset: var(--cc-focus-outline-offset, 2px);
         }
@@ -381,7 +381,7 @@ export class CcZoneInput extends LitElement {
 
         .label {
           border: 2px solid var(--bd-color, transparent);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-medium, 0.375em);
           box-sizing: border-box;
           display: block;
           padding: var(--cc-spacing-3, 0.5em);

--- a/src/components/cc-zone-picker/cc-zone-picker.js
+++ b/src/components/cc-zone-picker/cc-zone-picker.js
@@ -193,7 +193,7 @@ export class CcZonePicker extends CcFormControlElement {
         /* region legend layout & style */
         legend {
           display: flex;
-          gap: 0.25em;
+          gap: var(--cc-spacing-1, 0.25em);
           margin-block-end: var(--cc-form-label-gap, 0.35em);
         }
 
@@ -214,7 +214,7 @@ export class CcZonePicker extends CcFormControlElement {
         /* region global layout */
         .form-controls {
           display: grid;
-          gap: 1em;
+          gap: var(--cc-spacing-5, 1em);
           grid-template-columns: repeat(auto-fill, minmax(12.5em, 1fr));
           margin-inline-start: var(--cc-form-controls-indent, 34px);
         }
@@ -225,12 +225,12 @@ export class CcZonePicker extends CcFormControlElement {
           color: var(--cc-color-text-primary-strongest);
           font-family: var(--cc-ff-form-legend), inherit;
           font-size: 1.15em;
-          margin-block-end: 0.25em;
+          margin-block-end: var(--cc-spacing-1, 0.25em);
           margin-inline-start: var(--cc-form-controls-indent, 34px);
         }
 
         .form-controls + .zone-section-title {
-          margin-block-start: 1em;
+          margin-block-start: var(--cc-spacing-5, 1em);
         }
         /* endregion */
 
@@ -250,14 +250,14 @@ export class CcZonePicker extends CcFormControlElement {
         }
 
         cc-picker-option [slot='body'] {
-          margin-inline: -0.25em;
+          margin-inline: calc(var(--cc-spacing-1, 0.25em) * -1);
         }
 
         cc-picker-option .option-body--code {
           color: var(--cc-color-text-weak);
           font-size: 0.875em;
           line-height: 1.125;
-          padding-inline-start: 0.125em;
+          padding-inline-start: var(--cc-spacing-0, 0.125em);
         }
 
         cc-picker-option .option-body--name {
@@ -266,9 +266,9 @@ export class CcZonePicker extends CcFormControlElement {
         }
 
         cc-picker-option [slot='footer'] {
-          column-gap: 0.5em;
+          column-gap: var(--cc-spacing-3, 0.5em);
           display: flex;
-          padding-block: 0.75em;
+          padding-block: var(--cc-spacing-4, 0.75em);
         }
 
         cc-picker-option [slot='footer'] > cc-img {

--- a/src/components/cc-zone-picker/cc-zone-picker.js
+++ b/src/components/cc-zone-picker/cc-zone-picker.js
@@ -236,7 +236,7 @@ export class CcZonePicker extends CcFormControlElement {
 
         /* region cc-picker-option */
         input[type='radio']:focus-visible + label cc-picker-option {
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           outline: var(--cc-focus-outline, #000 solid 2px);
           outline-offset: var(--cc-focus-outline-offset, 2px);
         }

--- a/src/components/cc-zone-picker/cc-zone-picker.js
+++ b/src/components/cc-zone-picker/cc-zone-picker.js
@@ -236,7 +236,7 @@ export class CcZonePicker extends CcFormControlElement {
 
         /* region cc-picker-option */
         input[type='radio']:focus-visible + label cc-picker-option {
-          border-radius: var(--cc-border-radius-small, 0.25em);
+          border-radius: var(--cc-border-radius-medium, 0.375em);
           outline: var(--cc-focus-outline, #000 solid 2px);
           outline-offset: var(--cc-focus-outline-offset, 2px);
         }

--- a/src/components/cc-zone/cc-zone.js
+++ b/src/components/cc-zone/cc-zone.js
@@ -169,7 +169,7 @@ export class CcZone extends LitElement {
         }
 
         .flag {
-          border-radius: var(--cc-border-radius-small, 0.15em);
+          border-radius: var(--cc-border-radius-xs, 0.15em);
           box-shadow: 0 0 3px rgb(0 0 0 / 40%);
           display: inline-block;
           height: var(--lh);
@@ -238,7 +238,7 @@ export class CcZone extends LitElement {
         .tag {
           background-color: var(--cc-zone-tag-bgcolor, var(--cc-color-bg-soft, #eee));
           border: 1px solid var(--cc-zone-tag-bdcolor, transparent);
-          border-radius: var(--cc-border-radius-default, 0.25em);
+          border-radius: var(--cc-border-radius-small, 0.25em);
           box-sizing: border-box;
           color: var(--cc-zone-tag-textcolor, var(--cc-color-text-default, #000));
           display: flex;

--- a/src/components/cc-zone/cc-zone.js
+++ b/src/components/cc-zone/cc-zone.js
@@ -173,13 +173,13 @@ export class CcZone extends LitElement {
           box-shadow: 0 0 3px rgb(0 0 0 / 40%);
           display: inline-block;
           height: var(--lh);
-          margin-right: 1em;
+          margin-right: var(--cc-spacing-5, 1em);
           width: 2em;
         }
 
         :host([mode='small']) .flag,
         :host([mode='small-infra']) .flag {
-          margin-right: 0.5em;
+          margin-right: var(--cc-spacing-3, 0.5em);
           width: 1.33em;
         }
 
@@ -218,7 +218,7 @@ export class CcZone extends LitElement {
           --cc-img-fit: contain;
 
           height: var(--lh);
-          margin-left: 0.5em;
+          margin-left: var(--cc-spacing-3, 0.5em);
           width: 4em;
         }
 
@@ -231,8 +231,8 @@ export class CcZone extends LitElement {
         .tag-list {
           display: flex;
           flex-wrap: wrap;
-          gap: 0.5em;
-          margin-top: 0.1em;
+          gap: var(--cc-spacing-3, 0.5em);
+          margin-top: var(--cc-spacing-0, 0.125em);
         }
 
         .tag {

--- a/src/controllers/resize-controller.stories.js
+++ b/src/controllers/resize-controller.stories.js
@@ -265,14 +265,14 @@ export const defaultStory = () => {
         width: 1em;
         height: 1em;
         margin-right: 0.5em;
-        border-radius: var(--cc-border-radius-default, 0.25em);
+        border-radius: var(--cc-border-radius-small, 0.25em);
         vertical-align: middle;
       }
 
       pre {
         padding: 1em;
         background-color: #f5f5f5;
-        border-radius: var(--cc-border-radius-default, 0.25em);
+        border-radius: var(--cc-border-radius-small, 0.25em);
       }
 
       demo-resize-controller {

--- a/src/styles/default-theme.css
+++ b/src/styles/default-theme.css
@@ -313,6 +313,20 @@
   --cc-border-radius-small: 0.15em;
   /*endregion */
 
+  /*region spacing */
+  --cc-spacing-0: 0.125em;
+  --cc-spacing-1: 0.25em;
+  --cc-spacing-2: 0.35em;
+  --cc-spacing-3: 0.5em;
+  --cc-spacing-4: 0.75em;
+  --cc-spacing-5: 1em;
+  --cc-spacing-6: 1.25em;
+  --cc-spacing-7: 1.5em;
+  --cc-spacing-8: 2em;
+  --cc-spacing-9: 2.5em;
+  --cc-spacing-10: 3em;
+  /*endregion */
+
   /*region Miscellaneous*/
   /**
    * An opacity value that passes a11y tests.

--- a/src/styles/default-theme.css
+++ b/src/styles/default-theme.css
@@ -350,6 +350,12 @@
 
   /* space between a label and its control when inline */
   --cc-form-label-gap-inline: 0.75em;
+
+  /* font style of the "required" mention displayed next to a form control label */
+  --cc-form-required-font-style: italic;
+
+  /* text transform of the "required" mention displayed next to a form control label */
+  --cc-form-required-text-transform: lowercase;
   /*endregion*/
 
   /*region blur*/

--- a/src/styles/default-theme.css
+++ b/src/styles/default-theme.css
@@ -309,8 +309,10 @@
 
   /*region border radius */
   /* Beware: since we use `em` units, the computed value of these tokens might vary even within the same component */
-  --cc-border-radius-default: 0.25em;
-  --cc-border-radius-small: 0.15em;
+  --cc-border-radius-xs: 0.15em;
+  --cc-border-radius-small: 0.25em;
+  --cc-border-radius-medium: 0.375em;
+  --cc-border-radius-large: 0.5em;
   /*endregion */
 
   /*region spacing */

--- a/src/styles/info-tiles.js
+++ b/src/styles/info-tiles.js
@@ -10,7 +10,7 @@ export const tileStyles = css`
     padding: 1em;
     border: 1px solid var(--cc-color-border-neutral, #aaa);
     background-color: var(--cc-color-bg-default, #fff);
-    border-radius: var(--cc-border-radius-small, 0.25em);
+    border-radius: var(--cc-border-radius-medium, 0.375em);
     grid-gap: 1em;
     grid-template-rows: auto 1fr;
   }

--- a/src/styles/info-tiles.js
+++ b/src/styles/info-tiles.js
@@ -10,7 +10,7 @@ export const tileStyles = css`
     padding: 1em;
     border: 1px solid var(--cc-color-border-neutral, #aaa);
     background-color: var(--cc-color-bg-default, #fff);
-    border-radius: var(--cc-border-radius-default, 0.25em);
+    border-radius: var(--cc-border-radius-small, 0.25em);
     grid-gap: 1em;
     grid-template-rows: auto 1fr;
   }
@@ -50,7 +50,7 @@ export const instanceDetailsStyles = css`
     padding: 0 var(--bubble-r);
     border: 1px solid var(--cc-color-border-neutral, #aaa);
     background-color: var(--cc-color-bg-neutral);
-    border-radius: var(--cc-border-radius-default, 0.25em);
+    border-radius: var(--cc-border-radius-small, 0.25em);
     font-weight: bold;
     line-height: 1.65em;
     text-align: center;


### PR DESCRIPTION
Fixes #1765 

# What does this PR do?
  
This PR introduces and reworks several design tokens to better structure our design system:

- Spacing scale: adds a --cc-spacing-0 → --cc-spacing-10 scale (from 0.125em to 3em) and migrates all padding, margin and gap hardcoded values across components to use these tokens,
- Border radius scale: reworks the border-radius tokens into a consistent xs / small / medium / large scale (--cc-border-radius-default is removed in favour of --cc-border-radius-small),
- Required mention text style: adds --cc-form-required-font-style (italic) and --cc-form-required-text-transform (lowercase) tokens to control how the "required" mention is displayed next to a form control label,
- Updates the design-tokens.md documentation accordingly.

> ⚠️ Breaking change: --cc-border-radius-default no longer exists, its value (0.25em) is now carried by --cc-border-radius-small.

# How to review?

- Check the commits (one per token group: spacing, border-radius, required mention),
- Check the design tokens documentation,
- Check the <cc-input-text> [preview](https://clever-components-preview.cellar-c2.services.clever-cloud.com/refactor/design-token/index.html) for the required mention,