### PR TITLE
feat(cc-orga-member-list): let consumers deny member management

### DIFF
--- a/demo-smart/index.html
+++ b/demo-smart/index.html
@@ -1024,6 +1024,14 @@
                 <button
                   class="ctx-btn"
                   title="ownerId, currentUserId"
+                  data-context='{"ownerId":"orga_3547a882-d464-4c34-8168-add4b3e0c135","currentUserId":"user_d3d02829-8847-40ea-ab76-ada4e2f026c0", "readonly": "true"}'
+                >
+                  <span class="ctx-label">ACME BAR readonly</span>
+                  <span class="ctx-subtitle">ownerId, currentUserId</span>
+                </button>
+                <button
+                  class="ctx-btn"
+                  title="ownerId, currentUserId"
                   data-context='{"ownerId":"orga_540caeb6-521c-4a19-a955-efe6da35d142","currentUserId":"user_d3d02829-8847-40ea-ab76-ada4e2f026c0"}'
                 >
                   <span class="ctx-label">ACME FOO</span>

--- a/src/components/cc-orga-member-card/cc-orga-member-card.js
+++ b/src/components/cc-orga-member-card/cc-orga-member-card.js
@@ -45,6 +45,7 @@ const BREAKPOINTS = [BREAKPOINT_TINY, BREAKPOINT_SMALL, BREAKPOINT_MEDIUM];
  * With the right authorisations:
  * - This component provides a way to delete the member from the organisation.
  * - This component provides a way to edit the role of the member within a given organisation.
+ * - On the current user's card, the delete button becomes a "leave the organisation" button, gated by the `leave` authorisation.
  *
  * ## Technical Details
  *
@@ -69,6 +70,7 @@ export class CcOrgaMemberCard extends LitElement {
     this.authorisations = {
       edit: false,
       delete: false,
+      leave: true,
     };
 
     /** @type {OrgaMemberCardState} Sets the state and data of the member. */
@@ -256,7 +258,12 @@ export class CcOrgaMemberCard extends LitElement {
     const waiting = this.state.type === 'updating' || this.state.type === 'deleting';
     const hasName = this.state.name != null;
     const hasError = (this.state.type === 'loaded' || this.state.type === 'editing') && this.state.error;
-    const hasAdminRights = this.authorisations.edit && this.authorisations.delete;
+    // on the current user's card, the delete button is the "leave the organisation" button.
+    // `leave` may be omitted by consumers written before it existed, they fall back to the `delete` authorisation.
+    const mayRemove = this.state.isCurrentUser
+      ? (this.authorisations.leave ?? this.authorisations.delete)
+      : this.authorisations.delete;
+    const hasAdminRights = this.authorisations.edit && mayRemove;
 
     return html`
       <div class="wrapper ${classMap({ 'has-actions': hasAdminRights, 'has-error': hasError })}">

--- a/src/components/cc-orga-member-card/cc-orga-member-card.stories.js
+++ b/src/components/cc-orga-member-card/cc-orga-member-card.stories.js
@@ -66,9 +66,9 @@ export const dataLoadedWithEditAndDelete = makeStory(conf, {
     {
       state: { ...baseMember },
       authorisations: {
-        invite: true,
         edit: true,
         delete: true,
+        leave: true,
       },
     },
   ],
@@ -81,6 +81,25 @@ export const dataLoadedWithIsCurrentUser = makeStory(conf, {
       state: {
         ...baseMember,
         isCurrentUser: true,
+      },
+    },
+  ],
+});
+
+export const dataLoadedWithIsCurrentUserAndLeaveDenied = makeStory(conf, {
+  docs: 'On the current user\'s card, the delete button is the "leave the organisation" button. Without the `leave` authorisation, the action buttons are gone even for an admin.',
+  /** @type {Partial<CcOrgaMemberCard>[]} */
+  items: [
+    {
+      state: {
+        ...baseMember,
+        role: 'ADMIN',
+        isCurrentUser: true,
+      },
+      authorisations: {
+        edit: true,
+        delete: true,
+        leave: false,
       },
     },
   ],
@@ -157,9 +176,9 @@ export const editing = makeStory(conf, {
         type: 'editing',
       },
       authorisations: {
-        invite: true,
         edit: true,
         delete: true,
+        leave: true,
       },
     },
   ],
@@ -178,9 +197,9 @@ export const errorWithStateLoaded = makeStory(conf, {
         isCurrentUser: true,
       },
       authorisations: {
-        invite: true,
         edit: true,
         delete: true,
+        leave: true,
       },
     },
   ],
@@ -199,9 +218,9 @@ export const errorWithStateEditing = makeStory(conf, {
         isCurrentUser: true,
       },
       authorisations: {
-        invite: true,
         edit: true,
         delete: true,
+        leave: true,
       },
     },
   ],
@@ -216,9 +235,9 @@ export const updatingMemberRole = makeStory(conf, {
         type: 'updating',
       },
       authorisations: {
-        invite: true,
         edit: true,
         delete: true,
+        leave: true,
       },
     },
   ],
@@ -233,9 +252,9 @@ export const deletingMember = makeStory(conf, {
         type: 'deleting',
       },
       authorisations: {
-        invite: true,
         edit: true,
         delete: true,
+        leave: true,
       },
     },
   ],
@@ -247,9 +266,9 @@ export const simulations = makeStory(conf, {
     {
       state: baseMember,
       authorisations: {
-        invite: true,
         edit: true,
         delete: true,
+        leave: true,
       },
     },
   ],

--- a/src/components/cc-orga-member-card/cc-orga-member-card.types.d.ts
+++ b/src/components/cc-orga-member-card/cc-orga-member-card.types.d.ts
@@ -48,6 +48,7 @@ interface ToggleEditing {
 interface CardAuthorisations {
   edit: boolean;
   delete: boolean;
+  leave?: boolean; // Only used on the current user's card. Defaults to the `delete` authorisation, which used to gate the "leave" button.
 }
 
 interface UpdateMember extends OrgaMember {

--- a/src/components/cc-orga-member-list/cc-orga-member-list.js
+++ b/src/components/cc-orga-member-list/cc-orga-member-list.js
@@ -41,7 +41,8 @@ const ORGA_MEMBER_DOCUMENTATION = getDocUrl('/account/administrate-organization'
  * Depending on the current user authorisations:
  *
  *  - The current user may remove members,
- *  - The current user may edit the role of members.
+ *  - The current user may edit the role of members,
+ *  - The current user may leave the organisation.
  *
  * @cssdisplay block
  */
@@ -60,6 +61,8 @@ export class CcOrgaMemberList extends LitElement {
       invite: false,
       edit: false,
       delete: false,
+      // a plain member may always leave the organisation, this has to stay the default to remain backward compatible
+      leave: true,
     };
   }
 
@@ -369,7 +372,9 @@ export class CcOrgaMemberList extends LitElement {
             : ''}
         </cc-block-section>
 
-        ${this.memberListState.type === 'loaded' ? this._renderDangerZone(this.memberListState) : ''}
+        ${(this.authorisations.leave ?? true) && this.memberListState.type === 'loaded'
+          ? this._renderDangerZone(this.memberListState)
+          : ''}
 
         <div slot="footer-right">
           <cc-link href="${ORGA_MEMBER_DOCUMENTATION}" .icon="${iconInfo}">
@@ -460,6 +465,7 @@ export class CcOrgaMemberList extends LitElement {
               .authorisations=${{
                 edit: this.authorisations.edit,
                 delete: this.authorisations.delete,
+                leave: this.authorisations.leave,
               }}
               .state=${memberState}
               @cc-orga-member-leave=${this._onLeaveFromCard}

--- a/src/components/cc-orga-member-list/cc-orga-member-list.smart.js
+++ b/src/components/cc-orga-member-list/cc-orga-member-list.smart.js
@@ -30,12 +30,13 @@ defineSmartComponent({
   params: {
     apiConfig: { type: Object },
     ownerId: { type: String },
+    readonly: { type: Boolean, optional: true },
   },
   /**
    * @param {OnContextUpdateArgs<CcOrgaMemberList>} args
    */
   onContextUpdate({ component, context, onEvent, updateComponent, signal }) {
-    const { apiConfig, ownerId } = context;
+    const { apiConfig, ownerId, readonly } = context;
 
     /**
      * Checks if a manager is trying to edit an admin
@@ -56,12 +57,20 @@ defineSmartComponent({
      * @param {OrgaMemberRole} [role] - the current role of the member to update
      */
     function updateAuthorisations(role) {
+      if (readonly) {
+        updateComponent('authorisations', { invite: false, edit: false, delete: false, leave: false });
+        return;
+      }
+
       const hasAdminRights = role === 'ADMIN' || role === 'MANAGER';
+      // `updateAuthorisations()` is called without any role once the current user has left the organisation
+      const isMember = role != null;
 
       updateComponent('authorisations', {
         invite: hasAdminRights,
         edit: hasAdminRights,
         delete: hasAdminRights,
+        leave: isMember,
       });
     }
 

--- a/src/components/cc-orga-member-list/cc-orga-member-list.smart.md
+++ b/src/components/cc-orga-member-list/cc-orga-member-list.smart.md
@@ -23,10 +23,11 @@ title: '💡 Smart'
 
 ## ⚙️ Params
 
-| Name        | Type        | Details                                                 | Default |
-|-------------|-------------|---------------------------------------------------------|---------|
-| `apiConfig` | `ApiConfig` | Object with API configuration (target host, tokens...)  |         |
-| `ownerId`   | `string`    | UUID prefixed with orga_                                |         |
+| Name        | Type        | Details                                                                                                                                              | Default |
+|-------------|-------------|------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+| `apiConfig` | `ApiConfig` | Object with API configuration (target host, tokens...)                                                                                               |         |
+| `ownerId`   | `string`    | UUID prefixed with orga_                                                                                                                             |         |
+| `readonly`  | `boolean`   | *optional*. When `true`, the member list stays readable but every write is denied whatever the current user's role: no invite, no role change, no member removal and no leaving the organisation. | `false` |
 
 ```ts
 interface ApiConfig {
@@ -57,6 +58,7 @@ interface ApiConfig {
       OAUTH_CONSUMER_SECRET: "",
     },
     "ownerId": "",
+    "readonly": false,
 }'>
     <cc-orga-member-list></cc-orga-member-list>
 <cc-smart-container>

--- a/src/components/cc-orga-member-list/cc-orga-member-list.stories.js
+++ b/src/components/cc-orga-member-list/cc-orga-member-list.stories.js
@@ -49,6 +49,7 @@ const authorisationsAdmin = {
   invite: true,
   edit: true,
   delete: true,
+  leave: true,
 };
 /** @type {Partial<CcOrgaMemberList>} */
 const baseItem = {
@@ -337,6 +338,28 @@ export const dataLoadedWithCurrentUserAdmin = makeStory(conf, {
   items: [
     {
       authorisations: authorisationsAdmin,
+      memberListState: {
+        type: 'loaded',
+        memberList: baseMemberList,
+        identityFilter: '',
+        mfaDisabledOnlyFilter: false,
+        dangerZoneState: 'idle',
+      },
+    },
+  ],
+});
+
+export const dataLoadedWithMemberManagementDenied = makeStory(conf, {
+  docs: 'When member management is denied, the list stays readable but every write is gone: no invite form, no edit / remove buttons and no danger zone.',
+  /** @type {Partial<CcOrgaMemberList>[]} */
+  items: [
+    {
+      authorisations: {
+        invite: false,
+        edit: false,
+        delete: false,
+        leave: false,
+      },
       memberListState: {
         type: 'loaded',
         memberList: baseMemberList,

--- a/src/components/cc-orga-member-list/cc-orga-member-list.types.d.ts
+++ b/src/components/cc-orga-member-list/cc-orga-member-list.types.d.ts
@@ -27,6 +27,7 @@ interface ListAuthorisations {
   invite: boolean;
   edit: boolean;
   delete: boolean;
+  leave?: boolean; // Defaults to `true`
 }
 
 export interface InviteMemberFormState {


### PR DESCRIPTION
## Context

Closes #1807.

Partner-specific Consoles manage an organisation's membership through an external portal only, and
the API now exposes a per-organisation flag saying members must not be modified from the Console.
The Console handles the "members can't even be listed" case on its own by hiding the whole Members
tab; the case that reaches this component is the other one — the member list stays visible and
readable, but every write must go away: no invite, no role change, no member removal and no leaving
the organisation.

Invite, edit and delete were already gated by `authorisations`. Leaving was not: `_renderDangerZone`
ran as soon as the list was loaded, so an otherwise read-only list kept a fully working "Leave the
organisation" button.

## Changes

- New optional `leave` authorisation on `cc-orga-member-list`, gating the danger zone.
- `cc-orga-member-card` honours `leave` on the current user's card, where the delete button doubles
  as the "Leave the organisation" button.
- New optional `readonly` param on the smart component: when `true`, every authorisation is denied
  whatever the current user's role.
- Stories for both denied cases, and the smart doc params table.

### Implementation notes

**Naming.** A single boolean named `readonly`, rather than the `memberManagementDenied` floated in
the issue. It says what the consumer gets — a member list that is readable and nothing else —
without leaking the API's flag vocabulary into the component. If those per-organisation flags grow
into something richer, that is a second, additive param rather than a rename of this one.

**`leave` on the current user's card.** The card honours it, as the issue suggested. It falls back
to the `delete` authorisation when unset, which is exactly what used to gate that button.

**`leave` defaults to `true` instead of joining the all-`false` `INIT_AUTHORISATIONS`.** Leaving is
the one action a plain member has always had, independently of any admin right, so it is the sane
default for the dumb component. The smart component still computes it: `leave: role != null`, since
`updateAuthorisations()` is called with no role once the current user has left the organisation.

**Backward compatibility.** That default is what keeps this change invisible to existing consumers:
`leave` is optional, defaults to `true` on the list and falls back to `delete` on the card, so a
consumer rendering `<cc-orga-member-list>` without setting `authorisations` keeps its danger zone.
The only consumer-visible addition is the `readonly` smart param, which defaults to `false`.

## How to review

1. Start with `cc-orga-member-list.smart.js` — `updateAuthorisations()` is the load-bearing change,
   and shows what `readonly` maps to.
2. Then the two gates it feeds: the danger zone in `cc-orga-member-list.js`, and `mayRemove` in
   `cc-orga-member-card.js`.
3. On the preview, check the two new stories: `dataLoadedWithMemberManagementDenied` on the list
   (readable list, no invite form, no action buttons, no danger zone) and
   `dataLoadedWithIsCurrentUserAndLeaveDenied` on the card (admin, current user, no action buttons).
4. Worth a second look given the default above: the untouched stories should be unchanged, danger
   zone included.

**1 approval**, per the branch protection rule on `master`.
