### PR TITLE
feat(cc-orga-member-list): dispatch cc-orga-member-was-updated after a role change

### DIFF
--- a/src/components/cc-orga-member-list/cc-orga-member-list.events.js
+++ b/src/components/cc-orga-member-list/cc-orga-member-list.events.js
@@ -34,3 +34,18 @@ export class CcOrgaMemberLeftEvent extends CcEvent {
     super(CcOrgaMemberLeftEvent.TYPE, detail);
   }
 }
+
+/**
+ * Dispatched when an organisation member has been updated.
+ * @extends {CcEvent<OrgaMember>}
+ */
+export class CcOrgaMemberWasUpdatedEvent extends CcEvent {
+  static TYPE = 'cc-orga-member-was-updated';
+
+  /**
+   * @param {OrgaMember} detail
+   */
+  constructor(detail) {
+    super(CcOrgaMemberWasUpdatedEvent.TYPE, detail);
+  }
+}

--- a/src/components/cc-orga-member-list/cc-orga-member-list.smart.js
+++ b/src/components/cc-orga-member-list/cc-orga-member-list.smart.js
@@ -10,7 +10,7 @@ import { sendToApi } from '../../lib/send-to-api.js';
 import { defineSmartComponent } from '../../lib/smart/define-smart-component.js';
 import { i18n } from '../../translations/translation.js';
 import '../cc-smart-container/cc-smart-container.js';
-import { CcOrgaMemberLeftEvent } from './cc-orga-member-list.events.js';
+import { CcOrgaMemberLeftEvent, CcOrgaMemberWasUpdatedEvent } from './cc-orga-member-list.events.js';
 import { CcOrgaMemberList } from './cc-orga-member-list.js';
 
 const MEMBER_NOT_FOUND = 6501;
@@ -115,7 +115,9 @@ defineSmartComponent({
         });
     });
 
-    onEvent('cc-orga-member-update', ({ id, role, newRole, name, email, isCurrentUser }) => {
+    onEvent('cc-orga-member-update', ({ newRole, ...orgaMember }) => {
+      const { id, role, name, email, isCurrentUser } = orgaMember;
+
       if (component.memberListState.type !== 'loaded') {
         return;
       }
@@ -155,6 +157,8 @@ defineSmartComponent({
           if (isCurrentUser) {
             updateAuthorisations(newRole);
           }
+
+          component.dispatchEvent(new CcOrgaMemberWasUpdatedEvent({ ...orgaMember, role: newRole }));
         })
         .catch(
           /** @param {Error & {id: number}} error */

--- a/src/components/cc-orga-member-list/cc-orga-member-list.smart.md
+++ b/src/components/cc-orga-member-list/cc-orga-member-list.smart.md
@@ -18,6 +18,7 @@ title: '💡 Smart'
 | Name                  | Payload | Details                                                                                                       |
 |-----------------------|---------|---------------------------------------------------------------------------------------------------------------|
 | `cc-orga-member-left` |         | Fired when the current user leaves the organisation.<br/>Should be used to redirect the user to another page. |
+| `cc-orga-member-was-updated` | `OrgaMember` | Fired when a member has been updated successfully.<br/>Should be used to refresh anything derived from the member list, such as the current user's rights. The payload contains the member with its new role. |
 
 
 ## ⚙️ Params

--- a/src/lib/events-map.types.d.ts
+++ b/src/lib/events-map.types.d.ts
@@ -161,6 +161,7 @@ import {
 import {
   CcOrgaMemberInviteEvent,
   CcOrgaMemberLeftEvent,
+  CcOrgaMemberWasUpdatedEvent,
 } from '../components/cc-orga-member-list/cc-orga-member-list.events.js';
 import {
   CcPricingCurrencyChangeEvent,
@@ -350,6 +351,7 @@ declare global {
     'cc-orga-member-leave': CcOrgaMemberLeaveEvent;
     'cc-orga-member-left': CcOrgaMemberLeftEvent;
     'cc-orga-member-update': CcOrgaMemberUpdateEvent;
+    'cc-orga-member-was-updated': CcOrgaMemberWasUpdatedEvent;
     'cc-password-reset': CcPasswordResetEvent;
     'cc-pricing-currency-change': CcPricingCurrencyChangeEvent;
     'cc-pricing-plan-add': CcPricingPlanAddEvent;


### PR DESCRIPTION
## Context

`cc-orga-member-update` is an intent: it is dispatched before the API call, so it says nothing
about whether the role change went through. The only success signal this component emits today is
`cc-orga-member-left`, which covers the current user leaving the organisation. A member being
updated — including the current user updating their own role — is invisible to consumers.

That last case is the one that hurts. The smart component recomputes its own `authorisations` when
`isCurrentUser` is true, so the list itself stays correct, but the Console derives the user's
rights and its navigation from the role it loaded on its side and keeps the stale one until the
next reload.

## Changes

- New `CcOrgaMemberWasUpdatedEvent` (`cc-orga-member-was-updated`), registered in the events map.
- The smart component dispatches it from the success path of the `cc-orga-member-update` handler,
  right after the member state and the authorisations have been updated.
- The smart doc gets the event in its "Events fired" table.

### Implementation notes

**Payload.** The whole member, with `role` overwritten by the new one — not just an id. The
handler destructures `newRole` out and keeps the rest of the detail around precisely for that.
`isCurrentUser` travels with it, so a consumer can tell whether the change concerns the logged-in
user without comparing ids against its own copy.

**Naming.** `-was-updated` matches the existing past-tense convention for "this really happened"
events (`cc-token-was-updated`, `cc-oauth-consumer-was-updated`, `cc-env-vars-was-updated`), as
opposed to the imperative `cc-orga-member-update` intent it answers.

**Failure path untouched.** Nothing is dispatched when the API call fails, so a consumer that
refetches on this event never acts on a role the API refused.

## How to review

1. Read `cc-orga-member-list.smart.js` — the `cc-orga-member-update` handler is the whole change;
   check the dispatch sits in the `.then()`, after `updateAuthorisations()`.
2. Then `cc-orga-member-list.events.js` and the entry added to `src/lib/events-map.types.d.ts`.
3. `pnpm run typecheck` covers the event map wiring.

**1 approval**, per the branch protection rule on `master`.