### PR TITLE
fix(cc-link): collapse inner whitespace in inferred title

### DIFF
--- a/src/components/cc-link/cc-link.js
+++ b/src/components/cc-link/cc-link.js
@@ -117,6 +117,7 @@ export class CcLink extends LitElement {
         return node.textContent;
       })
       .join('')
+      .replace(/\s+/g, ' ')
       .trim();
   }
 


### PR DESCRIPTION
Closes #1476

## Context

`cc-link` derives its `title` attribute from the slotted `textContent`. That text carries the HTML indentation (tabs, newlines, repeated spaces) sitting between words, so a multi-line link produced a title full of inner gaps. The existing `.trim()` only stripped the edges.

## Proposal

Collapse runs of whitespace to a single space (`.replace(/\s+/g, ' ')`) before trimming, so the inferred title stays clean regardless of how the slot markup is formatted.

## How to test

1. Storybook → `cc-link`, use a story whose slotted content spans multiple indented lines.
2. Inspect the rendered `<a>` `title` attribute → single-spaced, no leading/trailing/inner whitespace runs.