### PR TITLE
fix(cc-logs): scroll within logs box instead of whole page (access + addon runtime)

### DIFF
--- a/src/components/cc-logs-addon-runtime/cc-logs-addon-runtime.js
+++ b/src/components/cc-logs-addon-runtime/cc-logs-addon-runtime.js
@@ -285,6 +285,7 @@ export class CcLogsAddonRuntime extends LitElement {
         }
 
         .logs-wrapper {
+          min-height: 0;
           position: relative;
         }
 

--- a/src/components/cc-logs-app-access/cc-logs-app-access.js
+++ b/src/components/cc-logs-app-access/cc-logs-app-access.js
@@ -358,6 +358,7 @@ export class CcLogsAppAccess extends LitElement {
         }
 
         .logs-wrapper {
+          min-height: 0;
           position: relative;
         }
 


### PR DESCRIPTION
## Context

The scrollbar showed up at the whole-page level instead of inside the logs box, on two views sharing the **same latent layout defect**:

- `cc-logs-app-access` (app access logs)
- `cc-logs-addon-runtime` (add-on runtime logs)

The `cc-logs-app-runtime` and `cc-logs-control` views were unaffected — they already constrain the height chain correctly.

- Not a regression of these components nor of the console.
- The defect has been present since these components were created and stayed harmless until the virtualizer migration.

## Proposal

The `.logs-wrapper` of both components could not shrink below the height of their content (grid row `minmax(auto, 1fr)` without `min-height: 0`). We align them with `cc-logs-app-runtime`.

```css
.logs-wrapper {
  min-height: 0; /* added */
  position: relative;
}
```

### Design decisions

The `@lit-labs/virtualizer` → `@tanstack/lit-virtual` migration (`53703606`) **exposed** the defect: the old virtualizer in `?scroller` mode hid the intrinsic height, while the new one sets an explicit height (`getTotalSize()`) that requires a firm constraint chain upstream to stay bounded.

### Audit

All 4 consumers of `<cc-logs>` were reviewed:

| Component | State |
|---|---|
| `cc-logs-app-access` | broken -> fixed |
| `cc-logs-addon-runtime` | broken -> fixed |
| `cc-logs-app-runtime` | OK (`min-height: 0`) |
| `cc-logs-control` | OK (`.center { min-height: 0 }`) |