### PR TITLE
revert(cc-domain-management): drop the de-emphasis of repeated hostnames

### DIFF
--- a/src/components/cc-domain-management/cc-domain-management.js
+++ b/src/components/cc-domain-management/cc-domain-management.js
@@ -55,37 +55,6 @@ const DNS_DOCUMENTATION = getDocUrl('/administrate/domain-names');
  */
 
 /**
- * Tells, for each domain, whether its hostname repeats the one displayed right above it.
- * Domains are sorted by hostname, so repeats are always consecutive and de-emphasizing them makes
- * the path prefixes stand out on apps exposing many paths on the same hostname.
- *
- * The hostname is compared with its wildcard prefix included, because `*.example.com` and
- * `example.com` are two different hostnames from the user point of view even though they share the
- * same `hostname` value.
- *
- * The first domain of a column is never flagged: its hostname sits at the top of a column, so the
- * previous domain is not displayed above it. `rowCount` marks a column break only when the list is
- * actually laid out on two columns. On a single column it merely skips one de-emphasis, which is
- * why it errs on that side: a de-emphasized hostname always has its full-color twin right above it.
- *
- * @param {FormattedDomainInfo[]} domains - sorted domains, as displayed
- * @param {number} rowCount - number of rows of the domain list layout
- * @returns {boolean[]} one flag per domain, in the same order
- */
-function getRepeatedHostnameFlags(domains, rowCount) {
-  return domains.map((domain, index) => {
-    if (index === 0 || index === rowCount) {
-      return false;
-    }
-    const previousDomain = domains[index - 1];
-    return (
-      getHostWithWildcard(domain.hostname, domain.isWildcard) ===
-      getHostWithWildcard(previousDomain.hostname, previousDomain.isWildcard)
-    );
-  });
-}
-
-/**
  * A component to manage domains associated to an application.
  *
  * @cssdisplay block
@@ -582,7 +551,6 @@ export class CcDomainManagement extends LitElement {
     // A single domain stays on one full width column.
     const columnCount = domains.length > 1 ? 2 : 1;
     const rowCount = Math.ceil(domains.length / columnCount);
-    const repeatedHostnameFlags = getRepeatedHostnameFlags(domains, rowCount);
 
     if (!hasDomains) {
       return html`
@@ -614,7 +582,7 @@ export class CcDomainManagement extends LitElement {
         ${repeat(
           domains,
           ({ id }) => id,
-          (domain, index) => this._renderDomain(domain, isOneRowMarkingPrimary, repeatedHostnameFlags[index]),
+          (domain) => this._renderDomain(domain, isOneRowMarkingPrimary),
         )}
       </div>
     `;
@@ -623,10 +591,9 @@ export class CcDomainManagement extends LitElement {
   /**
    * @param {FormattedDomainInfo} domainInfo
    * @param {boolean} isOneRowMarkingPrimary
-   * @param {boolean} isHostnameRepeated - whether the hostname is already displayed on the domain right above
    * @returns {TemplateResult}
    **/
-  _renderDomain(domainInfo, isOneRowMarkingPrimary, isHostnameRepeated) {
+  _renderDomain(domainInfo, isOneRowMarkingPrimary) {
     const {
       type: domainItemStateType,
       id,
@@ -641,7 +608,6 @@ export class CcDomainManagement extends LitElement {
     const isMarkingPrimaryDisabled = isOneRowMarkingPrimary || domainItemStateType === 'deleting';
     const hostWithWildcard = getHostWithWildcard(hostname, isWildcard);
     const domainUrl = getDomainUrl(hostname, pathPrefix, isWildcard, isHttpOnly);
-    const hostnameClass = isHostnameRepeated ? 'repeated-hostname' : '';
 
     return html`
       <!--
@@ -651,7 +617,7 @@ export class CcDomainManagement extends LitElement {
       <div class="domain ${classMap({ primary: isPrimary, waiting })}" tabindex="-1">
         <span class="domain-name-with-path">
           <!-- These tags need to remain on the same line so there is no white-space when pasting domain+path -->
-          <span class="${hostnameClass}">${hostWithWildcard}</span><span class="path-prefix">${pathPrefix}</span>
+          <span>${hostWithWildcard}</span><span class="path-prefix">${pathPrefix}</span>
           <a
             class="domain-link"
             href="${domainUrl}"
@@ -966,17 +932,6 @@ export class CcDomainManagement extends LitElement {
         .domain-name-with-path {
           flex: 1 0 100%;
           word-break: break-all;
-        }
-
-        /* When the hostname repeats the one right above, it is de-emphasized so that the path
-           prefixes are what stands out when scanning a column.
-           --cc-color-text-weak is only one step below --cc-color-text-default, which reads as the
-           same color, hence the raw palette color here. Contrast stays above AA on the card
-           background.
-           A waiting domain is left out: its whole name is already dimmed by an opacity, which no
-           de-emphasized color could go through while keeping an AA contrast. */
-        .domain:not(.waiting) .repeated-hostname {
-          color: var(--color-grey-60, #737373);
         }
 
         .path-prefix {


### PR DESCRIPTION
Fixes [console3#1401](https://gitlab.corp.clever-cloud.com/clever-cloud/console3/-/work_items/1401)

# What does this PR do?

- Revert ba4d6839 and 668f9e4d, which closed #1798: a hostname identical to the one displayed right above it was dimmed, so that the path prefixes stood out on applications routing by path,
- In practice the two shades read as an unexplained difference between entries — nothing tells which state each color stands for, so the list looks inconsistent rather than structured, which is what the console3 issue reports,
- All hostnames are back to the default text color, no distinction left: `getRepeatedHostnameFlags`, the `isHostnameRepeated` parameter, the `repeated-hostname` class and its rule are all gone,
- `rowCount` stays, it is still needed for the column layout.

# How to review?

- Check that the diff is the exact inverse of ba4d6839 + 668f9e4d,
- Open the `cc-domain-management` stories on an app exposing several paths on the same hostname and check every hostname now has the same color,
- 1 reviewer should be enough.