### PR TITLE
fix(cc-domain-management): only treat real cleverapps.io domains as test domains

### DIFF
--- a/src/lib/domain.js
+++ b/src/lib/domain.js
@@ -77,7 +77,7 @@ export function getDomainUrl(hostname, pathPrefix, isWildcard, isHttpOnly) {
  * @return {boolean}
  */
 export function isTestDomain(hostname) {
-  return hostname.endsWith('cleverapps.io');
+  return hostname.endsWith('.cleverapps.io');
 }
 
 /**


### PR DESCRIPTION
## Context

`isTestDomain()` used a bare suffix check (`hostname.endsWith('cleverapps.io')`), so any hostname *ending* in `cleverapps.io` matched — including unrelated domains such as `mycleverapps.io` or `notcleverapps.io`.

These were wrongly flagged as test domains and pushed into testing-only / HTTP-only behavior in `cc-domain-management`.

## Proposal

Match on the `.cleverapps.io` label boundary instead:

```js
return hostname.endsWith('.cleverapps.io');
```

This keeps every real app hostname (always a subdomain, e.g. `app-xxx.cleverapps.io`) while rejecting look-alike domains.

### Design decisions

- No `=== 'cleverapps.io'` apex case: a bare apex is never received as an app hostname in practice, so the leading-dot check is enough.

## How to test

```js
isTestDomain('app.cleverapps.io')   // true
isTestDomain('sub.main.cleverapps.io') // true
isTestDomain('mycleverapps.io')     // false (was true)
isTestDomain('notcleverapps.io')    // false (was true)
isTestDomain('example.com')         // false
```