### PR TITLE
cc-addon-info: fix Cellar object & bucket number format

### DIFF
--- a/src/components/cc-addon-info/cc-addon-info.js
+++ b/src/components/cc-addon-info/cc-addon-info.js
@@ -318,7 +318,7 @@ export class CcAddonInfo extends LitElement {
                         ${i18n('cc-addon-info.total-content.buckets')}
                       </dt>
                       <dd class="features__content__item__value data-decoration ${classMap({ skeleton })}">
-                        ${this.state.totalContent.buckets}
+                        ${i18n('cc-addon-info.total-content.count', { count: this.state.totalContent.buckets })}
                       </dd>
                     </div>
                     <div class="features__content__item">
@@ -326,7 +326,7 @@ export class CcAddonInfo extends LitElement {
                         ${i18n('cc-addon-info.total-content.objects')}
                       </dt>
                       <dd class="features__content__item__value data-decoration ${classMap({ skeleton })}">
-                        ${this.state.totalContent.objects}
+                        ${i18n('cc-addon-info.total-content.count', { count: this.state.totalContent.objects })}
                       </dd>
                     </div>
                   </dl>

--- a/src/components/cc-addon-info/cc-addon-info.stories.js
+++ b/src/components/cc-addon-info/cc-addon-info.stories.js
@@ -1,6 +1,7 @@
 import { getDocUrl } from '../../lib/dev-hub-url.js';
 import {
   azimuttInfo,
+  cellarInfo,
   elasticInfo,
   jenkinsInfo,
   keycloakInfo,
@@ -360,6 +361,34 @@ export const elastic = makeStory(conf, {
       docLink: {
         text: i18n('cc-addon-info.doc-link.elastic'),
         href: getDocUrl('/addons/elastic'),
+      },
+    },
+  ],
+});
+
+export const cellar = makeStory(conf, {
+  /** @type {Partial<CcAddonInfo>[]} */
+  items: [
+    {
+      /** @type {AddonInfoStateLoaded} */
+      state: {
+        type: 'loaded',
+        ...cellarInfo,
+      },
+      docLink: {
+        text: i18n('cc-addon-info.doc-link.cellar'),
+        href: getDocUrl('/addons/cellar'),
+      },
+    },
+    {
+      /** @type {AddonInfoStateLoading} */
+      state: {
+        type: 'loading',
+        ...cellarInfo,
+      },
+      docLink: {
+        text: i18n('cc-addon-info.doc-link.cellar'),
+        href: getDocUrl('/addons/cellar'),
       },
     },
   ],

--- a/src/stories/fixtures/addon-info.js
+++ b/src/stories/fixtures/addon-info.js
@@ -216,6 +216,22 @@ export const pulsarInfo = {
 }
 
 /** @type {AddonInfoStateBaseProperties} */
+export const cellarInfo = {
+  creationDate: '2025-08-06T15:03:00Z',
+  totalContent: {
+    buckets: 12,
+    objects: 97332478,
+  },
+  traffic: {
+    inbound: 10737418240,
+    outbound: 5368709120,
+  },
+  usedSpaces: {
+    size: 549755813888,
+  },
+}
+
+/** @type {AddonInfoStateBaseProperties} */
 export const configInfo = {
   creationDate: '2025-06-15T10:30:00Z',
 }

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -328,6 +328,7 @@ export const translations = {
   'cc-addon-info.specification.version': `Version`,
   'cc-addon-info.subnet.heading': `Subnet`,
   'cc-addon-info.total-content.buckets': `Buckets`,
+  'cc-addon-info.total-content.count': /** @param {{count: number}} _ */ ({ count }) => formatNumber(lang, count),
   'cc-addon-info.total-content.heading': `Content`,
   'cc-addon-info.total-content.objects': `Objects`,
   'cc-addon-info.traffic.heading': `Traffic`,

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -339,6 +339,7 @@ export const translations = {
   'cc-addon-info.specification.version': `Version`,
   'cc-addon-info.subnet.heading': `Sous-réseau`,
   'cc-addon-info.total-content.buckets': `Buckets`,
+  'cc-addon-info.total-content.count': /** @param {{count: number}} _ */ ({ count }) => formatNumber(lang, count),
   'cc-addon-info.total-content.heading': `Contenu`,
   'cc-addon-info.total-content.objects': `Objets`,
   'cc-addon-info.traffic.heading': `Trafic`,


### PR DESCRIPTION
Fixes #1787 

## What does this PR do?

- Formats Bucket & object counts in `cc-addon-info`,
- Adds a `Cellar` story that was missing to showcase the Cellar product.

## How to review?

- Check the Cellar story and compare to prod, numbers are now formatted,
- 1 reviewer should be enough for this one.