### PR TITLE
feat(cc-search-bar): add keyboard navigation and footer

### DIFF
--- a/src/components/cc-search-bar/cc-search-bar.js
+++ b/src/components/cc-search-bar/cc-search-bar.js
@@ -1,4 +1,5 @@
 import { css, html, LitElement, nothing } from 'lit';
+import { classMap } from 'lit/directives/class-map.js';
 import {
   iconRemixArrowRightSLine as iconArrowRight,
   iconRemixExternalLinkLine as iconExternalLink,
@@ -51,7 +52,9 @@ function getItemTypeBadgeLabel(itemType) {
 /**
  * @import { SearchBarItem, SearchBarItemType, SearchBarSection } from './cc-search-bar.types.js'
  * @import { BadgeIntent } from '../cc-badge/cc-badge.types.js'
+ * @import { IconModel } from '../common.types.js'
  * @import { CcInputEvent } from '../common.events.js'
+ * @import { PropertyValues } from 'lit'
  */
 
 /**
@@ -71,6 +74,7 @@ export class CcSearchBar extends LitElement {
       open: { type: Boolean, reflect: true },
       sections: { type: Array },
       value: { type: String },
+      _activeItemIndex: { type: Number, state: true },
     };
   }
 
@@ -85,6 +89,29 @@ export class CcSearchBar extends LitElement {
 
     /** @type {string} Sets the current search input value. */
     this.value = '';
+
+    /**
+     * @type {number} Index of the virtually focused item within the flattened list of filtered items.
+     * `-1` means no item is virtually focused: the real focus stays on the input.
+     */
+    this._activeItemIndex = -1;
+
+    /**
+     * @type {SearchBarSection[]} Cache of `_getFilteredSections()`, recomputed in `willUpdate` only when
+     * `value` or `sections` change (the filtering is otherwise run on every render, `updated` and keystroke).
+     */
+    this._filteredSections = [];
+
+    /** @type {SearchBarItem[]} Cache of the filtered items flattened into a single ordered list. */
+    this._flatItems = [];
+
+    // We listen to `keydown` in the capture phase because `cc-input-text` stops the propagation of keydown events
+    // during the bubbling phase (to avoid conflicts with shortcuts).
+    /** @type {{ handleEvent: (e: KeyboardEvent) => void, capture: boolean }} */
+    this._inputKeydownListener = {
+      handleEvent: (e) => this._onInputKeydown(e),
+      capture: true,
+    };
   }
 
   /** Opens the search bar dialog by setting the `open` property to true. */
@@ -136,16 +163,85 @@ export class CcSearchBar extends LitElement {
 
   _onDialogClose() {
     this.open = false;
+    this._activeItemIndex = -1;
   }
 
   /** @param {CcInputEvent} e */
   _onInput(e) {
     this.value = e.detail;
+    // As soon as the query changes, the filtered items change: the virtually focused item may disappear,
+    // so we reset the virtual focus back to the input.
+    this._activeItemIndex = -1;
+  }
+
+  /**
+   * Handles the keyboard navigation across the filtered items using a "virtual focus":
+   * the real focus stays on the input while the arrow keys move a purely visual selection.
+   *
+   * No ARIA is added on purpose: screen reader users keep the default experience (tabbing through the links).
+   *
+   * @param {KeyboardEvent} e
+   */
+  _onInputKeydown(e) {
+    const itemCount = this._flatItems.length;
+    if (itemCount === 0) {
+      return;
+    }
+
+    if (e.key === 'ArrowDown') {
+      // We prevent the native behavior (moving the caret / scrolling).
+      e.preventDefault();
+      // Loop back to the first item when reaching the end.
+      this._activeItemIndex = this._activeItemIndex >= itemCount - 1 ? 0 : this._activeItemIndex + 1;
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      // Loop back to the last item when reaching the start (including from the input, index `-1`).
+      this._activeItemIndex = this._activeItemIndex <= 0 ? itemCount - 1 : this._activeItemIndex - 1;
+    } else if (e.key === 'Enter' && this._activeItemIndex >= 0) {
+      e.preventDefault();
+      // Activating the virtually focused item mirrors a click on the corresponding link.
+      /** @type {HTMLAnchorElement} */
+      const activeItem = this.shadowRoot.querySelector(`.item[data-index="${this._activeItemIndex}"]`);
+      activeItem?.click();
+    }
+  }
+
+  /** @param {PropertyValues} changedProperties */
+  willUpdate(changedProperties) {
+    // The filtering only depends on `value` and `sections`, so we recompute the cache only when they change
+    // instead of on every render/`updated`/keystroke.
+    if (changedProperties.has('value') || changedProperties.has('sections')) {
+      this._filteredSections = this._getFilteredSections();
+      this._flatItems = this._filteredSections.flatMap((section) => section.items);
+    }
+  }
+
+  /** @param {PropertyValues} changedProperties */
+  updated(changedProperties) {
+    // If the virtually focused item no longer exists (e.g. the sections changed), reset the focus to the input.
+    if (this._activeItemIndex >= this._flatItems.length) {
+      this._activeItemIndex = -1;
+      return;
+    }
+    if (changedProperties.has('_activeItemIndex') && this._activeItemIndex >= 0) {
+      // `block: 'nearest'` keeps the selection visible when scrolling through a long list (or when zoomed in)
+      // without jumping around.
+      this.shadowRoot.querySelector('.item.active')?.scrollIntoView({ block: 'nearest' });
+    }
   }
 
   render() {
-    const filteredSections = this._getFilteredSections();
+    const filteredSections = this._filteredSections;
     const hasItems = filteredSections.length > 0;
+
+    // We flatten the items into a single ordered list so each rendered item gets a global index,
+    // used by the keyboard navigation to know which item is virtually focused.
+    let itemIndex = 0;
+    const indexedSections = filteredSections.map((section) => ({
+      ...section,
+      items: section.items.map((item) => ({ item, index: itemIndex++ })),
+    }));
+
     return html`
       <cc-dialog ?open="${this.open}" @cc-close="${this._onDialogClose}">
         <h1 slot="heading" class="heading">${i18n('cc-search-bar.heading')}</h1>
@@ -153,11 +249,31 @@ export class CcSearchBar extends LitElement {
           ${this._renderSearchInput()}
           ${hasItems
             ? html`<div class="sections" tabindex="-1">
-                ${filteredSections.map((section) => this._renderSection(section))}
+                ${indexedSections.map((section) => this._renderSection(section))}
               </div>`
             : this._renderEmpty()}
+          ${this._renderFooter()}
         </div>
       </cc-dialog>
+    `;
+  }
+
+  _renderFooter() {
+    return html`
+      <div class="footer">
+        <span class="footer-hint" aria-hidden="true">
+          <kbd class="footer-key">↑↓</kbd>
+          <span>${i18n('cc-search-bar.footer.navigate')}</span>
+        </span>
+        <span class="footer-hint">
+          <kbd class="footer-key">↵</kbd>
+          <span>${i18n('cc-search-bar.footer.select')}</span>
+        </span>
+        <span class="footer-hint">
+          <kbd class="footer-key footer-key--text">ESC</kbd>
+          <span>${i18n('cc-search-bar.footer.close')}</span>
+        </span>
+      </div>
     `;
   }
 
@@ -186,6 +302,7 @@ export class CcSearchBar extends LitElement {
             value="${this.value}"
             ?autofocus="${true}"
             @cc-input="${this._onInput}"
+            @keydown="${this._inputKeydownListener}"
           ></cc-input-text>
           <cc-icon class="search-icon" .icon="${iconSearch}" size="sm"></cc-icon>
         </div>
@@ -193,7 +310,7 @@ export class CcSearchBar extends LitElement {
     `;
   }
 
-  /** @param {SearchBarSection} section */
+  /** @param {{ label: string, icon: IconModel, items: Array<{ item: SearchBarItem, index: number }> }} section */
   _renderSection(section) {
     return html`
       <div class="section">
@@ -202,21 +319,26 @@ export class CcSearchBar extends LitElement {
           <span class="section-header-label">${section.label}</span>
         </h2>
         <ul class="section-items">
-          ${section.items.map((item) => this._renderItem(item))}
+          ${section.items.map(({ item, index }) => this._renderItem(item, index))}
         </ul>
       </div>
     `;
   }
 
-  /** @param {SearchBarItem} item */
-  _renderItem(item) {
+  /**
+   * @param {SearchBarItem} item
+   * @param {number} index
+   */
+  _renderItem(item, index) {
     const isExternal = isExternalUrl(item.href);
     const badgeIntent = item.itemType != null ? ITEM_TYPE_BADGE_INTENT[item.itemType] : null;
     const title = isExternal ? i18n('cc-search-bar.external-link.title', { linkText: item.label }) : nothing;
+    const isActive = index === this._activeItemIndex;
     return html`
       <li>
         <a
-          class="item"
+          class="${classMap({ item: true, active: isActive })}"
+          data-index="${index}"
           href="${item.href}"
           target="${isExternal ? '_blank' : nothing}"
           rel="${isExternal ? 'noreferrer' : nothing}"
@@ -298,7 +420,14 @@ export class CcSearchBar extends LitElement {
 
         .sections {
           flex: 1;
-          max-height: calc(100dvh - 16em);
+          /* Vertical space taken by everything that shares the dialog height with the scrollable list:
+             dialog padding, heading, search input and footer. We reserve it so the footer is never clipped
+             by the dialog's \`overflow: hidden\`.
+             /!\\ This value has no automatic relationship with the sizes of those elements: if you change the
+             footer/input/heading paddings or font sizes, adjust this reservation accordingly. */
+          --reserved-vertical-space: 19em;
+
+          max-height: calc(100dvh - var(--reserved-vertical-space));
           overflow-y: auto;
           padding: 0 var(--cc-spacing-3, 0.5em);
         }
@@ -388,6 +517,11 @@ export class CcSearchBar extends LitElement {
           background: var(--cc-color-bg-neutral, #f5f5f5);
         }
 
+        /* Virtual focus: we don't use \`outline\` here because it's already used for the real \`:focus-visible\` state. */
+        .item.active {
+          background: var(--cc-color-bg-neutral-active, #eaeaea);
+        }
+
         .item:focus-visible {
           border-radius: var(--cc-border-radius-large, 0.5em);
           outline: var(--cc-focus-outline);
@@ -417,8 +551,61 @@ export class CcSearchBar extends LitElement {
           flex-shrink: 0;
         }
 
-        .item:hover .hover-chevron {
+        .item:hover .hover-chevron,
+        .item.active .hover-chevron {
           display: inline-block;
+        }
+
+        .footer {
+          /* The dialog wraps its content in padding. We cancel it with negative margins so the footer spans the full
+             width and reaches the bottom edge of the dialog (full-bleed grey bar). We rebuild the same padding value
+             the dialog uses (\`--cc-dialog-padding-xl\` / \`--cc-dialog-padding-sm\`, both inherited from \`cc-dialog\`). */
+          --footer-dialog-padding: var(--cc-dialog-padding, var(--cc-dialog-padding-xl, 4em));
+
+          align-items: center;
+          background-color: var(--cc-color-bg-neutral, #f5f5f5);
+          border-top: solid 1px var(--cc-color-border-neutral-weak, #e7e7e7);
+          color: var(--cc-color-text-weak, #666);
+          display: flex;
+          flex-wrap: wrap;
+          gap: var(--cc-spacing-5, 1em);
+          justify-content: center;
+          margin-bottom: calc(-1 * var(--footer-dialog-padding));
+          margin-inline: calc(-1 * var(--footer-dialog-padding));
+          margin-top: var(--cc-spacing-3, 0.5em);
+          padding: var(--cc-spacing-3, 0.5em) var(--footer-dialog-padding);
+        }
+
+        /* stylelint-disable-next-line media-feature-range-notation */
+        @media screen and (max-width: 25em) {
+          .footer {
+            --footer-dialog-padding: var(--cc-dialog-padding, var(--cc-dialog-padding-sm, 2em));
+          }
+        }
+
+        .footer-hint {
+          align-items: center;
+          display: flex;
+          font-size: 0.75em;
+          gap: var(--cc-spacing-1, 0.25em);
+        }
+
+        .footer-key {
+          align-items: center;
+          background-color: var(--cc-color-bg-neutral, #f5f5f5);
+          border: solid 1px var(--cc-color-border-neutral-weak, #e7e7e7);
+          border-radius: var(--cc-border-radius-small, 0.25em);
+          display: inline-flex;
+          font-family: var(--cc-ff-monospace, monospace);
+          justify-content: center;
+          line-height: 1;
+          min-width: 1.5em;
+          padding: var(--cc-spacing-1, 0.25em);
+        }
+
+        /* Textual keys (e.g. \`ESC\`) get a smaller font so they don't look bigger than the single-glyph keys. */
+        .footer-key--text {
+          font-size: 0.85em;
         }
       `,
     ];

--- a/src/components/cc-search-bar/cc-search-bar.js
+++ b/src/components/cc-search-bar/cc-search-bar.js
@@ -267,7 +267,7 @@ export class CcSearchBar extends LitElement {
         </span>
         <span class="footer-hint">
           <kbd class="footer-key">↵</kbd>
-          <span>${i18n('cc-search-bar.footer.select')}</span>
+          <span>${i18n('cc-search-bar.footer.enter')}</span>
         </span>
         <span class="footer-hint">
           <kbd class="footer-key footer-key--text">ESC</kbd>

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -1874,6 +1874,9 @@ export const translations = {
   'cc-search-bar.external-link.name': `new window`,
   'cc-search-bar.external-link.title': /** @param {{linkText: string}} _ */ ({ linkText }) =>
     `${linkText} - new window`,
+  'cc-search-bar.footer.close': `Close`,
+  'cc-search-bar.footer.navigate': `Navigate`,
+  'cc-search-bar.footer.select': `Select`,
   'cc-search-bar.heading': `Search bar`,
   'cc-search-bar.initial.description': () =>
     sanitize`Start searching by keywords, id or filter (for example: <code>is:app</code>, <code>is:addon</code>…).<br>You can search across organizations, resources (applications, add-ons, etc.), pages and documentation.`,

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -1875,8 +1875,8 @@ export const translations = {
   'cc-search-bar.external-link.title': /** @param {{linkText: string}} _ */ ({ linkText }) =>
     `${linkText} - new window`,
   'cc-search-bar.footer.close': `Close`,
+  'cc-search-bar.footer.enter': `Enter`,
   'cc-search-bar.footer.navigate': `Navigate`,
-  'cc-search-bar.footer.select': `Select`,
   'cc-search-bar.heading': `Search bar`,
   'cc-search-bar.initial.description': () =>
     sanitize`Start searching by keywords, id or filter (for example: <code>is:app</code>, <code>is:addon</code>…).<br>You can search across organizations, resources (applications, add-ons, etc.), pages and documentation.`,

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -1897,6 +1897,9 @@ export const translations = {
   'cc-search-bar.external-link.name': `nouvelle fenêtre`,
   'cc-search-bar.external-link.title': /** @param {{linkText: string}} _ */ ({ linkText }) =>
     `${linkText} - nouvelle fenêtre`,
+  'cc-search-bar.footer.close': `Fermer`,
+  'cc-search-bar.footer.navigate': `Naviguer`,
+  'cc-search-bar.footer.select': `Sélectionner`,
   'cc-search-bar.heading': `Barre de recherche`,
   'cc-search-bar.initial.description': () =>
     sanitize`Commencez à chercher par mots-clés, id ou filtre (par exemple : <code>is:app</code>, <code>is:addon</code>…).<br>Vous pouvez effectuer une recherche parmi les organisations, les ressources (applications, add-ons, etc.), les pages et la documentation.`,

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -1898,8 +1898,8 @@ export const translations = {
   'cc-search-bar.external-link.title': /** @param {{linkText: string}} _ */ ({ linkText }) =>
     `${linkText} - nouvelle fenêtre`,
   'cc-search-bar.footer.close': `Fermer`,
+  'cc-search-bar.footer.enter': `Entrée`,
   'cc-search-bar.footer.navigate': `Naviguer`,
-  'cc-search-bar.footer.select': `Sélectionner`,
   'cc-search-bar.heading': `Barre de recherche`,
   'cc-search-bar.initial.description': () =>
     sanitize`Commencez à chercher par mots-clés, id ou filtre (par exemple : <code>is:app</code>, <code>is:addon</code>…).<br>Vous pouvez effectuer une recherche parmi les organisations, les ressources (applications, add-ons, etc.), les pages et la documentation.`,


### PR DESCRIPTION
# What does this PR do?

- Add arrow-key navigation over the filtered results using a virtual focus: the real focus stays on the input while `ArrowUp`/`ArrowDown` move a looping visual selection,
- Activate the virtually focused item with `Enter`, mirroring a click on the corresponding link,
- Reset the virtual focus back to the input when the query changes or when the selected item disappears, and scroll the selection into view,
- Keep the default screen reader experience on purpose (no ARIA added),
- Add a footer displaying the keyboard hints (navigate / select / close).

# How to review?

- Check the commits,
- Check the [preview](https://clever-components-preview.cellar-c2.services.clever-cloud.com/feat/cc-search-bar/keyboard-navigation/index.html?path=/story/%F0%9F%9B%A0-navigation-cc-search-bar--default-story)