### PR TITLE
Network Groups: specify `--org` flag in CLI examples

### DIFF
--- a/src/components/cc-network-group-list/cc-network-group-list.js
+++ b/src/components/cc-network-group-list/cc-network-group-list.js
@@ -47,6 +47,7 @@ import { CcNetworkGroupLinkEvent, CcNetworkGroupUnlinkEvent } from './cc-network
 export class CcNetworkGroupList extends LitElement {
   static get properties() {
     return {
+      ownerId: { type: String, attribute: 'owner-id' },
       resourceId: { type: String, attribute: 'resource-id' },
       state: { type: Object },
       _isUnlinkDialogOpen: { type: Boolean, state: true },
@@ -59,6 +60,9 @@ export class CcNetworkGroupList extends LitElement {
 
     /** @type {NetworkGroupListState} Sets the state of the component */
     this.state = { type: 'loading' };
+
+    /** @type {string} Sets the owner ID for CLI command documentation */
+    this.ownerId = '<OWNER_ID>';
 
     /** @type {string} Sets the resource ID for CLI command documentation */
     this.resourceId = '<RESOURCE_ID>';
@@ -201,23 +205,23 @@ export class CcNetworkGroupList extends LitElement {
             <dl>
               <dt>${i18n('cc-network-group-list.cli.content.list-command')}</dt>
               <dd>
-                <cc-code>clever ng</cc-code>
+                <cc-code>clever ng --org ${this.ownerId}</cc-code>
               </dd>
               <dt>${i18n('cc-network-group-list.cli.content.create-command')}</dt>
               <dd>
-                <cc-code>clever ng create &lt;NG_LABEL&gt;</cc-code>
+                <cc-code>clever ng create --org ${this.ownerId} &lt;NG_LABEL&gt;</cc-code>
               </dd>
               <dt>${i18n('cc-network-group-list.cli.content.delete-command')}</dt>
               <dd>
-                <cc-code>clever ng delete &lt;NG_ID&gt;</cc-code>
+                <cc-code>clever ng delete --org ${this.ownerId} &lt;NG_ID&gt;</cc-code>
               </dd>
               <dt>${i18n('cc-network-group-list.cli.content.link-command')}</dt>
               <dd>
-                <cc-code>clever ng link ${this.resourceId} &lt;NG_ID&gt;</cc-code>
+                <cc-code>clever ng link --org ${this.ownerId} ${this.resourceId} &lt;NG_ID&gt;</cc-code>
               </dd>
               <dt>${i18n('cc-network-group-list.cli.content.unlink-command')}</dt>
               <dd>
-                <cc-code>clever ng unlink ${this.resourceId} &lt;NG_ID&gt;</cc-code>
+                <cc-code>clever ng unlink --org ${this.ownerId} ${this.resourceId} &lt;NG_ID&gt;</cc-code>
               </dd>
             </dl>
           </div>

--- a/src/components/cc-network-group-list/cc-network-group-list.smart.js
+++ b/src/components/cc-network-group-list/cc-network-group-list.smart.js
@@ -49,6 +49,7 @@ defineSmartComponent({
     } = /** @type {Context} */ context;
     updateComponent('state', { type: 'loading' });
     updateComponent('resourceId', resourceId);
+    updateComponent('ownerId', ownerId);
 
     const ccApiClient = getCcApiClientWithOAuth(apiConfig);
     let resolvedResourceId;

--- a/src/components/cc-network-group-list/cc-network-group-list.stories.js
+++ b/src/components/cc-network-group-list/cc-network-group-list.stories.js
@@ -14,6 +14,7 @@ export default {
  */
 
 const RESOURCE_ID = 'app_XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX';
+const OWNER_ID = 'orga_XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX';
 
 const conf = {
   component: 'cc-network-group-list',
@@ -23,6 +24,7 @@ export const defaultStory = makeStory(conf, {
   /** @type {Partial<CcNetworkGroupList>[]} */
   items: [
     {
+      ownerId: OWNER_ID,
       resourceId: RESOURCE_ID,
       state: {
         type: 'loaded',
@@ -43,6 +45,7 @@ export const dataLoadedWithEmpty = makeStory(conf, {
   /** @type {Partial<CcNetworkGroupList>[]} */
   items: [
     {
+      ownerId: OWNER_ID,
       resourceId: RESOURCE_ID,
       state: {
         type: 'loaded',
@@ -63,6 +66,7 @@ export const dataLoadedWithNoNetworkGroupToLink = makeStory(conf, {
   /** @type {Partial<CcNetworkGroupList>[]} */
   items: [
     {
+      ownerId: OWNER_ID,
       resourceId: RESOURCE_ID,
       state: {
         type: 'loaded',
@@ -83,6 +87,7 @@ export const loading = makeStory(conf, {
   /** @type {Partial<CcNetworkGroupList>[]} */
   items: [
     {
+      ownerId: OWNER_ID,
       resourceId: RESOURCE_ID,
       state: { type: 'loading' },
     },
@@ -93,6 +98,7 @@ export const error = makeStory(conf, {
   /** @type {Partial<CcNetworkGroupList>[]} */
   items: [
     {
+      ownerId: OWNER_ID,
       resourceId: RESOURCE_ID,
       state: { type: 'error' },
     },
@@ -103,6 +109,7 @@ export const unsupported = makeStory(conf, {
   /** @type {Partial<CcNetworkGroupList>[]} */
   items: [
     {
+      ownerId: OWNER_ID,
       resourceId: RESOURCE_ID,
       state: {
         type: 'unsupported',
@@ -116,6 +123,7 @@ export const waitingWithLinking = makeStory(conf, {
   /** @type {Partial<CcNetworkGroupList>[]} */
   items: [
     {
+      ownerId: OWNER_ID,
       resourceId: RESOURCE_ID,
       state: {
         type: 'loaded',
@@ -136,6 +144,7 @@ export const waitingWithUnlinking = makeStory(conf, {
   /** @type {Partial<CcNetworkGroupList>[]} */
   items: [
     {
+      ownerId: OWNER_ID,
       resourceId: RESOURCE_ID,
       state: {
         type: 'loaded',

--- a/src/components/cc-network-group-member-list/cc-network-group-member-list.js
+++ b/src/components/cc-network-group-member-list/cc-network-group-member-list.js
@@ -230,13 +230,11 @@ export class CcNetworkGroupMemberList extends LitElement {
               </dd>
               <dt>${i18n('cc-network-group-member-list.cli.content.link-member-command')}</dt>
               <dd>
-                <cc-code>clever ng link --org ${this.ownerId} --ng ${this.networkGroupId} &lt;RESOURCE_ID&gt;</cc-code>
+                <cc-code>clever ng link --org ${this.ownerId} &lt;RESOURCE_ID&gt; ${this.networkGroupId}</cc-code>
               </dd>
               <dt>${i18n('cc-network-group-member-list.cli.content.unlink-member-command')}</dt>
               <dd>
-                <cc-code
-                  >clever ng unlink --org ${this.ownerId} --ng ${this.networkGroupId} &lt;RESOURCE_ID&gt;</cc-code
-                >
+                <cc-code>clever ng unlink --org ${this.ownerId} &lt;RESOURCE_ID&gt; ${this.networkGroupId}</cc-code>
               </dd>
             </dl>
           </div>

--- a/src/components/cc-network-group-member-list/cc-network-group-member-list.js
+++ b/src/components/cc-network-group-member-list/cc-network-group-member-list.js
@@ -43,6 +43,7 @@ export class CcNetworkGroupMemberList extends LitElement {
       linkFormState: { type: Object, attribute: 'link-form-state' },
       memberListState: { type: Object, attribute: 'member-list-state' },
       networkGroupId: { type: String, attribute: 'network-group-id' },
+      ownerId: { type: String, attribute: 'owner-id' },
       _memberIdToUnlink: { type: String, state: true },
       _showUnlinkDialog: { type: Boolean, state: true },
     };
@@ -59,6 +60,9 @@ export class CcNetworkGroupMemberList extends LitElement {
 
     /** @type {string} Sets the ID of the network group */
     this.networkGroupId = '<NETWORK_GROUP_ID>';
+
+    /** @type {string} Sets the owner ID for CLI command documentation */
+    this.ownerId = '<OWNER_ID>';
 
     /** @type {Ref<HTMLDivElement>} Ref to the empty text container */
     this._emptyTextRef = createRef();
@@ -222,15 +226,17 @@ export class CcNetworkGroupMemberList extends LitElement {
             <dl>
               <dt>${i18n('cc-network-group-member-list.cli.content.get-ng-command')}</dt>
               <dd>
-                <cc-code>clever ng get ${this.networkGroupId}</cc-code>
+                <cc-code>clever ng get --org ${this.ownerId} ${this.networkGroupId}</cc-code>
               </dd>
               <dt>${i18n('cc-network-group-member-list.cli.content.link-member-command')}</dt>
               <dd>
-                <cc-code>clever ng link --ng ${this.networkGroupId} &lt;RESOURCE_ID&gt;</cc-code>
+                <cc-code>clever ng link --org ${this.ownerId} --ng ${this.networkGroupId} &lt;RESOURCE_ID&gt;</cc-code>
               </dd>
               <dt>${i18n('cc-network-group-member-list.cli.content.unlink-member-command')}</dt>
               <dd>
-                <cc-code>clever ng unlink --ng ${this.networkGroupId} &lt;RESOURCE_ID&gt;</cc-code>
+                <cc-code
+                  >clever ng unlink --org ${this.ownerId} --ng ${this.networkGroupId} &lt;RESOURCE_ID&gt;</cc-code
+                >
               </dd>
             </dl>
           </div>

--- a/src/components/cc-network-group-member-list/cc-network-group-member-list.smart.js
+++ b/src/components/cc-network-group-member-list/cc-network-group-member-list.smart.js
@@ -54,6 +54,7 @@ defineSmartComponent({
     updateComponent('memberListState', { type: 'loading' });
     updateComponent('linkFormState', { type: 'loading' });
     updateComponent('networkGroupId', networkGroupId);
+    updateComponent('ownerId', ownerId);
     component.resetLinkForm();
 
     /** Fetches network group, applications, and addons, then updates both states. */

--- a/src/components/cc-network-group-member-list/cc-network-group-member-list.stories.js
+++ b/src/components/cc-network-group-member-list/cc-network-group-member-list.stories.js
@@ -23,12 +23,14 @@ const conf = {
 };
 
 const networkGroupId = 'ng_xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx';
+const ownerId = 'orga_XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX';
 
 export const defaultStory = makeStory(conf, {
   /** @type {Partial<CcNetworkGroupMemberList>[]} */
   items: [
     {
       networkGroupId,
+      ownerId,
       memberListState: {
         type: 'loaded',
         memberList: networkGroupMemberList,
@@ -46,6 +48,7 @@ export const loading = makeStory(conf, {
   items: [
     {
       networkGroupId,
+      ownerId,
       memberListState: { type: 'loading' },
       linkFormState: { type: 'loading' },
     },
@@ -57,6 +60,7 @@ export const loadingWithLinkForm = makeStory(conf, {
   items: [
     {
       networkGroupId,
+      ownerId,
       memberListState: {
         type: 'loaded',
         memberList: networkGroupMemberList,
@@ -71,6 +75,7 @@ export const error = makeStory(conf, {
   items: [
     {
       networkGroupId,
+      ownerId,
       memberListState: { type: 'error' },
       linkFormState: { type: 'error' },
     },
@@ -82,6 +87,7 @@ export const dataLoadedWithNoMembers = makeStory(conf, {
   items: [
     {
       networkGroupId,
+      ownerId,
       memberListState: {
         type: 'loaded',
         memberList: [],
@@ -99,6 +105,7 @@ export const dataLoadedWithLinkFormEmpty = makeStory(conf, {
   items: [
     {
       networkGroupId,
+      ownerId,
       memberListState: {
         type: 'loaded',
         memberList: networkGroupMemberList,
@@ -116,6 +123,7 @@ export const dataLoadedWithDeletedMembers = makeStory(conf, {
   items: [
     {
       networkGroupId,
+      ownerId,
       memberListState: {
         type: 'loaded',
         memberList: [...networkGroupMemberList, memberDeletedApp, memberDeletedAddon],
@@ -133,6 +141,7 @@ export const waitingWithLinkFormLinking = makeStory(conf, {
   items: [
     {
       networkGroupId,
+      ownerId,
       memberListState: {
         type: 'loaded',
         memberList: networkGroupMemberList,
@@ -151,6 +160,7 @@ export const waitingWithMemberListUnlinking = makeStory(conf, {
   items: [
     {
       networkGroupId,
+      ownerId,
       memberListState: {
         type: 'loaded',
         memberList: networkGroupMemberList,


### PR DESCRIPTION
## Context

- The Network Group components did not specify the `--org` flag in CLI examples which make them only viable for personal orgs
- This PR makes the `ownerId` pass from the smart to the UI components in order to show the relevant `--org ${ownerId}` flag.

## How to review?

- Check the commit,
- Check `demo-smart` locally,
- (optional) You may copy / paste each command to test it (that's what I did) against the actual CLI,
- 1 reviewer should be enough.