### PR TITLE
feat(cc-logs-instances): select every instance of a deployment at once

### DIFF
--- a/src/components/cc-logs-instances/cc-logs-instances.js
+++ b/src/components/cc-logs-instances/cc-logs-instances.js
@@ -1,4 +1,5 @@
 import { css, html, LitElement } from 'lit';
+import { repeat } from 'lit/directives/repeat.js';
 import {
   iconRemixToolsLine as iconBuildInstance,
   iconRemixCloseCircleFill as iconDeploymentCancelled,
@@ -16,6 +17,7 @@ import {
   iconRemixStopCircleLine as iconInstanceStopping,
 } from '../../assets/cc-remix.icons.js';
 import { groupBy } from '../../lib/utils.js';
+import { accessibilityStyles } from '../../styles/accessibility.js';
 import { i18n } from '../../translations/translation.js';
 import '../cc-datetime-relative/cc-datetime-relative.js';
 import '../cc-icon/cc-icon.js';
@@ -198,6 +200,27 @@ export class CcLogsInstances extends LitElement {
           selection: [...(this.state.selection ?? []), instanceId],
         };
       }
+
+      this.dispatchEvent(new CcLogsInstancesSelectionChangeEvent(this.state.selection));
+    }
+  }
+
+  /**
+   * Selects all the instances of a deployment, or deselects them all when they are already all selected.
+   *
+   * @param {Array<Instance>} instances
+   */
+  _onDeploymentClick(instances) {
+    if (this.state.state === 'loaded') {
+      const instanceIds = instances.map((instance) => instance.id);
+      const selection = this.state.selection ?? [];
+
+      this.state = {
+        ...this.state,
+        selection: instanceIds.every((instanceId) => selection.includes(instanceId))
+          ? selection.filter((instanceId) => !instanceIds.includes(instanceId))
+          : [...selection, ...instanceIds.filter((instanceId) => !selection.includes(instanceId))],
+      };
 
       this.dispatchEvent(new CcLogsInstancesSelectionChangeEvent(this.state.selection));
     }
@@ -423,22 +446,25 @@ export class CcLogsInstances extends LitElement {
   _renderInstancesGroupedByDeployment(instances) {
     const groups = groupBy(instances, (instance) => instance.deployment?.id);
 
+    const sortedGroups = Object.values(groups)
+      // deployment date is the date of the deployment of the first instance in the group
+      .map((instances) => ({ deploymentDate: instances[0].deployment.creationDate, instances }))
+      // sort by deployment date
+      .sort((o1, o2) => o2.deploymentDate - o1.deploymentDate);
+
     return html`
       <div class="section-content deployments">
-        ${Object.values(groups)
-          // deployment date is the date of the deployment of the first instance in the group
-          .map((instances) => ({ deploymentDate: instances[0].deployment.creationDate, instances }))
-          // sort by deployment date
-          .sort((o1, o2) => o2.deploymentDate - o1.deploymentDate)
-          // render group of instances
-          .map(
-            ({ instances }) => html`
-              <fieldset class="deployment">
-                ${this._renderDeploymentDetails(instances[0].deployment)}
-                <div class="instances">${this._renderInstances(instances, false)}</div>
-              </fieldset>
-            `,
-          )}
+        ${repeat(
+          sortedGroups,
+          // key on the deployment so that a reordering of the groups does not make lit reuse checkboxes by position
+          ({ instances }) => instances[0].deployment.id,
+          ({ instances }) => html`
+            <fieldset class="deployment">
+              ${this._renderDeploymentDetails(instances[0].deployment, instances)}
+              <div class="instances">${this._renderInstances(instances, false)}</div>
+            </fieldset>
+          `,
+        )}
       </div>
     `;
   }
@@ -473,16 +499,30 @@ export class CcLogsInstances extends LitElement {
 
   /**
    * @param {Deployment} deployment
+   * @param {Array<Instance>} instances
    */
-  _renderDeploymentDetails(deployment) {
+  _renderDeploymentDetails(deployment, instances) {
+    const id = `deployment-${deployment.id}`;
+    const selectedCount = instances.filter((instance) => this._isSelected(instance.id)).length;
+
     return html`
       <legend class="deployment-detail">
-        <div>${this._renderDeploymentState(deployment.state)}</div>
-        <div>
-          ${i18n('cc-logs-instances.deployment.deployed')}&nbsp;<cc-datetime-relative
-            datetime=${deployment.creationDate.toISOString()}
-          ></cc-datetime-relative>
-        </div>
+        <label class="deployment-selector" for="${id}" title="${i18n('cc-logs-instances.deployment.select')}">
+          <input
+            type="checkbox"
+            id="${id}"
+            .checked=${selectedCount === instances.length}
+            .indeterminate=${selectedCount > 0 && selectedCount < instances.length}
+            @change=${() => this._onDeploymentClick(instances)}
+          />
+          <span class="visually-hidden">${i18n('cc-logs-instances.deployment.select')}</span>
+          ${this._renderDeploymentState(deployment.state)}
+          <span>
+            ${i18n('cc-logs-instances.deployment.deployed')}&nbsp;<cc-datetime-relative
+              datetime=${deployment.creationDate.toISOString()}
+            ></cc-datetime-relative>
+          </span>
+        </label>
         ${this._renderCommit(deployment.commitId)}
       </legend>
     `;
@@ -541,6 +581,7 @@ export class CcLogsInstances extends LitElement {
 
   static get styles() {
     return [
+      accessibilityStyles,
       // language=CSS
       css`
         :host {
@@ -708,7 +749,13 @@ export class CcLogsInstances extends LitElement {
           color: var(--cc-color-text-weak, #555);
           display: grid;
           gap: var(--cc-spacing-3, 0.5em);
-          grid-template-columns: auto 1fr auto;
+          grid-template-columns: 1fr auto;
+        }
+
+        .deployment-selector {
+          align-items: center;
+          display: flex;
+          gap: var(--cc-spacing-3, 0.5em);
         }
 
         .deployment .instances {

--- a/src/components/cc-logs-instances/cc-logs-instances.stories.js
+++ b/src/components/cc-logs-instances/cc-logs-instances.stories.js
@@ -201,6 +201,20 @@ export const coldMode = makeStory(conf, {
   items: [{ state: { state: 'loaded', selection: [], instances: ALL_INSTANCES, mode: 'cold' } }],
 });
 
+export const coldModeWithPartialDeploymentSelection = makeStory(conf, {
+  /** @type {Array<Partial<CcLogsInstances>>} */
+  items: [
+    {
+      state: {
+        state: 'loaded',
+        selection: [ALL_INSTANCES[0].id, ALL_INSTANCES[2].id, ...ALL_INSTANCES.slice(5, 9).map((i) => i.id)],
+        instances: ALL_INSTANCES,
+        mode: 'cold',
+      },
+    },
+  ],
+});
+
 export const coldModeWithGhostInstances = makeStory(conf, {
   /** @type {Array<Partial<CcLogsInstances>>} */
   items: [{ state: { state: 'loaded', selection: [], instances: ALL_INSTANCES_WITH_GHOSTS, mode: 'cold' } }],

--- a/src/translations/translations.en.js
+++ b/src/translations/translations.en.js
@@ -1320,6 +1320,7 @@ export const translations = {
   'cc-logs-instances.deleted.header': `Deleted instances`,
   'cc-logs-instances.deploying.header': `Deployment in progress`,
   'cc-logs-instances.deployment.deployed': `Deployed`,
+  'cc-logs-instances.deployment.select': `Select all the instances listed for this deployment`,
   'cc-logs-instances.deployment.state.cancelled': `Deployment cancelled`,
   'cc-logs-instances.deployment.state.failed': `Deployment failed`,
   'cc-logs-instances.deployment.state.succeeded': `Deployment succeeded`,

--- a/src/translations/translations.fr.js
+++ b/src/translations/translations.fr.js
@@ -1331,6 +1331,7 @@ export const translations = {
   'cc-logs-instances.deleted.header': `Instances supprimées`,
   'cc-logs-instances.deploying.header': `Déploiement en cours`,
   'cc-logs-instances.deployment.deployed': `Déployée`,
+  'cc-logs-instances.deployment.select': `Sélectionner toutes les instances listées pour ce déploiement`,
   'cc-logs-instances.deployment.state.cancelled': `Déploiement annulé`,
   'cc-logs-instances.deployment.state.failed': `Déploiement en échec`,
   'cc-logs-instances.deployment.state.succeeded': `Déploiement réussi`,


### PR DESCRIPTION
## Why

In cold mode the instances panel groups instances by deployment, but filtering the logs on a whole deployment meant ticking each of its instances one by one.

## What

The deployment legend now carries a checkbox that selects, or deselects, every instance listed in its group. It dispatches the existing `cc-logs-instances-selection-change` event with the full list, so nothing changes for `cc-logs-app-runtime` or its smart component.

Design choices, all borrowed from what the panel already does:

- **A checkbox, not a clickable row.** The panel's whole vocabulary for "this filters the logs" is a checkbox. The deployment one sits at the group's left edge, and the instance checkboxes were already indented `1.5em` under it — so the hierarchy draws itself, no new indentation or borders.
- **`<label>` wrapping checkbox + state icon + "Deployed X ago"**, mirroring `_renderInstance`'s label around checkbox + name, so the text is clickable too. The commit chip stays outside the label, the same way the instance index chip does.
- **Tri-state**: checked when the whole group is selected, indeterminate when partial. Clicking a partially selected deployment completes the selection rather than clearing it.
- **CSS**: the legend grid went `auto 1fr auto` → `1fr auto`, with the label carrying the inner rhythm at the same `--cc-spacing-3` gap as `.instance`. One new rule, no new tokens, no new colors.

Since `_renderInstancesGroupedByDeployment` also backs live mode's **Deleted instances** section, that section gets the toggle too. That is why the label reads "all the instances *listed for* this deployment" — there the group holds only the deployment's deleted instances.

## Notes

- The groups are now rendered through `repeat()` keyed on the deployment id. Lit only re-commits a bound property when its cached value changes, while a click mutates `checked`/`indeterminate` directly, so a group reorder concurrent with a click could otherwise strand a checkbox showing state that no longer matches `state.selection` — `indeterminate` being property-only, with no attribute to fall back on.
- The purpose is exposed to assistive tech through a `.visually-hidden` span inside the label, using the existing `accessibilityStyles` helper. A `title` on the label would not have worked: the label's subtree text is what names the associated input.
- New `coldModeWithPartialDeploymentSelection` story covers the indeterminate and fully-checked states side by side.

## Checks

`lint`, `stylelint`, `format:check`, `lit-analyzer`, `components:check-i18n` and `components:events-map-check` are clean; `test:group a11y:cc-logs-instances` passes 34/34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)