### PR TITLE
feat(filter-sections): share the search and sidebar filter grammar

### DIFF
--- a/src/components/cc-search-bar/cc-search-bar.js
+++ b/src/components/cc-search-bar/cc-search-bar.js
@@ -5,14 +5,13 @@ import {
   iconRemixExternalLinkLine as iconExternalLink,
   iconRemixSearchLine as iconSearch,
 } from '../../assets/cc-remix.icons.js';
+import { filterSections } from '../../lib/filter-sections.js';
 import { isExternalUrl } from '../../lib/utils.js';
 import { i18n } from '../../translations/translation.js';
 import '../cc-badge/cc-badge.js';
 import '../cc-dialog/cc-dialog.js';
 import '../cc-icon/cc-icon.js';
 import '../cc-input-text/cc-input-text.js';
-
-const KEYWORD_TOKEN_REGEX = /^is:./;
 
 /** @type {Record<SearchBarItemType, BadgeIntent>} */
 const ITEM_TYPE_BADGE_INTENT = {
@@ -125,40 +124,22 @@ export class CcSearchBar extends LitElement {
   }
 
   /**
-   * Filters `this.sections` based on `this.value`, using a token-based syntax.
+   * Filters `this.sections` based on `this.value`, with the grammar shared with the console sidebar
+   * (see `lib/filter-sections.js`): `is:`/`project:` tokens are matched against an item's matchers,
+   * everything else is free text matched against its label and id, and every token must pass.
    *
-   * Tokens are split on whitespace and partitioned into:
-   * - keyword tokens (`is:<value>`): an item passes only if every keyword token
-   *   is present in its derived matchers (`is:<itemType>` and explicit `matchers`).
-   * - text tokens: an item passes only if every text token is `includes`'d in its
-   *   lowercased label or its lowercased id.
+   * `is:<itemType>` is folded into the matchers here so an item only setting `itemType` still answers
+   * `is:app`, and an empty query yields nothing rather than the whole list — a search bar shows no
+   * result until something is typed.
    *
    * @returns {SearchBarSection[]}
    */
   _getFilteredSections() {
-    const query = this.value.trim().toLowerCase();
-    if (query === '') {
-      return [];
-    }
-    const tokens = query.split(/\s+/);
-    const keywordTokens = tokens.filter((token) => KEYWORD_TOKEN_REGEX.test(token));
-    const textTokens = tokens.filter((token) => !KEYWORD_TOKEN_REGEX.test(token));
-
-    return this.sections
-      .map((section) => ({
-        ...section,
-        items: section.items.filter((item) => {
-          const itemMatchers = [...(item.itemType != null ? [`is:${item.itemType}`] : []), ...(item.matchers ?? [])];
-          const keywordsMatch = keywordTokens.every((keyword) => itemMatchers.includes(keyword));
-          if (!keywordsMatch) {
-            return false;
-          }
-          const label = item.label.toLowerCase();
-          const id = item.id?.toLowerCase() ?? '';
-          return textTokens.every((token) => label.includes(token) || id.includes(token));
-        }),
-      }))
-      .filter((section) => section.items.length > 0);
+    return filterSections(this.sections, this.value, {
+      getMatchers: (item) => [...(item.itemType != null ? [`is:${item.itemType}`] : []), ...(item.matchers ?? [])],
+      getTexts: (item) => [item.label, item.id],
+      emptyQuery: 'none',
+    });
   }
 
   _onDialogClose() {

--- a/src/components/cc-search-bar/cc-search-bar.stories.js
+++ b/src/components/cc-search-bar/cc-search-bar.stories.js
@@ -52,9 +52,14 @@ const defaultSections = [
     label: 'Ressources in this organisation',
     icon: iconResources,
     items: [
-      { label: 'APM --0307-42dc-af99-b485ecc44536', href: '#apm-1', itemType: 'app' },
-      { label: 'fs-matomot-with-posthog', href: '#matomot-1', itemType: 'addon' },
-      { label: 'APM - apps-0307-42dc-af99-b485ecc44536', href: '#apm-2', itemType: 'app' },
+      { label: 'APM --0307-42dc-af99-b485ecc44536', href: '#apm-1', itemType: 'app', matchers: ['project:billing'] },
+      { label: 'fs-matomot-with-posthog', href: '#matomot-1', itemType: 'addon', matchers: ['project:billing'] },
+      {
+        label: 'APM - apps-0307-42dc-af99-b485ecc44536',
+        href: '#apm-2',
+        itemType: 'app',
+        matchers: ['project:analytics'],
+      },
       {
         label: 'network-groupups_4d65a2d6-0307-af99-b485ecc44536',
         href: '#ng-1',
@@ -182,10 +187,14 @@ empty sections are hidden.
 
 export const withKeywordFilter = makeStory(conf, {
   docs: `
-The query supports \`is:<value>\` keyword tokens. Items match a keyword token when it is in their derived
-matchers — \`is:<itemType>\` is added automatically for items with an \`itemType\`, and additional matchers can
-be provided via the \`matchers\` field. Tokens can be combined: \`is:app apm\` keeps only \`itemType: 'app'\`
-items whose label includes \`apm\`.
+The query supports \`is:<value>\` and \`project:<value>\` keyword tokens. Items match a keyword token when it is
+in their derived matchers — \`is:<itemType>\` is added automatically for items with an \`itemType\`, and any
+other matcher, \`project:<name>\` included, is provided via the \`matchers\` field. Anything else in the query
+is free text, matched against an item's label and id, so a colon in a URL or an id still searches as text.
+
+Tokens can be combined and all must pass: \`is:app apm\` keeps only \`itemType: 'app'\` items whose label
+includes \`apm\`. The items of this story carry \`project:billing\` and \`project:analytics\` matchers — try
+\`project:billing\` alone, or \`is:app project:billing\` to see both kinds of token narrow the same list.
   `,
   /** @param {HTMLElement} container */
   dom: (container) => {

--- a/src/lib/filter-sections.js
+++ b/src/lib/filter-sections.js
@@ -68,8 +68,8 @@ export function matchesFilterQuery({ keywordTokens, textTokens }, matchers, text
  * @param {Array<S>} sections
  * @param {string} query
  * @param {object} [options]
- * @param {(item: any) => Array<string>} [options.getMatchers] - reads an item's matchers
- * @param {(item: any) => Array<string|null|undefined>} [options.getTexts] - reads an item's text fields
+ * @param {(item: S['items'][number]) => Array<string>} [options.getMatchers] - reads an item's matchers
+ * @param {(item: S['items'][number]) => Array<string|null|undefined>} [options.getTexts] - reads an item's text fields
  * @param {Array<string>} [options.keywordPrefixes]
  * @param {'all'|'none'} [options.emptyQuery] - what an empty query yields: every non-empty section, or
  * nothing. A sidebar shows everything unfiltered; a search bar shows no result until something is typed.

--- a/src/lib/filter-sections.js
+++ b/src/lib/filter-sections.js
@@ -2,10 +2,8 @@
  * Filter grammar shared by the resource lists that narrow sections of items with a text query:
  * `cc-search-bar` (global search) and the console's own sidebar.
  *
- * The two used to implement the grammar separately and had drifted apart — `project:` was a keyword on
- * one side and free text on the other, and they did not search the same fields. The tokenizing and the
- * matching semantics live here; what differs legitimately between call sites (which fields hold the
- * text, what an empty query means) stays configurable.
+ * The tokenizing and the matching semantics live here; what differs legitimately between call sites
+ * (which fields hold the text, what an empty query means) stays configurable.
  *
  * Grammar:
  * - the query is lowercased, trimmed, and split on whitespace into tokens,
@@ -74,7 +72,7 @@ export function matchesFilterQuery({ keywordTokens, textTokens }, matchers, text
  * @param {(item: any) => Array<string|null|undefined>} [options.getTexts] - reads an item's text fields
  * @param {Array<string>} [options.keywordPrefixes]
  * @param {'all'|'none'} [options.emptyQuery] - what an empty query yields: every non-empty section, or
- *   nothing. A sidebar shows everything unfiltered; a search bar shows no result until something is typed.
+ * nothing. A sidebar shows everything unfiltered; a search bar shows no result until something is typed.
  * @returns {Array<S>} the sections holding at least one matching item
  */
 export function filterSections(sections, query, options = {}) {

--- a/src/lib/filter-sections.js
+++ b/src/lib/filter-sections.js
@@ -1,0 +1,103 @@
+/**
+ * Filter grammar shared by the resource lists that narrow sections of items with a text query:
+ * `cc-search-bar` (global search) and the console's own sidebar.
+ *
+ * The two used to implement the grammar separately and had drifted apart — `project:` was a keyword on
+ * one side and free text on the other, and they did not search the same fields. The tokenizing and the
+ * matching semantics live here; what differs legitimately between call sites (which fields hold the
+ * text, what an empty query means) stays configurable.
+ *
+ * Grammar:
+ * - the query is lowercased, trimmed, and split on whitespace into tokens,
+ * - a token starting with one of `keywordPrefixes`, followed by at least one character, is a *keyword*:
+ *   the item passes only if that exact token is among its matchers,
+ * - any other token is *free text*: the item passes only if the token is a substring of at least one of
+ *   its text fields,
+ * - every token must pass (AND between tokens, OR across an item's text fields),
+ * - a section with no item is dropped, whether the query emptied it or it was already empty.
+ *
+ * The prefixes are an explicit list rather than a generic `<word>:` pattern on purpose: free text can
+ * legitimately contain a colon (a URL, an `app_xxx:yyy` id), and treating those as keywords would
+ * silently return nothing.
+ */
+
+/** @type {Array<string>} */
+export const DEFAULT_KEYWORD_PREFIXES = ['is:', 'project:'];
+
+/**
+ * Splits a raw query into keyword tokens and free-text tokens.
+ *
+ * @param {string} query - the raw user input
+ * @param {Array<string>} [keywordPrefixes] - prefixes marking a token as a keyword
+ * @returns {{ keywordTokens: Array<string>, textTokens: Array<string> }}
+ */
+export function parseFilterQuery(query, keywordPrefixes = DEFAULT_KEYWORD_PREFIXES) {
+  const normalized = query.trim().toLowerCase();
+  if (normalized === '') {
+    return { keywordTokens: [], textTokens: [] };
+  }
+  const tokens = normalized.split(/\s+/);
+  // A bare prefix (`is:`) is free text, not a keyword matching everything: the user is mid-typing.
+  /** @param {string} token */
+  const isKeyword = (token) =>
+    keywordPrefixes.some((prefix) => token.startsWith(prefix) && token.length > prefix.length);
+  return {
+    keywordTokens: tokens.filter(isKeyword),
+    textTokens: tokens.filter((token) => !isKeyword(token)),
+  };
+}
+
+/**
+ * Tells whether an item passes the parsed query.
+ *
+ * @param {{ keywordTokens: Array<string>, textTokens: Array<string> }} parsedQuery
+ * @param {Array<string>} matchers - the item's matchers, e.g. `['is:app', 'is:node', 'project:billing']`
+ * @param {Array<string|null|undefined>} texts - the item's searchable text fields, e.g. its label and id
+ * @returns {boolean}
+ */
+export function matchesFilterQuery({ keywordTokens, textTokens }, matchers, texts) {
+  if (!keywordTokens.every((keyword) => matchers.includes(keyword))) {
+    return false;
+  }
+  const lowerCasedTexts = texts.filter((text) => text != null).map((text) => text.toLowerCase());
+  return textTokens.every((token) => lowerCasedTexts.some((text) => text.includes(token)));
+}
+
+/**
+ * Filters sections and their items with the grammar above, without mutating the input.
+ *
+ * @template {{ items: Array<any> }} S
+ * @param {Array<S>} sections
+ * @param {string} query
+ * @param {object} [options]
+ * @param {(item: any) => Array<string>} [options.getMatchers] - reads an item's matchers
+ * @param {(item: any) => Array<string|null|undefined>} [options.getTexts] - reads an item's text fields
+ * @param {Array<string>} [options.keywordPrefixes]
+ * @param {'all'|'none'} [options.emptyQuery] - what an empty query yields: every non-empty section, or
+ *   nothing. A sidebar shows everything unfiltered; a search bar shows no result until something is typed.
+ * @returns {Array<S>} the sections holding at least one matching item
+ */
+export function filterSections(sections, query, options = {}) {
+  const {
+    getMatchers = (item) => item.matchers ?? [],
+    getTexts = (item) => [item.label, item.id],
+    keywordPrefixes = DEFAULT_KEYWORD_PREFIXES,
+    emptyQuery = 'all',
+  } = options;
+
+  const parsedQuery = parseFilterQuery(query, keywordPrefixes);
+  const hasQuery = parsedQuery.keywordTokens.length > 0 || parsedQuery.textTokens.length > 0;
+  if (!hasQuery) {
+    // Still drop the empty ones: the contract is "sections holding at least one item", so a caller never
+    // has to re-chain that filter — the kind of per-consumer detail that made the two grammars drift.
+    // Section objects are returned as-is here, since no item was filtered out.
+    return emptyQuery === 'none' ? [] : sections.filter((section) => section.items.length > 0);
+  }
+
+  return sections
+    .map((section) => ({
+      ...section,
+      items: section.items.filter((item) => matchesFilterQuery(parsedQuery, getMatchers(item), getTexts(item))),
+    }))
+    .filter((section) => section.items.length > 0);
+}

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -1880,7 +1880,7 @@ export const translations = {
   'cc-search-bar.footer.navigate': `Navigate`,
   'cc-search-bar.heading': `Search bar`,
   'cc-search-bar.initial.description': () =>
-    sanitize`Start searching by keywords, id or filter (for example: <code>is:app</code>, <code>is:addon</code>…).<br>You can search across organizations, resources (applications, add-ons, etc.), pages and documentation.`,
+    sanitize`Start searching by keywords, id or filter (for example: <code>is:app</code>, <code>is:addon</code>, <code>project:billing</code>…).<br>You can search across organizations, resources (applications, add-ons, etc.), pages and documentation.`,
   'cc-search-bar.initial.title': `Search across all your content`,
   'cc-search-bar.label': `What are you looking for?`,
   'cc-search-bar.no-result.description': `Try different keywords or check the spelling`,

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -1903,7 +1903,7 @@ export const translations = {
   'cc-search-bar.footer.navigate': `Naviguer`,
   'cc-search-bar.heading': `Barre de recherche`,
   'cc-search-bar.initial.description': () =>
-    sanitize`Commencez à chercher par mots-clés, id ou filtre (par exemple : <code>is:app</code>, <code>is:addon</code>…).<br>Vous pouvez effectuer une recherche parmi les organisations, les ressources (applications, add-ons, etc.), les pages et la documentation.`,
+    sanitize`Commencez à chercher par mots-clés, id ou filtre (par exemple : <code>is:app</code>, <code>is:addon</code>, <code>project:facturation</code>…).<br>Vous pouvez effectuer une recherche parmi les organisations, les ressources (applications, add-ons, etc.), les pages et la documentation.`,
   'cc-search-bar.initial.title': `Cherchez parmi tous vos contenus`,
   'cc-search-bar.label': `Que cherchez-vous ?`,
   'cc-search-bar.no-result.description': `Essayez d'autres mots-clés ou vérifiez l'orthographe`,

--- a/test/filter-sections.test.js
+++ b/test/filter-sections.test.js
@@ -1,0 +1,141 @@
+import { expect } from '@bundled-es-modules/chai';
+import { filterSections, matchesFilterQuery, parseFilterQuery } from '../src/lib/filter-sections.js';
+
+const SECTIONS = [
+  {
+    label: 'Resources',
+    items: [
+      { label: 'my-node-app', id: 'app_1', matchers: ['is:app', 'is:node', 'project:billing'] },
+      { label: 'my-php-app', id: 'app_2', matchers: ['is:app', 'is:php'] },
+      { label: 'main-db', id: 'addon_1', matchers: ['is:addon', 'is:postgresql-addon', 'project:billing'] },
+    ],
+  },
+  {
+    label: 'Organisations',
+    items: [{ label: 'Clever Cloud', id: 'orga_1', matchers: [] }],
+  },
+];
+
+const labelsFor = (query, options) =>
+  filterSections(SECTIONS, query, options).flatMap((section) => section.items.map((item) => item.label));
+
+describe('parseFilterQuery()', () => {
+  it('splits on whitespace and partitions keywords from free text', () => {
+    expect(parseFilterQuery('is:app project:billing my app')).to.deep.equal({
+      keywordTokens: ['is:app', 'project:billing'],
+      textTokens: ['my', 'app'],
+    });
+  });
+
+  it('lowercases and trims the query', () => {
+    expect(parseFilterQuery('  IS:App  MyApp ')).to.deep.equal({
+      keywordTokens: ['is:app'],
+      textTokens: ['myapp'],
+    });
+  });
+
+  it('treats a bare prefix as free text, since the user is mid-typing', () => {
+    expect(parseFilterQuery('is:')).to.deep.equal({ keywordTokens: [], textTokens: ['is:'] });
+  });
+
+  it('treats an unlisted prefix as free text, so colons in ids and URLs still search', () => {
+    expect(parseFilterQuery('https://example.com')).to.deep.equal({
+      keywordTokens: [],
+      textTokens: ['https://example.com'],
+    });
+  });
+
+  it('honours a custom prefix list', () => {
+    expect(parseFilterQuery('is:app project:billing', ['is:'])).to.deep.equal({
+      keywordTokens: ['is:app'],
+      textTokens: ['project:billing'],
+    });
+  });
+
+  it('returns no token for an empty query', () => {
+    expect(parseFilterQuery('   ')).to.deep.equal({ keywordTokens: [], textTokens: [] });
+  });
+});
+
+describe('matchesFilterQuery()', () => {
+  const parsed = (query) => parseFilterQuery(query);
+
+  it('requires every keyword to be among the matchers', () => {
+    expect(matchesFilterQuery(parsed('is:app is:node'), ['is:app', 'is:node'], ['x'])).to.equal(true);
+    expect(matchesFilterQuery(parsed('is:app is:node'), ['is:app'], ['x'])).to.equal(false);
+  });
+
+  it('matches free text against any one of the text fields', () => {
+    expect(matchesFilterQuery(parsed('node'), [], ['my-node-app', 'app_1'])).to.equal(true);
+    expect(matchesFilterQuery(parsed('app_1'), [], ['my-node-app', 'app_1'])).to.equal(true);
+    expect(matchesFilterQuery(parsed('nope'), [], ['my-node-app', 'app_1'])).to.equal(false);
+  });
+
+  it('requires every text token to match, possibly on different fields', () => {
+    expect(matchesFilterQuery(parsed('node app_1'), [], ['my-node-app', 'app_1'])).to.equal(true);
+    expect(matchesFilterQuery(parsed('node nope'), [], ['my-node-app', 'app_1'])).to.equal(false);
+  });
+
+  it('ignores nullish text fields', () => {
+    expect(matchesFilterQuery(parsed('node'), [], ['my-node-app', null, undefined])).to.equal(true);
+  });
+});
+
+describe('filterSections()', () => {
+  it('narrows items by keyword', () => {
+    expect(labelsFor('is:node')).to.deep.equal(['my-node-app']);
+  });
+
+  it('narrows items by project keyword', () => {
+    expect(labelsFor('project:billing')).to.deep.equal(['my-node-app', 'main-db']);
+  });
+
+  it('narrows items by free text, across label and id', () => {
+    expect(labelsFor('php')).to.deep.equal(['my-php-app']);
+    expect(labelsFor('addon_1')).to.deep.equal(['main-db']);
+  });
+
+  it('combines keywords and free text', () => {
+    expect(labelsFor('is:app my')).to.deep.equal(['my-node-app', 'my-php-app']);
+    expect(labelsFor('is:app main')).to.deep.equal([]);
+  });
+
+  it('drops sections left with no item', () => {
+    const sections = filterSections(SECTIONS, 'is:app');
+    expect(sections.map((section) => section.label)).to.deep.equal(['Resources']);
+  });
+
+  it('keeps every section on an empty query by default', () => {
+    expect(filterSections(SECTIONS, '  ')).to.deep.equal(SECTIONS);
+  });
+
+  it('returns nothing on an empty query when asked to', () => {
+    expect(filterSections(SECTIONS, '  ', { emptyQuery: 'none' })).to.deep.equal([]);
+  });
+
+  it('drops sections that were already empty, even without a query', () => {
+    const sections = [...SECTIONS, { label: 'Kubernetes', items: [] }];
+    expect(filterSections(sections, '  ').map((section) => section.label)).to.deep.equal([
+      'Resources',
+      'Organisations',
+    ]);
+  });
+
+  it('returns already-matching sections as-is when there is no query', () => {
+    expect(filterSections(SECTIONS, '  ')[0]).to.equal(SECTIONS[0]);
+  });
+
+  it('does not mutate the input sections', () => {
+    const before = JSON.parse(JSON.stringify(SECTIONS));
+    filterSections(SECTIONS, 'is:app');
+    expect(SECTIONS).to.deep.equal(before);
+  });
+
+  it('honours custom accessors', () => {
+    const sections = [{ items: [{ name: 'my-app', realId: 'zzz', tags: ['is:app'] }] }];
+    const options = { getMatchers: (item) => item.tags, getTexts: (item) => [item.name, item.realId] };
+    expect(filterSections(sections, 'zzz', options)[0].items).to.have.lengthOf(1);
+    expect(filterSections(sections, 'is:app', options)[0].items).to.have.lengthOf(1);
+    expect(filterSections(sections, 'nope', options)).to.deep.equal([]);
+  });
+});


### PR DESCRIPTION
# Context

`cc-search-bar` and the console sidebar both narrow sections of items with the same token syntax, each implementing it separately — and they had drifted apart:

| | console sidebar | `cc-search-bar` |
|---|---|---|
| Keywords | `is:` and `project:` | `is:` only (`/^is:./`) |
| Matchers read | `item.matchers` | derived `is:<itemType>` + `item.matchers` |
| Text fields | `name`, `id`, `realId` | `label`, `id` |
| Empty query | keeps everything | returns nothing |

The first row is a user-visible bug: typing `project:<name>` in the global search is treated as free text, looked for literally in the label, and silently returns nothing — while the same filter works in the sidebar.

This extracts the grammar so both sides share one engine. Note the vocabulary was already shared (the console builds matchers once for both); what was duplicated is how a query is matched against it.

# What does this PR do?

- Add `lib/filter-sections.js`, holding the tokenizing and the matching semantics, which the console can import for its sidebar the way it already imports a dozen other lib modules,
- Keep what legitimately differs between call sites configurable: which fields hold the text, which prefixes mark a keyword, and whether an empty query yields everything or nothing,
- Make keyword prefixes an explicit list rather than a generic `<word>:` pattern, so free text keeping a colon (a URL, an id) still searches as text,
- Treat `project:<name>` as a keyword in `cc-search-bar`, matched against an item's matchers instead of a literal string looked for in its label,
- Cover the grammar with 22 unit tests,
- No breaking change: `is:<itemType>` is still folded into the matchers, an empty query still yields no result, and the component's API is untouched.

# How to review?

- Check the commits,
- Check the [preview](https://clever-components-preview.cellar-c2.services.clever-cloud.com/feat/share-filter-grammar/index.html?path=/story/%F0%9F%9B%A0-navigation-cc-search-bar--with-keyword-filter)
