### PR TITLE
feat(cc-logs-app-runtime): add collapsible instances panel

### DIFF
--- a/src/components/cc-logs-app-runtime/cc-logs-app-runtime.js
+++ b/src/components/cc-logs-app-runtime/cc-logs-app-runtime.js
@@ -4,6 +4,8 @@ import { createRef, ref } from 'lit/directives/ref.js';
 import {
   iconRemixFullscreenExitLine as fullscreenExitIcon,
   iconRemixFullscreenLine as fullscreenIcon,
+  iconRemixSidebarFoldLine as instancesCollapseIcon,
+  iconRemixSidebarUnfoldLine as instancesExpandIcon,
 } from '../../assets/cc-remix.icons.js';
 import { i18n } from '../../translations/translation.js';
 import '../cc-loader/cc-loader.js';
@@ -43,6 +45,11 @@ const CUSTOM_METADATA_RENDERERS = {
  */
 
 /**
+ * A component displaying the runtime logs of an application.
+ *
+ * ## Keyboard shortcuts
+ *
+ * * `Alt+I` to collapse or expand the instances panel (the left panel).
  *
  * @beta
  */
@@ -55,6 +62,7 @@ export class CcLogsAppRuntime extends LitElement {
       selectedInstances: { type: Array, attribute: 'selected-instances' },
       state: { type: Object },
       _fullscreen: { type: Boolean, state: true },
+      _instancesCollapsed: { type: Boolean, state: true },
       _messageFilter: { type: Object, state: true },
     };
   }
@@ -105,6 +113,9 @@ export class CcLogsAppRuntime extends LitElement {
     };
 
     this._fullscreen = false;
+
+    /** @type {boolean} Whether the instances panel is collapsed. */
+    this._instancesCollapsed = false;
   }
 
   /* region Public methods */
@@ -133,6 +144,22 @@ export class CcLogsAppRuntime extends LitElement {
 
   _onFullscreenToggle() {
     this._fullscreen = !this._fullscreen;
+  }
+
+  _onInstancesCollapseToggle() {
+    this._instancesCollapsed = !this._instancesCollapsed;
+  }
+
+  /**
+   * @param {KeyboardEvent} event
+   */
+  _onKeyDown(event) {
+    // `Alt+I` toggles the instances panel.
+    // `event.code` is used instead of `event.key` because Alt (Option on macOS) alters `event.key` on some layouts.
+    if (event.altKey && !event.ctrlKey && !event.metaKey && !event.shiftKey && event.code === 'KeyI') {
+      event.preventDefault();
+      this._onInstancesCollapseToggle();
+    }
   }
 
   /**
@@ -166,13 +193,14 @@ export class CcLogsAppRuntime extends LitElement {
     const overlay = {
       overlay: true,
       fullscreen: this._fullscreen,
+      'instances-collapsed': this._instancesCollapsed,
     };
     const wrapper = {
       wrapper: true,
       fullscreen: this._fullscreen,
     };
     return html`
-      <div class=${classMap(overlay)}>
+      <div class=${classMap(overlay)} @keydown=${this._onKeyDown}>
         <div class=${classMap(wrapper)}>
           <div class="logs-wrapper">${this._renderLogs()}</div>
           ${this._renderLoadingProgress()}
@@ -267,6 +295,17 @@ export class CcLogsAppRuntime extends LitElement {
         @cc-log-inspect=${this._onLogInspect}
       >
         <div slot="header" class="logs-header">
+          <cc-button
+            class="header-instances-toggle-button"
+            .icon=${this._instancesCollapsed ? instancesExpandIcon : instancesCollapseIcon}
+            a11y-name=${this._instancesCollapsed
+              ? i18n('cc-logs-app-runtime.instances.expand')
+              : i18n('cc-logs-app-runtime.instances.collapse')}
+            hide-text
+            a11y-expanded=${!this._instancesCollapsed}
+            @cc-click=${this._onInstancesCollapseToggle}
+          ></cc-button>
+
           <cc-logs-date-range-selector-beta
             class="date-range-selector"
             .value=${this.dateRangeSelection}
@@ -378,7 +417,25 @@ export class CcLogsAppRuntime extends LitElement {
           background-color: var(--cc-color-bg-default, #fff);
           border: 1px solid var(--cc-color-border-neutral, #aaa);
           border-radius: var(--cc-border-radius-small, 0.25em);
+          overflow: hidden;
+          transition:
+            width 0.2s ease-in-out,
+            border-width 0.2s ease-in-out;
           width: var(--instances-width);
+        }
+
+        .overlay.instances-collapsed {
+          --instances-width: 0;
+        }
+
+        .overlay.instances-collapsed .instances {
+          border-width: 0;
+        }
+
+        @media (prefers-reduced-motion) {
+          .instances {
+            transition: none;
+          }
         }
 
         .logs-wrapper {

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -1267,6 +1267,8 @@ export const translations = {
   //#region cc-logs-app-runtime
   'cc-logs-app-runtime.fullscreen': `Fullscreen`,
   'cc-logs-app-runtime.fullscreen.exit': `Exit fullscreen`,
+  'cc-logs-app-runtime.instances.collapse': `Collapse instances panel`,
+  'cc-logs-app-runtime.instances.expand': `Expand instances panel`,
   'cc-logs-app-runtime.logs.error': `Something went wrong while loading logs`,
   'cc-logs-app-runtime.logs.loading': `Looking for log entries...`,
   'cc-logs-app-runtime.logs.warning.no-logs.message': `There are no logs matching the selected criteria`,

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -1278,6 +1278,8 @@ export const translations = {
   //#region cc-logs-app-runtime
   'cc-logs-app-runtime.fullscreen': `Mode plein écran`,
   'cc-logs-app-runtime.fullscreen.exit': `Sortir du mode plein écran`,
+  'cc-logs-app-runtime.instances.collapse': `Réduire le panneau des instances`,
+  'cc-logs-app-runtime.instances.expand': `Déplier le panneau des instances`,
   'cc-logs-app-runtime.logs.error': `Une erreur est survenue pendant le chargement des logs`,
   'cc-logs-app-runtime.logs.loading': `Recherche de logs…`,
   'cc-logs-app-runtime.logs.warning.no-logs.message': `Il n'y a aucun log qui correspond aux critères sélectionnés`,


### PR DESCRIPTION
## Context — a suggestion, not a mandate 🙂

I'm coming at this as a **user** of `cc-logs-app-runtime` in the console, not as a maintainer of this component. On narrower screens the fixed-width **Instances** panel eats a lot of horizontal space, and most of the time I just want to read the log stream. So this is a small quality-of-life proposal — very happy for you to take it, tweak it, or close it if it doesn't fit your plans for the component.

## What it does

Adds a way to collapse/expand the left **Instances** panel so the log stream can use the full width:

- A toggle **button** in the logs header (next to the fullscreen button), using the `sidebar-fold` / `sidebar-unfold` Remix icons.
- A keyboard shortcut: **`Alt+I`** (I = Instances). I checked the existing shortcuts in `cc-logs` (`Ctrl+C`, `Ctrl+A`, arrows, `Home`/`End`, `Escape`, `Space`/`Enter`) — `Alt`+letter was a free namespace, so no collision.

## How it's built (kept minimal + consistent)

- **Mirrors the existing fullscreen toggle**: internal reactive state (`_instancesCollapsed`), no new public property, no new event — so no `events-map` change.
- The collapse simply drives the existing **`--instances-width`** custom property to `0`, so the "no logs / loading" overlays that already center off that variable stay correct for free.
- **Accessibility**: the button carries `aria-expanded` (via `a11y-expanded`) and a translated `a11y-name` (EN + FR added), which `cc-button` also surfaces as the hover `title`.
- **Motion**: the width transition is disabled under `@media (prefers-reduced-motion)`.
- The `Alt+I` handler is element-scoped (`@keydown` on the component root), matching the existing keyboard-handling approach — no new global listeners. `event.code === 'KeyI'` is used because `Alt`/`Option` mutates `event.key` on some layouts.
- Documented the shortcut in the component's class JSDoc, same as `cc-logs` documents its keyboard navigation.

## Checks

Ran the CI-gate pieces locally on the touched files: `eslint`, `stylelint`, `components:check-i18n` (EN + FR present), and `components:events-map-check` (up to date — no new events). Happy to add a collapsed-state **story** and/or the `run-visual-tests` label if you'd like that before merging — just say the word.

## Open questions for you

- Placement/icon of the toggle OK, or would you prefer it attached to the panel's own header?
- Should the collapsed state be **persisted** (the console already stores date-range/options via its SettingManager)? I left it ephemeral to keep the change small, but I can wire a public property/event if you want the console to remember it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
