### PR TITLE
feat(cc-domain-management): dispatch cc-domain-list-change after add and delete

### DIFF
--- a/src/components/cc-domain-management/cc-domain-management.events.js
+++ b/src/components/cc-domain-management/cc-domain-management.events.js
@@ -63,3 +63,20 @@ export class CcDomainPrimaryChangeEvent extends CcEvent {
     super(CcDomainPrimaryChangeEvent.TYPE, detail);
   }
 }
+
+/**
+ * Dispatched when a domain addition or deletion has been taken into account.
+ *
+ * Unlike `cc-domain-add` and `cc-domain-delete`, which are intents dispatched before the API call, this one is
+ * dispatched once the API has answered. Consumers deriving something from the domain list can safely refetch
+ * when they receive it.
+ *
+ * @extends {CcEvent}
+ */
+export class CcDomainListChangeEvent extends CcEvent {
+  static TYPE = 'cc-domain-list-change';
+
+  constructor() {
+    super(CcDomainListChangeEvent.TYPE);
+  }
+}

--- a/src/components/cc-domain-management/cc-domain-management.smart.js
+++ b/src/components/cc-domain-management/cc-domain-management.smart.js
@@ -13,7 +13,7 @@ import { sendToApi } from '../../lib/send-to-api.js';
 import { defineSmartComponent } from '../../lib/smart/define-smart-component.js';
 import { i18n } from '../../translations/translation.js';
 import '../cc-smart-container/cc-smart-container.js';
-import { CcDomainPrimaryChangeEvent } from './cc-domain-management.events.js';
+import { CcDomainListChangeEvent, CcDomainPrimaryChangeEvent } from './cc-domain-management.events.js';
 import { CcDomainManagement } from './cc-domain-management.js';
 
 /**
@@ -114,6 +114,9 @@ defineSmartComponent({
               domainListState.domains.push(newDomain);
             },
           );
+
+          // Dispatch event so consumers can refresh whatever they derive from the domain list
+          component.dispatchEvent(new CcDomainListChangeEvent());
         })
         .catch(
           /** @param {Error} error */
@@ -160,6 +163,12 @@ defineSmartComponent({
               domainListState.domains = domainListState.domains.filter((domain) => domain.id !== id);
             },
           );
+
+          // Dispatch event so consumers can refresh whatever they derive from the domain list. Deleting the
+          // primary domain does not re-emit `cc-domain-primary-change`, so this is the only signal consumers
+          // get in that case.
+          component.dispatchEvent(new CcDomainListChangeEvent());
+
           notifySuccess(i18n('cc-domain-management.list.delete.success', { domain: domainWithPathAndWildcard }));
         })
         .catch((error) => {

--- a/src/components/cc-domain-management/cc-domain-management.smart.md
+++ b/src/components/cc-domain-management/cc-domain-management.smart.md
@@ -18,6 +18,7 @@ title: '💡 Smart'
 | Name                       | Payload | Details                                                                                                                           |
 |----------------------------|---------|-----------------------------------------------------------------------------------------------------------------------------------|
 | `cc-domain-primary-change` |         | Fired when the primary domain has been changed successfully.<br/>Should be used to refresh the app link within the console header |
+| `cc-domain-list-change`    |         | Fired when a domain has been added or deleted successfully.<br/>Should be used to refresh anything derived from the domain list, such as a link pointing at the app.<br/>Not fired on primary domain change, see `cc-domain-primary-change` |
 
 
 ## ⚙️ Params

--- a/src/lib/events-map.types.d.ts
+++ b/src/lib/events-map.types.d.ts
@@ -43,6 +43,7 @@ import {
 import {
   CcDomainAddEvent,
   CcDomainDeleteEvent,
+  CcDomainListChangeEvent,
   CcDomainMarkAsPrimaryEvent,
   CcDomainPrimaryChangeEvent,
 } from '../components/cc-domain-management/cc-domain-management.events.js';
@@ -260,6 +261,7 @@ declare global {
     'cc-deployment-cancel': CcDeploymentCancelEvent;
     'cc-domain-add': CcDomainAddEvent;
     'cc-domain-delete': CcDomainDeleteEvent;
+    'cc-domain-list-change': CcDomainListChangeEvent;
     'cc-domain-mark-as-primary': CcDomainMarkAsPrimaryEvent;
     'cc-domain-primary-change': CcDomainPrimaryChangeEvent;
     'cc-email-add': CcEmailAddEvent;


### PR DESCRIPTION
# What does this PR do?

- Dispatch a new `cc-domain-list-change` event from the smart component, once a domain addition or deletion has been acknowledged by the API,
- Unlike `cc-domain-add` and `cc-domain-delete`, which are intents dispatched before the call, this one lets consumers deriving something from the domain list refetch safely. `cc-domain-primary-change` only covered the mark-as-primary case, and deleting the primary domain never re-emits it,
- Use a single event carrying no detail, on purpose: it only says that the list changed, not how. Consumers are expected to refetch rather than patch their own copy, and the id of a freshly added domain is a client-side guess until the API returns real ids,
- Leave the mark-as-primary path untouched, since list membership is unchanged there,
- Document the event in the smart component page and regenerate the events map.

# How to review?

- Check the commits,
- Check the [preview](https://clever-components-preview.cellar-c2.services.clever-cloud.com/feat/domain-list-change-event/index.html?path=/story/%F0%9F%9B%A0-domains-cc-domain-management--default-story)
- 1 reviewer should be enough.
