### PR TITLE
fix(cc-logs): scroll within logs box instead of whole page (access + addon runtime)

### DIFF
--- a/src/components/cc-logs-addon-runtime/cc-logs-addon-runtime.js
+++ b/src/components/cc-logs-addon-runtime/cc-logs-addon-runtime.js
@@ -285,6 +285,7 @@ export class CcLogsAddonRuntime extends LitElement {
         }
 
         .logs-wrapper {
+          min-height: 0;
           position: relative;
         }
 

--- a/src/components/cc-logs-app-access/cc-logs-app-access.js
+++ b/src/components/cc-logs-app-access/cc-logs-app-access.js
@@ -358,6 +358,7 @@ export class CcLogsAppAccess extends LitElement {
         }
 
         .logs-wrapper {
+          min-height: 0;
           position: relative;
         }
 


### PR DESCRIPTION
## Context

La barre de scroll apparaissait au niveau de la page entière au lieu de
l'encadré des logs, sur deux vues partageant le **même défaut de layout
latent** :

- `cc-logs-app-access` (access logs d'une app)
- `cc-logs-addon-runtime` (runtime logs d'un add-on)

Les vues `cc-logs-app-runtime` et `cc-logs-control` étaient épargnées —
elles contraignent déjà correctement la chaîne de hauteur.

- Pas une régression des composants ni de la console.
- Défaut présent depuis l'init de ces composants, resté inoffensif
  jusqu'à la migration du virtualizer.

## Proposal

Les `.logs-wrapper` de ces deux composants ne pouvaient pas rétrécir sous
la hauteur de leur contenu (rangée grid `minmax(auto, 1fr)` sans
`min-height: 0`). On aligne sur `cc-logs-app-runtime`.

```css
.logs-wrapper {
  min-height: 0; /* ← ajout */
  position: relative;
}
```

### Design decisions

La migration `@lit-labs/virtualizer` → `@tanstack/lit-virtual`
(`53703606`) a **exposé** le défaut : l'ancien virtualizer en mode
`?scroller` masquait la hauteur intrinsèque, le nouveau pose une hauteur
explicite (`getTotalSize()`) qui exige une chaîne de contraintes ferme en
amont pour rester bornée.

### Audit

Les 4 consommateurs de `<cc-logs>` ont été passés en revue :

| Composant | État |
|---|---|
| `cc-logs-app-access` | ❌ → corrigé |
| `cc-logs-addon-runtime` | ❌ → corrigé |
| `cc-logs-app-runtime` | ✅ sain (`min-height: 0`) |
| `cc-logs-control` | ✅ sain (`.center { min-height: 0 }`) |

## How to test

1. Ouvrir une vue access logs (app) et une vue runtime logs (add-on).
2. Charger assez de lignes pour dépasser la hauteur visible.
3. Vérifier : scroll dans l'encadré des logs, pas au niveau de la page.