### PR TITLE
docs(cc-toaster): remove the outdated `animationend` mention

### DIFF
--- a/src/components/cc-toaster/cc-toaster.js
+++ b/src/components/cc-toaster/cc-toaster.js
@@ -117,9 +117,9 @@ const withFade = (spec) => {
  *
  * #### Internal implementation of the toast dismiss
  *
- * Internally, we do not remove the `cc-toast` node from the DOM directly after receiving the `cc-toast:dismiss` event.
- * Instead, we trigger a CSS animation and listen to the `animationend` event so that we can remove the `cc-toast`
- * element from the DOM after the animation has finished.
+ * Internally, we rely on the `animate` directive from `@lit-labs/motion` to animate the `cc-toast` elements.
+ * When a toast is dismissed, we remove it from the list of toasts to render and the directive takes care of
+ * playing the out animation before the `cc-toast` element is actually removed from the DOM.
  *
  * @cssdisplay block
  */


### PR DESCRIPTION
Fixes #961

# What does this PR do?

- Update the `cc-toaster` internal implementation docs to reflect that dismissed toasts are no longer removed through a CSS animation and an `animationend` listener,
- Document that the out animation is now handled by the `animate` directive from `@lit-labs/motion`.

# How to review?

- Check the commits,
- Check the [preview](https://clever-components-preview.cellar-c2.services.clever-cloud.com/docs/cc-toaster-remove-animationend-mention/index.html?path=/story/%F0%9F%9B%A0-toast-cc-toaster--default-story)
- 1 reviewer should be enough.