### PR TITLE
feat(cc-search-bar): match items on an optional aliases field

### DIFF
--- a/src/components/cc-search-bar/cc-search-bar.js
+++ b/src/components/cc-search-bar/cc-search-bar.js
@@ -127,7 +127,11 @@ export class CcSearchBar extends LitElement {
   /**
    * Filters `this.sections` based on `this.value`, with the grammar shared with the console sidebar
    * (see `lib/filter-sections.js`): `is:`/`project:` tokens are matched against an item's matchers,
-   * everything else is free text matched against its label and id, and every token must pass.
+   * everything else is free text matched against its label, id and aliases, and every token must pass.
+   *
+   * `aliases` holds the texts an item is also known by but never displays: an add-on's real id, or the
+   * keywords a page should answer to. Without it a caller can only make such a text searchable by
+   * cramming it into `label` (visible) or `id` (a single value).
    *
    * `is:<itemType>` is folded into the matchers here so an item only setting `itemType` still answers
    * `is:app`, and an empty query yields nothing rather than the whole list — a search bar shows no
@@ -138,7 +142,7 @@ export class CcSearchBar extends LitElement {
   _getFilteredSections() {
     return filterSections(this.sections, this.value, {
       getMatchers: (item) => [...(item.itemType != null ? [`is:${item.itemType}`] : []), ...(item.matchers ?? [])],
-      getTexts: (item) => [item.label, item.id],
+      getTexts: (item) => [item.label, item.id, ...(item.aliases ?? [])],
       emptyQuery: 'none',
     });
   }

--- a/src/components/cc-search-bar/cc-search-bar.stories.js
+++ b/src/components/cc-search-bar/cc-search-bar.stories.js
@@ -53,7 +53,14 @@ const defaultSections = [
     icon: iconResources,
     items: [
       { label: 'APM --0307-42dc-af99-b485ecc44536', href: '#apm-1', itemType: 'app', matchers: ['project:billing'] },
-      { label: 'fs-matomot-with-posthog', href: '#matomot-1', itemType: 'addon', matchers: ['project:billing'] },
+      {
+        label: 'fs-matomot-with-posthog',
+        href: '#matomot-1',
+        id: 'addon_4d65a2d6-0307-42dc-af99-b485ecc44536',
+        aliases: ['postgresql_4d65a2d6'],
+        itemType: 'addon',
+        matchers: ['project:billing'],
+      },
       {
         label: 'APM - apps-0307-42dc-af99-b485ecc44536',
         href: '#apm-2',
@@ -71,7 +78,13 @@ const defaultSections = [
         itemType: 'app',
       },
       { label: 'test-kube-config', href: '#kube-1', itemType: 'cke' },
-      { label: 'test-addon-pulsar', href: '#pulsar-1', itemType: 'addon' },
+      {
+        label: 'test-addon-pulsar',
+        href: '#pulsar-1',
+        id: 'addon_9a84bf38-f874-4caf-a860-7d37b0df2a17',
+        aliases: ['pulsar_9a84bf38'],
+        itemType: 'addon',
+      },
       { label: 'my-oauth-consumer', href: '#consumer-1', itemType: 'oauth-consumer' },
       { label: 'matomo-addon-provider', href: '#provider-1', itemType: 'addon-provider' },
     ],
@@ -185,12 +198,32 @@ empty sections are hidden.
   },
 });
 
+export const withAliases = makeStory(conf, {
+  docs: `
+An item can carry \`aliases\`: texts it is also found by, but never displayed. The add-ons of this story are
+labelled with their name and keep their \`addon_xxx\` id, while their real id (\`postgresql_xxx\`,
+\`pulsar_xxx\`) sits in \`aliases\` — try \`postgresql\` or \`pulsar_9a84bf38\`. The same field lets a
+page answer to keywords its label does not contain, such as a support page found by \`help\`.
+  `,
+  /** @param {HTMLElement} container */
+  dom: (container) => {
+    render(
+      html`
+        <cc-button @cc-click="${() => getCcSearchBar(container).show()}" primary>Open Search Bar</cc-button>
+        <cc-search-bar open value="postgresql" .sections="${defaultSections}"></cc-search-bar>
+      `,
+      container,
+    );
+  },
+});
+
 export const withKeywordFilter = makeStory(conf, {
   docs: `
 The query supports \`is:<value>\` and \`project:<value>\` keyword tokens. Items match a keyword token when it is
 in their derived matchers — \`is:<itemType>\` is added automatically for items with an \`itemType\`, and any
 other matcher, \`project:<name>\` included, is provided via the \`matchers\` field. Anything else in the query
-is free text, matched against an item's label and id, so a colon in a URL or an id still searches as text.
+is free text, matched against an item's label, id and aliases, so a colon in a URL or an id still searches as
+text.
 
 Tokens can be combined and all must pass: \`is:app apm\` keeps only \`itemType: 'app'\` items whose label
 includes \`apm\`. The items of this story carry \`project:billing\` and \`project:analytics\` matchers — try

--- a/src/components/cc-search-bar/cc-search-bar.types.d.ts
+++ b/src/components/cc-search-bar/cc-search-bar.types.d.ts
@@ -6,6 +6,8 @@ export interface SearchBarItem {
   label: string;
   href: string;
   id?: string;
+  /** Extra texts the item can be found by, searched like its label and id but never displayed. */
+  aliases?: string[];
   itemType?: SearchBarItemType;
   matchers?: string[];
 }


### PR DESCRIPTION
## Problem

`cc-search-bar` filters its items on `label` and `id` only, so an item exposes a single searchable identifier. Add-ons need to be searchable by their `realId` (`postgresql_xxx`), while the `id` already holds the `addon_xxx` the console routes use.

## Proposal

Items accept an optional `aliases: string[]` field. Those texts are searched like the label and the id, but they are never displayed.

The search grammar does not change. The `is:` and `project:` tokens still match against matchers, and free text now matches `label`, `id` and `aliases`.

No breaking change. The field is optional, and an item without `aliases` behaves as before.

## How to test

1. Run Storybook and open `cc-search-bar`, story `withAliases`.
2. Type `postgresql` or `pulsar_9a84bf38`. The matching add-ons show up even though their label does not contain that text.
3. Check that aliases appear nowhere in the rendered output.
