### PR TITLE
fix(cc-domain-management): prevent selecting the domain link with triple click

### DIFF
--- a/src/components/cc-domain-management/cc-domain-management.js
+++ b/src/components/cc-domain-management/cc-domain-management.js
@@ -991,6 +991,9 @@ export class CcDomainManagement extends LitElement {
 
           font-family: var(--cc-ff-monospace, monospace);
           padding: var(--cc-spacing-1, 0.25em);
+          /* Prevent selecting the domain link when triple clicking the domain line */
+          -webkit-user-select: none;
+          user-select: none;
           vertical-align: middle;
         }
 


### PR DESCRIPTION
## Context

In Firefox, triple clicking the domain name line selects both the domain and the link content.
When you copy it, you end up with  `www.example.com/ https://www.example.com/`.

This PR makes triple click only select the domain name and not the link content (link content is mostly here for a11y).

## How to review?

- Check the code,
- Check the preview:
  - triple click domain names within the list and copy paste the content => you should only get the domain name and not the link URL.