### PR TITLE
fix(cc-tile-requests): align the chart with the current hour

### DIFF
--- a/src/components/cc-tile-requests/cc-tile-requests.smart.js
+++ b/src/components/cc-tile-requests/cc-tile-requests.smart.js
@@ -11,6 +11,8 @@ import './cc-tile-requests.js';
  * @import { OnContextUpdateArgs } from '../../lib/smart/smart-component.types.js'
  */
 
+const ONE_HOUR = 1000 * 60 * 60;
+
 defineSmartComponent({
   selector: 'cc-tile-requests',
   params: {
@@ -46,20 +48,18 @@ defineSmartComponent({
  * @return {Promise<Array<RequestsData>>}
  */
 async function fetchRequests({ apiConfig, signal, ownerId, appId }) {
-  const to = new Date();
-  to.setHours(to.getHours() - 1, 0, 0, 0);
-
+  // Omitting `from`/`to` lets the API default to the last 24 whole hours ending at the current hour.
   const data = await getCcApiClientWithOAuth(apiConfig).send(
     new GetStatusCodeDistributionCommand({
       ownerId,
       applicationId: appId,
-      to,
     }),
     { signal },
   );
 
   return data.byDate.map((entry) => {
-    const time = new Date(entry.date).getTime();
-    return [time, time + 1000 * 60 * 60 - 1, entry.total];
+    // The API dates each bucket with its end boundary, the tile expects its start.
+    const end = new Date(entry.date).getTime();
+    return [end - ONE_HOUR, end - 1, entry.total];
   });
 }

--- a/src/components/cc-tile-requests/cc-tile-requests.smart.md
+++ b/src/components/cc-tile-requests/cc-tile-requests.smart.md
@@ -34,7 +34,7 @@ interface ApiConfig {
 
 | Method | URL                                               | Cache   |
 |--------|---------------------------------------------------|---------|
-| `GET`  | `/v4/stats/organisations/{ownerId}/http-requests` | Default |
+| `GET`  | `/v4/stats/organisations/{ownerId}/http-status-codes` | Default |
 
 ## ⬇️️ Examples
 


### PR DESCRIPTION
## Context

The `<cc-tile-requests>` chart is one hour out of sync: the traffic shown under a given
bar actually happened during the previous hour. The regression came in with the smart
binding added in #1755 — the tile had no smart binding before, so the bug is as old as it.

Two independent mistakes are involved, and they partly cancel each other out, which is
what makes the symptom confusing — the most recent bar carries a plausible label but the
wrong data.

1. **The `to` bound was pushed one hour into the past.** `fetchRequests` computed
   `to = current hour - 1h` and sent it to the API. The endpoint already defaults `to` to
   the current hour truncated and `from` to `to - 24h`, which is exactly what the tile
   wants, so the override was both redundant and wrong.
2. **The bucket date was read as a start, but the API returns an end.** Each entry is
   dated with the upper bound of its window (`]date - 1h, date]`), while the smart binding
   built its tuple as `[date, date + 1h]`, labelling every bar one hour too late.

Fixing only one of them would make things worse: dropping the `to` override alone pushes
the last bar into the future, and fixing the mapping alone drops the most recent hour.

## Changes

- Drop the `to` override so the API applies its `last 24 whole hours` default.
- Derive the bar window from the bucket end (`[date - 1h, date - 1]`), matching the
  `RequestsData` contract, which documents the first item as a start timestamp.
- Fix the endpoint listed in the smart doc: the tile calls `http-status-codes`, not
  `http-requests`.

## How to review

Verified against the production API (`/v4/stats/organisations/:id/http-status-codes`):

- With the server defaults, the response holds 24 buckets whose last date is the current
  hour truncated; with the previous `to = now - 1h`, the last bucket lands one hour earlier.
- Narrow-range probes confirm the tick is the window end: traffic recorded at 13:40 is
  returned under the `14:00` bucket for `from=13:00&to=14:00`, and `from=14:00&to=15:00`
  comes back empty.
- Replaying the new mapping over a real response yields 24 contiguous one-hour bars ending
  at the current hour.

`format:check`, `lint` and `typecheck` pass.
