### PR TITLE
fix(cc-network-group-member-list): prevent all members from being shown as deleted

### DIFF
--- a/demo-smart/index.html
+++ b/demo-smart/index.html
@@ -976,7 +976,7 @@
                 <button
                   class="ctx-btn"
                   title="ownerId, networkGroupId"
-                  data-context='{"ownerId":"orga_3547a882-d464-4c34-8168-add4b3e0c135","networkGroupId":"ng_b8711640-f593-437f-bae1-5b5e52d0fcc1","resourceId":"app_7c6f466c-3314-4753-9e06-f87912f6b856","networkGroupDashboardUrlPattern":"/organisations/orga_3547a882-d464-4c34-8168-add4b3e0c135/network-groups/:id","appOverviewUrlPattern":"/organisations/orga_3547a882-d464-4c34-8168-add4b3e0c135/applications/:id","addonDashboardUrlPattern":"/organisations/orga_3547a882-d464-4c34-8168-add4b3e0c135/addons/:id","networkGroupCreationUrl":"/network-groups/new"}'
+                  data-context='{"ownerId":"orga_3547a882-d464-4c34-8168-add4b3e0c135","networkGroupId":"ng_c7b2b3f8-ff6f-4ea2-8940-a13bd7d857cf","resourceId":"app_7c6f466c-3314-4753-9e06-f87912f6b856","networkGroupDashboardUrlPattern":"/organisations/orga_3547a882-d464-4c34-8168-add4b3e0c135/network-groups/:id","appOverviewUrlPattern":"/organisations/orga_3547a882-d464-4c34-8168-add4b3e0c135/applications/:id","addonDashboardUrlPattern":"/organisations/orga_3547a882-d464-4c34-8168-add4b3e0c135/addons/:id","networkGroupCreationUrl":"/network-groups/new"}'
                 >
                   <span class="ctx-label">Network Group</span>
                   <span class="ctx-subtitle">ownerId, networkGroupId</span>

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "typecheck:stats": "node tasks/typechecking-stats.js"
   },
   "dependencies": {
-    "@clevercloud/client": "^12.5.0",
+    "@clevercloud/client": "^12.5.1",
     "@lit-labs/motion": "^1.0.7",
     "@lit-labs/virtualizer": "^2.0.14",
     "@shoelace-style/shoelace": "^2.18.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@clevercloud/client':
-        specifier: ^12.5.0
-        version: 12.5.0(eventsource@4.1.0)
+        specifier: ^12.5.1
+        version: 12.5.1(eventsource@4.1.0)
       '@lit-labs/motion':
         specifier: ^1.0.7
         version: 1.1.0
@@ -59,22 +59,22 @@ importers:
         version: 3.1049.0
       '@babel/core':
         specifier: ^7.14.0
-        version: 7.29.0(supports-color@8.1.1)
+        version: 7.29.0
       '@babel/eslint-parser':
         specifier: ^7.28.0
-        version: 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))
+        version: 7.28.6(@babel/core@7.29.0)(eslint@9.39.4(jiti@1.21.7))
       '@babel/plugin-syntax-import-attributes':
         specifier: ^7.27.1
-        version: 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))
+        version: 7.28.6(@babel/core@7.29.0)
       '@babel/preset-react':
         specifier: ^7.13.13
-        version: 7.28.5(@babel/core@7.29.0(supports-color@8.1.1))
+        version: 7.28.5(@babel/core@7.29.0)
       '@bundled-es-modules/chai':
         specifier: ^4.2.2
         version: 4.3.7
       '@clevercloud/eslint-config':
         specifier: ^1.0.1
-        version: 1.1.0(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        version: 1.1.0(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
       '@clevercloud/reglage':
         specifier: ^0.0.6
         version: 0.0.6(zod@4.4.3)
@@ -89,7 +89,7 @@ importers:
         version: 0.9.9
       '@eslint/compat':
         specifier: ^1.2.0
-        version: 1.4.1(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))
+        version: 1.4.1(eslint@9.39.4(jiti@1.21.7))
       '@eslint/js':
         specifier: ^9.8.0
         version: 9.39.4
@@ -98,13 +98,13 @@ importers:
         version: 7.1.1
       '@html-eslint/eslint-plugin':
         specifier: ^0.41.0
-        version: 0.41.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))
+        version: 0.41.0(eslint@9.39.4(jiti@1.21.7))
       '@octokit/rest':
         specifier: ^22.0.0
         version: 22.0.1
       '@open-wc/dev-server-hmr':
         specifier: ^0.1.3
-        version: 0.1.4(supports-color@8.1.1)
+        version: 0.1.4
       '@open-wc/testing':
         specifier: ^4.0.0
         version: 4.0.0
@@ -170,7 +170,7 @@ importers:
         version: 1.0.8(rollup@2.80.0)
       '@web/test-runner':
         specifier: ^0.19.0
-        version: 0.19.0(supports-color@8.1.1)
+        version: 0.19.0
       '@web/test-runner-chrome':
         specifier: ^0.17.0
         version: 0.17.0
@@ -188,7 +188,7 @@ importers:
         version: 0.10.0
       babel-loader:
         specifier: ^8.2.2
-        version: 8.4.1(@babel/core@7.29.0(supports-color@8.1.1))(webpack@5.106.2(clean-css@5.3.3)(esbuild@0.12.29)(postcss@8.5.15))
+        version: 8.4.1(@babel/core@7.29.0)(webpack@5.106.2(clean-css@5.3.3)(esbuild@0.12.29)(postcss@8.5.15))
       babel-plugin-inline-svg:
         specifier: ^1.2.0
         version: 1.2.0
@@ -215,25 +215,25 @@ importers:
         version: 0.12.29
       eslint:
         specifier: ^9.32.0
-        version: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
+        version: 9.39.4(jiti@1.21.7)
       eslint-config-prettier:
         specifier: ^9.1.0
-        version: 9.1.2(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))
+        version: 9.1.2(eslint@9.39.4(jiti@1.21.7))
       eslint-plugin-import:
         specifier: ^2.31.0
-        version: 2.32.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))
+        version: 2.32.0(eslint@9.39.4(jiti@1.21.7))
       eslint-plugin-lit:
         specifier: ^1.15.0
-        version: 1.15.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))
+        version: 1.15.0(eslint@9.39.4(jiti@1.21.7))
       eslint-plugin-lit-a11y:
         specifier: ^4.1.4
-        version: 4.1.4(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))
+        version: 4.1.4(eslint@9.39.4(jiti@1.21.7))
       eslint-plugin-n:
         specifier: ^17.13.0
-        version: 17.24.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(typescript@5.9.3)
+        version: 17.24.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
       eslint-plugin-wc:
         specifier: ^2.2.0
-        version: 2.2.1(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))
+        version: 2.2.1(eslint@9.39.4(jiti@1.21.7))
       github-markdown-css:
         specifier: ^4.0.0
         version: 4.0.0
@@ -302,7 +302,7 @@ importers:
         version: 2.80.0
       rollup-plugin-babel:
         specifier: ^4.4.0
-        version: 4.4.0(@babel/core@7.29.0(supports-color@8.1.1))(rollup@2.80.0)
+        version: 4.4.0(@babel/core@7.29.0)(rollup@2.80.0)
       rollup-plugin-clear:
         specifier: ^2.0.7
         version: 2.0.7
@@ -323,19 +323,19 @@ importers:
         version: 10.4.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@testing-library/dom@10.4.1)(@types/react@19.2.14)(prettier@3.8.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       stylelint:
         specifier: ^16.10.0
-        version: 16.26.1(supports-color@8.1.1)(typescript@5.9.3)
+        version: 16.26.1(typescript@5.9.3)
       stylelint-config-standard:
         specifier: ^36.0.0
-        version: 36.0.1(stylelint@16.26.1(supports-color@8.1.1)(typescript@5.9.3))
+        version: 36.0.1(stylelint@16.26.1(typescript@5.9.3))
       stylelint-no-unsupported-browser-features:
         specifier: ^8.0.4
-        version: 8.1.1(stylelint@16.26.1(supports-color@8.1.1)(typescript@5.9.3))
+        version: 8.1.1(stylelint@16.26.1(typescript@5.9.3))
       stylelint-order:
         specifier: ^6.0.4
-        version: 6.0.4(stylelint@16.26.1(supports-color@8.1.1)(typescript@5.9.3))
+        version: 6.0.4(stylelint@16.26.1(typescript@5.9.3))
       superagent:
         specifier: ^6.1.0
-        version: 6.1.0(supports-color@8.1.1)
+        version: 6.1.0
       svgo:
         specifier: ^1.3.2
         version: 1.3.2
@@ -693,8 +693,8 @@ packages:
   '@cacheable/utils@2.4.1':
     resolution: {integrity: sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA==}
 
-  '@clevercloud/client@12.5.0':
-    resolution: {integrity: sha512-bk+xM7+bgDHafgwqOlx9FnWGgpYeVF1cFeYGVlFb+xeP8CMuw2YtbJDCMobEP1TiYyNWKQ9q3dpWxaSKQHMNxw==}
+  '@clevercloud/client@12.5.1':
+    resolution: {integrity: sha512-5D2olTLIvVZNHAFbFamy/xRG9AOHcalF0G6ZcA8vPiS/RZqCsUN7lUnZ9k5YRqjiBI/q3I0OHXtZRbVQ0k4FOw==}
     engines: {node: '>=22'}
     peerDependencies:
       eventsource: ^4.0.0
@@ -3752,7 +3752,7 @@ packages:
   git-raw-commits@2.0.11:
     resolution: {integrity: sha512-VnctFhw+xfj8Va1xtfEqCUD2XDrbAPSJx+hSrE5K7fGdjZruW7XV+QOrN7LF/RJyvspRiD2I0asWsxFp0ya26A==}
     engines: {node: '>=10'}
-    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   github-markdown-css@4.0.0:
@@ -6467,16 +6467,16 @@ snapshots:
 
   '@babel/compat-data@7.29.3': {}
 
-  '@babel/core@7.29.0(supports-color@8.1.1)':
+  '@babel/core@7.29.0':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
       '@babel/helper-compilation-targets': 7.28.6
-      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
       '@babel/helpers': 7.29.2
       '@babel/parser': 7.29.3
       '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0(supports-color@8.1.1)
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
@@ -6487,11 +6487,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/eslint-parser@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))':
+  '@babel/eslint-parser@7.28.6(@babel/core@7.29.0)(eslint@9.39.4(jiti@1.21.7))':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/core': 7.29.0
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
-      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
+      eslint: 9.39.4(jiti@1.21.7)
       eslint-visitor-keys: 2.1.0
       semver: 6.3.1
 
@@ -6515,15 +6515,15 @@ snapshots:
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-create-class-features-plugin@7.29.3(@babel/core@7.29.0(supports-color@8.1.1))':
+  '@babel/helper-create-class-features-plugin@7.29.3(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/core': 7.29.0
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/helper-replace-supers': 7.28.6(@babel/core@7.29.0)
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/traverse': 7.29.0(supports-color@8.1.1)
+      '@babel/traverse': 7.29.0
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -6532,24 +6532,24 @@ snapshots:
 
   '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
-      '@babel/traverse': 7.29.0(supports-color@8.1.1)
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-imports@7.28.6':
     dependencies:
-      '@babel/traverse': 7.29.0(supports-color@8.1.1)
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))':
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/core': 7.29.0
       '@babel/helper-module-imports': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0(supports-color@8.1.1)
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -6559,18 +6559,18 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.28.6': {}
 
-  '@babel/helper-replace-supers@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))':
+  '@babel/helper-replace-supers@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/core': 7.29.0
       '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/traverse': 7.29.0(supports-color@8.1.1)
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     dependencies:
-      '@babel/traverse': 7.29.0(supports-color@8.1.1)
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -6590,102 +6590,102 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
-  '@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.29.0(supports-color@8.1.1))':
+  '@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@8.1.1)
-      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/core': 7.29.0
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0(supports-color@8.1.1))':
+  '@babel/plugin-proposal-decorators@7.29.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@8.1.1)
-      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/core': 7.29.0
+      '@babel/helper-create-class-features-plugin': 7.29.3(@babel/core@7.29.0)
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-syntax-decorators': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-decorators': 7.28.6(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.0(supports-color@8.1.1))':
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-decorators@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))':
+  '@babel/plugin-syntax-decorators@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.29.0(supports-color@8.1.1))':
+  '@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-import-assertions@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))':
+  '@babel/plugin-syntax-import-assertions@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))':
+  '@babel/plugin-syntax-import-attributes@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))':
+  '@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.0(supports-color@8.1.1))':
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-react-display-name@7.28.0(@babel/core@7.29.0(supports-color@8.1.1))':
+  '@babel/plugin-transform-react-display-name@7.28.0(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/plugin-transform-react-jsx-development@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
+  '@babel/plugin-transform-react-jsx-development@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@8.1.1)
-      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0(supports-color@8.1.1))':
+  '@babel/plugin-transform-react-jsx@7.28.6(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/core': 7.29.0
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-module-imports': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/plugin-transform-react-pure-annotations@7.27.1(@babel/core@7.29.0(supports-color@8.1.1))':
+  '@babel/plugin-transform-react-pure-annotations@7.27.1(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/core': 7.29.0
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-plugin-utils': 7.28.6
 
-  '@babel/preset-react@7.28.5(@babel/core@7.29.0(supports-color@8.1.1))':
+  '@babel/preset-react@7.28.5(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-option': 7.27.1
-      '@babel/plugin-transform-react-display-name': 7.28.0(@babel/core@7.29.0(supports-color@8.1.1))
-      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))
-      '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
-      '@babel/plugin-transform-react-pure-annotations': 7.27.1(@babel/core@7.29.0(supports-color@8.1.1))
+      '@babel/plugin-transform-react-display-name': 7.28.0(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-development': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-pure-annotations': 7.27.1(@babel/core@7.29.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/register@7.29.3(@babel/core@7.29.0(supports-color@8.1.1))':
+  '@babel/register@7.29.3(@babel/core@7.29.0)':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/core': 7.29.0
       clone-deep: 4.0.1
       find-cache-dir: 2.1.0
       make-dir: 2.1.0
@@ -6700,7 +6700,7 @@ snapshots:
       '@babel/parser': 7.29.3
       '@babel/types': 7.29.0
 
-  '@babel/traverse@7.29.0(supports-color@8.1.1)':
+  '@babel/traverse@7.29.0':
     dependencies:
       '@babel/code-frame': 7.29.0
       '@babel/generator': 7.29.1
@@ -6731,18 +6731,18 @@ snapshots:
       hashery: 1.5.1
       keyv: 5.6.0
 
-  '@clevercloud/client@12.5.0(eventsource@4.1.0)':
+  '@clevercloud/client@12.5.1(eventsource@4.1.0)':
     dependencies:
       component-emitter: 1.3.1
       eventsource: 4.1.0
       fetch-event-stream: 0.1.6
 
-  '@clevercloud/eslint-config@1.1.0(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)':
+  '@clevercloud/eslint-config@1.1.0(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:
       '@eslint/js': 9.39.4
-      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
-      eslint-plugin-import-x: 4.16.2(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(supports-color@8.1.1)
-      eslint-plugin-n: 17.24.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@1.21.7)
+      eslint-plugin-import-x: 4.16.2(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@1.21.7))
+      eslint-plugin-n: 17.24.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
     transitivePeerDependencies:
       - '@typescript-eslint/utils'
       - eslint-import-resolver-node
@@ -7011,20 +7011,20 @@ snapshots:
   '@esbuild/win32-x64@0.27.7':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@1.21.7))':
     dependencies:
-      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
+      eslint: 9.39.4(jiti@1.21.7)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/compat@1.4.1(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))':
+  '@eslint/compat@1.4.1(eslint@9.39.4(jiti@1.21.7))':
     dependencies:
       '@eslint/core': 0.17.0
     optionalDependencies:
-      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
+      eslint: 9.39.4(jiti@1.21.7)
 
-  '@eslint/config-array@0.21.2(supports-color@8.1.1)':
+  '@eslint/config-array@0.21.2':
     dependencies:
       '@eslint/object-schema': 2.1.7
       debug: 4.4.3(supports-color@8.1.1)
@@ -7044,7 +7044,7 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.3.5(supports-color@8.1.1)':
+  '@eslint/eslintrc@3.3.5':
     dependencies:
       ajv: 6.15.0
       debug: 4.4.3(supports-color@8.1.1)
@@ -7093,13 +7093,13 @@ snapshots:
 
   '@hapi/bourne@3.0.0': {}
 
-  '@html-eslint/eslint-plugin@0.41.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))':
+  '@html-eslint/eslint-plugin@0.41.0(eslint@9.39.4(jiti@1.21.7))':
     dependencies:
       '@eslint/plugin-kit': 0.3.5
       '@html-eslint/parser': 0.41.0
       '@html-eslint/template-parser': 0.41.0
       '@html-eslint/template-syntax-parser': 0.41.0
-      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
+      eslint: 9.39.4(jiti@1.21.7)
 
   '@html-eslint/parser@0.41.0':
     dependencies:
@@ -7284,13 +7284,13 @@ snapshots:
 
   '@open-wc/dedupe-mixin@2.0.1': {}
 
-  '@open-wc/dev-server-hmr@0.1.4(supports-color@8.1.1)':
+  '@open-wc/dev-server-hmr@0.1.4':
     dependencies:
-      '@babel/core': 7.29.0(supports-color@8.1.1)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.0(supports-color@8.1.1))
-      '@babel/plugin-syntax-import-assertions': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.0(supports-color@8.1.1))
-      '@web/dev-server-core': 0.4.1(supports-color@8.1.1)
+      '@babel/core': 7.29.0
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.0)
+      '@babel/plugin-syntax-import-assertions': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.0)
+      '@web/dev-server-core': 0.4.1
       '@web/dev-server-hmr': 0.1.12
       picomatch: 2.3.2
     transitivePeerDependencies:
@@ -8155,9 +8155,9 @@ snapshots:
       get-stream: 6.0.1
       is-stream: 2.0.1
       isbinaryfile: 4.0.10
-      koa: 2.16.4(supports-color@8.1.1)
+      koa: 2.16.4
       koa-etag: 4.0.0
-      koa-send: 5.0.1(supports-color@8.1.1)
+      koa-send: 5.0.1
       koa-static: 5.0.0
       lru-cache: 6.0.0
       mime-types: 2.1.35
@@ -8169,7 +8169,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@web/dev-server-core@0.4.1(supports-color@8.1.1)':
+  '@web/dev-server-core@0.4.1':
     dependencies:
       '@types/koa': 2.15.1
       '@types/ws': 7.4.7
@@ -8180,9 +8180,9 @@ snapshots:
       get-stream: 6.0.1
       is-stream: 2.0.1
       isbinaryfile: 5.0.7
-      koa: 2.16.4(supports-color@8.1.1)
+      koa: 2.16.4
       koa-etag: 4.0.0
-      koa-send: 5.0.1(supports-color@8.1.1)
+      koa-send: 5.0.1
       koa-static: 5.0.0
       lru-cache: 6.0.0
       mime-types: 2.1.35
@@ -8205,9 +8205,9 @@ snapshots:
       get-stream: 6.0.1
       is-stream: 2.0.1
       isbinaryfile: 5.0.7
-      koa: 2.16.4(supports-color@8.1.1)
+      koa: 2.16.4
       koa-etag: 4.0.0
-      koa-send: 5.0.1(supports-color@8.1.1)
+      koa-send: 5.0.1
       koa-static: 5.0.0
       lru-cache: 8.0.5
       mime-types: 2.1.35
@@ -8221,7 +8221,7 @@ snapshots:
 
   '@web/dev-server-hmr@0.1.12':
     dependencies:
-      '@web/dev-server-core': 0.4.1(supports-color@8.1.1)
+      '@web/dev-server-core': 0.4.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -8268,7 +8268,7 @@ snapshots:
       internal-ip: 6.2.0
       nanocolors: 0.2.13
       open: 8.4.2
-      portfinder: 1.0.38(supports-color@8.1.1)
+      portfinder: 1.0.38
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -8394,7 +8394,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@web/test-runner@0.19.0(supports-color@8.1.1)':
+  '@web/test-runner@0.19.0':
     dependencies:
       '@web/browser-logs': 0.4.1
       '@web/config-loader': 0.3.3
@@ -8410,7 +8410,7 @@ snapshots:
       diff: 5.2.2
       globby: 11.1.0
       nanocolors: 0.2.13
-      portfinder: 1.0.38(supports-color@8.1.1)
+      portfinder: 1.0.38
       source-map: 0.7.6
     transitivePeerDependencies:
       - bare-abort-controller
@@ -8705,9 +8705,9 @@ snapshots:
       esutils: 2.0.3
       js-tokens: 3.0.2
 
-  babel-loader@8.4.1(@babel/core@7.29.0(supports-color@8.1.1))(webpack@5.106.2(clean-css@5.3.3)(esbuild@0.12.29)(postcss@8.5.15)):
+  babel-loader@8.4.1(@babel/core@7.29.0)(webpack@5.106.2(clean-css@5.3.3)(esbuild@0.12.29)(postcss@8.5.15)):
     dependencies:
-      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/core': 7.29.0
       find-cache-dir: 3.3.2
       loader-utils: 2.0.4
       make-dir: 3.1.0
@@ -9598,14 +9598,14 @@ snapshots:
     optionalDependencies:
       source-map: 0.6.1
 
-  eslint-compat-utils@0.5.1(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1)):
+  eslint-compat-utils@0.5.1(eslint@9.39.4(jiti@1.21.7)):
     dependencies:
-      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
+      eslint: 9.39.4(jiti@1.21.7)
       semver: 7.8.0
 
-  eslint-config-prettier@9.1.2(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1)):
+  eslint-config-prettier@9.1.2(eslint@9.39.4(jiti@1.21.7)):
     dependencies:
-      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
+      eslint: 9.39.4(jiti@1.21.7)
 
   eslint-import-context@0.1.9(unrs-resolver@1.12.2):
     dependencies:
@@ -9622,29 +9622,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@1.21.7)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
+      eslint: 9.39.4(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.10
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-es-x@7.8.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1)):
+  eslint-plugin-es-x@7.8.0(eslint@9.39.4(jiti@1.21.7)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@1.21.7))
       '@eslint-community/regexpp': 4.12.2
-      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
-      eslint-compat-utils: 0.5.1(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))
+      eslint: 9.39.4(jiti@1.21.7)
+      eslint-compat-utils: 0.5.1(eslint@9.39.4(jiti@1.21.7))
 
-  eslint-plugin-import-x@4.16.2(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(supports-color@8.1.1):
+  eslint-plugin-import-x@4.16.2(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@1.21.7)):
     dependencies:
       '@package-json/types': 0.0.12
       '@typescript-eslint/types': 8.59.4
       comment-parser: 1.4.6
       debug: 4.4.3(supports-color@8.1.1)
-      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
+      eslint: 9.39.4(jiti@1.21.7)
       eslint-import-context: 0.1.9(unrs-resolver@1.12.2)
       is-glob: 4.0.3
       minimatch: 10.2.5
@@ -9656,7 +9656,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1)):
+  eslint-plugin-import@2.32.0(eslint@9.39.4(jiti@1.21.7)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -9665,9 +9665,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
+      eslint: 9.39.4(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.10)(eslint@9.39.4(jiti@1.21.7))
       hasown: 2.0.3
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -9683,34 +9683,34 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-lit-a11y@4.1.4(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1)):
+  eslint-plugin-lit-a11y@4.1.4(eslint@9.39.4(jiti@1.21.7)):
     dependencies:
       '@thepassle/axobject-query': 4.0.0
       aria-query: 5.3.2
       axe-core: 4.4.3
       dom5: 3.0.1
       emoji-regex: 10.6.0
-      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
-      eslint-plugin-lit: 1.15.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))
+      eslint: 9.39.4(jiti@1.21.7)
+      eslint-plugin-lit: 1.15.0(eslint@9.39.4(jiti@1.21.7))
       eslint-rule-extender: 0.0.1
       language-tags: 1.0.9
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 6.0.1
       requireindex: 1.2.0
 
-  eslint-plugin-lit@1.15.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1)):
+  eslint-plugin-lit@1.15.0(eslint@9.39.4(jiti@1.21.7)):
     dependencies:
-      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
+      eslint: 9.39.4(jiti@1.21.7)
       parse5: 6.0.1
       parse5-htmlparser2-tree-adapter: 6.0.1
       requireindex: 1.2.0
 
-  eslint-plugin-n@17.24.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))(typescript@5.9.3):
+  eslint-plugin-n@17.24.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@1.21.7))
       enhanced-resolve: 5.21.5
-      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
-      eslint-plugin-es-x: 7.8.0(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))
+      eslint: 9.39.4(jiti@1.21.7)
+      eslint-plugin-es-x: 7.8.0(eslint@9.39.4(jiti@1.21.7))
       get-tsconfig: 4.14.0
       globals: 15.15.0
       globrex: 0.1.2
@@ -9720,9 +9720,9 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  eslint-plugin-wc@2.2.1(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1)):
+  eslint-plugin-wc@2.2.1(eslint@9.39.4(jiti@1.21.7)):
     dependencies:
-      eslint: 9.39.4(jiti@1.21.7)(supports-color@8.1.1)
+      eslint: 9.39.4(jiti@1.21.7)
       is-valid-element-name: 1.0.0
       js-levenshtein-esm: 1.2.0
 
@@ -9744,14 +9744,14 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1):
+  eslint@9.39.4(jiti@1.21.7):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@1.21.7)(supports-color@8.1.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@1.21.7))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.21.2(supports-color@8.1.1)
+      '@eslint/config-array': 0.21.2
       '@eslint/config-helpers': 0.4.2
       '@eslint/core': 0.17.0
-      '@eslint/eslintrc': 3.3.5(supports-color@8.1.1)
+      '@eslint/eslintrc': 3.3.5
       '@eslint/js': 9.39.4
       '@eslint/plugin-kit': 0.4.1
       '@humanfs/node': 0.16.8
@@ -10287,12 +10287,12 @@ snapshots:
 
   i18n-extract@0.6.7:
     dependencies:
-      '@babel/core': 7.29.0(supports-color@8.1.1)
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.29.0(supports-color@8.1.1))
-      '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0(supports-color@8.1.1))
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.29.0(supports-color@8.1.1))
-      '@babel/register': 7.29.3(@babel/core@7.29.0(supports-color@8.1.1))
-      '@babel/traverse': 7.29.0(supports-color@8.1.1)
+      '@babel/core': 7.29.0
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.29.0)
+      '@babel/plugin-proposal-decorators': 7.29.0(@babel/core@7.29.0)
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.29.0)
+      '@babel/register': 7.29.3(@babel/core@7.29.0)
+      '@babel/traverse': 7.29.0
       gettext-parser: 3.1.1
       glob: 7.2.3
     transitivePeerDependencies:
@@ -10653,7 +10653,7 @@ snapshots:
     dependencies:
       etag: 1.8.1
 
-  koa-send@5.0.1(supports-color@8.1.1):
+  koa-send@5.0.1:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
       http-errors: 1.8.1
@@ -10664,11 +10664,11 @@ snapshots:
   koa-static@5.0.0:
     dependencies:
       debug: 3.2.7
-      koa-send: 5.0.1(supports-color@8.1.1)
+      koa-send: 5.0.1
     transitivePeerDependencies:
       - supports-color
 
-  koa@2.16.4(supports-color@8.1.1):
+  koa@2.16.4:
     dependencies:
       accepts: 1.3.8
       cache-content-type: 1.0.1
@@ -11456,7 +11456,7 @@ snapshots:
 
   pngjs@7.0.0: {}
 
-  portfinder@1.0.38(supports-color@8.1.1):
+  portfinder@1.0.38:
     dependencies:
       async: 3.2.6
       debug: 4.4.3(supports-color@8.1.1)
@@ -11736,9 +11736,9 @@ snapshots:
     dependencies:
       glob: 7.2.3
 
-  rollup-plugin-babel@4.4.0(@babel/core@7.29.0(supports-color@8.1.1))(rollup@2.80.0):
+  rollup-plugin-babel@4.4.0(@babel/core@7.29.0)(rollup@2.80.0):
     dependencies:
-      '@babel/core': 7.29.0(supports-color@8.1.1)
+      '@babel/core': 7.29.0
       '@babel/helper-module-imports': 7.28.6
       rollup: 2.80.0
       rollup-pluginutils: 2.8.2
@@ -12119,29 +12119,29 @@ snapshots:
 
   strnum@2.3.0: {}
 
-  stylelint-config-recommended@14.0.1(stylelint@16.26.1(supports-color@8.1.1)(typescript@5.9.3)):
+  stylelint-config-recommended@14.0.1(stylelint@16.26.1(typescript@5.9.3)):
     dependencies:
-      stylelint: 16.26.1(supports-color@8.1.1)(typescript@5.9.3)
+      stylelint: 16.26.1(typescript@5.9.3)
 
-  stylelint-config-standard@36.0.1(stylelint@16.26.1(supports-color@8.1.1)(typescript@5.9.3)):
+  stylelint-config-standard@36.0.1(stylelint@16.26.1(typescript@5.9.3)):
     dependencies:
-      stylelint: 16.26.1(supports-color@8.1.1)(typescript@5.9.3)
-      stylelint-config-recommended: 14.0.1(stylelint@16.26.1(supports-color@8.1.1)(typescript@5.9.3))
+      stylelint: 16.26.1(typescript@5.9.3)
+      stylelint-config-recommended: 14.0.1(stylelint@16.26.1(typescript@5.9.3))
 
-  stylelint-no-unsupported-browser-features@8.1.1(stylelint@16.26.1(supports-color@8.1.1)(typescript@5.9.3)):
+  stylelint-no-unsupported-browser-features@8.1.1(stylelint@16.26.1(typescript@5.9.3)):
     dependencies:
       browserslist: 4.28.2
       doiuse: 6.0.6
       postcss: 8.5.15
-      stylelint: 16.26.1(supports-color@8.1.1)(typescript@5.9.3)
+      stylelint: 16.26.1(typescript@5.9.3)
 
-  stylelint-order@6.0.4(stylelint@16.26.1(supports-color@8.1.1)(typescript@5.9.3)):
+  stylelint-order@6.0.4(stylelint@16.26.1(typescript@5.9.3)):
     dependencies:
       postcss: 8.5.15
       postcss-sorting: 8.0.2(postcss@8.5.15)
-      stylelint: 16.26.1(supports-color@8.1.1)(typescript@5.9.3)
+      stylelint: 16.26.1(typescript@5.9.3)
 
-  stylelint@16.26.1(supports-color@8.1.1)(typescript@5.9.3):
+  stylelint@16.26.1(typescript@5.9.3):
     dependencies:
       '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
       '@csstools/css-syntax-patches-for-csstree': 1.1.4(css-tree@3.2.1)
@@ -12186,7 +12186,7 @@ snapshots:
       - supports-color
       - typescript
 
-  superagent@6.1.0(supports-color@8.1.1):
+  superagent@6.1.0:
     dependencies:
       component-emitter: 1.3.1
       cookiejar: 2.1.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,9 @@ allowBuilds:
 
 minimumReleaseAge: 10080
 
+minimumReleaseAgeExclude:
+  - '@clevercloud/client'
+
 # Pin axe-core to the version used before the pnpm migration (the npm lockfile
 # had 4.4.3). Newer versions flag pre-existing color-contrast issues on skeleton
 # placeholders; addressing those is tracked separately as an a11y task.


### PR DESCRIPTION
## Context

The API used to return `member.kind` in uppercase but now returns it
lowercase.
This makes the component code crash and display all resources as deleted.

In this commit we upgrade the client that now noramilizes the
`member.kind` field.

## How to review?

- No reviewers necessary, already reviewed in the client.